### PR TITLE
Add clipboard history command to niri spawn-at-startup options on NixOS

### DIFF
--- a/nix/niri.nix
+++ b/nix/niri.nix
@@ -90,9 +90,15 @@ in {
             })
 
             (lib.mkIf cfg.niri.enableSpawn {
-                spawn-at-startup = [
-                    {command = ["dms" "run"];}
-                ];
+                spawn-at-startup =
+                    [
+                        {command = ["dms" "run"];}
+                    ]
+                    ++ lib.optionals cfg.enableClipboard [
+                        {
+                            command = ["wl-paste" "--watch" "cliphist" "store"];
+                        }
+                    ];
             })
         ];
     };


### PR DESCRIPTION
This pull request fixes the clipboard history on Niri for NixOS. The change is to conditionally add the clipboard history command to the `spawn-at-startup` list when clipboard functionality is enabled.