### PR TITLE
small fix: correct width for per-monitor dropdown

### DIFF
--- a/Modules/Settings/PersonalizationTab.qml
+++ b/Modules/Settings/PersonalizationTab.qml
@@ -524,7 +524,7 @@ Item {
                         }
 
                         Column {
-                            width: parent.width
+                            width: parent.width - (Theme.iconSize + Theme.spacingM)
                             spacing: Theme.spacingS
                             visible: SessionData.perMonitorWallpaper
                             leftPadding: Theme.iconSize + Theme.spacingM
@@ -645,7 +645,7 @@ Item {
                                 Item {
                                     width: 200
                                     height: 45 + Theme.spacingM
-                                    
+
                                     DankTabBar {
                                         id: modeTabBar
 


### PR DESCRIPTION
<img width="533" height="455" alt="immagine" src="https://github.com/user-attachments/assets/b715eef2-1e6a-4dff-8df5-094bc5a2e6a3" />
