### PR TITLE
Fix ProcessList context menu visibility in DankPopout

### DIFF
--- a/quickshell/Modules/ProcessList/ProcessContextMenu.qml
+++ b/quickshell/Modules/ProcessList/ProcessContextMenu.qml
@@ -12,26 +12,26 @@ Popup {
     property var processData: null
 
     function show(x, y) {
-        if (!processContextMenu.parent && typeof Overlay !== "undefined" && Overlay.overlay) {
-            processContextMenu.parent = Overlay.overlay;
-        }
-
-        const menuWidth = 180;
-        const menuHeight = menuColumn.implicitHeight + Theme.spacingS * 2;
-        const screenWidth = Screen.width;
-        const screenHeight = Screen.height;
         let finalX = x;
         let finalY = y;
-        if (x + menuWidth > screenWidth - 20) {
-            finalX = x - menuWidth;
+
+        if (processContextMenu.parent) {
+            const parentWidth = processContextMenu.parent.width;
+            const parentHeight = processContextMenu.parent.height;
+            const menuWidth = processContextMenu.width;
+            const menuHeight = processContextMenu.height;
+
+            if (finalX + menuWidth > parentWidth) {
+                finalX = Math.max(0, parentWidth - menuWidth);
+            }
+
+            if (finalY + menuHeight > parentHeight) {
+                finalY = Math.max(0, parentHeight - menuHeight);
+            }
         }
 
-        if (y + menuHeight > screenHeight - 20) {
-            finalY = y - menuHeight;
-        }
-
-        processContextMenu.x = Math.max(20, finalX);
-        processContextMenu.y = Math.max(20, finalY);
+        processContextMenu.x = finalX;
+        processContextMenu.y = finalY;
         open();
     }
 

--- a/quickshell/Modules/ProcessList/ProcessListPopout.qml
+++ b/quickshell/Modules/ProcessList/ProcessListPopout.qml
@@ -37,7 +37,12 @@ DankPopout {
     screen: triggerScreen
     shouldBeVisible: false
 
-    onBackgroundClicked: close()
+    onBackgroundClicked: {
+        if (processContextMenu.visible) {
+            processContextMenu.close();
+        }
+        close();
+    }
 
     Ref {
         service: DgopService
@@ -63,6 +68,7 @@ DankPopout {
                 if (processListPopout.shouldBeVisible) {
                     forceActiveFocus();
                 }
+                processContextMenu.parent = processListContent;
             }
             Keys.onPressed: (event) => {
                 if (event.key === Qt.Key_Escape) {


### PR DESCRIPTION
Because the context menu did not appear for me, i fixed the context menu for processes in ProcessList: I bound ProcessContextMenu to the popup's contents, simplified menu positioning to the parent's local coordinates, and made it so that the menu would close immediately along with ProcessList without a delay.

Please check on your machine