### PR TITLE
Change default config path to account for monorepo update

### DIFF
--- a/core/internal/config/dms.go
+++ b/core/internal/config/dms.go
@@ -31,7 +31,7 @@ func LocateDMSConfig() (string, error) {
 
 	for _, dir := range strings.Split(configDirs, ":") {
 		if dir != "" {
-			primaryPaths = append(primaryPaths, filepath.Join(dir, "quickshell", "dms"))
+			primaryPaths = append(primaryPaths, filepath.Join(dir, "quickshell", "dms", "quickshell"))
 		}
 	}
 


### PR DESCRIPTION
This pull request changes the line
`primaryPaths = append(primaryPaths, filepath.Join(dir, "quickshell", "dms"))` to `primaryPaths = append(primaryPaths, filepath.Join(dir, "quickshell", "dms", "quickshell"))` to account for the monorepo changes. Because of the monorepo update, the quickshell location was changed and this file was not changed to account for it.
