### PR TITLE
matugen: pywalfox update via post_hook

### DIFF
--- a/matugen/configs/pywalfox.toml
+++ b/matugen/configs/pywalfox.toml
@@ -1,3 +1,4 @@
 [templates.dmspywalfox]
 input_path = './matugen/templates/pywalfox-colors.json'
 output_path = '~/.cache/wal/dank-pywalfox.json'
+post_hook = 'command -v pywalfox && test -f ~/.cache/wal/colors.json && pywalfox update'

--- a/scripts/matugen-worker.sh
+++ b/scripts/matugen-worker.sh
@@ -413,10 +413,6 @@ EOF
   set_system_color_scheme "$mode"
 }
 
-if command -v pywalfox >/dev/null 2>&1 && [[ -f "$HOME/.cache/wal/colors.json" ]]; then
-  pywalfox update >/dev/null 2>&1 || true
-fi
-
 while :; do
   DESIRED="$(read_desired)"
   WANT_KEY="$(key_of "$DESIRED")"


### PR DESCRIPTION
I noticed that my pywalfox colors lagged behind one wallpaper change because the update was performed before the build loop.
Registered the update as trap in the worker first, then thought the if statement looked out of place in the script since its only done for pywalfox, so using a post_hook in the config would be better.

Alternatively one could replace the `exit 0` to just break the loop and move the if below.