### PR TITLE
doc: Fixes DMS input url for nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ To install using home-manager, you need to add this repo into your flake inputs:
 
 ``` nix
 dankMaterialShell = {
-  url = "github:AvengeMedia/DankMaterialShell/make_niri_optional";
+  url = "github:AvengeMedia/DankMaterialShell";
   inputs.nixpkgs.follows = "nixpkgs";
 };
 ```


### PR DESCRIPTION
We pushed the latest PR with the nix input using the `make_niri_optional` branch by mistake, this PR just fixes taht