### PR TITLE
feat: Indicate when the mic is muted in the Privacy Indicator

### DIFF
--- a/Modules/DankBar/Widgets/PrivacyIndicator.qml
+++ b/Modules/DankBar/Widgets/PrivacyIndicator.qml
@@ -60,9 +60,8 @@ Rectangle {
 
             DankIcon {
                 name: {
-                    let muted = AudioService.source.audio.muted
-                    let volume = AudioService.source.audio.volume
-                    if (muted || volume === 0.0) return "mic_off"
+                    let muted = AudioService.source.audio.muted || AudioService.source.audio.volume === 0.0
+                    if (muted) return "mic_off"
                     return "mic"
                 }
                 size: Theme.iconSizeSmall
@@ -131,9 +130,8 @@ Rectangle {
 
             DankIcon {
                 name: {
-                    let muted = AudioService.source.audio.muted
-                    let volume = AudioService.source.audio.volume
-                    if (muted || volume === 0.0) return "mic_off"
+                    let muted = AudioService.source.audio.muted || AudioService.source.audio.volume === 0.0
+                    if (muted) return "mic_off"
                     return "mic"
                 }
                 size: Theme.iconSizeSmall


### PR DESCRIPTION
Small change that that shows the `mic_off` icon in the Privacy Indicator in the case the mic is muted or volume = `0`.

<img width="64" height="59" alt="image" src="https://github.com/user-attachments/assets/888c7943-ff99-46e7-8a6d-6ac8a404826d" />

Fixes #489.