### PR TITLE
Add configurable per-monitor workspaces and system tray options

### DIFF
--- a/Common/Paths.qml
+++ b/Common/Paths.qml
@@ -50,6 +50,10 @@ Singleton {
     function moddedAppId(appId: string): string {
         if (appId === "Spotify")
             return "spotify-launcher"
+        if (appId === "beepertexts")
+            return "beeper"
+        if (appId === "home assistant desktop")
+            return "homeassistant-desktop"
         return appId
     }
 }

--- a/Common/SettingsData.qml
+++ b/Common/SettingsData.qml
@@ -48,6 +48,7 @@ Singleton {
     property bool showWorkspacePadding: false
     property bool showWorkspaceApps: false
     property int maxWorkspaceIcons: 3
+    property bool workspacesPerMonitor: true
     property var workspaceNameIcons: ({})
     property bool clockCompactMode: false
     property bool focusedWindowCompactMode: false
@@ -199,6 +200,7 @@ Singleton {
                 showWorkspaceApps = settings.showWorkspaceApps !== undefined ? settings.showWorkspaceApps : false
                 maxWorkspaceIcons = settings.maxWorkspaceIcons !== undefined ? settings.maxWorkspaceIcons : 3
                 workspaceNameIcons = settings.workspaceNameIcons !== undefined ? settings.workspaceNameIcons : ({})
+                workspacesPerMonitor = settings.workspacesPerMonitor !== undefined ? settings.workspacesPerMonitor : true
                 clockCompactMode = settings.clockCompactMode !== undefined ? settings.clockCompactMode : false
                 focusedWindowCompactMode = settings.focusedWindowCompactMode !== undefined ? settings.focusedWindowCompactMode : false
                 runningAppsCompactMode = settings.runningAppsCompactMode !== undefined ? settings.runningAppsCompactMode : true
@@ -307,6 +309,8 @@ Singleton {
                                                 "showWorkspaceIndex": showWorkspaceIndex,
                                                 "showWorkspacePadding": showWorkspacePadding,
                                                 "showWorkspaceApps": showWorkspaceApps,
+                                                "maxWorkspaceIcons": maxWorkspaceIcons,
+                                                "workspacesPerMonitor": workspacesPerMonitor,
                                                 "workspaceNameIcons": workspaceNameIcons,
                                                 "clockCompactMode": clockCompactMode,
                                                 "focusedWindowCompactMode": focusedWindowCompactMode,
@@ -367,6 +371,11 @@ Singleton {
 
     function setMaxWorkspaceIcons(maxIcons) {
         maxWorkspaceIcons = maxIcons
+        saveSettings()
+    }
+
+    function setWorkspacesPerMonitor(enabled) {
+        workspacesPerMonitor = enabled
         saveSettings()
     }
 

--- a/Modules/Settings/DisplaysTab.qml
+++ b/Modules/Settings/DisplaysTab.qml
@@ -39,6 +39,11 @@ Item {
         "name": "Toast Messages",
         "description": "System toast notifications",
         "icon": "campaign"
+    }, {
+        "id": "systemTray",
+        "name": "System Tray",
+        "description": "System tray icons",
+        "icon": "notifications"
     }]
 
     function getScreenPreferences(componentId) {

--- a/Modules/Settings/WidgetTweaksTab.qml
+++ b/Modules/Settings/WidgetTweaksTab.qml
@@ -284,6 +284,16 @@ Item {
                             }
                         }
                     }
+
+                    DankToggle {
+                        width: parent.width
+                        text: "Per-Monitor Workspaces"
+                        description: "Show only workspaces belonging to each specific monitor."
+                        checked: SettingsData.workspacesPerMonitor
+                        onToggled: checked => {
+                            return SettingsData.setWorkspacesPerMonitor(checked);
+                        }
+                    }
                 }
             }
 

--- a/Modules/TopBar/TopBar.qml
+++ b/Modules/TopBar/TopBar.qml
@@ -705,6 +705,7 @@ PanelWindow {
                                 parentWindow: root
                                 parentScreen: root.screen
                                 widgetHeight: root.widgetHeight
+                                visible: SettingsData.getFilteredScreens("systemTray").includes(root.screen)
                             }
                         }
 


### PR DESCRIPTION
## Background

Love the shell, but I have multiple monitors and am using [split-monitor-workspaces](https://github.com/Duckonaut/split-monitor-workspaces) on Hyprland, so I don't want *all* the workspaces to show up on every monitor. 

## Workspaces per monitor
- Add `workspacesPerMonitor` setting (defaults to true for backward compatibility)
- Update `WorkspaceSwitcher` to respect the setting for both Hyprland and Niri
- Add UI toggle in Settings > Widgets > Workspace Settings
- Allows users without split-monitor setups to show all workspaces on every monitor
- Maintains current behavior for existing users while enabling traditional desktop workflow

## System tray monitor option
- Add the system tray to `variantComponents` so it can be shown only on specific monitors (useful on vertical monitors with limited horizontal space)

## Other
- Also add a couple of apps to `moddedAppId` since the icons were missing