### PR TITLE
Make popouts respect screen edge margins and align with windows

### DIFF
--- a/Common/Theme.qml
+++ b/Common/Theme.qml
@@ -17,7 +17,7 @@ Singleton {
     readonly property bool envDisableMatugen: Quickshell.env("DMS_DISABLE_MATUGEN") === "1" || Quickshell.env("DMS_DISABLE_MATUGEN") === "true"
 
     // ! TODO - Synchronize with niri/hyprland gaps?
-    readonly property real popupDistance: 2
+    readonly property real popupDistance: SettingsData.dankBarSpacing
 
     property string currentTheme: "blue"
     property string currentThemeCategory: "generic"

--- a/Widgets/DankPopout.qml
+++ b/Widgets/DankPopout.qml
@@ -87,9 +87,9 @@ PanelWindow {
     readonly property real alignedHeight: Theme.px(popupHeight, dpr)
     readonly property real alignedX: Theme.snap((() => {
         if (SettingsData.dankBarPosition === SettingsData.Position.Left) {
-            return triggerY
+            return triggerY + SettingsData.dankBarBottomGap
         } else if (SettingsData.dankBarPosition === SettingsData.Position.Right) {
-            return screenWidth - triggerY - popupWidth
+            return screenWidth - triggerY - SettingsData.dankBarBottomGap - popupWidth
         } else {
             const centerX = triggerX + (triggerWidth / 2) - (popupWidth / 2)
             return Math.max(Theme.popupDistance, Math.min(screenWidth - popupWidth - Theme.popupDistance, centerX))
@@ -100,9 +100,9 @@ PanelWindow {
             const centerY = triggerX + (triggerWidth / 2) - (popupHeight / 2)
             return Math.max(Theme.popupDistance, Math.min(screenHeight - popupHeight - Theme.popupDistance, centerY))
         } else if (SettingsData.dankBarPosition === SettingsData.Position.Bottom) {
-            return Math.max(Theme.popupDistance, Math.min(screenHeight - popupHeight - Theme.popupDistance, screenHeight - triggerY - popupHeight + Theme.popupDistance))
+            return Math.max(Theme.popupDistance, screenHeight - triggerY - popupHeight)
         } else {
-            return Math.max(Theme.popupDistance, Math.min(screenHeight - popupHeight - Theme.popupDistance, triggerY + Theme.popupDistance))
+            return Math.min(screenHeight - popupHeight - Theme.popupDistance, triggerY)
         }
     })(), dpr)
 

--- a/Widgets/DankTooltip.qml
+++ b/Widgets/DankTooltip.qml
@@ -48,13 +48,13 @@ PanelWindow {
 
     margins {
         left: {
-            if (alignLeft) return Math.round(targetX)
-            if (alignRight) return Math.round(targetX - implicitWidth)
-            return Math.round(targetX - implicitWidth / 2)
+            if (alignLeft) return Math.round(Math.max(Theme.spacingS, Math.min((targetScreen?.width ?? Screen.width) - implicitWidth - Theme.spacingS, targetX)))
+            if (alignRight) return Math.round(Math.max(Theme.spacingS, Math.min((targetScreen?.width ?? Screen.width) - implicitWidth - Theme.spacingS, targetX - implicitWidth)))
+            return Math.round(Math.max(Theme.spacingS, Math.min((targetScreen?.width ?? Screen.width) - implicitWidth - Theme.spacingS, targetX - implicitWidth / 2)))
         }
         top: {
-            if (alignLeft || alignRight) return Math.round(targetY - implicitHeight / 2)
-            return Math.round(targetY)
+            if (alignLeft || alignRight) return Math.round(Math.max(Theme.spacingS, Math.min((targetScreen?.height ?? Screen.height) - implicitHeight - Theme.spacingS, targetY - implicitHeight / 2)))
+            return Math.round(Math.max(Theme.spacingS, Math.min((targetScreen?.height ?? Screen.height) - implicitHeight - Theme.spacingS, targetY)))
         }
     }
 


### PR DESCRIPTION
Did some tweaks to make popouts respect screen edge margins. This is heavily carried by AI so please review it. I'm not entirely sure how it would look on hyprland. I tested all layouts for DankBar and it works fine.

One consideration is if it should strictly follow the DankBar's Exclusive Zone Offset like it does in this PR or if it should follow the Edge Spacing instead. To me this made the most sense but not by much. Not super confident in this PR but please let me know how it looks to you guys. It makes things look much better on my end at least :3

Some befores and afters:
<img width="464" height="139" alt="TooltipOld" src="https://github.com/user-attachments/assets/47ebb039-9aaf-492f-8c11-38cecdda4719" />
<img width="464" height="139" alt="TooltipNew" src="https://github.com/user-attachments/assets/b5d53e2b-c68a-484e-a8f4-c0a194a7221d" />
<img width="586" height="697" alt="LauncherOld" src="https://github.com/user-attachments/assets/390fffbc-2561-4019-833e-a149b163effc" />

<img width="704" height="702" alt="LauncherNew" src="https://github.com/user-attachments/assets/fcfce49f-cbdb-4901-886e-1d22a175f4c8" />
