### PR TITLE
Dropbox icon workaround when DankBar is vertical

### DIFF
--- a/Modules/DankBar/Widgets/SystemTrayBar.qml
+++ b/Modules/DankBar/Widgets/SystemTrayBar.qml
@@ -153,7 +153,10 @@ Rectangle {
 
                             const name = split[0];
                             const path = split[1];
-                            const fileName = name.substring(name.lastIndexOf("/") + 1);
+                            let fileName = name.substring(name.lastIndexOf("/") + 1);
+                            if (fileName.startsWith("dropboxstatus")) {
+                                fileName = `hicolor/16x16/status/${fileName}`;
+                            }
                             return `file://${path}/${fileName}`;
                         }
                         if (icon.startsWith("/") && !icon.startsWith("file://")) {


### PR DESCRIPTION
First, thanks for this great shell, I've been using it and enjoying it for a while :clap: 

I've noticed a little issue when I have DankBar set vertically, the dropbox icon becomes empty. Then, I saw this commit https://github.com/AvengeMedia/DankMaterialShell/commit/ed118f4e7ac067a53c100692b1144df2e223df58 which fixes the issue when the bar is at the top or bottom. So I replicated it for the vertical situation.