### PR TITLE
Fixed bugs in Workspace Switcher

### DIFF
--- a/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
+++ b/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
@@ -423,7 +423,8 @@ Item {
                         return SettingsData.showWorkspaceApps ? widgetHeight * 0.7 : widgetHeight * 0.5
                     }
                 }
-
+		
+		//DO NOT move this MouseArea. It should be on this level in order for the appMouseArea to work
 		MouseArea {
                     id: mouseArea
                     anchors.fill: parent


### PR DESCRIPTION
Recent update introduce two very breaking and annoying bugs to the workspace switcher and this pull request fixes them:

- when moving existing windows/moving focus from on window to another, information about positions and active windows on workspace switcher was not updated
- hovering/clicking on app icons didn't work, because of misplaced MouseArea

Video that shows the before/after (the upper bar is before)

https://github.com/user-attachments/assets/391627f3-437f-4db1-9339-3948e6bcb7be

