### PR TITLE
Fix 12-hour calendar event start/end time parsing

### DIFF
--- a/Services/CalendarService.qml
+++ b/Services/CalendarService.qml
@@ -174,17 +174,42 @@ Singleton {
                             // Parse time if available and not all-day
                             let timeStr = event['start-time']
                             if (timeStr) {
-                                let timeParts = timeStr.match(/(\d+):(\d+)/)
+                                // Match time with optional seconds and AM/PM
+                                let timeParts = timeStr.match(/(\d+):(\d+)(?::\d+)?\s*(AM|PM)?/i)
                                 if (timeParts) {
-                                    startTime.setHours(parseInt(timeParts[1]),
-                                                       parseInt(timeParts[2]))
+                                    let hours = parseInt(timeParts[1])
+                                    let minutes = parseInt(timeParts[2])
+
+                                    // Handle AM/PM conversion if present
+                                    if (timeParts[3]) {
+                                        let period = timeParts[3].toUpperCase()
+                                        if (period === 'PM' && hours !== 12) {
+                                            hours += 12
+                                        } else if (period === 'AM' && hours === 12) {
+                                            hours = 0
+                                        }
+                                    }
+
+                                    startTime.setHours(hours, minutes)
                                     if (event['end-time']) {
                                         let endTimeParts = event['end-time'].match(
-                                            /(\d+):(\d+)/)
-                                        if (endTimeParts)
-                                        endTime.setHours(
-                                            parseInt(endTimeParts[1]),
-                                            parseInt(endTimeParts[2]))
+                                            /(\d+):(\d+)(?::\d+)?\s*(AM|PM)?/i)
+                                        if (endTimeParts) {
+                                            let endHours = parseInt(endTimeParts[1])
+                                            let endMinutes = parseInt(endTimeParts[2])
+
+                                            // Handle AM/PM conversion if present
+                                            if (endTimeParts[3]) {
+                                                let endPeriod = endTimeParts[3].toUpperCase()
+                                                if (endPeriod === 'PM' && endHours !== 12) {
+                                                    endHours += 12
+                                                } else if (endPeriod === 'AM' && endHours === 12) {
+                                                    endHours = 0
+                                                }
+                                            }
+
+                                            endTime.setHours(endHours, endMinutes)
+                                        }
                                     } else {
                                         // Default to 1 hour duration on same day
                                         endTime = new Date(startTime)


### PR DESCRIPTION
This PR fixes Khal event time parsing to support 12-hour AM/PM format.

Originally calendar events displayed incorrect times when Khal was configured with 12-hour time formats and the existing parsing solution only selected for hours and minutes, causing all PM events to be parsed as AM events e.g. 2:00 PM -> 2:00 AM since the PM wasn't handled.

This updates the event start/end time parsing regex to support AM/PM and handles that accordingly. 