### PR TITLE
fix: bar and dock flickering autohide

### DIFF
--- a/quickshell/Modules/DankBar/DankBarWindow.qml
+++ b/quickshell/Modules/DankBar/DankBarWindow.qml
@@ -430,9 +430,9 @@ PanelWindow {
                 bottom: barWindow.isVertical ? parent.bottom : undefined
             }
             readonly property bool inOverview: CompositorService.isNiri && NiriService.inOverview && SettingsData.dankBarOpenOnOverview
-            hoverEnabled: SettingsData.dankBarAutoHide && !topBarCore.reveal && !inOverview
+            hoverEnabled: SettingsData.dankBarAutoHide && !inOverview
             acceptedButtons: Qt.NoButton
-            enabled: SettingsData.dankBarAutoHide && !topBarCore.reveal && !inOverview
+            enabled: SettingsData.dankBarAutoHide && !inOverview
 
             Item {
                 id: topBarContainer

--- a/quickshell/Modules/Dock/Dock.qml
+++ b/quickshell/Modules/Dock/Dock.qml
@@ -257,7 +257,8 @@ Variants {
 
             height: {
                 if (dock.isVertical) {
-                    return dock.reveal ? Math.min(dockBackground.implicitHeight + 4, maxDockHeight) : Math.min(Math.max(dockBackground.implicitHeight + 64, 200), screenHeight * 0.5)
+                    const hiddenHeight = Math.min(Math.max(dockBackground.implicitHeight + 64, 200), screenHeight * 0.5)
+                    return dock.reveal ? Math.max(Math.min(dockBackground.implicitHeight + 4, maxDockHeight), hiddenHeight) : hiddenHeight
                 } else {
                     return dock.reveal ? px(dock.effectiveBarHeight + SettingsData.dockSpacing + SettingsData.dockBottomGap + SettingsData.dockMargin) : 1
                 }
@@ -266,7 +267,8 @@ Variants {
                 if (dock.isVertical) {
                     return dock.reveal ? px(dock.effectiveBarHeight + SettingsData.dockSpacing + SettingsData.dockBottomGap + SettingsData.dockMargin) : 1
                 } else {
-                    return dock.reveal ? Math.min(dockBackground.implicitWidth + 4, maxDockWidth) : Math.min(Math.max(dockBackground.implicitWidth + 64, 200), screenWidth * 0.5)
+                    const hiddenWidth = Math.min(Math.max(dockBackground.implicitWidth + 64, 200), screenWidth * 0.5)
+                    return dock.reveal ? Math.max(Math.min(dockBackground.implicitWidth + 4, maxDockWidth), hiddenWidth) : hiddenWidth
                 }
             }
             anchors {


### PR DESCRIPTION
The bar needed to keep the mouseArea enabled even when the bar was hidden.

For the dock, ensure that the mouseArea does not shrink when the dock is revealed, which causes flickering.