### PR TITLE
spotlight: fix mouse action menu click

### DIFF
--- a/quickshell/Modals/Spotlight/SpotlightContextMenuContent.qml
+++ b/quickshell/Modals/Spotlight/SpotlightContextMenuContent.qml
@@ -281,7 +281,7 @@ Item {
                                     keyboardNavigation = false;
                                     selectedMenuIndex = itemIndex;
                                 }
-                                onClicked: modelData.action
+                                onClicked: modelData.action()
                             }
                         }
                     }


### PR DESCRIPTION
Fixes a regression in #840 where clicking in actions with the mouse wouldn't work anymore

