### PR TITLE
fix: use correct icon on CPU temp on bar

### DIFF
--- a/Modules/DankBar/Widgets/CpuTemperature.qml
+++ b/Modules/DankBar/Widgets/CpuTemperature.qml
@@ -65,7 +65,7 @@ Rectangle {
         spacing: 1
 
         DankIcon {
-            name: "memory"
+            name: "device_thermostat"
             size: Theme.iconSize - 8
             color: {
                 if (DgopService.cpuTemperature > 85) {
@@ -103,7 +103,7 @@ Rectangle {
         spacing: 3
 
         DankIcon {
-            name: "memory"
+            name: "device_thermostat"
             size: Theme.iconSize - 8
             color: {
                 if (DgopService.cpuTemperature > 85) {


### PR DESCRIPTION
Before

<img width="1278" height="679" alt="swappy-20251006_120440" src="https://github.com/user-attachments/assets/f2964c97-56b9-4988-953e-8dee313d45e5" />

After

<img width="403" height="86" alt="swappy-20251006_125900" src="https://github.com/user-attachments/assets/85dc693b-9630-48df-adec-77f561974cc7" />


There'still too much space between those icons..