### PR TITLE
fix: get desktop entry back

### DIFF
--- a/Modals/Spotlight/SpotlightResults.qml
+++ b/Modals/Spotlight/SpotlightResults.qml
@@ -162,7 +162,7 @@ Rectangle {
                 onClicked: mouse => {
                                if (mouse.button === Qt.LeftButton) {
                                    resultsList.itemClicked(index, model)
-                               } else if (mouse.button === Qt.RightButton) {
+                               } else if (mouse.button === Qt.RightButton && !model.isPlugin) {
                                    const globalPos = mapToItem(null, mouse.x, mouse.y)
                                    const modalPos = resultsContainer.parent.mapFromItem(null, globalPos.x, globalPos.y)
                                    resultsList.itemRightClicked(index, model, modalPos.x, modalPos.y)
@@ -314,7 +314,7 @@ Rectangle {
                 onClicked: mouse => {
                                if (mouse.button === Qt.LeftButton) {
                                    resultsGrid.itemClicked(index, model)
-                               } else if (mouse.button === Qt.RightButton) {
+                               } else if (mouse.button === Qt.RightButton && !model.isPlugin) {
                                    const globalPos = mapToItem(null, mouse.x, mouse.y)
                                    const modalPos = resultsContainer.parent.mapFromItem(null, globalPos.x, globalPos.y)
                                    resultsGrid.itemRightClicked(index, model, modalPos.x, modalPos.y)

--- a/Modules/AppDrawer/AppLauncher.qml
+++ b/Modules/AppDrawer/AppLauncher.qml
@@ -154,7 +154,8 @@ Item {
                                                       "comment": app.comment || "",
                                                       "categories": app.categories || [],
                                                       "isPlugin": isPluginItem,
-                                                      "appIndex": uniqueApps.length - 1
+                                                      "appIndex": uniqueApps.length - 1,
+                                                      "desktopEntry": isPluginItem ? null : app
                                                   })
                          }
                      })


### PR DESCRIPTION
Pin to dock and launch on dGPU requires desktopEntry

for now my approach is to disable the context menu for plugin items