### PR TITLE
fix(popouts): disable layer compositing and scale to keep text sharp

### DIFF
--- a/Widgets/DankPopout.qml
+++ b/Widgets/DankPopout.qml
@@ -57,16 +57,8 @@ PanelWindow {
     }
 
     color: "transparent"
-    WlrLayershell.layer: WlrLayershell.Top // if set to overlay -> virtual keyboards can be stuck under popup
+    WlrLayershell.layer: WlrLayershell.Top
     WlrLayershell.exclusiveZone: -1
-
-    // WlrLayershell.keyboardFocus should be set to Exclusive,
-    // if popup contains input fields and does NOT create new popups/modals
-    // with input fields.
-    // With OnDemand virtual keyboards can't send input to popup
-    // If set to Exclusive AND this popup creates other popups, that also have
-    // input fields -> they can't get keyboard focus, because the parent popup
-    // already took the lock
     WlrLayershell.keyboardFocus: shouldBeVisible ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None 
 
     anchors {
@@ -90,7 +82,7 @@ PanelWindow {
 
     Item {
         id: contentContainer
-        layer.enabled: true
+        layer.enabled: false
 
         readonly property real screenWidth: root.screen ? root.screen.width : 1920
         readonly property real screenHeight: root.screen ? root.screen.height : 1080
@@ -116,12 +108,12 @@ PanelWindow {
             }
         }
         
-        width: popupWidth
-        height: popupHeight
-        x: calculatedX
-        y: calculatedY
+        width: Math.round(popupWidth)
+        height: Math.round(popupHeight)
+        x: Math.round(calculatedX)
+        y: Math.round(calculatedY)
         opacity: shouldBeVisible ? 1 : 0
-        scale: shouldBeVisible ? 1 : 0.9
+        scale: 1
 
         Behavior on opacity {
             NumberAnimation {
@@ -130,12 +122,7 @@ PanelWindow {
             }
         }
 
-        Behavior on scale {
-            NumberAnimation {
-                duration: animationDuration
-                easing.type: animationEasing
-            }
-        }
+        
 
         Loader {
             id: contentLoader


### PR DESCRIPTION
The issue discussed in Discord has been fixed. Disabled offscreen layer compositing in popouts to avoid texture re-sampling. I hope I didn't break anything, check on your system.
Before
<img width="492" height="252" alt="image" src="https://github.com/user-attachments/assets/be54eebe-4c7f-423c-a2e8-0c3f528d9217" />

After
<img width="490" height="254" alt="image" src="https://github.com/user-attachments/assets/bc17f873-2207-4eb0-b14d-65011c0a629e" />

