### PR TITLE
disable sleep inhibitor when lock-before-suspend disabled

### DIFF
--- a/Services/SessionService.qml
+++ b/Services/SessionService.qml
@@ -339,6 +339,7 @@ Singleton {
             if (SettingsData.loginctlLockIntegration) {
                 syncLockBeforeSuspend()
             }
+            syncSleepInhibitor()
         }
     }
 
@@ -407,7 +408,7 @@ Singleton {
         if (!DMSService.apiVersion || DMSService.apiVersion < 4) return
 
         DMSService.sendRequest("loginctl.setSleepInhibitorEnabled", {
-            enabled: SettingsData.loginctlLockIntegration
+            enabled: SettingsData.loginctlLockIntegration && SettingsData.lockBeforeSuspend
         }, response => {
             if (response.error) {
                 console.warn("SessionService: Failed to sync sleep inhibitor:", response.error)


### PR DESCRIPTION
https://github.com/AvengeMedia/DankMaterialShell/commit/342cd55bc0934ae5c0a7dc591d636948742fa2f6 I believe the condition for disabling inhibitor is incorrect. This pr fixes it, resolving the delay in executing the suspend command when lock integration is enabled