### PR TITLE
fix: open settings

### DIFF
--- a/quickshell/Modules/DankDash/DankDashPopout.qml
+++ b/quickshell/Modules/DankDash/DankDashPopout.qml
@@ -301,7 +301,7 @@ DankPopout {
                         let settingsIndex = SettingsData.weatherEnabled ? 4 : 3;
                         if (index === settingsIndex) {
                             dashVisible = false;
-                            settingsModal.show();
+                            PopoutService.openSettings();
                         }
                     }
                 }


### PR DESCRIPTION
`settingsModal.show()` -> `PopoutService.openSettings()`. makes settings modal still open when settingsModal is null