### PR TITLE
Remove dependency and import of Niri HM module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,3 @@
-
 {
   description = "Dank material shell.";
 
@@ -6,8 +5,6 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     quickshell.url = "git+https://git.outfoxxed.me/quickshell/quickshell";
     quickshell.inputs.nixpkgs.follows = "nixpkgs";
-    niri.url = "github:sodiboo/niri-flake";
-    niri.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = { self, nixpkgs, niri, quickshell, ... }:
@@ -31,19 +28,24 @@
       homeModules.dankMaterialShell = { config, pkgs, lib, ... }:
         let cfg = config.programs.dankMaterialShell;
         in {
-          imports = [ niri.homeModules.niri ];
 
           options.programs.dankMaterialShell = {
             enable = lib.mkEnableOption "DankMaterialShell";
-            enableKeybinds = lib.mkEnableOption "DankMaterialShell Niri keybinds";
-            enableSystemd = lib.mkEnableOption "DankMaterialShell systemd startup";
+            enableKeybinds =
+              lib.mkEnableOption "DankMaterialShell Niri keybinds";
+            enableSystemd =
+              lib.mkEnableOption "DankMaterialShell systemd startup";
+            enableSpawn =
+              lib.mkEnableOption "DankMaterialShell Niri spawn-at-startup";
           };
 
           config = lib.mkIf cfg.enable {
             programs.quickshell = {
               enable = true;
               package = quickshell.packages.${system}.quickshell;
-              configs.DankMaterialShell = "${self.packages.${system}.dankMaterialShell}/etc/xdg/quickshell/DankMaterialShell";
+              configs.DankMaterialShell = "${
+                  self.packages.${system}.dankMaterialShell
+                }/etc/xdg/quickshell/DankMaterialShell";
               activeConfig = lib.mkIf cfg.enableSystemd "DankMaterialShell";
               systemd = lib.mkIf cfg.enableSystemd {
                 enable = true;
@@ -53,34 +55,107 @@
 
             programs.niri.settings = lib.mkMerge [
               (lib.mkIf cfg.enableKeybinds {
-                binds = with config.lib.niri.actions; {
-                  "Mod+Space".action = spawn "qs" "-c" "DankMaterialShell" "ipc" "call" "spotlight" "toggle";
-                  "Mod+V".action = spawn "qs" "-c" "DankMaterialShell" "ipc" "call" "clipboard" "toggle";
-                  "Mod+M".action = spawn "qs" "-c" "DankMaterialShell" "ipc" "call" "processlist" "toggle";
-                  "Mod+Comma".action = spawn "qs" "-c" "DankMaterialShell" "ipc" "call" "settings" "toggle";
-                  "Super+Alt+L".action = spawn "qs" "-c" "DankMaterialShell" "ipc" "call" "lock" "lock";
+                binds = {
+                  "Mod+Space".action.spawn = [
+                    "qs"
+                    "-c"
+                    "DankMaterialShell"
+                    "ipc"
+                    "call"
+                    "spotlight"
+                    "toggle"
+                  ];
+                  "Mod+V".action.spawn = [
+                    "qs"
+                    "-c"
+                    "DankMaterialShell"
+                    "ipc"
+                    "call"
+                    "clipboard"
+                    "toggle"
+                  ];
+                  "Mod+M".action.spawn = [
+                    "qs"
+                    "-c"
+                    "DankMaterialShell"
+                    "ipc"
+                    "call"
+                    "processlist"
+                    "toggle"
+                  ];
+                  "Mod+Comma".action.spawn = [
+                    "qs"
+                    "-c"
+                    "DankMaterialShell"
+                    "ipc"
+                    "call"
+                    "settings"
+                    "toggle"
+                  ];
+                  "Super+Alt+L".action.spawn = [
+                    "qs"
+                    "-c"
+                    "DankMaterialShell"
+                    "ipc"
+                    "call"
+                    "lock"
+                    "lock"
+                  ];
                   "XF86AudioRaiseVolume" = {
                     allow-when-locked = true;
-                    action = spawn "qs" "-c" "DankMaterialShell" "ipc" "call" "audio" "increment" "3";
+                    action.spawn = [
+                      "qs"
+                      "-c"
+                      "DankMaterialShell"
+                      "ipc"
+                      "call"
+                      "audio"
+                      "increment"
+                      "3"
+                    ];
                   };
                   "XF86AudioLowerVolume" = {
                     allow-when-locked = true;
-                    action = spawn "qs" "-c" "DankMaterialShell" "ipc" "call" "audio" "decrement" "3";
+                    action.spawn = [
+                      "qs"
+                      "-c"
+                      "DankMaterialShell"
+                      "ipc"
+                      "call"
+                      "audio"
+                      "decrement"
+                      "3"
+                    ];
                   };
                   "XF86AudioMute" = {
                     allow-when-locked = true;
-                    action = spawn "qs" "-c" "DankMaterialShell" "ipc" "call" "audio" "mute";
+                    action.spawn = [
+                      "qs"
+                      "-c"
+                      "DankMaterialShell"
+                      "ipc"
+                      "call"
+                      "audio"
+                      "mute"
+                    ];
                   };
                   "XF86AudioMicMute" = {
                     allow-when-locked = true;
-                    action = spawn "qs" "-c" "DankMaterialShell" "ipc" "call" "audio" "micmute";
+                    action.spawn = [
+                      "qs"
+                      "-c"
+                      "DankMaterialShell"
+                      "ipc"
+                      "call"
+                      "audio"
+                      "micmute"
+                    ];
                   };
                 };
               })
-              (lib.mkIf (!cfg.enableSystemd) {
-                spawn-at-startup = [{
-                  command = [ "qs" "-c" "DankMaterialShell" ];
-                }];
+              (lib.mkIf (cfg.enableSpawn) {
+                spawn-at-startup =
+                  [{ command = [ "qs" "-c" "DankMaterialShell" ]; }];
               })
             ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     quickshell.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, niri, quickshell, ... }:
+  outputs = { self, nixpkgs, quickshell, ... }:
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};


### PR DESCRIPTION
DankMaterialShell's flake failed to build on my system because it imported the Niri Home-Manager module a second time, after my config. 

This PR refactors the flake to no longer require the Niri flake to be imported directly. The Niri flake is now only needed if the user wants to use an option that requires it, such as enableKeybinds or enableSpawn. This also reduces the download requirements of the flake.