### PR TITLE
Add namespace to notification popup

### DIFF
--- a/Modules/Notifications/Popup/NotificationPopup.qml
+++ b/Modules/Notifications/Popup/NotificationPopup.qml
@@ -11,6 +11,8 @@ import qs.Widgets
 PanelWindow {
     id: win
 
+    WlrLayershell.namespace: "quickshell:notification"
+
     required property var notificationData
     required property string notificationId
     readonly property bool hasValidData: notificationData && notificationData.notification


### PR DESCRIPTION
Adds a namespace to the notification popup to add layer rules (i.e blocking out notifications from [screencasts on niri](https://github.com/YaLTeR/niri/wiki/Screencasting#block-out-windows))