### PR TITLE
Fixed path to dms-colors.json in Modules/Greetd/README.md

### DIFF
--- a/Modules/Greetd/README.md
+++ b/Modules/Greetd/README.md
@@ -52,7 +52,7 @@ sudo chmod -R g+rX ~/.config/DankMaterialShell ~/.local/state/DankMaterialShell 
 # Create symlinks
 sudo ln -sf ~/.config/DankMaterialShell/settings.json /var/cache/dms-greeter/settings.json
 sudo ln -sf ~/.local/state/DankMaterialShell/session.json /var/cache/dms-greeter/session.json
-sudo ln -sf ~/.cache/quickshell/dankshell/dms-colors.json /var/cache/dms-greeter/colors.json
+sudo ln -sf ~/.cache/DankMaterialShell/dms-colors.json /var/cache/dms-greeter/colors.json
 
 # Logout and login for group membership to take effect
 ```
@@ -251,7 +251,7 @@ sudo chmod -R g+rX ~/.config/DankMaterialShell ~/.local/state/DankMaterialShell 
 # Create symlinks for theme files
 sudo ln -sf ~/.config/DankMaterialShell/settings.json /var/cache/dms-greeter/settings.json
 sudo ln -sf ~/.local/state/DankMaterialShell/session.json /var/cache/dms-greeter/session.json
-sudo ln -sf ~/.cache/quickshell/dankshell/dms-colors.json /var/cache/dms-greeter/colors.json
+sudo ln -sf ~/.cache/DankMaterialShell/dms-colors.json /var/cache/dms-greeter/colors.json
 
 # Logout and login for group membership to take effect
 ```


### PR DESCRIPTION
Fixed the path to dms-colors.json, as the previous path did not actually exist, resulting in a broken symbolic link and the colors not actually being right in the login screen.