### PR TITLE
Add middle-click close and collapse popout

### DIFF
--- a/quickshell/Modules/ControlCenter/ControlCenterPopout.qml
+++ b/quickshell/Modules/ControlCenter/ControlCenterPopout.qml
@@ -92,8 +92,6 @@ DankPopout {
             });
         } else {
             Qt.callLater(() => {
-                collapseAll();
-
                 if (NetworkService.activeService) {
                     NetworkService.activeService.autoRefreshEnabled = false;
                 }


### PR DESCRIPTION
Collapse all components on close in order to prevent having a different height in the control center when opening it again. It's pretty convenient to close the applications with the middle click