### PR TITLE
fix: recreate plugin popout binding even if contentHeight is already set

### DIFF
--- a/quickshell/Modules/Plugins/PluginPopout.qml
+++ b/quickshell/Modules/Plugins/PluginPopout.qml
@@ -74,7 +74,7 @@ DankPopout {
                                 root.close()
                             }
                         }
-                        if (root.contentHeight === 0 && item) {
+                        if (item) {
                             root.contentHeight = Qt.binding(() => item.implicitHeight + Theme.spacingS * 2)
                         }
                     }


### PR DESCRIPTION
Hello,

Sorry about sending another PR for the same thing. It seems like my patch doesn't work entirely, because when you reopen the popout, it will not resize anymore. 

I think this happens:
- popout is opened for the first time:
- Qt.binding is created and is correct
- popout is closed and opened
- Qt.binding is no longer valid
    - I'm not 100% sure why. It might be that the popout is reloaded so the binding pointing to the old one is not valid anymore. At any rate, this patch solves it by recreating the binding in onLoaded even if root.contentHeight is already set.
- popout size stays the same as when it was closed

Again, sorry for proposing a patch that does not work entirely.