### PR TITLE
Close ControlCenter popout on Settings open.

### DIFF
--- a/Modules/ControlCenter/Components/HeaderPane.qml
+++ b/Modules/ControlCenter/Components/HeaderPane.qml
@@ -11,6 +11,7 @@ Rectangle {
     signal powerButtonClicked()
     signal lockRequested()
     signal editModeToggled()
+    signal settingsButtonClicked()
 
     implicitHeight: 70
     radius: Theme.cornerRadius
@@ -96,6 +97,7 @@ Rectangle {
             iconColor: Theme.surfaceText
             backgroundColor: "transparent"
             onClicked: {
+                root.settingsButtonClicked()
                 settingsModal.show()
             }
         }

--- a/Modules/ControlCenter/ControlCenterPopout.qml
+++ b/Modules/ControlCenter/ControlCenterPopout.qml
@@ -140,6 +140,9 @@ DankPopout {
                         root.close()
                         root.lockRequested()
                     }
+                    onSettingsButtonClicked: {
+                        root.close()
+                    }
                 }
 
                 DragDropGrid {


### PR DESCRIPTION
Closes the ControlCenter popout when you open Settings. Improves UX by not having to manually click elsewhere on the screen to close the ControlCenter popout after being done doing what you wanted in Settings.