### PR TITLE
feat: layer namespaces

### DIFF
--- a/Modals/BluetoothPairingModal.qml
+++ b/Modals/BluetoothPairingModal.qml
@@ -7,6 +7,8 @@ import qs.Widgets
 DankModal {
     id: root
 
+    layerNamespace: "dms:bluetooth-pairing"
+
     property string deviceName: ""
     property string deviceAddress: ""
     property string requestType: ""

--- a/Modals/Clipboard/ClipboardHistoryModal.qml
+++ b/Modals/Clipboard/ClipboardHistoryModal.qml
@@ -12,6 +12,8 @@ import qs.Widgets
 DankModal {
     id: clipboardHistoryModal
 
+    layerNamespace: "dms:clipboard"
+
     property int totalCount: 0
     property var clipboardEntries: []
     property string searchText: ""

--- a/Modals/Common/DankModal.qml
+++ b/Modals/Common/DankModal.qml
@@ -8,8 +8,8 @@ import qs.Services
 PanelWindow {
     id: root
 
-    property string blurNamespace: "dms:modal"
-    WlrLayershell.namespace: blurNamespace
+    property string layerNamespace: "dms:modal"
+    WlrLayershell.namespace: layerNamespace
 
     property alias content: contentLoader.sourceComponent
     property alias contentLoader: contentLoader

--- a/Modals/DankColorPickerModal.qml
+++ b/Modals/DankColorPickerModal.qml
@@ -10,6 +10,8 @@ import qs.Widgets
 DankModal {
     id: root
 
+    layerNamespace: "dms:color-picker"
+
     property string pickerTitle: "Choose Color"
     property color selectedColor: SessionData.recentColors.length > 0 ? SessionData.recentColors[0] : Theme.primary
     property var onColorSelectedCallback: null

--- a/Modals/FileBrowser/FileBrowserModal.qml
+++ b/Modals/FileBrowser/FileBrowserModal.qml
@@ -11,6 +11,8 @@ import qs.Widgets
 DankModal {
     id: fileBrowserModal
 
+    layerNamespace: "dms:file-browser"
+
     property string homeDir: StandardPaths.writableLocation(StandardPaths.HomeLocation)
     property string docsDir: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
     property string musicDir: StandardPaths.writableLocation(StandardPaths.MusicLocation)

--- a/Modals/HyprKeybindsModal.qml
+++ b/Modals/HyprKeybindsModal.qml
@@ -9,6 +9,8 @@ import qs.Widgets
 DankModal {
     id: root
 
+    layerNamespace: "dms:hyprkeybinds"
+
     width: 1400
     height: 900
     onBackgroundClicked: close()

--- a/Modals/NetworkInfoModal.qml
+++ b/Modals/NetworkInfoModal.qml
@@ -8,6 +8,8 @@ import qs.Widgets
 DankModal {
     id: root
 
+    layerNamespace: "dms:network-info"
+
     property bool networkInfoModalVisible: false
     property string networkSSID: ""
     property var networkData: null

--- a/Modals/NetworkWiredInfoModal.qml
+++ b/Modals/NetworkWiredInfoModal.qml
@@ -8,6 +8,8 @@ import qs.Widgets
 DankModal {
     id: root
 
+    layerNamespace: "dms:network-info-wired"
+
     property bool networkWiredInfoModalVisible: false
     property string networkID: ""
     property var networkData: null

--- a/Modals/NotificationModal.qml
+++ b/Modals/NotificationModal.qml
@@ -9,6 +9,8 @@ import qs.Widgets
 DankModal {
     id: notificationModal
 
+    layerNamespace: "dms:notification-modal"
+
     property bool notificationModalOpen: false
     property var notificationListRef: null
 

--- a/Modals/PolkitAuthModal.qml
+++ b/Modals/PolkitAuthModal.qml
@@ -7,6 +7,8 @@ import qs.Widgets
 DankModal {
     id: root
 
+    layerNamespace: "dms:polkit"
+
     property string passwordInput: ""
     property var currentFlow: PolkitService.agent?.flow
     property bool isLoading: false

--- a/Modals/PowerMenuModal.qml
+++ b/Modals/PowerMenuModal.qml
@@ -7,6 +7,8 @@ import qs.Widgets
 DankModal {
     id: root
 
+    layerNamespace: "dms:power-menu"
+
     property int selectedIndex: 0
     property int optionCount: SessionService.hibernateSupported ? 5 : 4
     property rect parentBounds: Qt.rect(0, 0, 0, 0)

--- a/Modals/ProcessListModal.qml
+++ b/Modals/ProcessListModal.qml
@@ -9,6 +9,8 @@ import qs.Widgets
 DankModal {
     id: processListModal
 
+    layerNamespace: "dms:process-list-modal"
+
     property int currentTab: 0
     property var tabNames: ["Processes", "Performance", "System"]
 

--- a/Modals/Settings/SettingsModal.qml
+++ b/Modals/Settings/SettingsModal.qml
@@ -11,6 +11,8 @@ import qs.Widgets
 DankModal {
     id: settingsModal
 
+    layerNamespace: "dms:settings"
+
     property Component settingsContent
     property alias profileBrowser: profileBrowser
     property int currentTabIndex: 0

--- a/Modals/Spotlight/SpotlightModal.qml
+++ b/Modals/Spotlight/SpotlightModal.qml
@@ -12,6 +12,8 @@ import qs.Widgets
 DankModal {
     id: spotlightModal
 
+    layerNamespace: "dms:spotlight"
+
     property bool spotlightOpen: false
     property alias spotlightContent: spotlightContentInstance
 

--- a/Modals/WifiPasswordModal.qml
+++ b/Modals/WifiPasswordModal.qml
@@ -7,6 +7,8 @@ import qs.Widgets
 DankModal {
     id: root
 
+    layerNamespace: "dms:wifi-password"
+
     property string wifiPasswordSSID: ""
     property string wifiPasswordInput: ""
     property string wifiUsernameInput: ""

--- a/Modules/AppDrawer/AppDrawerPopout.qml
+++ b/Modules/AppDrawer/AppDrawerPopout.qml
@@ -13,6 +13,8 @@ import qs.Widgets
 DankPopout {
     id: appDrawerPopout
 
+    layerNamespace: "dms:app-launcher"
+
     property var triggerScreen: null
 
     // Setting to Exclusive, so virtual keyboards can send input to app drawer

--- a/Modules/ControlCenter/ControlCenterPopout.qml
+++ b/Modules/ControlCenter/ControlCenterPopout.qml
@@ -20,6 +20,8 @@ import "./utils/state.js" as StateUtils
 DankPopout {
     id: root
 
+    layerNamespace: "dms:control-center"
+
     property string expandedSection: ""
     property var triggerScreen: null
     property bool editMode: false

--- a/Modules/DankBar/DankBar.qml
+++ b/Modules/DankBar/DankBar.qml
@@ -146,7 +146,7 @@ Item {
             }
 
             WlrLayershell.layer: dBarLayer
-            WlrLayershell.namespace: "quickshell:bar"
+            WlrLayershell.namespace: "dms:bar"
 
             property var modelData: item
 

--- a/Modules/DankBar/Popouts/BatteryPopout.qml
+++ b/Modules/DankBar/Popouts/BatteryPopout.qml
@@ -11,6 +11,8 @@ import qs.Widgets
 DankPopout {
     id: root
 
+    layerNamespace: "dms:battery"
+
     property var triggerScreen: null
 
     function setTriggerPosition(x, y, width, section, screen) {

--- a/Modules/DankBar/Popouts/VpnPopout.qml
+++ b/Modules/DankBar/Popouts/VpnPopout.qml
@@ -13,6 +13,8 @@ import qs.Widgets
 DankPopout {
     id: root
 
+    layerNamespace: "dms:vpn"
+
     Ref {
         service: DMSNetworkService
     }

--- a/Modules/DankDash/DankDashPopout.qml
+++ b/Modules/DankDash/DankDashPopout.qml
@@ -12,6 +12,8 @@ import qs.Modules.DankDash
 DankPopout {
     id: root
 
+    layerNamespace: "dms:dash"
+
     property bool dashVisible: false
     property var triggerScreen: null
     property int currentTabIndex: 0

--- a/Modules/Dock/Dock.qml
+++ b/Modules/Dock/Dock.qml
@@ -18,7 +18,7 @@ Variants {
     delegate: PanelWindow {
         id: dock
 
-        WlrLayershell.namespace: "quickshell:dock"
+        WlrLayershell.namespace: "dms:dock"
 
         readonly property bool isVertical: SettingsData.dockPosition === SettingsData.Position.Left || SettingsData.dockPosition === SettingsData.Position.Right
 

--- a/Modules/HyprWorkspaces/HyprlandOverview.qml
+++ b/Modules/HyprWorkspaces/HyprlandOverview.qml
@@ -32,7 +32,7 @@ Scope {
                 visible: overviewScope.overviewOpen
                 color: "transparent"
 
-                WlrLayershell.namespace: "quickshell:overview"
+                WlrLayershell.namespace: "dms:workspace-overview"
                 WlrLayershell.layer: WlrLayer.Overlay
                 WlrLayershell.exclusiveZone: -1
                 WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive

--- a/Modules/Notifications/Center/NotificationCenterPopout.qml
+++ b/Modules/Notifications/Center/NotificationCenterPopout.qml
@@ -12,6 +12,8 @@ import qs.Modules.Notifications.Center
 DankPopout {
     id: root
 
+    layerNamespace: "dms:notification-center"
+
     property bool notificationHistoryVisible: false
     property var triggerScreen: null
 

--- a/Modules/Notifications/Popup/NotificationPopup.qml
+++ b/Modules/Notifications/Popup/NotificationPopup.qml
@@ -12,7 +12,7 @@ import qs.Widgets
 PanelWindow {
     id: win
 
-    WlrLayershell.namespace: "quickshell:notification"
+    WlrLayershell.namespace: "dms:notification-popup"
 
     required property var notificationData
     required property string notificationId

--- a/Modules/ProcessList/ProcessListPopout.qml
+++ b/Modules/ProcessList/ProcessListPopout.qml
@@ -14,6 +14,8 @@ import qs.Widgets
 DankPopout {
     id: processListPopout
 
+    layerNamespace: "dms:process-list-popout"
+
     property var parentWidget: null
     property var triggerScreen: null
 

--- a/Modules/SystemUpdatePopout.qml
+++ b/Modules/SystemUpdatePopout.qml
@@ -11,6 +11,8 @@ import qs.Widgets
 DankPopout {
     id: systemUpdatePopout
 
+    layerNamespace: "dms:system-update"
+
     property var parentWidget: null
     property var triggerScreen: null
 

--- a/Widgets/DankPopout.qml
+++ b/Widgets/DankPopout.qml
@@ -8,8 +8,8 @@ import qs.Services
 PanelWindow {
     id: root
 
-    property string blurNamespace: "dms:popout"
-    WlrLayershell.namespace: blurNamespace
+    property string layerNamespace: "dms:popout"
+    WlrLayershell.namespace: layerNamespace
 
     property alias content: contentLoader.sourceComponent
     property alias contentLoader: contentLoader

--- a/Widgets/DankSlideout.qml
+++ b/Widgets/DankSlideout.qml
@@ -10,7 +10,8 @@ pragma ComponentBehavior: Bound
 PanelWindow {
     id: root
 
-    WlrLayershell.namespace: "quickshell:slideout"
+    property string layerNamespace: "dms:slideout"
+    WlrLayershell.namespace: layerNamespace
 
     property bool isVisible: false
     property var targetScreen: null


### PR DESCRIPTION
Adds more layer namespaces as discussed in #400.

- Every namespaces now starts with `dms:`.
- Some layers could've had conflicting namespaces so they have a little suffixe, for example the modal process list is `dms:process-list-modal` and the popout process list is `dms:process-list-popout`.
- Component who don't have a specific namespaces will fallback to `dms:modal` or `dms:popout`, it's only the case for plugins I think (hoping I can make it possible for plugin devs to add their own namespaces in the future).

Here's a full list of each namespaces:

### Modals
| Component            | Namespace                |
| -------------------- | ------------------------ |
| Clipboard history  | `dms:clipboard`          |
| File browser         | `dms:file-browser`       |
| Settings             | `dms:settings`           |
| Spotlight            | `dms:spotlight`          |
| Bluetooth pairing    | `dms:bluetooth-pairing`  |
| Color picker         | `dms:color-picker`       |
| Hyprkeybinds         | `dms:hyprkeybinds`       |
| Network info         | `dms:network-info`       |
| Network info (wired) | `dms:network-info-wired` |
| Notification         | `dms:notification-modal` |
| Polkit               | `dms:polkit`             |
| Power menu           | `dms:power-menu`         |
| Process list         | `dms:process-list-modal` |
| Wifi password        | `dms:wifi-password`      |
| Fallback namespace   | `dms:modal`              |

### Popouts
| Component           | Namespace                 |
| ------------------- | ------------------------- |
| App drawer          | `dms:app-launcher`        |
| Control center      | `dms:control-center`      |
| Battery             | `dms:battery`             |
| Vpn                 | `dms:vpn`                 |
| DankDash            | `dms:dash`                |
| Notification center | `dms:notification-center` |
| Process list        | `dms:process-list-popout` |
| Fallback namespace  | `dms:popout`              |

### Misc Components
| Component          | Namespace                |
| ------------------ | ------------------------ |
| DankBar            | `dms:bar`                |
| Dock               | `dms:dock`               |
| Workspace overview | `dms:workspace-overview` ||
| Notification popup | `dms:notification-popup`|
| OSD                | `dms:osd`                |
Slideout           | `dms:slideout`           |

[Documentation PR](https://github.com/AvengeMedia/DankLinux-Docs/pull/2)