### PR TITLE
Feature/privacy widget fix

### DIFF
--- a/quickshell/Services/PrivacyService.qml
+++ b/quickshell/Services/PrivacyService.qml
@@ -44,6 +44,10 @@ Singleton {
 
         for (let i = 0; i < Pipewire.nodes.values.length; i++) {
             const node = Pipewire.nodes.values[i]
+            if (!node || !node.ready) {
+                continue
+            }
+            
             if (node.properties && node.properties["media.class"] === "Stream/Input/Video") {
                 if (node.properties["stream.is-live"] === "true") {
                     return true


### PR DESCRIPTION
When the camera is streaming, the icon does not goes red
I have updated the global tracker to ensure that non-audio devices are included