### PR TITLE
Add Workspace Indicator scrolling

### DIFF
--- a/Common/SettingsData.qml
+++ b/Common/SettingsData.qml
@@ -99,6 +99,7 @@ Singleton {
 
     property bool showWorkspaceIndex: false
     property bool showWorkspacePadding: false
+    property bool workspaceScrolling: false
     property bool showWorkspaceApps: false
     property int maxWorkspaceIcons: 3
     property bool workspacesPerMonitor: true
@@ -361,6 +362,7 @@ Singleton {
                 ]
                 showWorkspaceIndex = settings.showWorkspaceIndex !== undefined ? settings.showWorkspaceIndex : false
                 showWorkspacePadding = settings.showWorkspacePadding !== undefined ? settings.showWorkspacePadding : false
+                workspaceScrolling = settings.workspaceScrolling !== undefined ? settings.workspaceScrolling : false
                 showWorkspaceApps = settings.showWorkspaceApps !== undefined ? settings.showWorkspaceApps : false
                 maxWorkspaceIcons = settings.maxWorkspaceIcons !== undefined ? settings.maxWorkspaceIcons : 3
                 workspaceNameIcons = settings.workspaceNameIcons !== undefined ? settings.workspaceNameIcons : ({})
@@ -561,6 +563,7 @@ Singleton {
                                                 "controlCenterShowAudioIcon": controlCenterShowAudioIcon,
                                                 "controlCenterWidgets": controlCenterWidgets,
                                                 "showWorkspaceIndex": showWorkspaceIndex,
+                                                "workspaceScrolling": workspaceScrolling,
                                                 "showWorkspacePadding": showWorkspacePadding,
                                                 "showWorkspaceApps": showWorkspaceApps,
                                                 "maxWorkspaceIcons": maxWorkspaceIcons,
@@ -692,7 +695,7 @@ Singleton {
             "selectedGpuIndex", "enabledGpuPciIds", "showSystemTray", "showClock",
             "showNotificationButton", "showBattery", "showControlCenterButton",
             "controlCenterShowNetworkIcon", "controlCenterShowBluetoothIcon", "controlCenterShowAudioIcon",
-            "controlCenterWidgets", "showWorkspaceIndex", "showWorkspacePadding", "showWorkspaceApps",
+            "controlCenterWidgets", "showWorkspaceIndex", "workspaceScrolling", "showWorkspacePadding", "showWorkspaceApps",
             "maxWorkspaceIcons", "workspacesPerMonitor", "workspaceNameIcons", "waveProgressEnabled",
             "clockCompactMode", "focusedWindowCompactMode", "runningAppsCompactMode",
             "runningAppsCurrentWorkspace", "clockDateFormat", "lockDateFormat", "mediaSize",
@@ -1153,6 +1156,11 @@ Singleton {
 
     function setShowWorkspaceIndex(enabled) {
         showWorkspaceIndex = enabled
+        saveSettings()
+    }
+    
+    function setWorkspaceScrolling(enabled) {
+        workspaceScrolling = enabled
         saveSettings()
     }
 

--- a/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
+++ b/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
@@ -15,6 +15,9 @@ Rectangle {
     property string screenName: ""
     property real widgetHeight: 30
     property real barThickness: 48
+    readonly property var sortedToplevels: {
+        return CompositorService.filterCurrentWorkspace(CompositorService.sortedToplevels, parentScreen?.name);
+    }
     property int currentWorkspace: {
         if (CompositorService.isNiri) {
             return getNiriActiveWorkspace()
@@ -252,14 +255,84 @@ Rectangle {
                      const direction = deltaY < 0 ? 1 : -1
 
                      if (isMouseWheel) {
-                         switchWorkspace(direction)
+                        if (!SettingsData.workspaceScrolling) {
+                            switchWorkspace(direction)
+                        }
+                        else {
+                            const windows = root.sortedToplevels;
+                            if (windows.length < 2) {
+                                return;
+                            }
+                         let currentIndex = -1;
+                         for (let i = 0; i < windows.length; i++) {
+                            if (windows[i].activated) {
+                                currentIndex = i;
+                                break;
+                            }
+                            
+                         }
+                         let nextIndex;
+                         if (deltaY < 0) {
+                            if (currentIndex === -1) {
+                                nextIndex = 0;
+                            } else {
+                                nextIndex = currentIndex +1;
+                            }
+                         } else {
+                            if (currentIndex === -1) {
+                                nextIndex = windows.length -1;
+                            } else {
+                                nextIndex = currentIndex - 1
+                            }
+                         }
+                         const nextWindow = windows[nextIndex];
+                         if (nextWindow) {
+                            nextWindow.activate();
+                         }
+                        }
+                         
                      } else {
                          scrollAccumulator += deltaY
 
                          if (Math.abs(scrollAccumulator) >= touchpadThreshold) {
                              const touchDirection = scrollAccumulator < 0 ? 1 : -1
-                             switchWorkspace(touchDirection)
-                             scrollAccumulator = 0
+                             if (!SettingsData.workspaceScrolling) {
+                                switchWorkspace(touchDirection)
+                             }
+                             else {
+                                const windows = root.sortedToplevels;
+                                if (windows.length < 2) {
+                                    return;
+                                }
+                                let currentIndex = -1;
+                                for (let i = 0; i < windows.length; i++) {
+                                    if (windows[i].activated) {
+                                        currentIndex = i;
+                                        break;
+                                    }
+                            
+                                }
+                                let nextIndex;
+                                if (deltaY < 0) {
+                                    if (currentIndex === -1) {
+                                    nextIndex = 0;
+                                } else {
+                                    nextIndex = currentIndex +1;
+                                }
+                            } else {
+                                if (currentIndex === -1) {
+                                    nextIndex = windows.length -1;
+                                } else {
+                                    nextIndex = currentIndex - 1
+                                }
+                            }
+                            const nextWindow = windows[nextIndex];
+                            if (nextWindow) {
+                                nextWindow.activate();
+                            }
+                        }
+                             
+                            scrollAccumulator = 0
                          }
                      }
 

--- a/Modules/Settings/WidgetTweaksTab.qml
+++ b/Modules/Settings/WidgetTweaksTab.qml
@@ -65,6 +65,15 @@ Item {
                                            checked)
                                    }
                     }
+                    DankToggle {
+                        width: parent.width
+                        text: I18n.tr("Window Scrolling")
+                        description: "Scroll through windows, rather than workspaces"
+                        checked: SettingsData.workspaceScrolling
+                        onToggled: checked => {
+                            return SettingsData.setWorkspaceScrolling(checked)
+                        }
+                    }
 
                     DankToggle {
                         width: parent.width


### PR DESCRIPTION
Adds a settings option to scroll through the windows on a workspace rather than scrolling through the workspaces themselves when scrolling on the workspace indicator.