### PR TITLE
Fix READNE.md matugen package name error

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ sudo make install
 # Arch Linux
 ```bash
 sudo pacman -S cava wl-clipboard cliphist brightnessctl
-paru -S matugen dgop
+paru -S matugen-bin dgop
 ```
 # Fedora
 ```bash


### PR DESCRIPTION
matugen is not available in the official Arch repositories; use the AUR package matugen-bin instead