### PR TITLE
Fixed broken app icons on Niri

### DIFF
--- a/Modules/TopBar/WorkspaceSwitcher.qml
+++ b/Modules/TopBar/WorkspaceSwitcher.qml
@@ -80,7 +80,7 @@ Rectangle {
                              return
                          }
 
-                         const keyBase = (w.appId || w.class || w.windowClass || "unknown").toLowerCase()
+                         const keyBase = (w.app_id || w.appId || w.class || w.windowClass || "unknown").toLowerCase()
                          const key = isActiveWs ? `${keyBase}_${i}` : keyBase
 
                          if (!byApp[key]) {


### PR DESCRIPTION
<img width="442" height="144" alt="image" src="https://github.com/user-attachments/assets/6590cdf0-7581-4277-a967-6e0ecf9d9258" />

Someone broke my icons on Niri, while changing the Workspace Switcher code (I think that was a pull request with per monitor changes), so i fixed it