### PR TITLE
remove screen dimming from dropdown menus

### DIFF
--- a/Widgets/DankDropdown.qml
+++ b/Widgets/DankDropdown.qml
@@ -222,6 +222,7 @@ Item {
         height: Math.min(root.maxPopupHeight, (root.enableFuzzySearch ? 54 : 0) + Math.min(filteredOptions.length, 10) * 36 + 16)
         padding: 0
         modal: true
+        dim: false
         closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
         background: Rectangle {


### PR DESCRIPTION
Removed the dim on dropdowns. I felt this dim was a bit jarring and was more reminiscent of screen flicker rather than its intended use of bringing focus to the dropdown. Especially noticeable on opening the LauncherButton's AppDrawer which doesn't have a dim and then clicking the category dropdown but also just generally speaking for everything else too.