### PR TITLE
bar: fix scroll on widgets that doesn't handle scroll

### DIFF
--- a/quickshell/Modules/Plugins/BasePill.qml
+++ b/quickshell/Modules/Plugins/BasePill.qml
@@ -143,6 +143,7 @@ Item {
             root.clicked();
         }
         onWheel: function (wheelEvent) {
+            wheelEvent.accepted = false;
             root.wheel(wheelEvent);
         }
     }


### PR DESCRIPTION
Closes #808 

The scroll isn't working over widgets that doesn't use scroll since #802. This fixes this regression by not accepting the scroll event by default (a child component would have to set `event.accepted = true` explicitely, as the Media widget currently does)