### PR TITLE
Fix: Lock button regression after 1ed4abd347f276b648ca1d491001aa9a588df6ce

### DIFF
--- a/DMSShell.qml
+++ b/DMSShell.qml
@@ -195,7 +195,7 @@ Item {
           powerMenuModalLoader: controlCenterLoader.powerModalLoaderRef
 
           onLockRequested: {
-              lock.activate()
+              SessionService.lockSession()
           }
 
           Component.onCompleted: {


### PR DESCRIPTION
### Summary

This PR addresses a regression introduced by commit **1ed4abd347f276b648ca1d491001aa9a588df6ce**, where clicking the lock button in the Control Center failed to activate the lock screen.

### The Issue

The previous commit moved the lock screen logic into a `LazyLoader`. This caused a `ReferenceError` when the lock button's action was triggered, as the `lock` object was no longer in scope.

The log showed the following warning when attempting to lock:
```
WARN scene: @DMSShell.qml[198:-1]: ReferenceError: lock is not defined
```

### The Fix

This PR implements that intended fix by calling `SessionService.lockSession()` inside the `onLockRequested()` signal handler, ensuring the session is locked correctly regardless of how the lock screen component is loaded.