### PR TITLE
fix: Enable "Show on Last Display" for Notepad Slideout and System Tray

### DIFF
--- a/Modules/Settings/DisplaysTab.qml
+++ b/Modules/Settings/DisplaysTab.qml
@@ -697,7 +697,7 @@ Item {
                                         text: I18n.tr("Show on Last Display")
                                         description: I18n.tr("Always show when there's only one connected display")
                                         checked: displaysTab.getShowOnLastDisplay(parent.componentId)
-                                        visible: !displaysTab.getScreenPreferences(parent.componentId).includes("all") && ["dankBar", "dock", "notifications", "osd", "toast"].includes(parent.componentId)
+                                        visible: !displaysTab.getScreenPreferences(parent.componentId).includes("all") && ["dankBar", "dock", "notifications", "osd", "toast", "notepad", "systemTray"].includes(parent.componentId)
                                         onToggled: (checked) => {
                                             displaysTab.setShowOnLastDisplay(parent.componentId, checked);
                                         }


### PR DESCRIPTION
This just enables the toggle for "Show on last display" for Notepad Slideout and System Tray.

<img width="755" height="1059" alt="image" src="https://github.com/user-attachments/assets/953a8b0b-ef0a-4500-9a4a-cdc71cda2bec" />

Fixes #588.