### PR TITLE
nix: replace pkgs.system with pkgs.stdenv.hostPlatform.system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,9 +25,9 @@
             ["aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux"]
             (system: fn system nixpkgs.legacyPackages.${system});
         buildDmsPkgs = pkgs: {
-            dmsCli = dms-cli.packages.${pkgs.system}.default;
-            dgop = dgop.packages.${pkgs.system}.dgop;
-            dankMaterialShell = self.packages.${pkgs.system}.dankMaterialShell;
+            dmsCli = dms-cli.packages.${pkgs.stdenv.hostPlatform.system}.default;
+            dgop = dgop.packages.${pkgs.stdenv.hostPlatform.system}.dgop;
+            dankMaterialShell = self.packages.${pkgs.stdenv.hostPlatform.system}.dankMaterialShell;
         };
     in {
         formatter = forEachSystem (_: pkgs: pkgs.alejandra);


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/blob/4e7c982139775f67f33e73c9c2fe60d082d36125/pkgs/top-level/aliases.nix#L1438

```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```
