### PR TITLE
feat: Only colour Bluetooth icon in DankBar if a device is connected

### DIFF
--- a/Modules/DankBar/Widgets/ControlCenterButton.qml
+++ b/Modules/DankBar/Widgets/ControlCenterButton.qml
@@ -67,7 +67,7 @@ Rectangle {
         DankIcon {
             name: "bluetooth"
             size: Theme.barIconSize(barThickness)
-            color: BluetoothService.enabled ? Theme.primary : Theme.outlineButton
+            color: BluetoothService.connected ? Theme.primary : Theme.outlineButton
             anchors.horizontalCenter: parent.horizontalCenter
             visible: root.showBluetoothIcon && BluetoothService.available && BluetoothService.enabled
         }
@@ -169,7 +169,7 @@ Rectangle {
 
             name: "bluetooth"
             size: Theme.barIconSize(barThickness)
-            color: BluetoothService.enabled ? Theme.primary : Theme.outlineButton
+            color: BluetoothService.connected ? Theme.primary : Theme.outlineButton
             anchors.verticalCenter: parent.verticalCenter
             visible: root.showBluetoothIcon && BluetoothService.available && BluetoothService.enabled
         }

--- a/Services/BluetoothService.qml
+++ b/Services/BluetoothService.qml
@@ -15,6 +15,15 @@ Singleton {
     readonly property bool enabled: (adapter && adapter.enabled) ?? false
     readonly property bool discovering: (adapter && adapter.discovering) ?? false
     readonly property var devices: adapter ? adapter.devices : null
+    readonly property bool connected: {
+        if (!adapter || !adapter.devices) {
+            return false
+        }
+
+        let isConnected = false
+        adapter.devices.values.forEach(dev => { if (dev.connected) isConnected = true })
+        return isConnected
+    }
     readonly property var pairedDevices: {
         if (!adapter || !adapter.devices) {
             return []


### PR DESCRIPTION
This adds a new property `BluetoothService.connected` which determines if there is any currently connected devices and then we use that to determine which colour the bluetooth icon in the DankBar should have. Showcase below:

Adapter disabled:
<img width="81" height="43" alt="image" src="https://github.com/user-attachments/assets/b1806819-8067-426d-88b7-5ae15d2cf1d7" />

Adapter enabled, no devices connected:
<img width="94" height="37" alt="image" src="https://github.com/user-attachments/assets/35b3933e-d28f-4109-a282-e59c19ab688d" />

Adapter enabled, with device connected:
<img width="94" height="37" alt="image" src="https://github.com/user-attachments/assets/a8bc1fdc-3131-41d1-b904-d355c00c3608" />

Fixes #487.
