### PR TITLE
Follow symlinks when searching for sessions

### DIFF
--- a/quickshell/Modules/Greetd/GreeterContent.qml
+++ b/quickshell/Modules/Greetd/GreeterContent.qml
@@ -1086,9 +1086,9 @@ Item {
                 })
             }
             // 1. Explicit system/user paths 
-            var explicitFind = "find " + paths.join(" ") + " -maxdepth 1 -name '*.desktop' -type f 2>/dev/null"
+            var explicitFind = "find " + paths.join(" ") + " -maxdepth 1 -name '*.desktop' -type f -follow 2>/dev/null"
             // 2. Scan all /home user directories for local session files
-            var homeScan = "find /home -maxdepth 5 \\( -path '*/wayland-sessions/*.desktop' -o -path '*/xsessions/*.desktop' \\) -type f 2>/dev/null"
+            var homeScan = "find /home -maxdepth 5 \\( -path '*/wayland-sessions/*.desktop' -o -path '*/xsessions/*.desktop' \\) -type f -follow 2>/dev/null"
             var findCmd = "(" + explicitFind + "; " + homeScan + ") | sort -u"
             return ["sh", "-c", findCmd]
         }


### PR DESCRIPTION
Fixes #724 

Follow symlinks again when looking for session in the greeter. This is necessary on NixOS because the session desktop files are symlinks to elsewhere in the Nix store. I tested that this makes the session selection work again on my PC.