### PR TITLE
core: replace all use of interface{} with any in the go code

### DIFF
--- a/core/internal/keybinds/providers/jsonfile.go
+++ b/core/internal/keybinds/providers/jsonfile.go
@@ -44,7 +44,7 @@ func (j *JSONFileProvider) GetCheatSheet() (*keybinds.CheatSheet, error) {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
 
-	var rawData map[string]interface{}
+	var rawData map[string]any
 	if err := json.Unmarshal(data, &rawData); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
@@ -63,9 +63,9 @@ func (j *JSONFileProvider) GetCheatSheet() (*keybinds.CheatSheet, error) {
 	}
 
 	switch binds := bindsRaw.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		for category, categoryBindsRaw := range binds {
-			categoryBindsList, ok := categoryBindsRaw.([]interface{})
+			categoryBindsList, ok := categoryBindsRaw.([]any)
 			if !ok {
 				continue
 			}
@@ -79,7 +79,7 @@ func (j *JSONFileProvider) GetCheatSheet() (*keybinds.CheatSheet, error) {
 			categorizedBinds[category] = keybindsList
 		}
 
-	case []interface{}:
+	case []any:
 		flatBindsJSON, _ := json.Marshal(binds)
 		var flatBinds []struct {
 			Key         string `json:"key"`

--- a/core/internal/log/log.go
+++ b/core/internal/log/log.go
@@ -13,10 +13,10 @@ import (
 type Logger struct{ *cblog.Logger }
 
 // Printf routes goose/info-style logs through Infof.
-func (l *Logger) Printf(format string, v ...interface{}) { l.Infof(format, v...) }
+func (l *Logger) Printf(format string, v ...any) { l.Infof(format, v...) }
 
 // Fatalf keeps goose’s contract of exiting the program.
-func (l *Logger) Fatalf(format string, v ...interface{}) { l.Logger.Fatalf(format, v...) }
+func (l *Logger) Fatalf(format string, v ...any) { l.Logger.Fatalf(format, v...) }
 
 var (
 	logger     *Logger
@@ -104,13 +104,13 @@ func GetLogger() *Logger {
 
 // * Convenience wrappers
 
-func Debug(msg interface{}, keyvals ...interface{}) { GetLogger().Logger.Debug(msg, keyvals...) }
-func Debugf(format string, v ...interface{})        { GetLogger().Logger.Debugf(format, v...) }
-func Info(msg interface{}, keyvals ...interface{})  { GetLogger().Logger.Info(msg, keyvals...) }
-func Infof(format string, v ...interface{})         { GetLogger().Logger.Infof(format, v...) }
-func Warn(msg interface{}, keyvals ...interface{})  { GetLogger().Logger.Warn(msg, keyvals...) }
-func Warnf(format string, v ...interface{})         { GetLogger().Logger.Warnf(format, v...) }
-func Error(msg interface{}, keyvals ...interface{}) { GetLogger().Logger.Error(msg, keyvals...) }
-func Errorf(format string, v ...interface{})        { GetLogger().Logger.Errorf(format, v...) }
-func Fatal(msg interface{}, keyvals ...interface{}) { GetLogger().Logger.Fatal(msg, keyvals...) }
-func Fatalf(format string, v ...interface{})        { GetLogger().Logger.Fatalf(format, v...) }
+func Debug(msg any, keyvals ...any)  { GetLogger().Logger.Debug(msg, keyvals...) }
+func Debugf(format string, v ...any) { GetLogger().Logger.Debugf(format, v...) }
+func Info(msg any, keyvals ...any)   { GetLogger().Logger.Info(msg, keyvals...) }
+func Infof(format string, v ...any)  { GetLogger().Logger.Infof(format, v...) }
+func Warn(msg any, keyvals ...any)   { GetLogger().Logger.Warn(msg, keyvals...) }
+func Warnf(format string, v ...any)  { GetLogger().Logger.Warnf(format, v...) }
+func Error(msg any, keyvals ...any)  { GetLogger().Logger.Error(msg, keyvals...) }
+func Errorf(format string, v ...any) { GetLogger().Logger.Errorf(format, v...) }
+func Fatal(msg any, keyvals ...any)  { GetLogger().Logger.Fatal(msg, keyvals...) }
+func Fatalf(format string, v ...any) { GetLogger().Logger.Fatalf(format, v...) }

--- a/core/internal/mocks/brightness/mock_DBusConn.go
+++ b/core/internal/mocks/brightness/mock_DBusConn.go
@@ -93,7 +93,7 @@ type MockDBusConn_Object_Call struct {
 // Object is a helper method to define mock.On call
 //   - dest string
 //   - path dbus.ObjectPath
-func (_e *MockDBusConn_Expecter) Object(dest interface{}, path interface{}) *MockDBusConn_Object_Call {
+func (_e *MockDBusConn_Expecter) Object(dest any, path any) *MockDBusConn_Object_Call {
 	return &MockDBusConn_Object_Call{Call: _e.mock.On("Object", dest, path)}
 }
 
@@ -119,7 +119,8 @@ func (_c *MockDBusConn_Object_Call) RunAndReturn(run func(string, dbus.ObjectPat
 func NewMockDBusConn(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockDBusConn {
+},
+) *MockDBusConn {
 	mock := &MockDBusConn{}
 	mock.Mock.Test(t)
 

--- a/core/internal/mocks/cups/mock_CUPSClientInterface.go
+++ b/core/internal/mocks/cups/mock_CUPSClientInterface.go
@@ -141,7 +141,7 @@ type MockCUPSClientInterface_CancelAllJob_Call struct {
 // CancelAllJob is a helper method to define mock.On call
 //   - printer string
 //   - purge bool
-func (_e *MockCUPSClientInterface_Expecter) CancelAllJob(printer interface{}, purge interface{}) *MockCUPSClientInterface_CancelAllJob_Call {
+func (_e *MockCUPSClientInterface_Expecter) CancelAllJob(printer any, purge any) *MockCUPSClientInterface_CancelAllJob_Call {
 	return &MockCUPSClientInterface_CancelAllJob_Call{Call: _e.mock.On("CancelAllJob", printer, purge)}
 }
 
@@ -188,7 +188,7 @@ type MockCUPSClientInterface_CancelJob_Call struct {
 // CancelJob is a helper method to define mock.On call
 //   - jobID int
 //   - purge bool
-func (_e *MockCUPSClientInterface_Expecter) CancelJob(jobID interface{}, purge interface{}) *MockCUPSClientInterface_CancelJob_Call {
+func (_e *MockCUPSClientInterface_Expecter) CancelJob(jobID any, purge any) *MockCUPSClientInterface_CancelJob_Call {
 	return &MockCUPSClientInterface_CancelJob_Call{Call: _e.mock.On("CancelJob", jobID, purge)}
 }
 
@@ -558,7 +558,7 @@ type MockCUPSClientInterface_GetJobs_Call struct {
 //   - firstJobId int
 //   - limit int
 //   - attributes []string
-func (_e *MockCUPSClientInterface_Expecter) GetJobs(printer interface{}, class interface{}, whichJobs interface{}, myJobs interface{}, firstJobId interface{}, limit interface{}, attributes interface{}) *MockCUPSClientInterface_GetJobs_Call {
+func (_e *MockCUPSClientInterface_Expecter) GetJobs(printer any, class any, whichJobs any, myJobs any, firstJobId any, limit any, attributes any) *MockCUPSClientInterface_GetJobs_Call {
 	return &MockCUPSClientInterface_GetJobs_Call{Call: _e.mock.On("GetJobs", printer, class, whichJobs, myJobs, firstJobId, limit, attributes)}
 }
 
@@ -673,7 +673,7 @@ type MockCUPSClientInterface_GetPrinters_Call struct {
 
 // GetPrinters is a helper method to define mock.On call
 //   - attributes []string
-func (_e *MockCUPSClientInterface_Expecter) GetPrinters(attributes interface{}) *MockCUPSClientInterface_GetPrinters_Call {
+func (_e *MockCUPSClientInterface_Expecter) GetPrinters(attributes any) *MockCUPSClientInterface_GetPrinters_Call {
 	return &MockCUPSClientInterface_GetPrinters_Call{Call: _e.mock.On("GetPrinters", attributes)}
 }
 
@@ -813,7 +813,7 @@ type MockCUPSClientInterface_PausePrinter_Call struct {
 
 // PausePrinter is a helper method to define mock.On call
 //   - printer string
-func (_e *MockCUPSClientInterface_Expecter) PausePrinter(printer interface{}) *MockCUPSClientInterface_PausePrinter_Call {
+func (_e *MockCUPSClientInterface_Expecter) PausePrinter(printer any) *MockCUPSClientInterface_PausePrinter_Call {
 	return &MockCUPSClientInterface_PausePrinter_Call{Call: _e.mock.On("PausePrinter", printer)}
 }
 
@@ -1009,7 +1009,7 @@ type MockCUPSClientInterface_ResumePrinter_Call struct {
 
 // ResumePrinter is a helper method to define mock.On call
 //   - printer string
-func (_e *MockCUPSClientInterface_Expecter) ResumePrinter(printer interface{}) *MockCUPSClientInterface_ResumePrinter_Call {
+func (_e *MockCUPSClientInterface_Expecter) ResumePrinter(printer any) *MockCUPSClientInterface_ResumePrinter_Call {
 	return &MockCUPSClientInterface_ResumePrinter_Call{Call: _e.mock.On("ResumePrinter", printer)}
 }
 
@@ -1069,7 +1069,7 @@ type MockCUPSClientInterface_SendRequest_Call struct {
 //   - url string
 //   - req *ipp.Request
 //   - additionalResponseData io.Writer
-func (_e *MockCUPSClientInterface_Expecter) SendRequest(url interface{}, req interface{}, additionalResponseData interface{}) *MockCUPSClientInterface_SendRequest_Call {
+func (_e *MockCUPSClientInterface_Expecter) SendRequest(url any, req any, additionalResponseData any) *MockCUPSClientInterface_SendRequest_Call {
 	return &MockCUPSClientInterface_SendRequest_Call{Call: _e.mock.On("SendRequest", url, req, additionalResponseData)}
 }
 

--- a/core/internal/mocks/evdev/mock_EvdevDevice.go
+++ b/core/internal/mocks/evdev/mock_EvdevDevice.go
@@ -259,7 +259,7 @@ type MockEvdevDevice_State_Call struct {
 
 // State is a helper method to define mock.On call
 //   - t go_evdev.EvType
-func (_e *MockEvdevDevice_Expecter) State(t interface{}) *MockEvdevDevice_State_Call {
+func (_e *MockEvdevDevice_Expecter) State(t any) *MockEvdevDevice_State_Call {
 	return &MockEvdevDevice_State_Call{Call: _e.mock.On("State", t)}
 }
 
@@ -285,7 +285,8 @@ func (_c *MockEvdevDevice_State_Call) RunAndReturn(run func(go_evdev.EvType) (go
 func NewMockEvdevDevice(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockEvdevDevice {
+},
+) *MockEvdevDevice {
 	mock := &MockEvdevDevice{}
 	mock.Mock.Test(t)
 

--- a/core/internal/mocks/github.com/Wifx/gonetworkmanager/v2/mock_ActiveConnection.go
+++ b/core/internal/mocks/github.com/Wifx/gonetworkmanager/v2/mock_ActiveConnection.go
@@ -989,7 +989,7 @@ type MockActiveConnection_SubscribeState_Call struct {
 // SubscribeState is a helper method to define mock.On call
 //   - receiver chan gonetworkmanager.StateChange
 //   - exit chan struct{}
-func (_e *MockActiveConnection_Expecter) SubscribeState(receiver interface{}, exit interface{}) *MockActiveConnection_SubscribeState_Call {
+func (_e *MockActiveConnection_Expecter) SubscribeState(receiver any, exit any) *MockActiveConnection_SubscribeState_Call {
 	return &MockActiveConnection_SubscribeState_Call{Call: _e.mock.On("SubscribeState", receiver, exit)}
 }
 

--- a/core/internal/mocks/github.com/Wifx/gonetworkmanager/v2/mock_Connection.go
+++ b/core/internal/mocks/github.com/Wifx/gonetworkmanager/v2/mock_Connection.go
@@ -359,7 +359,7 @@ type MockConnection_GetSecrets_Call struct {
 
 // GetSecrets is a helper method to define mock.On call
 //   - settingName string
-func (_e *MockConnection_Expecter) GetSecrets(settingName interface{}) *MockConnection_GetSecrets_Call {
+func (_e *MockConnection_Expecter) GetSecrets(settingName any) *MockConnection_GetSecrets_Call {
 	return &MockConnection_GetSecrets_Call{Call: _e.mock.On("GetSecrets", settingName)}
 }
 
@@ -564,7 +564,7 @@ type MockConnection_Update_Call struct {
 
 // Update is a helper method to define mock.On call
 //   - settings gonetworkmanager.ConnectionSettings
-func (_e *MockConnection_Expecter) Update(settings interface{}) *MockConnection_Update_Call {
+func (_e *MockConnection_Expecter) Update(settings any) *MockConnection_Update_Call {
 	return &MockConnection_Update_Call{Call: _e.mock.On("Update", settings)}
 }
 
@@ -610,7 +610,7 @@ type MockConnection_UpdateUnsaved_Call struct {
 
 // UpdateUnsaved is a helper method to define mock.On call
 //   - settings gonetworkmanager.ConnectionSettings
-func (_e *MockConnection_Expecter) UpdateUnsaved(settings interface{}) *MockConnection_UpdateUnsaved_Call {
+func (_e *MockConnection_Expecter) UpdateUnsaved(settings any) *MockConnection_UpdateUnsaved_Call {
 	return &MockConnection_UpdateUnsaved_Call{Call: _e.mock.On("UpdateUnsaved", settings)}
 }
 

--- a/core/internal/mocks/github.com/Wifx/gonetworkmanager/v2/mock_Device.go
+++ b/core/internal/mocks/github.com/Wifx/gonetworkmanager/v2/mock_Device.go
@@ -1463,7 +1463,7 @@ type MockDevice_Reapply_Call struct {
 //   - connection gonetworkmanager.Connection
 //   - versionId uint64
 //   - flags uint32
-func (_e *MockDevice_Expecter) Reapply(connection interface{}, versionId interface{}, flags interface{}) *MockDevice_Reapply_Call {
+func (_e *MockDevice_Expecter) Reapply(connection any, versionId any, flags any) *MockDevice_Reapply_Call {
 	return &MockDevice_Reapply_Call{Call: _e.mock.On("Reapply", connection, versionId, flags)}
 }
 
@@ -1509,7 +1509,7 @@ type MockDevice_SetPropertyAutoConnect_Call struct {
 
 // SetPropertyAutoConnect is a helper method to define mock.On call
 //   - _a0 bool
-func (_e *MockDevice_Expecter) SetPropertyAutoConnect(_a0 interface{}) *MockDevice_SetPropertyAutoConnect_Call {
+func (_e *MockDevice_Expecter) SetPropertyAutoConnect(_a0 any) *MockDevice_SetPropertyAutoConnect_Call {
 	return &MockDevice_SetPropertyAutoConnect_Call{Call: _e.mock.On("SetPropertyAutoConnect", _a0)}
 }
 
@@ -1555,7 +1555,7 @@ type MockDevice_SetPropertyManaged_Call struct {
 
 // SetPropertyManaged is a helper method to define mock.On call
 //   - _a0 bool
-func (_e *MockDevice_Expecter) SetPropertyManaged(_a0 interface{}) *MockDevice_SetPropertyManaged_Call {
+func (_e *MockDevice_Expecter) SetPropertyManaged(_a0 any) *MockDevice_SetPropertyManaged_Call {
 	return &MockDevice_SetPropertyManaged_Call{Call: _e.mock.On("SetPropertyManaged", _a0)}
 }
 
@@ -1602,7 +1602,7 @@ type MockDevice_SubscribeState_Call struct {
 // SubscribeState is a helper method to define mock.On call
 //   - receiver chan gonetworkmanager.DeviceStateChange
 //   - exit chan struct{}
-func (_e *MockDevice_Expecter) SubscribeState(receiver interface{}, exit interface{}) *MockDevice_SubscribeState_Call {
+func (_e *MockDevice_Expecter) SubscribeState(receiver any, exit any) *MockDevice_SubscribeState_Call {
 	return &MockDevice_SubscribeState_Call{Call: _e.mock.On("SubscribeState", receiver, exit)}
 }
 

--- a/core/internal/mocks/github.com/Wifx/gonetworkmanager/v2/mock_DeviceWireless.go
+++ b/core/internal/mocks/github.com/Wifx/gonetworkmanager/v2/mock_DeviceWireless.go
@@ -2021,7 +2021,7 @@ type MockDeviceWireless_Reapply_Call struct {
 //   - connection gonetworkmanager.Connection
 //   - versionId uint64
 //   - flags uint32
-func (_e *MockDeviceWireless_Expecter) Reapply(connection interface{}, versionId interface{}, flags interface{}) *MockDeviceWireless_Reapply_Call {
+func (_e *MockDeviceWireless_Expecter) Reapply(connection any, versionId any, flags any) *MockDeviceWireless_Reapply_Call {
 	return &MockDeviceWireless_Reapply_Call{Call: _e.mock.On("Reapply", connection, versionId, flags)}
 }
 
@@ -2112,7 +2112,7 @@ type MockDeviceWireless_SetPropertyAutoConnect_Call struct {
 
 // SetPropertyAutoConnect is a helper method to define mock.On call
 //   - _a0 bool
-func (_e *MockDeviceWireless_Expecter) SetPropertyAutoConnect(_a0 interface{}) *MockDeviceWireless_SetPropertyAutoConnect_Call {
+func (_e *MockDeviceWireless_Expecter) SetPropertyAutoConnect(_a0 any) *MockDeviceWireless_SetPropertyAutoConnect_Call {
 	return &MockDeviceWireless_SetPropertyAutoConnect_Call{Call: _e.mock.On("SetPropertyAutoConnect", _a0)}
 }
 
@@ -2158,7 +2158,7 @@ type MockDeviceWireless_SetPropertyManaged_Call struct {
 
 // SetPropertyManaged is a helper method to define mock.On call
 //   - _a0 bool
-func (_e *MockDeviceWireless_Expecter) SetPropertyManaged(_a0 interface{}) *MockDeviceWireless_SetPropertyManaged_Call {
+func (_e *MockDeviceWireless_Expecter) SetPropertyManaged(_a0 any) *MockDeviceWireless_SetPropertyManaged_Call {
 	return &MockDeviceWireless_SetPropertyManaged_Call{Call: _e.mock.On("SetPropertyManaged", _a0)}
 }
 
@@ -2205,7 +2205,7 @@ type MockDeviceWireless_SubscribeState_Call struct {
 // SubscribeState is a helper method to define mock.On call
 //   - receiver chan gonetworkmanager.DeviceStateChange
 //   - exit chan struct{}
-func (_e *MockDeviceWireless_Expecter) SubscribeState(receiver interface{}, exit interface{}) *MockDeviceWireless_SubscribeState_Call {
+func (_e *MockDeviceWireless_Expecter) SubscribeState(receiver any, exit any) *MockDeviceWireless_SubscribeState_Call {
 	return &MockDeviceWireless_SubscribeState_Call{Call: _e.mock.On("SubscribeState", receiver, exit)}
 }
 

--- a/core/internal/mocks/github.com/Wifx/gonetworkmanager/v2/mock_NetworkManager.go
+++ b/core/internal/mocks/github.com/Wifx/gonetworkmanager/v2/mock_NetworkManager.go
@@ -61,7 +61,7 @@ type MockNetworkManager_ActivateConnection_Call struct {
 //   - connection gonetworkmanager.Connection
 //   - device gonetworkmanager.Device
 //   - specificObject *dbus.Object
-func (_e *MockNetworkManager_Expecter) ActivateConnection(connection interface{}, device interface{}, specificObject interface{}) *MockNetworkManager_ActivateConnection_Call {
+func (_e *MockNetworkManager_Expecter) ActivateConnection(connection any, device any, specificObject any) *MockNetworkManager_ActivateConnection_Call {
 	return &MockNetworkManager_ActivateConnection_Call{Call: _e.mock.On("ActivateConnection", connection, device, specificObject)}
 }
 
@@ -121,7 +121,7 @@ type MockNetworkManager_ActivateWirelessConnection_Call struct {
 //   - connection gonetworkmanager.Connection
 //   - device gonetworkmanager.Device
 //   - accessPoint gonetworkmanager.AccessPoint
-func (_e *MockNetworkManager_Expecter) ActivateWirelessConnection(connection interface{}, device interface{}, accessPoint interface{}) *MockNetworkManager_ActivateWirelessConnection_Call {
+func (_e *MockNetworkManager_Expecter) ActivateWirelessConnection(connection any, device any, accessPoint any) *MockNetworkManager_ActivateWirelessConnection_Call {
 	return &MockNetworkManager_ActivateWirelessConnection_Call{Call: _e.mock.On("ActivateWirelessConnection", connection, device, accessPoint)}
 }
 
@@ -143,7 +143,7 @@ func (_c *MockNetworkManager_ActivateWirelessConnection_Call) RunAndReturn(run f
 }
 
 // AddAndActivateConnection provides a mock function with given fields: connection, device
-func (_m *MockNetworkManager) AddAndActivateConnection(connection map[string]map[string]interface{}, device gonetworkmanager.Device) (gonetworkmanager.ActiveConnection, error) {
+func (_m *MockNetworkManager) AddAndActivateConnection(connection map[string]map[string]any, device gonetworkmanager.Device) (gonetworkmanager.ActiveConnection, error) {
 	ret := _m.Called(connection, device)
 
 	if len(ret) == 0 {
@@ -152,10 +152,10 @@ func (_m *MockNetworkManager) AddAndActivateConnection(connection map[string]map
 
 	var r0 gonetworkmanager.ActiveConnection
 	var r1 error
-	if rf, ok := ret.Get(0).(func(map[string]map[string]interface{}, gonetworkmanager.Device) (gonetworkmanager.ActiveConnection, error)); ok {
+	if rf, ok := ret.Get(0).(func(map[string]map[string]any, gonetworkmanager.Device) (gonetworkmanager.ActiveConnection, error)); ok {
 		return rf(connection, device)
 	}
-	if rf, ok := ret.Get(0).(func(map[string]map[string]interface{}, gonetworkmanager.Device) gonetworkmanager.ActiveConnection); ok {
+	if rf, ok := ret.Get(0).(func(map[string]map[string]any, gonetworkmanager.Device) gonetworkmanager.ActiveConnection); ok {
 		r0 = rf(connection, device)
 	} else {
 		if ret.Get(0) != nil {
@@ -163,7 +163,7 @@ func (_m *MockNetworkManager) AddAndActivateConnection(connection map[string]map
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(map[string]map[string]interface{}, gonetworkmanager.Device) error); ok {
+	if rf, ok := ret.Get(1).(func(map[string]map[string]any, gonetworkmanager.Device) error); ok {
 		r1 = rf(connection, device)
 	} else {
 		r1 = ret.Error(1)
@@ -178,15 +178,15 @@ type MockNetworkManager_AddAndActivateConnection_Call struct {
 }
 
 // AddAndActivateConnection is a helper method to define mock.On call
-//   - connection map[string]map[string]interface{}
+//   - connection map[string]map[string]any
 //   - device gonetworkmanager.Device
-func (_e *MockNetworkManager_Expecter) AddAndActivateConnection(connection interface{}, device interface{}) *MockNetworkManager_AddAndActivateConnection_Call {
+func (_e *MockNetworkManager_Expecter) AddAndActivateConnection(connection any, device any) *MockNetworkManager_AddAndActivateConnection_Call {
 	return &MockNetworkManager_AddAndActivateConnection_Call{Call: _e.mock.On("AddAndActivateConnection", connection, device)}
 }
 
-func (_c *MockNetworkManager_AddAndActivateConnection_Call) Run(run func(connection map[string]map[string]interface{}, device gonetworkmanager.Device)) *MockNetworkManager_AddAndActivateConnection_Call {
+func (_c *MockNetworkManager_AddAndActivateConnection_Call) Run(run func(connection map[string]map[string]any, device gonetworkmanager.Device)) *MockNetworkManager_AddAndActivateConnection_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(map[string]map[string]interface{}), args[1].(gonetworkmanager.Device))
+		run(args[0].(map[string]map[string]any), args[1].(gonetworkmanager.Device))
 	})
 	return _c
 }
@@ -196,13 +196,13 @@ func (_c *MockNetworkManager_AddAndActivateConnection_Call) Return(_a0 gonetwork
 	return _c
 }
 
-func (_c *MockNetworkManager_AddAndActivateConnection_Call) RunAndReturn(run func(map[string]map[string]interface{}, gonetworkmanager.Device) (gonetworkmanager.ActiveConnection, error)) *MockNetworkManager_AddAndActivateConnection_Call {
+func (_c *MockNetworkManager_AddAndActivateConnection_Call) RunAndReturn(run func(map[string]map[string]any, gonetworkmanager.Device) (gonetworkmanager.ActiveConnection, error)) *MockNetworkManager_AddAndActivateConnection_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // AddAndActivateWirelessConnection provides a mock function with given fields: connection, device, accessPoint
-func (_m *MockNetworkManager) AddAndActivateWirelessConnection(connection map[string]map[string]interface{}, device gonetworkmanager.Device, accessPoint gonetworkmanager.AccessPoint) (gonetworkmanager.ActiveConnection, error) {
+func (_m *MockNetworkManager) AddAndActivateWirelessConnection(connection map[string]map[string]any, device gonetworkmanager.Device, accessPoint gonetworkmanager.AccessPoint) (gonetworkmanager.ActiveConnection, error) {
 	ret := _m.Called(connection, device, accessPoint)
 
 	if len(ret) == 0 {
@@ -211,10 +211,10 @@ func (_m *MockNetworkManager) AddAndActivateWirelessConnection(connection map[st
 
 	var r0 gonetworkmanager.ActiveConnection
 	var r1 error
-	if rf, ok := ret.Get(0).(func(map[string]map[string]interface{}, gonetworkmanager.Device, gonetworkmanager.AccessPoint) (gonetworkmanager.ActiveConnection, error)); ok {
+	if rf, ok := ret.Get(0).(func(map[string]map[string]any, gonetworkmanager.Device, gonetworkmanager.AccessPoint) (gonetworkmanager.ActiveConnection, error)); ok {
 		return rf(connection, device, accessPoint)
 	}
-	if rf, ok := ret.Get(0).(func(map[string]map[string]interface{}, gonetworkmanager.Device, gonetworkmanager.AccessPoint) gonetworkmanager.ActiveConnection); ok {
+	if rf, ok := ret.Get(0).(func(map[string]map[string]any, gonetworkmanager.Device, gonetworkmanager.AccessPoint) gonetworkmanager.ActiveConnection); ok {
 		r0 = rf(connection, device, accessPoint)
 	} else {
 		if ret.Get(0) != nil {
@@ -222,7 +222,7 @@ func (_m *MockNetworkManager) AddAndActivateWirelessConnection(connection map[st
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(map[string]map[string]interface{}, gonetworkmanager.Device, gonetworkmanager.AccessPoint) error); ok {
+	if rf, ok := ret.Get(1).(func(map[string]map[string]any, gonetworkmanager.Device, gonetworkmanager.AccessPoint) error); ok {
 		r1 = rf(connection, device, accessPoint)
 	} else {
 		r1 = ret.Error(1)
@@ -237,16 +237,16 @@ type MockNetworkManager_AddAndActivateWirelessConnection_Call struct {
 }
 
 // AddAndActivateWirelessConnection is a helper method to define mock.On call
-//   - connection map[string]map[string]interface{}
+//   - connection map[string]map[string]any
 //   - device gonetworkmanager.Device
 //   - accessPoint gonetworkmanager.AccessPoint
-func (_e *MockNetworkManager_Expecter) AddAndActivateWirelessConnection(connection interface{}, device interface{}, accessPoint interface{}) *MockNetworkManager_AddAndActivateWirelessConnection_Call {
+func (_e *MockNetworkManager_Expecter) AddAndActivateWirelessConnection(connection any, device any, accessPoint any) *MockNetworkManager_AddAndActivateWirelessConnection_Call {
 	return &MockNetworkManager_AddAndActivateWirelessConnection_Call{Call: _e.mock.On("AddAndActivateWirelessConnection", connection, device, accessPoint)}
 }
 
-func (_c *MockNetworkManager_AddAndActivateWirelessConnection_Call) Run(run func(connection map[string]map[string]interface{}, device gonetworkmanager.Device, accessPoint gonetworkmanager.AccessPoint)) *MockNetworkManager_AddAndActivateWirelessConnection_Call {
+func (_c *MockNetworkManager_AddAndActivateWirelessConnection_Call) Run(run func(connection map[string]map[string]any, device gonetworkmanager.Device, accessPoint gonetworkmanager.AccessPoint)) *MockNetworkManager_AddAndActivateWirelessConnection_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(map[string]map[string]interface{}), args[1].(gonetworkmanager.Device), args[2].(gonetworkmanager.AccessPoint))
+		run(args[0].(map[string]map[string]any), args[1].(gonetworkmanager.Device), args[2].(gonetworkmanager.AccessPoint))
 	})
 	return _c
 }
@@ -256,7 +256,7 @@ func (_c *MockNetworkManager_AddAndActivateWirelessConnection_Call) Return(_a0 g
 	return _c
 }
 
-func (_c *MockNetworkManager_AddAndActivateWirelessConnection_Call) RunAndReturn(run func(map[string]map[string]interface{}, gonetworkmanager.Device, gonetworkmanager.AccessPoint) (gonetworkmanager.ActiveConnection, error)) *MockNetworkManager_AddAndActivateWirelessConnection_Call {
+func (_c *MockNetworkManager_AddAndActivateWirelessConnection_Call) RunAndReturn(run func(map[string]map[string]any, gonetworkmanager.Device, gonetworkmanager.AccessPoint) (gonetworkmanager.ActiveConnection, error)) *MockNetworkManager_AddAndActivateWirelessConnection_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -332,7 +332,7 @@ type MockNetworkManager_CheckpointAdjustRollbackTimeout_Call struct {
 // CheckpointAdjustRollbackTimeout is a helper method to define mock.On call
 //   - checkpoint gonetworkmanager.Checkpoint
 //   - addTimeout uint32
-func (_e *MockNetworkManager_Expecter) CheckpointAdjustRollbackTimeout(checkpoint interface{}, addTimeout interface{}) *MockNetworkManager_CheckpointAdjustRollbackTimeout_Call {
+func (_e *MockNetworkManager_Expecter) CheckpointAdjustRollbackTimeout(checkpoint any, addTimeout any) *MockNetworkManager_CheckpointAdjustRollbackTimeout_Call {
 	return &MockNetworkManager_CheckpointAdjustRollbackTimeout_Call{Call: _e.mock.On("CheckpointAdjustRollbackTimeout", checkpoint, addTimeout)}
 }
 
@@ -392,7 +392,7 @@ type MockNetworkManager_CheckpointCreate_Call struct {
 //   - devices []gonetworkmanager.Device
 //   - rollbackTimeout uint32
 //   - flags uint32
-func (_e *MockNetworkManager_Expecter) CheckpointCreate(devices interface{}, rollbackTimeout interface{}, flags interface{}) *MockNetworkManager_CheckpointCreate_Call {
+func (_e *MockNetworkManager_Expecter) CheckpointCreate(devices any, rollbackTimeout any, flags any) *MockNetworkManager_CheckpointCreate_Call {
 	return &MockNetworkManager_CheckpointCreate_Call{Call: _e.mock.On("CheckpointCreate", devices, rollbackTimeout, flags)}
 }
 
@@ -438,7 +438,7 @@ type MockNetworkManager_CheckpointDestroy_Call struct {
 
 // CheckpointDestroy is a helper method to define mock.On call
 //   - checkpoint gonetworkmanager.Checkpoint
-func (_e *MockNetworkManager_Expecter) CheckpointDestroy(checkpoint interface{}) *MockNetworkManager_CheckpointDestroy_Call {
+func (_e *MockNetworkManager_Expecter) CheckpointDestroy(checkpoint any) *MockNetworkManager_CheckpointDestroy_Call {
 	return &MockNetworkManager_CheckpointDestroy_Call{Call: _e.mock.On("CheckpointDestroy", checkpoint)}
 }
 
@@ -496,7 +496,7 @@ type MockNetworkManager_CheckpointRollback_Call struct {
 
 // CheckpointRollback is a helper method to define mock.On call
 //   - checkpoint gonetworkmanager.Checkpoint
-func (_e *MockNetworkManager_Expecter) CheckpointRollback(checkpoint interface{}) *MockNetworkManager_CheckpointRollback_Call {
+func (_e *MockNetworkManager_Expecter) CheckpointRollback(checkpoint any) *MockNetworkManager_CheckpointRollback_Call {
 	return &MockNetworkManager_CheckpointRollback_Call{Call: _e.mock.On("CheckpointRollback", checkpoint)}
 }
 
@@ -542,7 +542,7 @@ type MockNetworkManager_DeactivateConnection_Call struct {
 
 // DeactivateConnection is a helper method to define mock.On call
 //   - connection gonetworkmanager.ActiveConnection
-func (_e *MockNetworkManager_Expecter) DeactivateConnection(connection interface{}) *MockNetworkManager_DeactivateConnection_Call {
+func (_e *MockNetworkManager_Expecter) DeactivateConnection(connection any) *MockNetworkManager_DeactivateConnection_Call {
 	return &MockNetworkManager_DeactivateConnection_Call{Call: _e.mock.On("DeactivateConnection", connection)}
 }
 
@@ -588,7 +588,7 @@ type MockNetworkManager_Enable_Call struct {
 
 // Enable is a helper method to define mock.On call
 //   - enableNDisable bool
-func (_e *MockNetworkManager_Expecter) Enable(enableNDisable interface{}) *MockNetworkManager_Enable_Call {
+func (_e *MockNetworkManager_Expecter) Enable(enableNDisable any) *MockNetworkManager_Enable_Call {
 	return &MockNetworkManager_Enable_Call{Call: _e.mock.On("Enable", enableNDisable)}
 }
 
@@ -703,7 +703,7 @@ type MockNetworkManager_GetDeviceByIpIface_Call struct {
 
 // GetDeviceByIpIface is a helper method to define mock.On call
 //   - interfaceId string
-func (_e *MockNetworkManager_Expecter) GetDeviceByIpIface(interfaceId interface{}) *MockNetworkManager_GetDeviceByIpIface_Call {
+func (_e *MockNetworkManager_Expecter) GetDeviceByIpIface(interfaceId any) *MockNetworkManager_GetDeviceByIpIface_Call {
 	return &MockNetworkManager_GetDeviceByIpIface_Call{Call: _e.mock.On("GetDeviceByIpIface", interfaceId)}
 }
 
@@ -2087,7 +2087,7 @@ type MockNetworkManager_Reload_Call struct {
 
 // Reload is a helper method to define mock.On call
 //   - flags uint32
-func (_e *MockNetworkManager_Expecter) Reload(flags interface{}) *MockNetworkManager_Reload_Call {
+func (_e *MockNetworkManager_Expecter) Reload(flags any) *MockNetworkManager_Reload_Call {
 	return &MockNetworkManager_Reload_Call{Call: _e.mock.On("Reload", flags)}
 }
 
@@ -2133,7 +2133,7 @@ type MockNetworkManager_SetPropertyWirelessEnabled_Call struct {
 
 // SetPropertyWirelessEnabled is a helper method to define mock.On call
 //   - _a0 bool
-func (_e *MockNetworkManager_Expecter) SetPropertyWirelessEnabled(_a0 interface{}) *MockNetworkManager_SetPropertyWirelessEnabled_Call {
+func (_e *MockNetworkManager_Expecter) SetPropertyWirelessEnabled(_a0 any) *MockNetworkManager_SetPropertyWirelessEnabled_Call {
 	return &MockNetworkManager_SetPropertyWirelessEnabled_Call{Call: _e.mock.On("SetPropertyWirelessEnabled", _a0)}
 }
 
@@ -2179,7 +2179,7 @@ type MockNetworkManager_Sleep_Call struct {
 
 // Sleep is a helper method to define mock.On call
 //   - sleepNWake bool
-func (_e *MockNetworkManager_Expecter) Sleep(sleepNWake interface{}) *MockNetworkManager_Sleep_Call {
+func (_e *MockNetworkManager_Expecter) Sleep(sleepNWake any) *MockNetworkManager_Sleep_Call {
 	return &MockNetworkManager_Sleep_Call{Call: _e.mock.On("Sleep", sleepNWake)}
 }
 

--- a/core/internal/mocks/github.com/Wifx/gonetworkmanager/v2/mock_Settings.go
+++ b/core/internal/mocks/github.com/Wifx/gonetworkmanager/v2/mock_Settings.go
@@ -57,7 +57,7 @@ type MockSettings_AddConnection_Call struct {
 
 // AddConnection is a helper method to define mock.On call
 //   - settings gonetworkmanager.ConnectionSettings
-func (_e *MockSettings_Expecter) AddConnection(settings interface{}) *MockSettings_AddConnection_Call {
+func (_e *MockSettings_Expecter) AddConnection(settings any) *MockSettings_AddConnection_Call {
 	return &MockSettings_AddConnection_Call{Call: _e.mock.On("AddConnection", settings)}
 }
 
@@ -115,7 +115,7 @@ type MockSettings_AddConnectionUnsaved_Call struct {
 
 // AddConnectionUnsaved is a helper method to define mock.On call
 //   - settings gonetworkmanager.ConnectionSettings
-func (_e *MockSettings_Expecter) AddConnectionUnsaved(settings interface{}) *MockSettings_AddConnectionUnsaved_Call {
+func (_e *MockSettings_Expecter) AddConnectionUnsaved(settings any) *MockSettings_AddConnectionUnsaved_Call {
 	return &MockSettings_AddConnectionUnsaved_Call{Call: _e.mock.On("AddConnectionUnsaved", settings)}
 }
 
@@ -173,7 +173,7 @@ type MockSettings_GetConnectionByUUID_Call struct {
 
 // GetConnectionByUUID is a helper method to define mock.On call
 //   - uuid string
-func (_e *MockSettings_Expecter) GetConnectionByUUID(uuid interface{}) *MockSettings_GetConnectionByUUID_Call {
+func (_e *MockSettings_Expecter) GetConnectionByUUID(uuid any) *MockSettings_GetConnectionByUUID_Call {
 	return &MockSettings_GetConnectionByUUID_Call{Call: _e.mock.On("GetConnectionByUUID", uuid)}
 }
 
@@ -431,7 +431,7 @@ type MockSettings_SaveHostname_Call struct {
 
 // SaveHostname is a helper method to define mock.On call
 //   - hostname string
-func (_e *MockSettings_Expecter) SaveHostname(hostname interface{}) *MockSettings_SaveHostname_Call {
+func (_e *MockSettings_Expecter) SaveHostname(hostname any) *MockSettings_SaveHostname_Call {
 	return &MockSettings_SaveHostname_Call{Call: _e.mock.On("SaveHostname", hostname)}
 }
 

--- a/core/internal/mocks/github.com/godbus/dbus/v5/mock_BusObject.go
+++ b/core/internal/mocks/github.com/godbus/dbus/v5/mock_BusObject.go
@@ -24,11 +24,11 @@ func (_m *MockBusObject) EXPECT() *MockBusObject_Expecter {
 
 // AddMatchSignal provides a mock function with given fields: iface, member, options
 func (_m *MockBusObject) AddMatchSignal(iface string, member string, options ...dbus.MatchOption) *dbus.Call {
-	_va := make([]interface{}, len(options))
+	_va := make([]any, len(options))
 	for _i := range options {
 		_va[_i] = options[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, iface, member)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -58,9 +58,9 @@ type MockBusObject_AddMatchSignal_Call struct {
 //   - iface string
 //   - member string
 //   - options ...dbus.MatchOption
-func (_e *MockBusObject_Expecter) AddMatchSignal(iface interface{}, member interface{}, options ...interface{}) *MockBusObject_AddMatchSignal_Call {
+func (_e *MockBusObject_Expecter) AddMatchSignal(iface any, member any, options ...any) *MockBusObject_AddMatchSignal_Call {
 	return &MockBusObject_AddMatchSignal_Call{Call: _e.mock.On("AddMatchSignal",
-		append([]interface{}{iface, member}, options...)...)}
+		append([]any{iface, member}, options...)...)}
 }
 
 func (_c *MockBusObject_AddMatchSignal_Call) Run(run func(iface string, member string, options ...dbus.MatchOption)) *MockBusObject_AddMatchSignal_Call {
@@ -87,8 +87,8 @@ func (_c *MockBusObject_AddMatchSignal_Call) RunAndReturn(run func(string, strin
 }
 
 // Call provides a mock function with given fields: method, flags, args
-func (_m *MockBusObject) Call(method string, flags dbus.Flags, args ...interface{}) *dbus.Call {
-	var _ca []interface{}
+func (_m *MockBusObject) Call(method string, flags dbus.Flags, args ...any) *dbus.Call {
+	var _ca []any
 	_ca = append(_ca, method, flags)
 	_ca = append(_ca, args...)
 	ret := _m.Called(_ca...)
@@ -98,7 +98,7 @@ func (_m *MockBusObject) Call(method string, flags dbus.Flags, args ...interface
 	}
 
 	var r0 *dbus.Call
-	if rf, ok := ret.Get(0).(func(string, dbus.Flags, ...interface{}) *dbus.Call); ok {
+	if rf, ok := ret.Get(0).(func(string, dbus.Flags, ...any) *dbus.Call); ok {
 		r0 = rf(method, flags, args...)
 	} else {
 		if ret.Get(0) != nil {
@@ -117,18 +117,18 @@ type MockBusObject_Call_Call struct {
 // Call is a helper method to define mock.On call
 //   - method string
 //   - flags dbus.Flags
-//   - args ...interface{}
-func (_e *MockBusObject_Expecter) Call(method interface{}, flags interface{}, args ...interface{}) *MockBusObject_Call_Call {
+//   - args ...any
+func (_e *MockBusObject_Expecter) Call(method any, flags any, args ...any) *MockBusObject_Call_Call {
 	return &MockBusObject_Call_Call{Call: _e.mock.On("Call",
-		append([]interface{}{method, flags}, args...)...)}
+		append([]any{method, flags}, args...)...)}
 }
 
-func (_c *MockBusObject_Call_Call) Run(run func(method string, flags dbus.Flags, args ...interface{})) *MockBusObject_Call_Call {
+func (_c *MockBusObject_Call_Call) Run(run func(method string, flags dbus.Flags, args ...any)) *MockBusObject_Call_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]interface{}, len(args)-2)
+		variadicArgs := make([]any, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
-				variadicArgs[i] = a.(interface{})
+				variadicArgs[i] = a.(any)
 			}
 		}
 		run(args[0].(string), args[1].(dbus.Flags), variadicArgs...)
@@ -141,14 +141,14 @@ func (_c *MockBusObject_Call_Call) Return(_a0 *dbus.Call) *MockBusObject_Call_Ca
 	return _c
 }
 
-func (_c *MockBusObject_Call_Call) RunAndReturn(run func(string, dbus.Flags, ...interface{}) *dbus.Call) *MockBusObject_Call_Call {
+func (_c *MockBusObject_Call_Call) RunAndReturn(run func(string, dbus.Flags, ...any) *dbus.Call) *MockBusObject_Call_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CallWithContext provides a mock function with given fields: ctx, method, flags, args
-func (_m *MockBusObject) CallWithContext(ctx context.Context, method string, flags dbus.Flags, args ...interface{}) *dbus.Call {
-	var _ca []interface{}
+func (_m *MockBusObject) CallWithContext(ctx context.Context, method string, flags dbus.Flags, args ...any) *dbus.Call {
+	var _ca []any
 	_ca = append(_ca, ctx, method, flags)
 	_ca = append(_ca, args...)
 	ret := _m.Called(_ca...)
@@ -158,7 +158,7 @@ func (_m *MockBusObject) CallWithContext(ctx context.Context, method string, fla
 	}
 
 	var r0 *dbus.Call
-	if rf, ok := ret.Get(0).(func(context.Context, string, dbus.Flags, ...interface{}) *dbus.Call); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, dbus.Flags, ...any) *dbus.Call); ok {
 		r0 = rf(ctx, method, flags, args...)
 	} else {
 		if ret.Get(0) != nil {
@@ -178,18 +178,18 @@ type MockBusObject_CallWithContext_Call struct {
 //   - ctx context.Context
 //   - method string
 //   - flags dbus.Flags
-//   - args ...interface{}
-func (_e *MockBusObject_Expecter) CallWithContext(ctx interface{}, method interface{}, flags interface{}, args ...interface{}) *MockBusObject_CallWithContext_Call {
+//   - args ...any
+func (_e *MockBusObject_Expecter) CallWithContext(ctx any, method any, flags any, args ...any) *MockBusObject_CallWithContext_Call {
 	return &MockBusObject_CallWithContext_Call{Call: _e.mock.On("CallWithContext",
-		append([]interface{}{ctx, method, flags}, args...)...)}
+		append([]any{ctx, method, flags}, args...)...)}
 }
 
-func (_c *MockBusObject_CallWithContext_Call) Run(run func(ctx context.Context, method string, flags dbus.Flags, args ...interface{})) *MockBusObject_CallWithContext_Call {
+func (_c *MockBusObject_CallWithContext_Call) Run(run func(ctx context.Context, method string, flags dbus.Flags, args ...any)) *MockBusObject_CallWithContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]interface{}, len(args)-3)
+		variadicArgs := make([]any, len(args)-3)
 		for i, a := range args[3:] {
 			if a != nil {
-				variadicArgs[i] = a.(interface{})
+				variadicArgs[i] = a.(any)
 			}
 		}
 		run(args[0].(context.Context), args[1].(string), args[2].(dbus.Flags), variadicArgs...)
@@ -202,7 +202,7 @@ func (_c *MockBusObject_CallWithContext_Call) Return(_a0 *dbus.Call) *MockBusObj
 	return _c
 }
 
-func (_c *MockBusObject_CallWithContext_Call) RunAndReturn(run func(context.Context, string, dbus.Flags, ...interface{}) *dbus.Call) *MockBusObject_CallWithContext_Call {
+func (_c *MockBusObject_CallWithContext_Call) RunAndReturn(run func(context.Context, string, dbus.Flags, ...any) *dbus.Call) *MockBusObject_CallWithContext_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -287,7 +287,7 @@ type MockBusObject_GetProperty_Call struct {
 
 // GetProperty is a helper method to define mock.On call
 //   - p string
-func (_e *MockBusObject_Expecter) GetProperty(p interface{}) *MockBusObject_GetProperty_Call {
+func (_e *MockBusObject_Expecter) GetProperty(p any) *MockBusObject_GetProperty_Call {
 	return &MockBusObject_GetProperty_Call{Call: _e.mock.On("GetProperty", p)}
 }
 
@@ -309,8 +309,8 @@ func (_c *MockBusObject_GetProperty_Call) RunAndReturn(run func(string) (dbus.Va
 }
 
 // Go provides a mock function with given fields: method, flags, ch, args
-func (_m *MockBusObject) Go(method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
-	var _ca []interface{}
+func (_m *MockBusObject) Go(method string, flags dbus.Flags, ch chan *dbus.Call, args ...any) *dbus.Call {
+	var _ca []any
 	_ca = append(_ca, method, flags, ch)
 	_ca = append(_ca, args...)
 	ret := _m.Called(_ca...)
@@ -320,7 +320,7 @@ func (_m *MockBusObject) Go(method string, flags dbus.Flags, ch chan *dbus.Call,
 	}
 
 	var r0 *dbus.Call
-	if rf, ok := ret.Get(0).(func(string, dbus.Flags, chan *dbus.Call, ...interface{}) *dbus.Call); ok {
+	if rf, ok := ret.Get(0).(func(string, dbus.Flags, chan *dbus.Call, ...any) *dbus.Call); ok {
 		r0 = rf(method, flags, ch, args...)
 	} else {
 		if ret.Get(0) != nil {
@@ -340,18 +340,18 @@ type MockBusObject_Go_Call struct {
 //   - method string
 //   - flags dbus.Flags
 //   - ch chan *dbus.Call
-//   - args ...interface{}
-func (_e *MockBusObject_Expecter) Go(method interface{}, flags interface{}, ch interface{}, args ...interface{}) *MockBusObject_Go_Call {
+//   - args ...any
+func (_e *MockBusObject_Expecter) Go(method any, flags any, ch any, args ...any) *MockBusObject_Go_Call {
 	return &MockBusObject_Go_Call{Call: _e.mock.On("Go",
-		append([]interface{}{method, flags, ch}, args...)...)}
+		append([]any{method, flags, ch}, args...)...)}
 }
 
-func (_c *MockBusObject_Go_Call) Run(run func(method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{})) *MockBusObject_Go_Call {
+func (_c *MockBusObject_Go_Call) Run(run func(method string, flags dbus.Flags, ch chan *dbus.Call, args ...any)) *MockBusObject_Go_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]interface{}, len(args)-3)
+		variadicArgs := make([]any, len(args)-3)
 		for i, a := range args[3:] {
 			if a != nil {
-				variadicArgs[i] = a.(interface{})
+				variadicArgs[i] = a.(any)
 			}
 		}
 		run(args[0].(string), args[1].(dbus.Flags), args[2].(chan *dbus.Call), variadicArgs...)
@@ -364,14 +364,14 @@ func (_c *MockBusObject_Go_Call) Return(_a0 *dbus.Call) *MockBusObject_Go_Call {
 	return _c
 }
 
-func (_c *MockBusObject_Go_Call) RunAndReturn(run func(string, dbus.Flags, chan *dbus.Call, ...interface{}) *dbus.Call) *MockBusObject_Go_Call {
+func (_c *MockBusObject_Go_Call) RunAndReturn(run func(string, dbus.Flags, chan *dbus.Call, ...any) *dbus.Call) *MockBusObject_Go_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GoWithContext provides a mock function with given fields: ctx, method, flags, ch, args
-func (_m *MockBusObject) GoWithContext(ctx context.Context, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
-	var _ca []interface{}
+func (_m *MockBusObject) GoWithContext(ctx context.Context, method string, flags dbus.Flags, ch chan *dbus.Call, args ...any) *dbus.Call {
+	var _ca []any
 	_ca = append(_ca, ctx, method, flags, ch)
 	_ca = append(_ca, args...)
 	ret := _m.Called(_ca...)
@@ -381,7 +381,7 @@ func (_m *MockBusObject) GoWithContext(ctx context.Context, method string, flags
 	}
 
 	var r0 *dbus.Call
-	if rf, ok := ret.Get(0).(func(context.Context, string, dbus.Flags, chan *dbus.Call, ...interface{}) *dbus.Call); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, dbus.Flags, chan *dbus.Call, ...any) *dbus.Call); ok {
 		r0 = rf(ctx, method, flags, ch, args...)
 	} else {
 		if ret.Get(0) != nil {
@@ -402,18 +402,18 @@ type MockBusObject_GoWithContext_Call struct {
 //   - method string
 //   - flags dbus.Flags
 //   - ch chan *dbus.Call
-//   - args ...interface{}
-func (_e *MockBusObject_Expecter) GoWithContext(ctx interface{}, method interface{}, flags interface{}, ch interface{}, args ...interface{}) *MockBusObject_GoWithContext_Call {
+//   - args ...any
+func (_e *MockBusObject_Expecter) GoWithContext(ctx any, method any, flags any, ch any, args ...any) *MockBusObject_GoWithContext_Call {
 	return &MockBusObject_GoWithContext_Call{Call: _e.mock.On("GoWithContext",
-		append([]interface{}{ctx, method, flags, ch}, args...)...)}
+		append([]any{ctx, method, flags, ch}, args...)...)}
 }
 
-func (_c *MockBusObject_GoWithContext_Call) Run(run func(ctx context.Context, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{})) *MockBusObject_GoWithContext_Call {
+func (_c *MockBusObject_GoWithContext_Call) Run(run func(ctx context.Context, method string, flags dbus.Flags, ch chan *dbus.Call, args ...any)) *MockBusObject_GoWithContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]interface{}, len(args)-4)
+		variadicArgs := make([]any, len(args)-4)
 		for i, a := range args[4:] {
 			if a != nil {
-				variadicArgs[i] = a.(interface{})
+				variadicArgs[i] = a.(any)
 			}
 		}
 		run(args[0].(context.Context), args[1].(string), args[2].(dbus.Flags), args[3].(chan *dbus.Call), variadicArgs...)
@@ -426,7 +426,7 @@ func (_c *MockBusObject_GoWithContext_Call) Return(_a0 *dbus.Call) *MockBusObjec
 	return _c
 }
 
-func (_c *MockBusObject_GoWithContext_Call) RunAndReturn(run func(context.Context, string, dbus.Flags, chan *dbus.Call, ...interface{}) *dbus.Call) *MockBusObject_GoWithContext_Call {
+func (_c *MockBusObject_GoWithContext_Call) RunAndReturn(run func(context.Context, string, dbus.Flags, chan *dbus.Call, ...any) *dbus.Call) *MockBusObject_GoWithContext_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -478,11 +478,11 @@ func (_c *MockBusObject_Path_Call) RunAndReturn(run func() dbus.ObjectPath) *Moc
 
 // RemoveMatchSignal provides a mock function with given fields: iface, member, options
 func (_m *MockBusObject) RemoveMatchSignal(iface string, member string, options ...dbus.MatchOption) *dbus.Call {
-	_va := make([]interface{}, len(options))
+	_va := make([]any, len(options))
 	for _i := range options {
 		_va[_i] = options[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, iface, member)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -512,9 +512,9 @@ type MockBusObject_RemoveMatchSignal_Call struct {
 //   - iface string
 //   - member string
 //   - options ...dbus.MatchOption
-func (_e *MockBusObject_Expecter) RemoveMatchSignal(iface interface{}, member interface{}, options ...interface{}) *MockBusObject_RemoveMatchSignal_Call {
+func (_e *MockBusObject_Expecter) RemoveMatchSignal(iface any, member any, options ...any) *MockBusObject_RemoveMatchSignal_Call {
 	return &MockBusObject_RemoveMatchSignal_Call{Call: _e.mock.On("RemoveMatchSignal",
-		append([]interface{}{iface, member}, options...)...)}
+		append([]any{iface, member}, options...)...)}
 }
 
 func (_c *MockBusObject_RemoveMatchSignal_Call) Run(run func(iface string, member string, options ...dbus.MatchOption)) *MockBusObject_RemoveMatchSignal_Call {
@@ -541,7 +541,7 @@ func (_c *MockBusObject_RemoveMatchSignal_Call) RunAndReturn(run func(string, st
 }
 
 // SetProperty provides a mock function with given fields: p, v
-func (_m *MockBusObject) SetProperty(p string, v interface{}) error {
+func (_m *MockBusObject) SetProperty(p string, v any) error {
 	ret := _m.Called(p, v)
 
 	if len(ret) == 0 {
@@ -549,7 +549,7 @@ func (_m *MockBusObject) SetProperty(p string, v interface{}) error {
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, interface{}) error); ok {
+	if rf, ok := ret.Get(0).(func(string, any) error); ok {
 		r0 = rf(p, v)
 	} else {
 		r0 = ret.Error(0)
@@ -565,14 +565,14 @@ type MockBusObject_SetProperty_Call struct {
 
 // SetProperty is a helper method to define mock.On call
 //   - p string
-//   - v interface{}
-func (_e *MockBusObject_Expecter) SetProperty(p interface{}, v interface{}) *MockBusObject_SetProperty_Call {
+//   - v any
+func (_e *MockBusObject_Expecter) SetProperty(p any, v any) *MockBusObject_SetProperty_Call {
 	return &MockBusObject_SetProperty_Call{Call: _e.mock.On("SetProperty", p, v)}
 }
 
-func (_c *MockBusObject_SetProperty_Call) Run(run func(p string, v interface{})) *MockBusObject_SetProperty_Call {
+func (_c *MockBusObject_SetProperty_Call) Run(run func(p string, v any)) *MockBusObject_SetProperty_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(interface{}))
+		run(args[0].(string), args[1].(any))
 	})
 	return _c
 }
@@ -582,13 +582,13 @@ func (_c *MockBusObject_SetProperty_Call) Return(_a0 error) *MockBusObject_SetPr
 	return _c
 }
 
-func (_c *MockBusObject_SetProperty_Call) RunAndReturn(run func(string, interface{}) error) *MockBusObject_SetProperty_Call {
+func (_c *MockBusObject_SetProperty_Call) RunAndReturn(run func(string, any) error) *MockBusObject_SetProperty_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // StoreProperty provides a mock function with given fields: p, value
-func (_m *MockBusObject) StoreProperty(p string, value interface{}) error {
+func (_m *MockBusObject) StoreProperty(p string, value any) error {
 	ret := _m.Called(p, value)
 
 	if len(ret) == 0 {
@@ -596,7 +596,7 @@ func (_m *MockBusObject) StoreProperty(p string, value interface{}) error {
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, interface{}) error); ok {
+	if rf, ok := ret.Get(0).(func(string, any) error); ok {
 		r0 = rf(p, value)
 	} else {
 		r0 = ret.Error(0)
@@ -612,14 +612,14 @@ type MockBusObject_StoreProperty_Call struct {
 
 // StoreProperty is a helper method to define mock.On call
 //   - p string
-//   - value interface{}
-func (_e *MockBusObject_Expecter) StoreProperty(p interface{}, value interface{}) *MockBusObject_StoreProperty_Call {
+//   - value any
+func (_e *MockBusObject_Expecter) StoreProperty(p any, value any) *MockBusObject_StoreProperty_Call {
 	return &MockBusObject_StoreProperty_Call{Call: _e.mock.On("StoreProperty", p, value)}
 }
 
-func (_c *MockBusObject_StoreProperty_Call) Run(run func(p string, value interface{})) *MockBusObject_StoreProperty_Call {
+func (_c *MockBusObject_StoreProperty_Call) Run(run func(p string, value any)) *MockBusObject_StoreProperty_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(interface{}))
+		run(args[0].(string), args[1].(any))
 	})
 	return _c
 }
@@ -629,7 +629,7 @@ func (_c *MockBusObject_StoreProperty_Call) Return(_a0 error) *MockBusObject_Sto
 	return _c
 }
 
-func (_c *MockBusObject_StoreProperty_Call) RunAndReturn(run func(string, interface{}) error) *MockBusObject_StoreProperty_Call {
+func (_c *MockBusObject_StoreProperty_Call) RunAndReturn(run func(string, any) error) *MockBusObject_StoreProperty_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/internal/mocks/internal/plugins/mock_GitClient.go
+++ b/core/internal/mocks/internal/plugins/mock_GitClient.go
@@ -52,7 +52,7 @@ type MockGitClient_HasUpdates_Call struct {
 
 // HasUpdates is a helper method to define mock.On call
 //   - path string
-func (_e *MockGitClient_Expecter) HasUpdates(path interface{}) *MockGitClient_HasUpdates_Call {
+func (_e *MockGitClient_Expecter) HasUpdates(path any) *MockGitClient_HasUpdates_Call {
 	return &MockGitClient_HasUpdates_Call{Call: _e.mock.On("HasUpdates", path)}
 }
 
@@ -99,7 +99,7 @@ type MockGitClient_PlainClone_Call struct {
 // PlainClone is a helper method to define mock.On call
 //   - path string
 //   - url string
-func (_e *MockGitClient_Expecter) PlainClone(path interface{}, url interface{}) *MockGitClient_PlainClone_Call {
+func (_e *MockGitClient_Expecter) PlainClone(path any, url any) *MockGitClient_PlainClone_Call {
 	return &MockGitClient_PlainClone_Call{Call: _e.mock.On("PlainClone", path, url)}
 }
 
@@ -145,7 +145,7 @@ type MockGitClient_Pull_Call struct {
 
 // Pull is a helper method to define mock.On call
 //   - path string
-func (_e *MockGitClient_Expecter) Pull(path interface{}) *MockGitClient_Pull_Call {
+func (_e *MockGitClient_Expecter) Pull(path any) *MockGitClient_Pull_Call {
 	return &MockGitClient_Pull_Call{Call: _e.mock.On("Pull", path)}
 }
 

--- a/core/internal/mocks/net/mock_Conn.go
+++ b/core/internal/mocks/net/mock_Conn.go
@@ -150,7 +150,7 @@ type MockConn_Read_Call struct {
 
 // Read is a helper method to define mock.On call
 //   - b []byte
-func (_e *MockConn_Expecter) Read(b interface{}) *MockConn_Read_Call {
+func (_e *MockConn_Expecter) Read(b any) *MockConn_Read_Call {
 	return &MockConn_Read_Call{Call: _e.mock.On("Read", b)}
 }
 
@@ -243,7 +243,7 @@ type MockConn_SetDeadline_Call struct {
 
 // SetDeadline is a helper method to define mock.On call
 //   - t time.Time
-func (_e *MockConn_Expecter) SetDeadline(t interface{}) *MockConn_SetDeadline_Call {
+func (_e *MockConn_Expecter) SetDeadline(t any) *MockConn_SetDeadline_Call {
 	return &MockConn_SetDeadline_Call{Call: _e.mock.On("SetDeadline", t)}
 }
 
@@ -289,7 +289,7 @@ type MockConn_SetReadDeadline_Call struct {
 
 // SetReadDeadline is a helper method to define mock.On call
 //   - t time.Time
-func (_e *MockConn_Expecter) SetReadDeadline(t interface{}) *MockConn_SetReadDeadline_Call {
+func (_e *MockConn_Expecter) SetReadDeadline(t any) *MockConn_SetReadDeadline_Call {
 	return &MockConn_SetReadDeadline_Call{Call: _e.mock.On("SetReadDeadline", t)}
 }
 
@@ -335,7 +335,7 @@ type MockConn_SetWriteDeadline_Call struct {
 
 // SetWriteDeadline is a helper method to define mock.On call
 //   - t time.Time
-func (_e *MockConn_Expecter) SetWriteDeadline(t interface{}) *MockConn_SetWriteDeadline_Call {
+func (_e *MockConn_Expecter) SetWriteDeadline(t any) *MockConn_SetWriteDeadline_Call {
 	return &MockConn_SetWriteDeadline_Call{Call: _e.mock.On("SetWriteDeadline", t)}
 }
 
@@ -391,7 +391,7 @@ type MockConn_Write_Call struct {
 
 // Write is a helper method to define mock.On call
 //   - b []byte
-func (_e *MockConn_Expecter) Write(b interface{}) *MockConn_Write_Call {
+func (_e *MockConn_Expecter) Write(b any) *MockConn_Write_Call {
 	return &MockConn_Write_Call{Call: _e.mock.On("Write", b)}
 }
 

--- a/core/internal/mocks/network/mock_Backend.go
+++ b/core/internal/mocks/network/mock_Backend.go
@@ -45,7 +45,7 @@ type MockBackend_ActivateWiredConnection_Call struct {
 
 // ActivateWiredConnection is a helper method to define mock.On call
 //   - uuid string
-func (_e *MockBackend_Expecter) ActivateWiredConnection(uuid interface{}) *MockBackend_ActivateWiredConnection_Call {
+func (_e *MockBackend_Expecter) ActivateWiredConnection(uuid any) *MockBackend_ActivateWiredConnection_Call {
 	return &MockBackend_ActivateWiredConnection_Call{Call: _e.mock.On("ActivateWiredConnection", uuid)}
 }
 
@@ -91,7 +91,7 @@ type MockBackend_CancelCredentials_Call struct {
 
 // CancelCredentials is a helper method to define mock.On call
 //   - token string
-func (_e *MockBackend_Expecter) CancelCredentials(token interface{}) *MockBackend_CancelCredentials_Call {
+func (_e *MockBackend_Expecter) CancelCredentials(token any) *MockBackend_CancelCredentials_Call {
 	return &MockBackend_CancelCredentials_Call{Call: _e.mock.On("CancelCredentials", token)}
 }
 
@@ -137,7 +137,7 @@ type MockBackend_ClearVPNCredentials_Call struct {
 
 // ClearVPNCredentials is a helper method to define mock.On call
 //   - uuidOrName string
-func (_e *MockBackend_Expecter) ClearVPNCredentials(uuidOrName interface{}) *MockBackend_ClearVPNCredentials_Call {
+func (_e *MockBackend_Expecter) ClearVPNCredentials(uuidOrName any) *MockBackend_ClearVPNCredentials_Call {
 	return &MockBackend_ClearVPNCredentials_Call{Call: _e.mock.On("ClearVPNCredentials", uuidOrName)}
 }
 
@@ -261,7 +261,7 @@ type MockBackend_ConnectVPN_Call struct {
 // ConnectVPN is a helper method to define mock.On call
 //   - uuidOrName string
 //   - singleActive bool
-func (_e *MockBackend_Expecter) ConnectVPN(uuidOrName interface{}, singleActive interface{}) *MockBackend_ConnectVPN_Call {
+func (_e *MockBackend_Expecter) ConnectVPN(uuidOrName any, singleActive any) *MockBackend_ConnectVPN_Call {
 	return &MockBackend_ConnectVPN_Call{Call: _e.mock.On("ConnectVPN", uuidOrName, singleActive)}
 }
 
@@ -307,7 +307,7 @@ type MockBackend_ConnectWiFi_Call struct {
 
 // ConnectWiFi is a helper method to define mock.On call
 //   - req network.ConnectionRequest
-func (_e *MockBackend_Expecter) ConnectWiFi(req interface{}) *MockBackend_ConnectWiFi_Call {
+func (_e *MockBackend_Expecter) ConnectWiFi(req any) *MockBackend_ConnectWiFi_Call {
 	return &MockBackend_ConnectWiFi_Call{Call: _e.mock.On("ConnectWiFi", req)}
 }
 
@@ -353,7 +353,7 @@ type MockBackend_DeleteVPN_Call struct {
 
 // DeleteVPN is a helper method to define mock.On call
 //   - uuidOrName string
-func (_e *MockBackend_Expecter) DeleteVPN(uuidOrName interface{}) *MockBackend_DeleteVPN_Call {
+func (_e *MockBackend_Expecter) DeleteVPN(uuidOrName any) *MockBackend_DeleteVPN_Call {
 	return &MockBackend_DeleteVPN_Call{Call: _e.mock.On("DeleteVPN", uuidOrName)}
 }
 
@@ -489,7 +489,7 @@ type MockBackend_DisconnectEthernetDevice_Call struct {
 
 // DisconnectEthernetDevice is a helper method to define mock.On call
 //   - device string
-func (_e *MockBackend_Expecter) DisconnectEthernetDevice(device interface{}) *MockBackend_DisconnectEthernetDevice_Call {
+func (_e *MockBackend_Expecter) DisconnectEthernetDevice(device any) *MockBackend_DisconnectEthernetDevice_Call {
 	return &MockBackend_DisconnectEthernetDevice_Call{Call: _e.mock.On("DisconnectEthernetDevice", device)}
 }
 
@@ -535,7 +535,7 @@ type MockBackend_DisconnectVPN_Call struct {
 
 // DisconnectVPN is a helper method to define mock.On call
 //   - uuidOrName string
-func (_e *MockBackend_Expecter) DisconnectVPN(uuidOrName interface{}) *MockBackend_DisconnectVPN_Call {
+func (_e *MockBackend_Expecter) DisconnectVPN(uuidOrName any) *MockBackend_DisconnectVPN_Call {
 	return &MockBackend_DisconnectVPN_Call{Call: _e.mock.On("DisconnectVPN", uuidOrName)}
 }
 
@@ -626,7 +626,7 @@ type MockBackend_DisconnectWiFiDevice_Call struct {
 
 // DisconnectWiFiDevice is a helper method to define mock.On call
 //   - device string
-func (_e *MockBackend_Expecter) DisconnectWiFiDevice(device interface{}) *MockBackend_DisconnectWiFiDevice_Call {
+func (_e *MockBackend_Expecter) DisconnectWiFiDevice(device any) *MockBackend_DisconnectWiFiDevice_Call {
 	return &MockBackend_DisconnectWiFiDevice_Call{Call: _e.mock.On("DisconnectWiFiDevice", device)}
 }
 
@@ -672,7 +672,7 @@ type MockBackend_ForgetWiFiNetwork_Call struct {
 
 // ForgetWiFiNetwork is a helper method to define mock.On call
 //   - ssid string
-func (_e *MockBackend_Expecter) ForgetWiFiNetwork(ssid interface{}) *MockBackend_ForgetWiFiNetwork_Call {
+func (_e *MockBackend_Expecter) ForgetWiFiNetwork(ssid any) *MockBackend_ForgetWiFiNetwork_Call {
 	return &MockBackend_ForgetWiFiNetwork_Call{Call: _e.mock.On("ForgetWiFiNetwork", ssid)}
 }
 
@@ -881,7 +881,7 @@ type MockBackend_GetVPNConfig_Call struct {
 
 // GetVPNConfig is a helper method to define mock.On call
 //   - uuidOrName string
-func (_e *MockBackend_Expecter) GetVPNConfig(uuidOrName interface{}) *MockBackend_GetVPNConfig_Call {
+func (_e *MockBackend_Expecter) GetVPNConfig(uuidOrName any) *MockBackend_GetVPNConfig_Call {
 	return &MockBackend_GetVPNConfig_Call{Call: _e.mock.On("GetVPNConfig", uuidOrName)}
 }
 
@@ -1041,7 +1041,7 @@ type MockBackend_GetWiFiNetworkDetails_Call struct {
 
 // GetWiFiNetworkDetails is a helper method to define mock.On call
 //   - ssid string
-func (_e *MockBackend_Expecter) GetWiFiNetworkDetails(ssid interface{}) *MockBackend_GetWiFiNetworkDetails_Call {
+func (_e *MockBackend_Expecter) GetWiFiNetworkDetails(ssid any) *MockBackend_GetWiFiNetworkDetails_Call {
 	return &MockBackend_GetWiFiNetworkDetails_Call{Call: _e.mock.On("GetWiFiNetworkDetails", ssid)}
 }
 
@@ -1156,7 +1156,7 @@ type MockBackend_GetWiredNetworkDetails_Call struct {
 
 // GetWiredNetworkDetails is a helper method to define mock.On call
 //   - uuid string
-func (_e *MockBackend_Expecter) GetWiredNetworkDetails(uuid interface{}) *MockBackend_GetWiredNetworkDetails_Call {
+func (_e *MockBackend_Expecter) GetWiredNetworkDetails(uuid any) *MockBackend_GetWiredNetworkDetails_Call {
 	return &MockBackend_GetWiredNetworkDetails_Call{Call: _e.mock.On("GetWiredNetworkDetails", uuid)}
 }
 
@@ -1215,7 +1215,7 @@ type MockBackend_ImportVPN_Call struct {
 // ImportVPN is a helper method to define mock.On call
 //   - filePath string
 //   - name string
-func (_e *MockBackend_Expecter) ImportVPN(filePath interface{}, name interface{}) *MockBackend_ImportVPN_Call {
+func (_e *MockBackend_Expecter) ImportVPN(filePath any, name any) *MockBackend_ImportVPN_Call {
 	return &MockBackend_ImportVPN_Call{Call: _e.mock.On("ImportVPN", filePath, name)}
 }
 
@@ -1522,7 +1522,7 @@ type MockBackend_ScanWiFiDevice_Call struct {
 
 // ScanWiFiDevice is a helper method to define mock.On call
 //   - device string
-func (_e *MockBackend_Expecter) ScanWiFiDevice(device interface{}) *MockBackend_ScanWiFiDevice_Call {
+func (_e *MockBackend_Expecter) ScanWiFiDevice(device any) *MockBackend_ScanWiFiDevice_Call {
 	return &MockBackend_ScanWiFiDevice_Call{Call: _e.mock.On("ScanWiFiDevice", device)}
 }
 
@@ -1568,7 +1568,7 @@ type MockBackend_SetPromptBroker_Call struct {
 
 // SetPromptBroker is a helper method to define mock.On call
 //   - broker network.PromptBroker
-func (_e *MockBackend_Expecter) SetPromptBroker(broker interface{}) *MockBackend_SetPromptBroker_Call {
+func (_e *MockBackend_Expecter) SetPromptBroker(broker any) *MockBackend_SetPromptBroker_Call {
 	return &MockBackend_SetPromptBroker_Call{Call: _e.mock.On("SetPromptBroker", broker)}
 }
 
@@ -1617,7 +1617,7 @@ type MockBackend_SetVPNCredentials_Call struct {
 //   - username string
 //   - password string
 //   - save bool
-func (_e *MockBackend_Expecter) SetVPNCredentials(uuid interface{}, username interface{}, password interface{}, save interface{}) *MockBackend_SetVPNCredentials_Call {
+func (_e *MockBackend_Expecter) SetVPNCredentials(uuid any, username any, password any, save any) *MockBackend_SetVPNCredentials_Call {
 	return &MockBackend_SetVPNCredentials_Call{Call: _e.mock.On("SetVPNCredentials", uuid, username, password, save)}
 }
 
@@ -1664,7 +1664,7 @@ type MockBackend_SetWiFiAutoconnect_Call struct {
 // SetWiFiAutoconnect is a helper method to define mock.On call
 //   - ssid string
 //   - autoconnect bool
-func (_e *MockBackend_Expecter) SetWiFiAutoconnect(ssid interface{}, autoconnect interface{}) *MockBackend_SetWiFiAutoconnect_Call {
+func (_e *MockBackend_Expecter) SetWiFiAutoconnect(ssid any, autoconnect any) *MockBackend_SetWiFiAutoconnect_Call {
 	return &MockBackend_SetWiFiAutoconnect_Call{Call: _e.mock.On("SetWiFiAutoconnect", ssid, autoconnect)}
 }
 
@@ -1710,7 +1710,7 @@ type MockBackend_SetWiFiEnabled_Call struct {
 
 // SetWiFiEnabled is a helper method to define mock.On call
 //   - enabled bool
-func (_e *MockBackend_Expecter) SetWiFiEnabled(enabled interface{}) *MockBackend_SetWiFiEnabled_Call {
+func (_e *MockBackend_Expecter) SetWiFiEnabled(enabled any) *MockBackend_SetWiFiEnabled_Call {
 	return &MockBackend_SetWiFiEnabled_Call{Call: _e.mock.On("SetWiFiEnabled", enabled)}
 }
 
@@ -1756,7 +1756,7 @@ type MockBackend_StartMonitoring_Call struct {
 
 // StartMonitoring is a helper method to define mock.On call
 //   - onStateChange func()
-func (_e *MockBackend_Expecter) StartMonitoring(onStateChange interface{}) *MockBackend_StartMonitoring_Call {
+func (_e *MockBackend_Expecter) StartMonitoring(onStateChange any) *MockBackend_StartMonitoring_Call {
 	return &MockBackend_StartMonitoring_Call{Call: _e.mock.On("StartMonitoring", onStateChange)}
 }
 
@@ -1836,7 +1836,7 @@ type MockBackend_SubmitCredentials_Call struct {
 //   - token string
 //   - secrets map[string]string
 //   - save bool
-func (_e *MockBackend_Expecter) SubmitCredentials(token interface{}, secrets interface{}, save interface{}) *MockBackend_SubmitCredentials_Call {
+func (_e *MockBackend_Expecter) SubmitCredentials(token any, secrets any, save any) *MockBackend_SubmitCredentials_Call {
 	return &MockBackend_SubmitCredentials_Call{Call: _e.mock.On("SubmitCredentials", token, secrets, save)}
 }
 
@@ -1858,7 +1858,7 @@ func (_c *MockBackend_SubmitCredentials_Call) RunAndReturn(run func(string, map[
 }
 
 // UpdateVPNConfig provides a mock function with given fields: uuid, updates
-func (_m *MockBackend) UpdateVPNConfig(uuid string, updates map[string]interface{}) error {
+func (_m *MockBackend) UpdateVPNConfig(uuid string, updates map[string]any) error {
 	ret := _m.Called(uuid, updates)
 
 	if len(ret) == 0 {
@@ -1866,7 +1866,7 @@ func (_m *MockBackend) UpdateVPNConfig(uuid string, updates map[string]interface
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, map[string]interface{}) error); ok {
+	if rf, ok := ret.Get(0).(func(string, map[string]any) error); ok {
 		r0 = rf(uuid, updates)
 	} else {
 		r0 = ret.Error(0)
@@ -1882,14 +1882,14 @@ type MockBackend_UpdateVPNConfig_Call struct {
 
 // UpdateVPNConfig is a helper method to define mock.On call
 //   - uuid string
-//   - updates map[string]interface{}
-func (_e *MockBackend_Expecter) UpdateVPNConfig(uuid interface{}, updates interface{}) *MockBackend_UpdateVPNConfig_Call {
+//   - updates map[string]any
+func (_e *MockBackend_Expecter) UpdateVPNConfig(uuid any, updates any) *MockBackend_UpdateVPNConfig_Call {
 	return &MockBackend_UpdateVPNConfig_Call{Call: _e.mock.On("UpdateVPNConfig", uuid, updates)}
 }
 
-func (_c *MockBackend_UpdateVPNConfig_Call) Run(run func(uuid string, updates map[string]interface{})) *MockBackend_UpdateVPNConfig_Call {
+func (_c *MockBackend_UpdateVPNConfig_Call) Run(run func(uuid string, updates map[string]any)) *MockBackend_UpdateVPNConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(map[string]interface{}))
+		run(args[0].(string), args[1].(map[string]any))
 	})
 	return _c
 }
@@ -1899,7 +1899,7 @@ func (_c *MockBackend_UpdateVPNConfig_Call) Return(_a0 error) *MockBackend_Updat
 	return _c
 }
 
-func (_c *MockBackend_UpdateVPNConfig_Call) RunAndReturn(run func(string, map[string]interface{}) error) *MockBackend_UpdateVPNConfig_Call {
+func (_c *MockBackend_UpdateVPNConfig_Call) RunAndReturn(run func(string, map[string]any) error) *MockBackend_UpdateVPNConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/internal/mocks/version/mock_VersionFetcher.go
+++ b/core/internal/mocks/version/mock_VersionFetcher.go
@@ -52,7 +52,7 @@ type MockVersionFetcher_GetCurrentVersion_Call struct {
 
 // GetCurrentVersion is a helper method to define mock.On call
 //   - dmsPath string
-func (_e *MockVersionFetcher_Expecter) GetCurrentVersion(dmsPath interface{}) *MockVersionFetcher_GetCurrentVersion_Call {
+func (_e *MockVersionFetcher_Expecter) GetCurrentVersion(dmsPath any) *MockVersionFetcher_GetCurrentVersion_Call {
 	return &MockVersionFetcher_GetCurrentVersion_Call{Call: _e.mock.On("GetCurrentVersion", dmsPath)}
 }
 
@@ -108,7 +108,7 @@ type MockVersionFetcher_GetLatestVersion_Call struct {
 
 // GetLatestVersion is a helper method to define mock.On call
 //   - dmsPath string
-func (_e *MockVersionFetcher_Expecter) GetLatestVersion(dmsPath interface{}) *MockVersionFetcher_GetLatestVersion_Call {
+func (_e *MockVersionFetcher_Expecter) GetLatestVersion(dmsPath any) *MockVersionFetcher_GetLatestVersion_Call {
 	return &MockVersionFetcher_GetLatestVersion_Call{Call: _e.mock.On("GetLatestVersion", dmsPath)}
 }
 

--- a/core/internal/server/bluez/handlers.go
+++ b/core/internal/server/bluez/handlers.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Request struct {
-	ID     int                    `json:"id,omitempty"`
-	Method string                 `json:"method"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	ID     int            `json:"id,omitempty"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 type SuccessResult struct {
@@ -190,7 +190,7 @@ func handlePairingSubmit(conn net.Conn, req Request, manager *Manager) {
 		return
 	}
 
-	secretsRaw, ok := req.Params["secrets"].(map[string]interface{})
+	secretsRaw, ok := req.Params["secrets"].(map[string]any)
 	secrets := make(map[string]string)
 	if ok {
 		for k, v := range secretsRaw {

--- a/core/internal/server/brightness/types.go
+++ b/core/internal/server/brightness/types.go
@@ -34,9 +34,9 @@ type DeviceUpdate struct {
 }
 
 type Request struct {
-	ID     interface{}            `json:"id"`
-	Method string                 `json:"method"`
-	Params map[string]interface{} `json:"params"`
+	ID     any            `json:"id"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params"`
 }
 
 type Manager struct {

--- a/core/internal/server/cups/handlers.go
+++ b/core/internal/server/cups/handlers.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Request struct {
-	ID     int                    `json:"id,omitempty"`
-	Method string                 `json:"method"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	ID     int            `json:"id,omitempty"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 type SuccessResult struct {

--- a/core/internal/server/cups/handlers_test.go
+++ b/core/internal/server/cups/handlers_test.go
@@ -75,7 +75,7 @@ func TestHandleGetPrinters_Error(t *testing.T) {
 
 	handleGetPrinters(conn, req, m)
 
-	var resp models.Response[interface{}]
+	var resp models.Response[any]
 	err := json.NewDecoder(buf).Decode(&resp)
 	assert.NoError(t, err)
 	assert.Nil(t, resp.Result)
@@ -103,7 +103,7 @@ func TestHandleGetJobs(t *testing.T) {
 	req := Request{
 		ID:     1,
 		Method: "cups.getJobs",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"printerName": "printer1",
 		},
 	}
@@ -130,12 +130,12 @@ func TestHandleGetJobs_MissingParam(t *testing.T) {
 	req := Request{
 		ID:     1,
 		Method: "cups.getJobs",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	handleGetJobs(conn, req, m)
 
-	var resp models.Response[interface{}]
+	var resp models.Response[any]
 	err := json.NewDecoder(buf).Decode(&resp)
 	assert.NoError(t, err)
 	assert.Nil(t, resp.Result)
@@ -155,7 +155,7 @@ func TestHandlePausePrinter(t *testing.T) {
 	req := Request{
 		ID:     1,
 		Method: "cups.pausePrinter",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"printerName": "printer1",
 		},
 	}
@@ -182,7 +182,7 @@ func TestHandleResumePrinter(t *testing.T) {
 	req := Request{
 		ID:     1,
 		Method: "cups.resumePrinter",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"printerName": "printer1",
 		},
 	}
@@ -209,7 +209,7 @@ func TestHandleCancelJob(t *testing.T) {
 	req := Request{
 		ID:     1,
 		Method: "cups.cancelJob",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"jobID": float64(1),
 		},
 	}
@@ -236,7 +236,7 @@ func TestHandlePurgeJobs(t *testing.T) {
 	req := Request{
 		ID:     1,
 		Method: "cups.purgeJobs",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"printerName": "printer1",
 		},
 	}
@@ -267,7 +267,7 @@ func TestHandleRequest_UnknownMethod(t *testing.T) {
 
 	HandleRequest(conn, req, m)
 
-	var resp models.Response[interface{}]
+	var resp models.Response[any]
 	err := json.NewDecoder(buf).Decode(&resp)
 	assert.NoError(t, err)
 	assert.Nil(t, resp.Result)

--- a/core/internal/server/cups/subscription.go
+++ b/core/internal/server/cups/subscription.go
@@ -62,7 +62,7 @@ func (sm *SubscriptionManager) createSubscription() (int, error) {
 	req.OperationAttributes[ipp.AttributeRequestingUserName] = "dms"
 
 	// Subscription attributes go in SubscriptionAttributes (subscription-attributes-tag in IPP)
-	req.SubscriptionAttributes = map[string]interface{}{
+	req.SubscriptionAttributes = map[string]any{
 		"notify-events": []string{
 			"printer-state-changed",
 			"printer-added",

--- a/core/internal/server/cups/subscription_dbus.go
+++ b/core/internal/server/cups/subscription_dbus.go
@@ -83,7 +83,7 @@ func (sm *DBusSubscriptionManager) createDBusSubscription() (int, error) {
 	req.OperationAttributes[ipp.AttributePrinterURI] = fmt.Sprintf("%s/", sm.baseURL)
 	req.OperationAttributes[ipp.AttributeRequestingUserName] = "dms"
 
-	req.SubscriptionAttributes = map[string]interface{}{
+	req.SubscriptionAttributes = map[string]any{
 		"notify-events": []string{
 			"printer-state-changed",
 			"printer-added",

--- a/core/internal/server/dwl/handlers.go
+++ b/core/internal/server/dwl/handlers.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Request struct {
-	ID     int                    `json:"id,omitempty"`
-	Method string                 `json:"method"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	ID     int            `json:"id,omitempty"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 type SuccessResult struct {

--- a/core/internal/server/dwl/types.go
+++ b/core/internal/server/dwl/types.go
@@ -41,7 +41,7 @@ type Manager struct {
 	display  *wlclient.Display
 	ctx      *wlclient.Context
 	registry *wlclient.Registry
-	manager  interface{}
+	manager  any
 
 	outputs syncmap.Map[uint32, *outputState]
 
@@ -67,7 +67,7 @@ type outputState struct {
 	id           uint32
 	registryName uint32
 	output       *wlclient.Output
-	ipcOutput    interface{}
+	ipcOutput    any
 	name         string
 	active       uint32
 	tags         []TagState

--- a/core/internal/server/evdev/handlers.go
+++ b/core/internal/server/evdev/handlers.go
@@ -7,9 +7,9 @@ import (
 )
 
 type Request struct {
-	ID     interface{}            `json:"id"`
-	Method string                 `json:"method"`
-	Params map[string]interface{} `json:"params"`
+	ID     any            `json:"id"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params"`
 }
 
 func HandleRequest(conn net.Conn, req Request, m *Manager) {

--- a/core/internal/server/evdev/handlers_test.go
+++ b/core/internal/server/evdev/handlers_test.go
@@ -56,7 +56,7 @@ func TestHandleRequest(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "evdev.getState",
-			Params: map[string]interface{}{},
+			Params: map[string]any{},
 		}
 
 		HandleRequest(conn, req, m)
@@ -85,7 +85,7 @@ func TestHandleRequest(t *testing.T) {
 		req := Request{
 			ID:     456,
 			Method: "evdev.unknownMethod",
-			Params: map[string]interface{}{},
+			Params: map[string]any{},
 		}
 
 		HandleRequest(conn, req, m)
@@ -114,7 +114,7 @@ func TestHandleGetState(t *testing.T) {
 	req := Request{
 		ID:     789,
 		Method: "evdev.getState",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	handleGetState(conn, req, m)

--- a/core/internal/server/extworkspace/handlers.go
+++ b/core/internal/server/extworkspace/handlers.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Request struct {
-	ID     int                    `json:"id,omitempty"`
-	Method string                 `json:"method"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	ID     int            `json:"id,omitempty"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 type SuccessResult struct {

--- a/core/internal/server/freedesktop/handlers.go
+++ b/core/internal/server/freedesktop/handlers.go
@@ -8,9 +8,9 @@ import (
 )
 
 type Request struct {
-	ID     int                    `json:"id,omitempty"`
-	Method string                 `json:"method"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	ID     int            `json:"id,omitempty"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 type SuccessResult struct {

--- a/core/internal/server/freedesktop/handlers_test.go
+++ b/core/internal/server/freedesktop/handlers_test.go
@@ -56,7 +56,7 @@ func mockGetAllAccountsProperties() *dbus.Call {
 		"Locked":        dbus.MakeVariant(false),
 		"PasswordMode":  dbus.MakeVariant(int32(1)),
 	}
-	return &dbus.Call{Err: nil, Body: []interface{}{props}}
+	return &dbus.Call{Err: nil, Body: []any{props}}
 }
 
 func TestRespondError_Freedesktop(t *testing.T) {
@@ -134,7 +134,7 @@ func TestHandleSetIconFile(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "freedesktop.accounts.setIconFile",
-			Params: map[string]interface{}{},
+			Params: map[string]any{},
 		}
 
 		handleSetIconFile(conn, req, manager)
@@ -167,7 +167,7 @@ func TestHandleSetIconFile(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "freedesktop.accounts.setIconFile",
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"path": "/path/to/icon.png",
 			},
 		}
@@ -199,7 +199,7 @@ func TestHandleSetIconFile(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "freedesktop.accounts.setIconFile",
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"path": "/path/to/icon.png",
 			},
 		}
@@ -226,7 +226,7 @@ func TestHandleSetRealName(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "freedesktop.accounts.setRealName",
-			Params: map[string]interface{}{},
+			Params: map[string]any{},
 		}
 
 		handleSetRealName(conn, req, manager)
@@ -259,7 +259,7 @@ func TestHandleSetRealName(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "freedesktop.accounts.setRealName",
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"name": "New Name",
 			},
 		}
@@ -289,7 +289,7 @@ func TestHandleSetEmail(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "freedesktop.accounts.setEmail",
-			Params: map[string]interface{}{},
+			Params: map[string]any{},
 		}
 
 		handleSetEmail(conn, req, manager)
@@ -322,7 +322,7 @@ func TestHandleSetEmail(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "freedesktop.accounts.setEmail",
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"email": "test@example.com",
 			},
 		}
@@ -352,7 +352,7 @@ func TestHandleSetLanguage(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "freedesktop.accounts.setLanguage",
-			Params: map[string]interface{}{},
+			Params: map[string]any{},
 		}
 
 		handleSetLanguage(conn, req, manager)
@@ -377,7 +377,7 @@ func TestHandleSetLocation(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "freedesktop.accounts.setLocation",
-			Params: map[string]interface{}{},
+			Params: map[string]any{},
 		}
 
 		handleSetLocation(conn, req, manager)
@@ -402,7 +402,7 @@ func TestHandleGetUserIconFile(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "freedesktop.accounts.getUserIconFile",
-			Params: map[string]interface{}{},
+			Params: map[string]any{},
 		}
 
 		handleGetUserIconFile(conn, req, manager)
@@ -429,7 +429,7 @@ func TestHandleGetUserIconFile(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "freedesktop.accounts.getUserIconFile",
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"username": "testuser",
 			},
 		}
@@ -473,7 +473,7 @@ func TestHandleGetColorScheme(t *testing.T) {
 		mockSettingsObj := mockdbus.NewMockBusObject(t)
 		mockCall := &dbus.Call{
 			Err:  nil,
-			Body: []interface{}{dbus.MakeVariant(uint32(1))},
+			Body: []any{dbus.MakeVariant(uint32(1))},
 		}
 		mockSettingsObj.EXPECT().Call("org.freedesktop.portal.Settings.ReadOne", dbus.Flags(0), "org.freedesktop.appearance", "color-scheme").Return(mockCall)
 
@@ -564,7 +564,7 @@ func TestHandleRequest(t *testing.T) {
 			req := Request{
 				ID:     123,
 				Method: method,
-				Params: map[string]interface{}{},
+				Params: map[string]any{},
 			}
 
 			HandleRequest(conn, req, manager)

--- a/core/internal/server/loginctl/handlers.go
+++ b/core/internal/server/loginctl/handlers.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Request struct {
-	ID     int                    `json:"id,omitempty"`
-	Method string                 `json:"method"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	ID     int            `json:"id,omitempty"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 type SuccessResult struct {

--- a/core/internal/server/loginctl/handlers_test.go
+++ b/core/internal/server/loginctl/handlers_test.go
@@ -266,7 +266,7 @@ func TestHandleSetIdleHint(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "loginctl.setIdleHint",
-			Params: map[string]interface{}{},
+			Params: map[string]any{},
 		}
 
 		handleSetIdleHint(conn, req, manager)
@@ -294,7 +294,7 @@ func TestHandleSetIdleHint(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "loginctl.setIdleHint",
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"idle": true,
 			},
 		}
@@ -327,7 +327,7 @@ func TestHandleSetIdleHint(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "loginctl.setIdleHint",
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"idle": false,
 			},
 		}

--- a/core/internal/server/loginctl/manager.go
+++ b/core/internal/server/loginctl/manager.go
@@ -164,7 +164,7 @@ func (m *Manager) updateSessionState() error {
 		}
 	}
 	if v, ok := props["User"]; ok {
-		if userArr, ok := v.Value().([]interface{}); ok && len(userArr) >= 1 {
+		if userArr, ok := v.Value().([]any); ok && len(userArr) >= 1 {
 			if uid, ok := userArr[0].(uint32); ok {
 				m.state.User = uid
 			}
@@ -201,7 +201,7 @@ func (m *Manager) updateSessionState() error {
 		}
 	}
 	if v, ok := props["Seat"]; ok {
-		if seatArr, ok := v.Value().([]interface{}); ok && len(seatArr) >= 1 {
+		if seatArr, ok := v.Value().([]any); ok && len(seatArr) >= 1 {
 			if seatID, ok := seatArr[0].(string); ok {
 				m.state.Seat = seatID
 			}

--- a/core/internal/server/loginctl/monitor_test.go
+++ b/core/internal/server/loginctl/monitor_test.go
@@ -64,7 +64,7 @@ func TestManager_HandleDBusSignal_PrepareForSleep(t *testing.T) {
 
 		sig := &dbus.Signal{
 			Name: "org.freedesktop.login1.Manager.PrepareForSleep",
-			Body: []interface{}{true},
+			Body: []any{true},
 		}
 
 		manager.handleDBusSignal(sig)
@@ -85,7 +85,7 @@ func TestManager_HandleDBusSignal_PrepareForSleep(t *testing.T) {
 
 		sig := &dbus.Signal{
 			Name: "org.freedesktop.login1.Manager.PrepareForSleep",
-			Body: []interface{}{false},
+			Body: []any{false},
 		}
 
 		manager.handleDBusSignal(sig)
@@ -106,7 +106,7 @@ func TestManager_HandleDBusSignal_PrepareForSleep(t *testing.T) {
 
 		sig := &dbus.Signal{
 			Name: "org.freedesktop.login1.Manager.PrepareForSleep",
-			Body: []interface{}{},
+			Body: []any{},
 		}
 
 		manager.handleDBusSignal(sig)
@@ -129,7 +129,7 @@ func TestManager_HandlePropertiesChanged(t *testing.T) {
 
 		sig := &dbus.Signal{
 			Name: "org.freedesktop.DBus.Properties.PropertiesChanged",
-			Body: []interface{}{
+			Body: []any{
 				"org.freedesktop.login1.Session",
 				map[string]dbus.Variant{
 					"Active": dbus.MakeVariant(true),
@@ -155,7 +155,7 @@ func TestManager_HandlePropertiesChanged(t *testing.T) {
 
 		sig := &dbus.Signal{
 			Name: "org.freedesktop.DBus.Properties.PropertiesChanged",
-			Body: []interface{}{
+			Body: []any{
 				"org.freedesktop.login1.Session",
 				map[string]dbus.Variant{
 					"IdleHint": dbus.MakeVariant(true),
@@ -181,7 +181,7 @@ func TestManager_HandlePropertiesChanged(t *testing.T) {
 
 		sig := &dbus.Signal{
 			Name: "org.freedesktop.DBus.Properties.PropertiesChanged",
-			Body: []interface{}{
+			Body: []any{
 				"org.freedesktop.login1.Session",
 				map[string]dbus.Variant{
 					"IdleSinceHint": dbus.MakeVariant(uint64(123456789)),
@@ -208,7 +208,7 @@ func TestManager_HandlePropertiesChanged(t *testing.T) {
 
 		sig := &dbus.Signal{
 			Name: "org.freedesktop.DBus.Properties.PropertiesChanged",
-			Body: []interface{}{
+			Body: []any{
 				"org.freedesktop.login1.Session",
 				map[string]dbus.Variant{
 					"LockedHint": dbus.MakeVariant(true),
@@ -235,7 +235,7 @@ func TestManager_HandlePropertiesChanged(t *testing.T) {
 
 		sig := &dbus.Signal{
 			Name: "org.freedesktop.DBus.Properties.PropertiesChanged",
-			Body: []interface{}{
+			Body: []any{
 				"org.freedesktop.SomeOtherInterface",
 				map[string]dbus.Variant{
 					"Active": dbus.MakeVariant(true),
@@ -259,7 +259,7 @@ func TestManager_HandlePropertiesChanged(t *testing.T) {
 
 		sig := &dbus.Signal{
 			Name: "org.freedesktop.DBus.Properties.PropertiesChanged",
-			Body: []interface{}{},
+			Body: []any{},
 		}
 
 		assert.NotPanics(t, func() {
@@ -279,7 +279,7 @@ func TestManager_HandlePropertiesChanged(t *testing.T) {
 
 		sig := &dbus.Signal{
 			Name: "org.freedesktop.DBus.Properties.PropertiesChanged",
-			Body: []interface{}{
+			Body: []any{
 				"org.freedesktop.login1.Session",
 				map[string]dbus.Variant{
 					"Active":   dbus.MakeVariant(true),

--- a/core/internal/server/models/types.go
+++ b/core/internal/server/models/types.go
@@ -8,9 +8,9 @@ import (
 )
 
 type Request struct {
-	ID     int                    `json:"id,omitempty"`
-	Method string                 `json:"method"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	ID     int            `json:"id,omitempty"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 type Response[T any] struct {

--- a/core/internal/server/network/backend.go
+++ b/core/internal/server/network/backend.go
@@ -35,7 +35,7 @@ type Backend interface {
 	ListVPNPlugins() ([]VPNPlugin, error)
 	ImportVPN(filePath string, name string) (*VPNImportResult, error)
 	GetVPNConfig(uuidOrName string) (*VPNConfig, error)
-	UpdateVPNConfig(uuid string, updates map[string]interface{}) error
+	UpdateVPNConfig(uuid string, updates map[string]any) error
 	SetVPNCredentials(uuid string, username string, password string, save bool) error
 	DeleteVPN(uuidOrName string) error
 

--- a/core/internal/server/network/backend_hybrid_iwd_networkd.go
+++ b/core/internal/server/network/backend_hybrid_iwd_networkd.go
@@ -196,7 +196,7 @@ func (b *HybridIwdNetworkdBackend) GetVPNConfig(uuidOrName string) (*VPNConfig, 
 	return nil, fmt.Errorf("VPN not supported in hybrid mode")
 }
 
-func (b *HybridIwdNetworkdBackend) UpdateVPNConfig(uuid string, updates map[string]interface{}) error {
+func (b *HybridIwdNetworkdBackend) UpdateVPNConfig(uuid string, updates map[string]any) error {
 	return fmt.Errorf("VPN not supported in hybrid mode")
 }
 

--- a/core/internal/server/network/backend_iwd_unimplemented.go
+++ b/core/internal/server/network/backend_iwd_unimplemented.go
@@ -66,7 +66,7 @@ func (b *IWDBackend) GetVPNConfig(uuidOrName string) (*VPNConfig, error) {
 	return nil, fmt.Errorf("VPN not supported by iwd backend")
 }
 
-func (b *IWDBackend) UpdateVPNConfig(uuid string, updates map[string]interface{}) error {
+func (b *IWDBackend) UpdateVPNConfig(uuid string, updates map[string]any) error {
 	return fmt.Errorf("VPN not supported by iwd backend")
 }
 

--- a/core/internal/server/network/backend_networkd_unimplemented.go
+++ b/core/internal/server/network/backend_networkd_unimplemented.go
@@ -66,7 +66,7 @@ func (b *SystemdNetworkdBackend) GetVPNConfig(uuidOrName string) (*VPNConfig, er
 	return nil, fmt.Errorf("VPN not supported by networkd backend")
 }
 
-func (b *SystemdNetworkdBackend) UpdateVPNConfig(uuid string, updates map[string]interface{}) error {
+func (b *SystemdNetworkdBackend) UpdateVPNConfig(uuid string, updates map[string]any) error {
 	return fmt.Errorf("VPN not supported by networkd backend")
 }
 

--- a/core/internal/server/network/backend_networkmanager.go
+++ b/core/internal/server/network/backend_networkmanager.go
@@ -45,12 +45,12 @@ type ethernetDeviceInfo struct {
 }
 
 type NetworkManagerBackend struct {
-	nmConn          interface{}
-	ethernetDevice  interface{}
+	nmConn          any
+	ethernetDevice  any
 	ethernetDevices map[string]*ethernetDeviceInfo
-	wifiDevice      interface{}
-	settings        interface{}
-	wifiDev         interface{}
+	wifiDevice      any
+	settings        any
+	wifiDev         any
 	wifiDevices     map[string]*wifiDeviceInfo
 
 	dbusConn *dbus.Conn

--- a/core/internal/server/network/backend_networkmanager_ethernet.go
+++ b/core/internal/server/network/backend_networkmanager_ethernet.go
@@ -155,8 +155,8 @@ func (b *NetworkManagerBackend) ConnectEthernet() error {
 		}
 	}
 
-	settings := make(map[string]map[string]interface{})
-	settings["connection"] = map[string]interface{}{
+	settings := make(map[string]map[string]any)
+	settings["connection"] = map[string]any{
 		"id":   "Wired connection",
 		"type": "802-3-ethernet",
 	}

--- a/core/internal/server/network/backend_networkmanager_signals_test.go
+++ b/core/internal/server/network/backend_networkmanager_signals_test.go
@@ -17,7 +17,7 @@ func TestNetworkManagerBackend_HandleDBusSignal_NewConnection(t *testing.T) {
 
 	sig := &dbus.Signal{
 		Name: "org.freedesktop.NetworkManager.Settings.NewConnection",
-		Body: []interface{}{"/org/freedesktop/NetworkManager/Settings/1"},
+		Body: []any{"/org/freedesktop/NetworkManager/Settings/1"},
 	}
 
 	assert.NotPanics(t, func() {
@@ -33,7 +33,7 @@ func TestNetworkManagerBackend_HandleDBusSignal_ConnectionRemoved(t *testing.T) 
 
 	sig := &dbus.Signal{
 		Name: "org.freedesktop.NetworkManager.Settings.ConnectionRemoved",
-		Body: []interface{}{"/org/freedesktop/NetworkManager/Settings/1"},
+		Body: []any{"/org/freedesktop/NetworkManager/Settings/1"},
 	}
 
 	assert.NotPanics(t, func() {
@@ -49,7 +49,7 @@ func TestNetworkManagerBackend_HandleDBusSignal_InvalidBody(t *testing.T) {
 
 	sig := &dbus.Signal{
 		Name: "org.freedesktop.DBus.Properties.PropertiesChanged",
-		Body: []interface{}{"only-one-element"},
+		Body: []any{"only-one-element"},
 	}
 
 	assert.NotPanics(t, func() {
@@ -65,7 +65,7 @@ func TestNetworkManagerBackend_HandleDBusSignal_InvalidInterface(t *testing.T) {
 
 	sig := &dbus.Signal{
 		Name: "org.freedesktop.DBus.Properties.PropertiesChanged",
-		Body: []interface{}{123, map[string]dbus.Variant{}},
+		Body: []any{123, map[string]dbus.Variant{}},
 	}
 
 	assert.NotPanics(t, func() {
@@ -81,7 +81,7 @@ func TestNetworkManagerBackend_HandleDBusSignal_InvalidChanges(t *testing.T) {
 
 	sig := &dbus.Signal{
 		Name: "org.freedesktop.DBus.Properties.PropertiesChanged",
-		Body: []interface{}{dbusNMInterface, "not-a-map"},
+		Body: []any{dbusNMInterface, "not-a-map"},
 	}
 
 	assert.NotPanics(t, func() {
@@ -137,7 +137,7 @@ func TestNetworkManagerBackend_HandleNetworkManagerChange_ActiveConnections(t *t
 	mockNM.EXPECT().GetPropertyPrimaryConnection().Return(nil, nil).Maybe()
 
 	changes := map[string]dbus.Variant{
-		"ActiveConnections": dbus.MakeVariant([]interface{}{}),
+		"ActiveConnections": dbus.MakeVariant([]any{}),
 	}
 
 	assert.NotPanics(t, func() {
@@ -200,7 +200,7 @@ func TestNetworkManagerBackend_HandleWiFiChange_AccessPoints(t *testing.T) {
 	assert.NoError(t, err)
 
 	changes := map[string]dbus.Variant{
-		"AccessPoints": dbus.MakeVariant([]interface{}{}),
+		"AccessPoints": dbus.MakeVariant([]any{}),
 	}
 
 	assert.NotPanics(t, func() {

--- a/core/internal/server/network/backend_networkmanager_state.go
+++ b/core/internal/server/network/backend_networkmanager_state.go
@@ -114,7 +114,7 @@ func (b *NetworkManagerBackend) getDeviceStateReason(dev gonetworkmanager.Device
 		return 0
 	}
 
-	if stateReasonStruct, ok := variant.Value().([]interface{}); ok && len(stateReasonStruct) >= 2 {
+	if stateReasonStruct, ok := variant.Value().([]any); ok && len(stateReasonStruct) >= 2 {
 		if reason, ok := stateReasonStruct[1].(uint32); ok {
 			return reason
 		}

--- a/core/internal/server/network/backend_networkmanager_vpn.go
+++ b/core/internal/server/network/backend_networkmanager_vpn.go
@@ -589,7 +589,7 @@ func (b *NetworkManagerBackend) ClearVPNCredentials(uuidOrName string) error {
 					vpnSettings["password-flags"] = uint32(1)
 				}
 
-				settings["vpn-secrets"] = make(map[string]interface{})
+				settings["vpn-secrets"] = make(map[string]any)
 			}
 
 			if err := conn.Update(settings); err != nil {
@@ -1057,7 +1057,7 @@ func (b *NetworkManagerBackend) GetVPNConfig(uuidOrName string) (*VPNConfig, err
 	return nil, fmt.Errorf("VPN connection not found: %s", uuidOrName)
 }
 
-func (b *NetworkManagerBackend) UpdateVPNConfig(connUUID string, updates map[string]interface{}) error {
+func (b *NetworkManagerBackend) UpdateVPNConfig(connUUID string, updates map[string]any) error {
 	s := b.settings
 	if s == nil {
 		var err error
@@ -1103,7 +1103,7 @@ func (b *NetworkManagerBackend) UpdateVPNConfig(connUUID string, updates map[str
 			connMeta["autoconnect"] = autoconnect
 		}
 
-		if data, ok := updates["data"].(map[string]interface{}); ok {
+		if data, ok := updates["data"].(map[string]any); ok {
 			if vpnSettings, ok := settings["vpn"]; ok {
 				existingData, _ := vpnSettings["data"].(map[string]string)
 				if existingData == nil {
@@ -1185,7 +1185,7 @@ func (b *NetworkManagerBackend) SetVPNCredentials(connUUID string, username stri
 
 		vpnSettings, ok := settings["vpn"]
 		if !ok {
-			vpnSettings = make(map[string]interface{})
+			vpnSettings = make(map[string]any)
 			settings["vpn"] = vpnSettings
 		}
 

--- a/core/internal/server/network/backend_networkmanager_wifi.go
+++ b/core/internal/server/network/backend_networkmanager_wifi.go
@@ -555,19 +555,19 @@ func (b *NetworkManagerBackend) createAndConnectWiFiOnDevice(req ConnectionReque
 			req.SSID, req.Interactive)
 	}
 
-	settings := make(map[string]map[string]interface{})
+	settings := make(map[string]map[string]any)
 
-	settings["connection"] = map[string]interface{}{
+	settings["connection"] = map[string]any{
 		"id":          req.SSID,
 		"type":        "802-11-wireless",
 		"autoconnect": true,
 	}
 
-	settings["ipv4"] = map[string]interface{}{"method": "auto"}
-	settings["ipv6"] = map[string]interface{}{"method": "auto"}
+	settings["ipv4"] = map[string]any{"method": "auto"}
+	settings["ipv6"] = map[string]any{"method": "auto"}
 
 	if secured {
-		settings["802-11-wireless"] = map[string]interface{}{
+		settings["802-11-wireless"] = map[string]any{
 			"ssid":     []byte(req.SSID),
 			"mode":     "infrastructure",
 			"security": "802-11-wireless-security",
@@ -575,7 +575,7 @@ func (b *NetworkManagerBackend) createAndConnectWiFiOnDevice(req ConnectionReque
 
 		switch {
 		case isEnterprise || req.Username != "":
-			settings["802-11-wireless-security"] = map[string]interface{}{
+			settings["802-11-wireless-security"] = map[string]any{
 				"key-mgmt": "wpa-eap",
 			}
 
@@ -594,7 +594,7 @@ func (b *NetworkManagerBackend) createAndConnectWiFiOnDevice(req ConnectionReque
 				useSystemCACerts = *req.UseSystemCACerts
 			}
 
-			x := map[string]interface{}{
+			x := map[string]any{
 				"eap":             []string{eapMethod},
 				"system-ca-certs": useSystemCACerts,
 				"password-flags":  uint32(0),
@@ -634,7 +634,7 @@ func (b *NetworkManagerBackend) createAndConnectWiFiOnDevice(req ConnectionReque
 				eapMethod, phase2Auth, req.Username, req.Interactive, useSystemCACerts, req.DomainSuffixMatch)
 
 		case isPsk:
-			sec := map[string]interface{}{
+			sec := map[string]any{
 				"key-mgmt":  "wpa-psk",
 				"psk-flags": uint32(0),
 			}
@@ -644,7 +644,7 @@ func (b *NetworkManagerBackend) createAndConnectWiFiOnDevice(req ConnectionReque
 			settings["802-11-wireless-security"] = sec
 
 		case isSae:
-			sec := map[string]interface{}{
+			sec := map[string]any{
 				"key-mgmt":  "sae",
 				"pmf":       int32(3),
 				"psk-flags": uint32(0),
@@ -658,7 +658,7 @@ func (b *NetworkManagerBackend) createAndConnectWiFiOnDevice(req ConnectionReque
 			return fmt.Errorf("secured network but not SAE/PSK/802.1X (rsn=0x%x wpa=0x%x)", rsnFlags, wpaFlags)
 		}
 	} else {
-		settings["802-11-wireless"] = map[string]interface{}{
+		settings["802-11-wireless"] = map[string]any{
 			"ssid": []byte(req.SSID),
 			"mode": "infrastructure",
 		}

--- a/core/internal/server/network/handlers.go
+++ b/core/internal/server/network/handlers.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Request struct {
-	ID     int                    `json:"id,omitempty"`
-	Method string                 `json:"method"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	ID     int            `json:"id,omitempty"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 type SuccessResult struct {
@@ -97,7 +97,7 @@ func handleCredentialsSubmit(conn net.Conn, req Request, manager *Manager) {
 		return
 	}
 
-	secretsRaw, ok := req.Params["secrets"].(map[string]interface{})
+	secretsRaw, ok := req.Params["secrets"].(map[string]any)
 	if !ok {
 		log.Warnf("handleCredentialsSubmit: missing or invalid secrets parameter")
 		models.RespondError(conn, req.ID, "missing or invalid 'secrets' parameter")
@@ -603,7 +603,7 @@ func handleUpdateVPNConfig(conn net.Conn, req Request, manager *Manager) {
 		return
 	}
 
-	updates := make(map[string]interface{})
+	updates := make(map[string]any)
 
 	if name, ok := req.Params["name"].(string); ok {
 		updates["name"] = name
@@ -611,7 +611,7 @@ func handleUpdateVPNConfig(conn net.Conn, req Request, manager *Manager) {
 	if autoconnect, ok := req.Params["autoconnect"].(bool); ok {
 		updates["autoconnect"] = autoconnect
 	}
-	if data, ok := req.Params["data"].(map[string]interface{}); ok {
+	if data, ok := req.Params["data"].(map[string]any); ok {
 		updates["data"] = data
 	}
 

--- a/core/internal/server/network/handlers_test.go
+++ b/core/internal/server/network/handlers_test.go
@@ -128,7 +128,7 @@ func TestHandleConnectWiFi(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "network.wifi.connect",
-			Params: map[string]interface{}{},
+			Params: map[string]any{},
 		}
 
 		handleConnectWiFi(conn, req, manager)
@@ -152,7 +152,7 @@ func TestHandleSetPreference(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "network.preference.set",
-			Params: map[string]interface{}{},
+			Params: map[string]any{},
 		}
 
 		handleSetPreference(conn, req, manager)
@@ -176,7 +176,7 @@ func TestHandleGetNetworkInfo(t *testing.T) {
 		req := Request{
 			ID:     123,
 			Method: "network.info",
-			Params: map[string]interface{}{},
+			Params: map[string]any{},
 		}
 
 		handleGetNetworkInfo(conn, req, manager)

--- a/core/internal/server/network/manager.go
+++ b/core/internal/server/network/manager.go
@@ -554,7 +554,7 @@ func (m *Manager) GetVPNConfig(uuidOrName string) (*VPNConfig, error) {
 	return m.backend.GetVPNConfig(uuidOrName)
 }
 
-func (m *Manager) UpdateVPNConfig(uuid string, updates map[string]interface{}) error {
+func (m *Manager) UpdateVPNConfig(uuid string, updates map[string]any) error {
 	return m.backend.UpdateVPNConfig(uuid, updates)
 }
 

--- a/core/internal/server/network/priority.go
+++ b/core/internal/server/network/priority.go
@@ -94,14 +94,14 @@ func (m *Manager) setConnectionMetrics(connType string, metric uint32) error {
 		if connMeta, ok := connSettings["connection"]; ok {
 			if cType, ok := connMeta["type"].(string); ok && cType == connType {
 				if connSettings["ipv4"] == nil {
-					connSettings["ipv4"] = make(map[string]interface{})
+					connSettings["ipv4"] = make(map[string]any)
 				}
 				if ipv4Map := connSettings["ipv4"]; ipv4Map != nil {
 					ipv4Map["route-metric"] = int64(metric)
 				}
 
 				if connSettings["ipv6"] == nil {
-					connSettings["ipv6"] = make(map[string]interface{})
+					connSettings["ipv6"] = make(map[string]any)
 				}
 				if ipv6Map := connSettings["ipv6"]; ipv6Map != nil {
 					ipv6Map["route-metric"] = int64(metric)

--- a/core/internal/server/plugins/handlers_test.go
+++ b/core/internal/server/plugins/handlers_test.go
@@ -17,7 +17,7 @@ func TestHandleList(t *testing.T) {
 	req := models.Request{
 		ID:     123,
 		Method: "plugins.list",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	HandleList(conn, req)
@@ -30,7 +30,7 @@ func TestHandleListInstalled(t *testing.T) {
 	req := models.Request{
 		ID:     123,
 		Method: "plugins.listInstalled",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	HandleListInstalled(conn, req)
@@ -47,7 +47,7 @@ func TestHandleInstallMissingName(t *testing.T) {
 	req := models.Request{
 		ID:     123,
 		Method: "plugins.install",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	HandleInstall(conn, req)
@@ -70,7 +70,7 @@ func TestHandleInstallInvalidName(t *testing.T) {
 	req := models.Request{
 		ID:     123,
 		Method: "plugins.install",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"name": 123,
 		},
 	}
@@ -94,7 +94,7 @@ func TestHandleUninstallMissingName(t *testing.T) {
 	req := models.Request{
 		ID:     123,
 		Method: "plugins.uninstall",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	HandleUninstall(conn, req)
@@ -116,7 +116,7 @@ func TestHandleUpdateMissingName(t *testing.T) {
 	req := models.Request{
 		ID:     123,
 		Method: "plugins.update",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	HandleUpdate(conn, req)
@@ -138,7 +138,7 @@ func TestHandleSearchMissingQuery(t *testing.T) {
 	req := models.Request{
 		ID:     123,
 		Method: "plugins.search",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	HandleSearch(conn, req)

--- a/core/internal/server/server.go
+++ b/core/internal/server/server.go
@@ -46,8 +46,8 @@ type ServerInfo struct {
 }
 
 type ServiceEvent struct {
-	Service string      `json:"service"`
-	Data    interface{} `json:"data"`
+	Service string `json:"service"`
+	Data    any    `json:"data"`
 }
 
 var networkManager *network.Manager
@@ -453,7 +453,7 @@ func handleSubscribe(conn net.Conn, req models.Request) {
 	clientID := fmt.Sprintf("meta-client-%p", conn)
 
 	var services []string
-	if servicesParam, ok := req.Params["services"].([]interface{}); ok {
+	if servicesParam, ok := req.Params["services"].([]any); ok {
 		for _, s := range servicesParam {
 			if str, ok := s.(string); ok {
 				services = append(services, str)

--- a/core/internal/server/wayland/handlers.go
+++ b/core/internal/server/wayland/handlers.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Request struct {
-	ID     int                    `json:"id,omitempty"`
-	Method string                 `json:"method"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	ID     int            `json:"id,omitempty"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 type SuccessResult struct {

--- a/core/internal/server/wayland/types.go
+++ b/core/internal/server/wayland/types.go
@@ -47,7 +47,7 @@ type Manager struct {
 	display             *wlclient.Display
 	ctx                 *wlclient.Context
 	registry            *wlclient.Registry
-	gammaControl        interface{}
+	gammaControl        any
 	availableOutputs    []*wlclient.Output
 	outputRegNames      syncmap.Map[uint32, uint32]
 	outputs             syncmap.Map[uint32, *outputState]
@@ -83,7 +83,7 @@ type outputState struct {
 	name         string
 	registryName uint32
 	output       *wlclient.Output
-	gammaControl interface{}
+	gammaControl any
 	rampSize     uint32
 	failed       bool
 	isVirtual    bool

--- a/core/internal/server/wlroutput/handlers.go
+++ b/core/internal/server/wlroutput/handlers.go
@@ -12,9 +12,9 @@ import (
 )
 
 type Request struct {
-	ID     int                    `json:"id,omitempty"`
-	Method string                 `json:"method"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	ID     int            `json:"id,omitempty"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 type SuccessResult struct {

--- a/core/pkg/ipp/adapter-http.go
+++ b/core/pkg/ipp/adapter-http.go
@@ -102,7 +102,7 @@ func (h *HttpAdapter) SendRequest(url string, req *Request, additionalResponseDa
 	return ippResp, nil
 }
 
-func (h *HttpAdapter) GetHttpUri(namespace string, object interface{}) string {
+func (h *HttpAdapter) GetHttpUri(namespace string, object any) string {
 	proto := "http"
 	if h.useTLS {
 		proto = "https"

--- a/core/pkg/ipp/adapter.go
+++ b/core/pkg/ipp/adapter.go
@@ -4,6 +4,6 @@ import "io"
 
 type Adapter interface {
 	SendRequest(url string, req *Request, additionalResponseData io.Writer) (*Response, error)
-	GetHttpUri(namespace string, object interface{}) string
+	GetHttpUri(namespace string, object any) string
 	TestConnection() error
 }

--- a/core/pkg/ipp/attribute.go
+++ b/core/pkg/ipp/attribute.go
@@ -23,7 +23,7 @@ func NewAttributeEncoder(w io.Writer) *AttributeEncoder {
 
 // Encode encodes a attribute and its value to a io.Writer
 // the tag is determined by the AttributeTagMapping map
-func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
+func (e *AttributeEncoder) Encode(attribute string, value any) error {
 	tag, ok := AttributeTagMapping[attribute]
 	if !ok {
 		return fmt.Errorf("cannot get tag of attribute %s", attribute)
@@ -346,7 +346,7 @@ func (e *AttributeEncoder) writeNullByte() error {
 type Attribute struct {
 	Tag   int8
 	Name  string
-	Value interface{}
+	Value any
 }
 
 // Resolution defines the resolution attribute

--- a/core/pkg/ipp/cups-client.go
+++ b/core/pkg/ipp/cups-client.go
@@ -307,7 +307,7 @@ func (c *CUPSClient) PrintTestPage(printer string, testPageData io.Reader, size 
 		Name:     "Test Page",
 		Size:     size,
 		MimeType: MimeTypePDF,
-	}, printer, map[string]interface{}{
+	}, printer, map[string]any{
 		AttributeJobName: "Test Page",
 	})
 }

--- a/core/pkg/ipp/ipp-client.go
+++ b/core/pkg/ipp/ipp-client.go
@@ -62,7 +62,7 @@ func (c *IPPClient) SendRequest(url string, req *Request, additionalResponseData
 }
 
 // PrintDocuments prints one or more documents using a Create-Job operation followed by one or more Send-Document operation(s). custom job settings can be specified via the jobAttributes parameter
-func (c *IPPClient) PrintDocuments(docs []Document, printer string, jobAttributes map[string]interface{}) (int, error) {
+func (c *IPPClient) PrintDocuments(docs []Document, printer string, jobAttributes map[string]any) (int, error) {
 	printerURI := c.getPrinterUri(printer)
 
 	req := NewRequest(OperationCreateJob, 1)
@@ -112,7 +112,7 @@ func (c *IPPClient) PrintDocuments(docs []Document, printer string, jobAttribute
 }
 
 // PrintJob prints a document using a Print-Job operation. custom job settings can be specified via the jobAttributes parameter
-func (c *IPPClient) PrintJob(doc Document, printer string, jobAttributes map[string]interface{}) (int, error) {
+func (c *IPPClient) PrintJob(doc Document, printer string, jobAttributes map[string]any) (int, error) {
 	printerURI := c.getPrinterUri(printer)
 
 	req := NewRequest(OperationPrintJob, 1)
@@ -147,7 +147,7 @@ func (c *IPPClient) PrintJob(doc Document, printer string, jobAttributes map[str
 }
 
 // PrintFile prints a local file on the file system. custom job settings can be specified via the jobAttributes parameter
-func (c *IPPClient) PrintFile(filePath, printer string, jobAttributes map[string]interface{}) (int, error) {
+func (c *IPPClient) PrintFile(filePath, printer string, jobAttributes map[string]any) (int, error) {
 	fileStats, err := os.Stat(filePath)
 	if os.IsNotExist(err) {
 		return -1, err

--- a/core/pkg/ipp/request.go
+++ b/core/pkg/ipp/request.go
@@ -14,10 +14,10 @@ type Request struct {
 	Operation int16
 	RequestId int32
 
-	OperationAttributes    map[string]interface{}
-	JobAttributes          map[string]interface{}
-	PrinterAttributes      map[string]interface{}
-	SubscriptionAttributes map[string]interface{} // Added for subscription operations
+	OperationAttributes    map[string]any
+	JobAttributes          map[string]any
+	PrinterAttributes      map[string]any
+	SubscriptionAttributes map[string]any // Added for subscription operations
 
 	File     io.Reader
 	FileSize int
@@ -30,10 +30,10 @@ func NewRequest(op int16, reqID int32) *Request {
 		ProtocolVersionMinor:   ProtocolVersionMinor,
 		Operation:              op,
 		RequestId:              reqID,
-		OperationAttributes:    make(map[string]interface{}),
-		JobAttributes:          make(map[string]interface{}),
-		PrinterAttributes:      make(map[string]interface{}),
-		SubscriptionAttributes: make(map[string]interface{}),
+		OperationAttributes:    make(map[string]any),
+		JobAttributes:          make(map[string]any),
+		PrinterAttributes:      make(map[string]any),
+		SubscriptionAttributes: make(map[string]any),
 		File:                   nil,
 		FileSize:               -1,
 	}
@@ -65,7 +65,7 @@ func (r *Request) Encode() ([]byte, error) {
 	}
 
 	if r.OperationAttributes == nil {
-		r.OperationAttributes = make(map[string]interface{}, 2)
+		r.OperationAttributes = make(map[string]any, 2)
 	}
 
 	if _, found := r.OperationAttributes[AttributeCharset]; !found {
@@ -232,7 +232,7 @@ func (d *RequestDecoder) Decode(data io.Writer) (*Request, error) {
 
 		if startByte == TagOperation {
 			if req.OperationAttributes == nil {
-				req.OperationAttributes = make(map[string]interface{})
+				req.OperationAttributes = make(map[string]any)
 			}
 
 			tag = TagOperation
@@ -242,7 +242,7 @@ func (d *RequestDecoder) Decode(data io.Writer) (*Request, error) {
 
 		if startByte == TagJob {
 			if req.JobAttributes == nil {
-				req.JobAttributes = make(map[string]interface{})
+				req.JobAttributes = make(map[string]any)
 			}
 			tag = TagJob
 			tagSet = true
@@ -250,7 +250,7 @@ func (d *RequestDecoder) Decode(data io.Writer) (*Request, error) {
 
 		if startByte == TagPrinter {
 			if req.PrinterAttributes == nil {
-				req.PrinterAttributes = make(map[string]interface{})
+				req.PrinterAttributes = make(map[string]any)
 			}
 			tag = TagPrinter
 			tagSet = true
@@ -287,7 +287,7 @@ func (d *RequestDecoder) Decode(data io.Writer) (*Request, error) {
 	return req, nil
 }
 
-func appendAttributeToRequest(req *Request, tag int8, name string, value interface{}) {
+func appendAttributeToRequest(req *Request, tag int8, name string, value any) {
 	switch tag {
 	case TagOperation:
 		req.OperationAttributes[name] = value

--- a/core/pkg/ipp/response.go
+++ b/core/pkg/ipp/response.go
@@ -114,7 +114,7 @@ func (r *Response) Encode() ([]byte, error) {
 					continue
 				}
 
-				values := make([]interface{}, len(attr))
+				values := make([]any, len(attr))
 				for i, v := range attr {
 					values[i] = v.Value
 				}
@@ -143,7 +143,7 @@ func (r *Response) Encode() ([]byte, error) {
 					continue
 				}
 
-				values := make([]interface{}, len(attr))
+				values := make([]any, len(attr))
 				for i, v := range attr {
 					values[i] = v.Value
 				}
@@ -199,7 +199,7 @@ func encodeOperationAttribute(enc *AttributeEncoder, name string, attr []Attribu
 		return nil
 	}
 
-	values := make([]interface{}, len(attr))
+	values := make([]any, len(attr))
 	for i, v := range attr {
 		values[i] = v.Value
 	}


### PR DESCRIPTION
Motivation: any is an alias for interface{} and recommended for new code.

imo it makes the code easier to read.