### PR TITLE
Fedora(dms-greeter): Tell users to use graphical.target so greeter loads at startup

### DIFF
--- a/distro/fedora/dms-greeter.spec
+++ b/distro/fedora/dms-greeter.spec
@@ -234,7 +234,10 @@ Next steps:
 2. Enable greetd service:
      sudo systemctl enable greetd
 
-3. (Optional) Sync your theme with the greeter:
+3. Make your system load the greeter at startup:
+     sudo systemctl set-default graphical.target
+
+4. (Optional) Sync your theme with the greeter:
      If you have DankMaterialShell (DMS) installed, you can sync with:
      dms greeter sync
 


### PR DESCRIPTION
This PR updates the Fedora-specific post-install guide of `dms-greeter` by adding an instruction on how to **enable the greeter at startup**.

Users on Fedora 43 Minimal will find that `dms-greeter` doesn't load at startup. That's because:
1. The system defaults to `multi-user.target`.
2. `dms-greeter` only launches automatically if the default target is `graphical.target`.

The fix to this is to set `graphical.target` as the default:
```bash
sudo systemctl set-default graphical.target
```

Here is a video demonstrating the solution: Before the fix the system boots into **tty**, and after the fix it boots directly into **dms-greeter**.

https://github.com/user-attachments/assets/6138d630-e20d-4fe8-a38c-4f7d62e42fe5