### PR TITLE
nix: use standard way to remove option

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,6 +8,9 @@
     cfg = config.programs.dankMaterialShell;
     jsonFormat = pkgs.formats.json { };
 in {
+    imports = [
+        (lib.mkRemovedOptionModule ["programs" "dankMaterialShell" "enableNightMode"] "Night mode is now always available.")
+    ];
     options.programs.dankMaterialShell = with lib.types; {
         enable = lib.mkEnableOption "DankMaterialShell";
 


### PR DESCRIPTION
From #524 and 7bf73ab14d6f64beb8967b26e95e26f6c79e35a8, we can see that the `enableNightMode` option has become obsolete. However, in #516 this option was removed directly, which is not the correct approach for nixpkgs module. We should use `lib.mkRemovedOptionModule` instead to inform users that the option has been removed. Otherwise, users who still have `enableNightMode = true;` in their configuration will encounter eval failures and may need to go through the same investigation I described above.
