### PR TITLE
feat: allow popout to resize to its contents

### DIFF
--- a/quickshell/Modules/Plugins/PluginPopout.qml
+++ b/quickshell/Modules/Plugins/PluginPopout.qml
@@ -75,7 +75,7 @@ DankPopout {
                             }
                         }
                         if (root.contentHeight === 0 && item) {
-                            root.contentHeight = item.implicitHeight + Theme.spacingS * 2
+                            root.contentHeight = Qt.binding(() => item.implicitHeight + Theme.spacingS * 2)
                         }
                     }
                 }


### PR DESCRIPTION
Hello,

This was originally going to be a feature request, but I figured I'd make it  PR because I figured out how to do it. The size of a plugin popout is calculated when it's created, so when more things are added after that, the popout does not update. Adding a Qt.binding solves that.

Use cases:

1. Dynamically loaded data (list of lights, docker containers, etc.) without having to scroll.
2. Opening a drop down menu (like clicking on an item and having options appear below it).

Without the feature, space needs to be allocated beforehand, resulting in empty space, or the user has to scroll to see the options.

I'm not sure if this will result in existing plugins breaking (though I doubt it will).