### PR TITLE
fixed a crash with spacer widget

### DIFF
--- a/Modules/DankBar/WidgetHost.qml
+++ b/Modules/DankBar/WidgetHost.qml
@@ -75,10 +75,7 @@ Loader {
 
     onLoaded: {
         if (item) {
-            contentItemReady(item)
-            if (widgetId === "spacer") {
-                item.spacerSize = Qt.binding(() => spacerSize)
-            }
+            contentItemReady(item)            
             if (axis && "isVertical" in item) {
                 try {
                     item.isVertical = axis.isVertical


### PR DESCRIPTION
dms crashed on my end while using the spacer widget. the dump pointed me to the s`pacerSize` which doesn't  exist in the component as it's using `parent.spacerSize`

[crash.zip](https://github.com/user-attachments/files/22951588/crash.zip)
