### PR TITLE
HyprKeybindsModal: use Theme.secondary for key color instead of diminished opacity

### DIFF
--- a/Modals/HyprKeybindsModal.qml
+++ b/Modals/HyprKeybindsModal.qml
@@ -147,12 +147,13 @@ DankModal {
                                         width: Math.min(140, parent.width * 0.42)
                                         height: 22
                                         radius: 4
-                                        opacity: 0.3
+                                        opacity: 0.9
 
                                         StyledText {
                                             anchors.centerIn: parent
                                             anchors.margins: 2
                                             width: parent.width - 4
+                                            color: Theme.secondary
                                             text: {
                                                 const mods = modelData.mods || []
                                                 const key = modelData.key || ""
@@ -225,12 +226,13 @@ DankModal {
                                             width: Math.min(140, parent.width * 0.42)
                                             height: 22
                                             radius: 4
-                                            opacity: 0.3
+                                            opacity: 0.9
 
                                             StyledText {
                                                 anchors.centerIn: parent
                                                 anchors.margins: 2
                                                 width: parent.width - 4
+                                                color: Theme.secondary
                                                 text: {
                                                     const mods = modelData.mods || []
                                                     const key = modelData.key || ""


### PR DESCRIPTION
Old:
<img width="1182" height="691" alt="image" src="https://github.com/user-attachments/assets/71b96165-8c78-439b-8498-d90e1ee1496f" />


New:
<img width="1182" height="687" alt="image" src="https://github.com/user-attachments/assets/9379cb00-2975-44e5-aefe-918631be2fb9" />
