### PR TITLE
Dock: Support ultrawide monitors and wide docks

### DIFF
--- a/Modules/Dock/Dock.qml
+++ b/Modules/Dock/Dock.qml
@@ -252,8 +252,8 @@ Variants {
             property real currentScreen: modelData ? modelData : dock.screen
             property real screenWidth: currentScreen ? currentScreen.geometry.width : 1920
             property real screenHeight: currentScreen ? currentScreen.geometry.height : 1080
-            property real maxDockWidth: Math.min(screenWidth * 0.8, 1200)
-            property real maxDockHeight: Math.min(screenHeight * 0.8, 1200)
+            property real maxDockWidth: screenWidth * 0.98
+            property real maxDockHeight: screenHeight * 0.98
 
             height: {
                 if (dock.isVertical) {


### PR DESCRIPTION
Noticed the dock boundary is hardcoded to a 1200px width. I use a lot of icons and realized I can't click the ones on the edge. This fix makes it work properly for wider monitors (mine is 3440px wide).