### PR TITLE
Minor improvement: external system update trigger

### DIFF
--- a/Services/SystemUpdateService.qml
+++ b/Services/SystemUpdateService.qml
@@ -263,4 +263,16 @@ Singleton {
         running: refCount > 0 && distributionSupported && (pkgManager || updChecker)
         onTriggered: checkForUpdates()
     }
+    
+    IpcHandler {
+        target: "systemupdater"
+
+        function updatestatus(): string {
+            if (root.isChecking) {
+                return "ERROR: already checking"
+            }
+            root.checkForUpdates()
+            return "SUCCESS: Now checking..."
+        }
+    }
 }

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -407,6 +407,21 @@ dms ipc call bar hide
 dms ipc call bar status
 ```
 
+## Target: `systemupdater`
+
+System updater external check request.
+
+### Functions
+
+**`updatestatus`**
+- Trigger a system update check
+- Returns: Success confirmation
+
+### Examples
+```bash
+dms ipc call systemupdater updatestatus
+```
+
 ## Modal Controls
 
 These targets control various modal windows and overlays.


### PR DESCRIPTION
External IPC call to trigger a check for system updates. Useful if a user is using a different system than the shell and updates the status at the end of the procedure.