### PR TITLE
feat: plugin layer namespace

### DIFF
--- a/quickshell/Modules/Plugins/PluginComponent.qml
+++ b/quickshell/Modules/Plugins/PluginComponent.qml
@@ -6,6 +6,8 @@ import qs.Widgets
 Item {
     id: root
 
+    property string layerNamespacePlugin: "plugin"
+
     property var axis: null
     property string section: "center"
     property var parentScreen: null

--- a/quickshell/Modules/Plugins/PluginPopout.qml
+++ b/quickshell/Modules/Plugins/PluginPopout.qml
@@ -6,6 +6,8 @@ import qs.Widgets
 DankPopout {
     id: root
 
+    layerNamespace: "dms-plugin:" + layerNamespacePlugin
+
     WlrLayershell.keyboardFocus: shouldBeVisible ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None 
 
     property var triggerScreen: null

--- a/quickshell/PLUGINS/ExampleEmojiPlugin/EmojiWidget.qml
+++ b/quickshell/PLUGINS/ExampleEmojiPlugin/EmojiWidget.qml
@@ -8,6 +8,8 @@ import qs.Modules.Plugins
 PluginComponent {
     id: root
 
+    layerNamespacePlugin: "emoji-cycler"
+
     property var enabledEmojis: pluginData.emojis || ["😊", "😢", "❤️"]
     property int cycleInterval: pluginData.cycleInterval || 3000
     property int maxBarEmojis: pluginData.maxBarEmojis || 3


### PR DESCRIPTION
Added a way for popout widget plugin to have their own layer namespace

By default plugin have `dms-plugin:plugin` as a layer namespace, devs can add they own by adding `layerNamespacePlugin: "<plugin namespace>"`. The shell automatically adds `dms-plugin:` as a prefix so they gotta only add the namespace without a prefix, u can see it in the example emoji cycler plugin

I set `dms-plugin:` as a prefix for plugins, that way we can be sure a plugin's layer namespace doesn't conflict with a layer namespace from the shell, also helps differentiate which one are from a plugin and which one aren't

Documentation PR [here](https://github.com/AvengeMedia/DankLinux-Docs/pull/6)