### PR TITLE
fix: Matugen relative paths

### DIFF
--- a/scripts/matugen-worker.sh
+++ b/scripts/matugen-worker.sh
@@ -187,8 +187,7 @@ EOF
 
   for config in "$USER_MATUGEN_DIR/configs"/*.toml; do
     [[ -f "$config" ]] || continue
-    sed "s|input_path = '\./matugen/templates/|input_path = '$SHELL_DIR/matugen/templates/|g" \
-      "$config" >> "$TMP_CFG"
+    cat "$config" >> "$TMP_CFG"
     echo "" >> "$TMP_CFG"
   done
   


### PR DESCRIPTION
The Problem

All matugen config files (matugen/configs/*.toml) used relative paths like:

input_path = './matugen/templates/gtk-colors.css'

However, matugen was interpreting the relative paths ./matugen/templates/ as relative to its current execution context (which could be /tmp or another directory), not relative to $SHELL_DIR. This caused the "template doesn't exist" warnings and the "Failed to get input and output paths from hashmap" errors.

The Fix

Modified scripts/matugen-worker.sh to replace all relative template paths with absolute paths before passing them to matugen:

`sed "s|input_path = '\./matugen/templates/|input_path = '$SHELL_DIR/matugen/templates/|g"`