### PR TITLE
fix: slider movement for edge cases at 2% and 97% fill

### DIFF
--- a/Widgets/DankSlider.qml
+++ b/Widgets/DankSlider.qml
@@ -52,8 +52,9 @@ Item {
             StyledRect {
                 id: sliderFill
 
-                width: parent.width * ((slider.value - slider.minimum)
-                                       / (slider.maximum - slider.minimum))
+                width: (parent.width - sliderHandle.width) * (
+                    (slider.value - slider.minimum) / (slider.maximum - slider.minimum)
+                ) + sliderHandle.width
                 height: parent.height
                 radius: parent.radius
                 color: slider.enabled ? Theme.primary : Theme.surfaceVariantText
@@ -78,8 +79,7 @@ Item {
                                                    Theme.surfaceVariantText,
                                                    1.3)
                 border.width: 2
-                x: Math.max(0, Math.min(parent.width - width,
-                                        sliderFill.width - width / 2))
+                x: sliderFill.width - width
                 anchors.verticalCenter: parent.verticalCenter
                 scale: sliderMouseArea.containsMouse
                        || sliderMouseArea.pressed ? 1.2 : 1


### PR DESCRIPTION
This PR addresses a UI issue where the slider would not move properly to and from the 2% and 97% fill positions due to constraints in the minimum and maximum fill widths.