### PR TITLE
feat(notification): Add j/k keyboard navigation

### DIFF
--- a/Modules/Notifications/Center/NotificationKeyboardController.qml
+++ b/Modules/Notifications/Center/NotificationKeyboardController.qml
@@ -368,7 +368,7 @@ QtObject {
                     onClose()
                 event.accepted = true
             }
-        } else if (event.key === Qt.Key_Down || event.key === 16777237) {
+        } else if (event.key === Qt.Key_Down || event.key === Qt.Key_J || event.key === 16777237) {
             if (!keyboardNavigationActive) {
                 keyboardNavigationActive = true
                 rebuildFlatNavigation() // Ensure we have fresh navigation data
@@ -385,7 +385,7 @@ QtObject {
                 selectNext()
                 event.accepted = true
             }
-        } else if (event.key === Qt.Key_Up || event.key === 16777235) {
+        } else if (event.key === Qt.Key_Up || event.key === Qt.Key_K || event.key === 16777235) {
             if (!keyboardNavigationActive) {
                 keyboardNavigationActive = true
                 rebuildFlatNavigation() // Ensure we have fresh navigation data

--- a/Modules/Notifications/Center/NotificationKeyboardHints.qml
+++ b/Modules/Notifications/Center/NotificationKeyboardHints.qml
@@ -23,7 +23,7 @@ Rectangle {
         spacing: 2
 
         StyledText {
-            text: "↑/↓: Nav • Space: Expand • Enter: Action/Expand • E: Text"
+            text: "↓/↑ (j/k): Nav • Space: Expand • Enter: Action/Expand • E: Text"
             font.pixelSize: Theme.fontSizeSmall
             color: Theme.surfaceText
             width: parent.width


### PR DESCRIPTION
This just adds `j/k` as an alternative to `up/down` for navigating the notifications in Notification Center.

Not sure if it's necessary to express these key bindings in the cheat sheet, but added just in case.