### PR TITLE
nix: fix NixOS systemd service PATH

### DIFF
--- a/distro/nix/nixos.nix
+++ b/distro/nix/nixos.nix
@@ -18,7 +18,7 @@ in {
 
         systemd.user.services.dms = lib.mkIf cfg.systemd.enable {
             description = "DankMaterialShell";
-            path = [cfg.quickshell.package];
+            path = lib.mkForce [];
 
             partOf = ["graphical-session.target"];
             after = ["graphical-session.target"];


### PR DESCRIPTION
Currently, the SystemD service has the PATH defined only to have Quickshell, making most of functions not work. This disables the path override for the service, using the system PATH instead.

Note that we're not just passing all needed packages to the service so other binaries can still be detected without being explicitly defined, for cases like plugins and binaries detected by matugen (e.g. vesktop) for generating themes.