### PR TITLE
fix: update command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ mkdir -p ~/.config/quickshell
 git clone https://github.com/AvengeMedia/DankMaterialShell.git ~/.config/quickshell/dms
 ```
 ```bash
-qs -c DankMaterialShell
+qs -c dms
 ```
 
 ### Detailed Setup


### PR DESCRIPTION
```qs -c DankMaterialShell``` - This command is not working, I presume it's because we are cloning as "dms" and not "DankMaterialShell"