### PR TITLE
Workspace switcher: max icons setting

### DIFF
--- a/Common/SettingsData.qml
+++ b/Common/SettingsData.qml
@@ -46,6 +46,7 @@ Singleton {
     property bool showWorkspaceIndex: false
     property bool showWorkspacePadding: false
     property bool showWorkspaceApps: false
+    property int maxWorkspaceIcons: 3
     property var workspaceNameIcons: ({})
     property bool clockCompactMode: false
     property bool focusedWindowCompactMode: false
@@ -232,6 +233,8 @@ Singleton {
                         !== undefined ? settings.showWorkspacePadding : false
                 showWorkspaceApps = settings.showWorkspaceApps
                         !== undefined ? settings.showWorkspaceApps : false
+		maxWorkspaceIcons = settings.maxWorkspaceIcons
+                        !== undefined ? settings.maxWorkspaceIcons : 3
                 workspaceNameIcons = settings.workspaceNameIcons
                         !== undefined ? settings.workspaceNameIcons : ({})
                 clockCompactMode = settings.clockCompactMode
@@ -429,6 +432,11 @@ Singleton {
 
     function setShowWorkspaceApps(enabled) {
         showWorkspaceApps = enabled
+        saveSettings()
+    }
+    
+    function setMaxWorkspaceIcons(maxIcons) {
+        maxWorkspaceIcons = maxIcons
         saveSettings()
     }
 

--- a/Modules/Settings/WidgetTweaksTab.qml
+++ b/Modules/Settings/WidgetTweaksTab.qml
@@ -242,6 +242,48 @@ Item {
                                            checked)
                                    }
                     }
+
+		    Row {
+                        width: parent.width - Theme.spacingL
+                        spacing: Theme.spacingL
+                        visible: SettingsData.showWorkspaceApps
+                        opacity: visible ? 1 : 0
+                        anchors.left: parent.left
+                        anchors.leftMargin: Theme.spacingL
+
+                        Column {
+                            width: 120
+                            spacing: Theme.spacingS
+
+                            StyledText {
+                                text: "Max apps to show"
+                                font.pixelSize: Theme.fontSizeSmall
+                                color: Theme.surfaceText
+                                font.weight: Font.Medium
+                            }
+
+                            DankTextField {
+                                width: 100
+                                height: 28
+                                placeholderText: "#ffffff"
+                                text: SettingsData.maxWorkspaceIcons
+                                maximumLength: 7
+                                font.pixelSize: Theme.fontSizeSmall
+                                topPadding: Theme.spacingXS
+                                bottomPadding: Theme.spacingXS
+                                onEditingFinished: {
+                                    SettingsData.setMaxWorkspaceIcons(parseInt(text, 10))
+                                }
+                            }
+                        }
+
+                        Behavior on opacity {
+                            NumberAnimation {
+                                duration: Theme.mediumDuration
+                                easing.type: Theme.emphasizedEasing
+                            }
+                        }
+                    }
                 }
             }
 

--- a/Modules/TopBar/WorkspaceSwitcher.qml
+++ b/Modules/TopBar/WorkspaceSwitcher.qml
@@ -366,7 +366,7 @@ Rectangle {
                     visible: SettingsData.showWorkspaceApps && icons.length > 0
 
                     Repeater {
-                        model: icons.slice(0, 3)
+                        model: icons.slice(0, SettingsData.maxWorkspaceIcons)
                         delegate: Item {
                             width: 18
                             height: 18


### PR DESCRIPTION
There was a regression when merging Advanced Workspace Switcher with a normal one: only 3 app icons could be shown on the workspace, which makes the widget not very useful, when opening many windows on niri on one workspace.

This pull request adds a configurable option, that limits this number of icons on one workspace (default: 3).

P.s. this workspace animation lags like hell 

https://github.com/user-attachments/assets/f882aed4-b6af-4624-8efa-72227d9ae519

P.p.s. Someone can implement in the future, that if there're more icons than maxWorkspaceIcons, then show "..." as the last icon to tell user, that there're more windows there