### PR TITLE
Feat: add nerd font app icon support

### DIFF
--- a/Modules/DankBar/Widgets/FocusedApp.qml
+++ b/Modules/DankBar/Widgets/FocusedApp.qml
@@ -91,6 +91,7 @@ BasePill {
 
     content: Component {
         Item {
+            id: contentItem
             implicitWidth: {
                 if (!root.hasWindowsOnCurrentWorkspace) return 0
                 if (root.isVerticalOrientation) return root.widgetThickness - root.horizontalPadding * 2
@@ -100,13 +101,33 @@ BasePill {
             implicitHeight: root.widgetThickness - root.horizontalPadding * 2
             clip: false
 
+            property string nerdFontIcon: {
+                if (!activeWindow || !activeWindow.appId) return ""
+                return AppIconService.getNerdFontIcon(activeWindow.appId) || ""
+            }
+
+            Text {
+                id: nerdIcon
+                anchors.centerIn: parent
+                width: 18
+                height: 18
+                text: contentItem.nerdFontIcon
+                font.family: "FiraCode Nerd Font"
+                font.pixelSize: 14
+                color: Theme.surfaceText
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                visible: root.isVerticalOrientation && activeWindow && contentItem.nerdFontIcon !== ""
+            }
+
             IconImage {
                 id: appIcon
                 anchors.centerIn: parent
                 width: 18
                 height: 18
-                visible: root.isVerticalOrientation && activeWindow && status === Image.Ready
+                visible: root.isVerticalOrientation && activeWindow && status === Image.Ready && contentItem.nerdFontIcon === ""
                 source: {
+                    if (contentItem.nerdFontIcon !== "") return ""
                     if (!activeWindow || !activeWindow.appId) return ""
                     const moddedId = Paths.moddedAppId(activeWindow.appId)
                     if (moddedId.toLowerCase().includes("steam_app")) return ""
@@ -123,6 +144,7 @@ BasePill {
                 name: "sports_esports"
                 color: Theme.surfaceText
                 visible: {
+                    if (contentItem.nerdFontIcon !== "") return false
                     if (!root.isVerticalOrientation || !activeWindow || !activeWindow.appId) return false
                     const moddedId = Paths.moddedAppId(activeWindow.appId)
                     return moddedId.toLowerCase().includes("steam_app")
@@ -132,6 +154,7 @@ BasePill {
             Text {
                 anchors.centerIn: parent
                 visible: {
+                    if (contentItem.nerdFontIcon !== "") return false
                     if (!root.isVerticalOrientation || !activeWindow || !activeWindow.appId) return false
                     if (appIcon.status === Image.Ready) return false
                     const moddedId = Paths.moddedAppId(activeWindow.appId)

--- a/Modules/DankBar/Widgets/RunningApps.qml
+++ b/Modules/DankBar/Widgets/RunningApps.qml
@@ -276,7 +276,24 @@ Item {
                             }
                         }
 
-                        // App icon
+                        property string nerdFontIcon: AppIconService.getNerdFontIcon(appId) || ""
+
+                        Text {
+                            id: nerdIcon
+                            anchors.left: parent.left
+                            anchors.leftMargin: SettingsData.runningAppsCompactMode ? (parent.width - 18) / 2 : Theme.spacingXS
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 18
+                            height: 18
+                            text: visualContent.nerdFontIcon
+                            font.family: "FiraCode Nerd Font"
+                            font.pixelSize: 14
+                            color: Theme.surfaceText
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                            visible: visualContent.nerdFontIcon !== ""
+                        }
+
                         IconImage {
                             id: iconImg
                             anchors.left: parent.left
@@ -285,6 +302,9 @@ Item {
                             width: 18
                             height: 18
                             source: {
+                                if (visualContent.nerdFontIcon !== "") {
+                                    return ""
+                                }
                                 const moddedId = Paths.moddedAppId(appId)
                                 if (moddedId.toLowerCase().includes("steam_app")) {
                                     return ""
@@ -294,7 +314,7 @@ Item {
                             smooth: true
                             mipmap: true
                             asynchronous: true
-                            visible: status === Image.Ready
+                            visible: status === Image.Ready && visualContent.nerdFontIcon === ""
                         }
 
                         DankIcon {
@@ -305,15 +325,20 @@ Item {
                             name: "sports_esports"
                             color: Theme.surfaceText
                             visible: {
+                                if (visualContent.nerdFontIcon !== "") {
+                                    return false
+                                }
                                 const moddedId = Paths.moddedAppId(appId)
                                 return moddedId.toLowerCase().includes("steam_app")
                             }
                         }
 
-                        // Fallback text if no icon found
                         Text {
                             anchors.centerIn: parent
                             visible: {
+                                if (visualContent.nerdFontIcon !== "") {
+                                    return false
+                                }
                                 const moddedId = Paths.moddedAppId(appId)
                                 const isSteamApp = moddedId.toLowerCase().includes("steam_app")
                                 return !iconImg.visible && !isSteamApp

--- a/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
+++ b/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
@@ -96,10 +96,12 @@ Item {
                          if (!byApp[key]) {
                              const moddedId = Paths.moddedAppId(keyBase)
                              const isSteamApp = moddedId.toLowerCase().includes("steam_app")
+                             const nerdIcon = AppIconService.getNerdFontIcon(keyBase) || ""
                              const icon = isSteamApp ? "" : Quickshell.iconPath(DesktopEntries.heuristicLookup(moddedId)?.icon, true)
                              byApp[key] = {
                                  "type": "icon",
                                  "icon": icon,
+                                 "nerdIcon": nerdIcon,
                                  "isSteamApp": isSteamApp,
                                  "active": !!(w.activated || (CompositorService.isNiri && w.is_focused)),
                                  "count": 1,
@@ -568,13 +570,26 @@ Item {
                                         width: 18
                                         height: 18
 
+                                        Text {
+                                            id: nerdIcon
+                                            anchors.fill: parent
+                                            text: modelData.nerdIcon || ""
+                                            font.family: "FiraCode Nerd Font"
+                                            font.pixelSize: 14
+                                            color: isActive ? Qt.rgba(Theme.surfaceContainer.r, Theme.surfaceContainer.g, Theme.surfaceContainer.b, 0.95) : Theme.surfaceText
+                                            horizontalAlignment: Text.AlignHCenter
+                                            verticalAlignment: Text.AlignVCenter
+                                            opacity: modelData.active ? 1.0 : appMouseArea.containsMouse ? 0.8 : 0.6
+                                            visible: modelData.nerdIcon && modelData.nerdIcon !== ""
+                                        }
+
                                         IconImage {
                                             id: appIcon
                                             property var windowId: modelData.windowId
                                             anchors.fill: parent
                                             source: modelData.icon
                                             opacity: modelData.active ? 1.0 : appMouseArea.containsMouse ? 0.8 : 0.6
-                                            visible: !modelData.isSteamApp
+                                            visible: (!modelData.nerdIcon || modelData.nerdIcon === "") && !modelData.isSteamApp
                                         }
 
                                         DankIcon {
@@ -583,7 +598,7 @@ Item {
                                             name: "sports_esports"
                                             color: Theme.surfaceText
                                             opacity: modelData.active ? 1.0 : appMouseArea.containsMouse ? 0.8 : 0.6
-                                            visible: modelData.isSteamApp
+                                            visible: (!modelData.nerdIcon || modelData.nerdIcon === "") && modelData.isSteamApp
                                         }
 
                                         MouseArea {
@@ -637,13 +652,26 @@ Item {
                                         width: 18
                                         height: 18
 
+                                        Text {
+                                            id: nerdIcon
+                                            anchors.fill: parent
+                                            text: modelData.nerdIcon || ""
+                                            font.family: "FiraCode Nerd Font"
+                                            font.pixelSize: 14
+                                            color: isActive ? Qt.rgba(Theme.surfaceContainer.r, Theme.surfaceContainer.g, Theme.surfaceContainer.b, 0.95) : Theme.surfaceText
+                                            horizontalAlignment: Text.AlignHCenter
+                                            verticalAlignment: Text.AlignVCenter
+                                            opacity: modelData.active ? 1.0 : appMouseArea.containsMouse ? 0.8 : 0.6
+                                            visible: modelData.nerdIcon && modelData.nerdIcon !== ""
+                                        }
+
                                         IconImage {
                                             id: appIcon
                                             property var windowId: modelData.windowId
                                             anchors.fill: parent
                                             source: modelData.icon
                                             opacity: modelData.active ? 1.0 : appMouseArea.containsMouse ? 0.8 : 0.6
-                                            visible: !modelData.isSteamApp
+                                            visible: (!modelData.nerdIcon || modelData.nerdIcon === "") && !modelData.isSteamApp
                                         }
 
                                         DankIcon {
@@ -652,7 +680,7 @@ Item {
                                             name: "sports_esports"
                                             color: Theme.surfaceText
                                             opacity: modelData.active ? 1.0 : appMouseArea.containsMouse ? 0.8 : 0.6
-                                            visible: modelData.isSteamApp
+                                            visible: (!modelData.nerdIcon || modelData.nerdIcon === "") && modelData.isSteamApp
                                         }
 
                                         MouseArea {

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ sudo dnf copr enable avengemedia/danklinux && sudo dnf install quickshell-git
 ```
 
 #### 2. Install fonts
-*Inter Variable* and *Fira Code* are not strictly required, but they are the default fonts of dms.
+*Inter Variable* and *FiraCode Nerd Font* are not strictly required, but they are the default fonts of dms.
 
 #### 2.1 Install Material Symbols
 ```bash
@@ -279,10 +279,15 @@ sudo curl -L "https://github.com/google/material-design-icons/raw/master/variabl
 sudo curl -L "https://github.com/rsms/inter/raw/refs/tags/v4.1/docs/font-files/InterVariable.ttf" -o /usr/share/fonts/InterVariable.ttf
 ```
 
-#### 2.3 Install Fira Code (monospace font)
+#### 2.3 Install FiraCode Nerd Font (monospace font with icon glyphs)
 ```bash
-sudo curl -L "https://github.com/tonsky/FiraCode/releases/latest/download/FiraCode-Regular.ttf" -o /usr/share/fonts/FiraCode-Regular.ttf
+sudo curl -L "https://github.com/ryanoasis/nerd-fonts/releases/latest/download/FiraCode.tar.xz" -o /tmp/FiraCode.tar.xz
+sudo mkdir -p /usr/share/fonts/nerd-fonts
+sudo tar -xJf /tmp/FiraCode.tar.xz -C /usr/share/fonts/nerd-fonts/
+rm /tmp/FiraCode.tar.xz
 ```
+
+**Note:** FiraCode Nerd Font includes the standard Fira Code font plus thousands of icon glyphs from Font Awesome, Material Design Icons, and more. This enables brand-specific application icons in the workspace indicators.
 
 #### 2.4 Refresh font cache
 ```bash

--- a/Services/AppIconService.qml
+++ b/Services/AppIconService.qml
@@ -1,0 +1,136 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import qs.Common
+
+Singleton {
+    id: root
+
+    readonly property var brandIcons: ({
+        "firefox": "\udb80\ude39",
+        "google-chrome": "\uf268",
+        "chromium": "\uf268",
+        "chrome": "\uf268",
+        "safari": "\uf267",
+        "edge": "\uf282",
+        "opera": "\uf26a",
+        "brave": "\uf269",
+        "brave-browser": "\uf269",
+        "zen": "\udb83\ude95",
+
+        "code": "\ue70c",
+        "vscode": "\ue70c",
+        "visual-studio-code": "\ue70c",
+        "atom": "\uf29c",
+        "sublime": "\ue7aa",
+        "vim": "\ue62b",
+        "nvim": "\ue62b",
+        "neovim": "\ue62b",
+        "webstorm": "\uf29b",
+        "pycharm": "\uf29b",
+        "intellij": "\uf29b",
+
+        "discord": "\uf392",
+        "slack": "\uf198",
+        "telegram": "\uf2c6",
+        "skype": "\uf17e",
+        "teams": "\uf30a",
+        "zoom": "\uf03d",
+        "zoom workplace": "\uf03d",
+        "signal": "\uf2c6",
+        "whatsapp": "\uf232",
+        "beepertexts": "\udb83\udd45",
+
+        "github": "\uf408",
+        "github-desktop": "\uf408",
+        "gitlab": "\uf296",
+        "docker": "\uf308",
+        "kubernetes": "\uf308",
+        "git": "\uf1d3",
+        "terminal": "\uf120",
+        "kitty": "\uf120",
+        "alacritty": "\uf120",
+        "wezterm": "\uf120",
+        "datagrip": "\ue7bd",
+
+        "spotify": "\uf1bc",
+        "vlc": "\uf03d",
+        "gimp": "\uf1c5",
+        "blender": "\uf1c5",
+        "obs": "\uf03d",
+        "obs-studio": "\uf03d",
+        "inkscape": "\uf1c5",
+        "darktable": "\uf030",
+        "rawtherapee": "\uf030",
+        "krita": "\uf1fc",
+        "kolourpaint": "\uf1fc",
+
+        "libreoffice": "\uf1c2",
+        "writer": "\uf1c2",
+        "calc": "\uf1c3",
+        "impress": "\uf1c4",
+        "thunderbird": "\uf0e0",
+        "notion": "\ue848",
+
+        "nautilus": "\uf07c",
+        "thunar": "\uf07c",
+        "dolphin": "\uf07c",
+        "files": "\uf07c",
+        "file-manager": "\uf07c",
+        "calculator": "\uf1ec",
+        "qalculate": "\uf1ec",
+        "io.github.qalculate.qalculate-qt": "\uf1ec",
+        "settings": "\uf013",
+        "gnome-settings": "\uf013",
+        "systemsettings": "\uf013",
+        "blueman-manager": "\uf293",
+
+        "steam": "\uf1b6",
+        "lutris": "\uf11b",
+        "heroic": "\uf11b",
+
+        "twitter": "\uf099",
+        "reddit": "\uf281",
+        "youtube": "\uf167",
+        "twitch": "\uf1e8",
+        "bluesky": "\ue28e",
+
+        "evolution": "\uf0e0",
+        "kmail": "\uf0e0",
+        "calendar": "\uf073",
+
+        "ticktick": "\udb80\udd34",
+        "home assistant desktop": "\udb81\udfd0",
+        "aws vpn client": "\ue7ad",
+        "tv.plex.plex": "\udb81\udeba",
+        "protonvpn-app": "\udb81\udd82"
+    })
+
+    function getNerdFontIcon(appId) {
+        if (!appId) {
+            return null;
+        }
+
+        const cleanAppId = appId.toLowerCase();
+
+        if (brandIcons[cleanAppId]) {
+            return brandIcons[cleanAppId];
+        }
+
+        for (const key in brandIcons) {
+            if (cleanAppId.includes(key) || key.includes(cleanAppId)) {
+                return brandIcons[key];
+            }
+        }
+
+        return null;
+    }
+
+    function getAppIcon(appId) {
+        const moddedAppId = Paths.moddedAppId(appId);
+        const desktopEntry = DesktopEntries.heuristicLookup(moddedAppId);
+        return Quickshell.iconPath(desktopEntry?.icon, true);
+    }
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -140,7 +140,7 @@ in {
             [
                 pkgs.material-symbols
                 pkgs.inter
-                pkgs.fira-code
+                (pkgs.nerdfonts.override { fonts = [ "FiraCode" ]; })
 
                 pkgs.ddcutil
                 pkgs.libsForQt5.qt5ct

--- a/nix/greeter.nix
+++ b/nix/greeter.nix
@@ -88,7 +88,7 @@ in {
             settings.default_session.command = lib.mkDefault (lib.getExe greeterScript);
         };
         fonts.packages = with pkgs; [
-            fira-code
+            (nerdfonts.override { fonts = [ "FiraCode" ]; })
             inter
             material-symbols
         ];


### PR DESCRIPTION
Before:
<img width="332" height="44" alt="image" src="https://github.com/user-attachments/assets/d13d6f64-e054-49b9-9404-aefe29c52b51" />

After:
<img width="336" height="43" alt="image" src="https://github.com/user-attachments/assets/fa4d87f5-6f36-45c7-88ae-75663d969ae8" />


This PR adds support for Nerd Fonts to provide a consistent app icon appearance. I've updated the documentation to recommend FiraCode Nerd Font instead of regular FiraCode, but any Nerd Font can be used. It does require manual mapping of app -> icon, and I've added some to start. It should fall back to the normal app icon if none is mapped.