### PR TITLE
Fix display of the status of multiple batteries

### DIFF
--- a/Services/BatteryService.qml
+++ b/Services/BatteryService.qml
@@ -51,7 +51,7 @@ Singleton {
         }
         return Math.round((batteryEnergy * 100) / batteryCapacity)
     }
-    readonly property bool isCharging: batteryAvailable && batteries.some(b => b.state === UPowerDeviceState.Charging || b.state === UPowerDeviceState.FullyCharged)
+    readonly property bool isCharging: batteryAvailable && batteries.some(b => b.state === UPowerDeviceState.Charging)
 
     // Is the system plugged in (none of the batteries are discharging or empty)
     readonly property bool isPluggedIn: batteryAvailable && batteries.every(b => b.state !== UPowerDeviceState.Discharging)


### PR DESCRIPTION
When there are several batteries, one of them is fully charged, and the other is discharging, this leads to the incorrect display of the overall status as “Charging”