### PR TITLE
Allow setting quickshell package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,12 +40,19 @@
               lib.mkEnableOption "DankMaterialShell systemd startup";
             enableSpawn =
               lib.mkEnableOption "DankMaterialShell Niri spawn-at-startup";
+
+            quickshell = {
+              package =  lib.mkPackageOption pkgs "quickshell" {
+                default = quickshell.packages.${pkgs.system}.quickshell;
+                nullable = false;
+              };
+            };
           };
 
           config = lib.mkIf cfg.enable {
             programs.quickshell = {
               enable = true;
-              package = quickshell.packages.${pkgs.system}.quickshell;
+              package = cfg.quickshell.package;
               configs.DankMaterialShell = "${
                   self.packages.${pkgs.system}.dankMaterialShell
                 }/etc/xdg/quickshell/DankMaterialShell";

--- a/flake.nix
+++ b/flake.nix
@@ -63,109 +63,37 @@
               };
             };
 
-            programs.niri.settings = lib.mkMerge [
+            programs.niri.settings = lib.mkMerge let
+              quickShellIpc = spawn "${cfg.quickshell.package}/bin/qs" "-c" "DankMaterialShell" "ipc" "call";
+              in [
               (lib.mkIf cfg.enableKeybinds {
                 binds = {
-                  "Mod+Space".action.spawn = [
-                    "qs"
-                    "-c"
-                    "DankMaterialShell"
-                    "ipc"
-                    "call"
-                    "spotlight"
-                    "toggle"
-                  ];
-                  "Mod+V".action.spawn = [
-                    "qs"
-                    "-c"
-                    "DankMaterialShell"
-                    "ipc"
-                    "call"
-                    "clipboard"
-                    "toggle"
-                  ];
-                  "Mod+M".action.spawn = [
-                    "qs"
-                    "-c"
-                    "DankMaterialShell"
-                    "ipc"
-                    "call"
-                    "processlist"
-                    "toggle"
-                  ];
-                  "Mod+Comma".action.spawn = [
-                    "qs"
-                    "-c"
-                    "DankMaterialShell"
-                    "ipc"
-                    "call"
-                    "settings"
-                    "toggle"
-                  ];
-                  "Super+Alt+L".action.spawn = [
-                    "qs"
-                    "-c"
-                    "DankMaterialShell"
-                    "ipc"
-                    "call"
-                    "lock"
-                    "lock"
-                  ];
+                  "Mod+Space".action = quickShellIpc "spotlight" "toggle";
+                  "Mod+V".action = quickShellIpc "clipboard" "toggle";
+                  "Mod+M".action = quickShellIpc "processlist" "toggle";
+                  "Mod+Comma".action = quickShellIpc "settings" "toggle";
+                  "Super+Alt+L".action = quickShellIpc "lock" "lock";
                   "XF86AudioRaiseVolume" = {
                     allow-when-locked = true;
-                    action.spawn = [
-                      "qs"
-                      "-c"
-                      "DankMaterialShell"
-                      "ipc"
-                      "call"
-                      "audio"
-                      "increment"
-                      "3"
-                    ];
+                    action = quickShellIpc "audio" "increment" "3";
                   };
                   "XF86AudioLowerVolume" = {
                     allow-when-locked = true;
-                    action.spawn = [
-                      "qs"
-                      "-c"
-                      "DankMaterialShell"
-                      "ipc"
-                      "call"
-                      "audio"
-                      "decrement"
-                      "3"
-                    ];
+                    action = quickShellIpc "audio" "decrement" "3";
                   };
                   "XF86AudioMute" = {
                     allow-when-locked = true;
-                    action.spawn = [
-                      "qs"
-                      "-c"
-                      "DankMaterialShell"
-                      "ipc"
-                      "call"
-                      "audio"
-                      "mute"
-                    ];
+                    action = quickShellIpc "audio" "mute";
                   };
                   "XF86AudioMicMute" = {
                     allow-when-locked = true;
-                    action.spawn = [
-                      "qs"
-                      "-c"
-                      "DankMaterialShell"
-                      "ipc"
-                      "call"
-                      "audio"
-                      "micmute"
-                    ];
+                    action = quickShellIpc "audio" "micmute";
                   };
                 };
               })
               (lib.mkIf (cfg.enableSpawn) {
                 spawn-at-startup =
-                  [{ command = [ "qs" "-c" "DankMaterialShell" ]; }];
+                  [{ command = [ "${cfg.quickshell.package}/bin/qs" "-c" "DankMaterialShell" ]; }];
               })
             ];
 


### PR DESCRIPTION
This PR makes it possible to set the quickshell package manually if the user so desires.

It is useful if you use the same quickshell input in some other place of your configuration and want to make sure it is the same binary