### PR TITLE
Allow user's matugen config to be ran by dms

### DIFF
--- a/scripts/matugen-worker.sh
+++ b/scripts/matugen-worker.sh
@@ -68,11 +68,7 @@ build_once() {
   [[ -z "$surface_base" ]] && surface_base="sc"
 
   CONFIG_DIR="${CONFIG_DIR:-$HOME/.config}"
-  
-  # Create user directories
   USER_MATUGEN_DIR="$CONFIG_DIR/matugen/dms"
-  [[ -d "$USER_MATUGEN_DIR/configs" ]] || mkdir -p "$USER_MATUGEN_DIR/configs"
-  [[ -d "$USER_MATUGEN_DIR/templates" ]] || mkdir -p "$USER_MATUGEN_DIR/templates"
   
   TMP_CFG="$(mktemp)"
   trap 'rm -f "$TMP_CFG"' RETURN


### PR DESCRIPTION
matugen-workers.sh now also loads the configs and templates from `~/.config/matugen/dms` and handles them the same way dms does its own matugen configs.

A good way to test it is to create:

`~/.config/matugen/dms/templates/dank-colors.colors`

```
#!/bin/bash

show_color() {
  local rgb="$1" label="${2:-color1}"
  local r g b
  IFS=',' read -r r g b < <(printf '%s' "$rgb" | tr -d 'rgb() ')
  printf '\033[38;2;%d;%d;%dmThis is %s in %s\033[0m\n' "$r" "$g" "$b" "$label" "$rgb"
}

<* for name, value in colors *>
show_color "{{value.default.rgb}}" "colors.{{name}}.default"
<* endfor *>
```

`~/.config/matugen/dms/configs/dank-colors.toml`

```
[templates.dank-colors]
input_path = '~/.config/matugen/dms/templates/dank-colors.colors'
output_path = '~/.config/matugen/dms/dank-colors.sh'
```

Then once the theme gets generated `chmod +x dank-colors.sh` and run it to see all the possible colors printed out to figure out how to theme your apps using it.

I hope this can be of some help!
