### PR TITLE
fix: Load launcher plugin no-trigger settings.

### DIFF
--- a/Services/PluginService.qml
+++ b/Services/PluginService.qml
@@ -573,6 +573,12 @@ Singleton {
     function getPluginTrigger(pluginId) {
         const plugin = getLauncherPlugin(pluginId)
         if (plugin) {
+            // Check if noTrigger is set (always active mode)
+            const noTrigger = SettingsData.getPluginSetting(pluginId, "noTrigger", false)
+            if (noTrigger) {
+                return ""
+            }
+            // Otherwise load the custom trigger, defaulting to plugin manifest trigger
             const customTrigger = SettingsData.getPluginSetting(pluginId, "trigger", plugin.trigger || "!")
             return customTrigger
         }


### PR DESCRIPTION
getPluginTrigger() function only loaded the trigger setting but completely ignored the noTrigger boolean setting.

When noTrigger was enabled and saved as:
- noTrigger: true
- trigger: ""

On reboot, the function would load trigger which was "", but since empty string is falsy in the fallback expression, it would revert to plugin.trigger || "!" from the plugin.json manifest, which is "=" for the Calculator plugin.