### PR TITLE
core: fix crash on tui startup on nixos after removal of component de…

### DIFF
--- a/core/internal/dms/app.go
+++ b/core/internal/dms/app.go
@@ -105,14 +105,19 @@ type MenuItem struct {
 
 func NewModel(version string) Model {
 	detector, _ := NewDetector()
-	dependencies := detector.GetInstalledComponents()
+	var dependencies []DependencyInfo
+	var hyprlandInstalled, niriInstalled bool
+	var err error
+	if detector != nil {
+		dependencies = detector.GetInstalledComponents()
 
-	// Use the proper detection method for both window managers
-	hyprlandInstalled, niriInstalled, err := detector.GetWindowManagerStatus()
-	if err != nil {
-		// Fallback to false if detection fails
-		hyprlandInstalled = false
-		niriInstalled = false
+		// Use the proper detection method for both window managers
+		hyprlandInstalled, niriInstalled, err = detector.GetWindowManagerStatus()
+		if err != nil {
+			// Fallback to false if detection fails
+			hyprlandInstalled = false
+			niriInstalled = false
+		}
 	}
 
 	updateToggles := make(map[string]bool)

--- a/core/internal/dms/views_common.go
+++ b/core/internal/dms/views_common.go
@@ -109,6 +109,9 @@ func (m Model) renderAboutView() string {
 
 	b.WriteString(normalStyle.Render("Components:"))
 	b.WriteString("\n")
+	if len(m.dependencies) == 0 {
+		b.WriteString(normalStyle.Render("\n  Component detection not supported on this platform."))
+	}
 	for _, dep := range m.dependencies {
 		status := "✗"
 		if dep.Status == 1 {


### PR DESCRIPTION
…tection

```sh
❯ dms
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xb2fbe5]

goroutine 1 [running]:
github.com/AvengeMedia/DankMaterialShell/core/internal/dms.(*Detector).GetDependencyStatus(0x0)
        github.com/AvengeMedia/DankMaterialShell/core/internal/dms/detector.go:56 +0x25
github.com/AvengeMedia/DankMaterialShell/core/internal/dms.(*Detector).GetInstalledComponents(0x421dd1?)
        github.com/AvengeMedia/DankMaterialShell/core/internal/dms/detector.go:120 +0x1f
github.com/AvengeMedia/DankMaterialShell/core/internal/dms.NewModel({_, _})
        github.com/AvengeMedia/DankMaterialShell/core/internal/dms/app.go:108 +0x67
main.runInteractiveMode(0xc0001e3000?, {0xdabb80?, 0x4?, 0xdabae0?})
        github.com/AvengeMedia/DankMaterialShell/core/cmd/dms/commands_root.go:85 +0x85
github.com/spf13/cobra.(*Command).execute(0x1549460, {0xc0000360d0, 0x0, 0x0})
        github.com/spf13/cobra@v1.10.1/command.go:1019 +0xae7
github.com/spf13/cobra.(*Command).ExecuteC(0x1549460)
        github.com/spf13/cobra@v1.10.1/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.10.1/command.go:1071
main.main()
        github.com/AvengeMedia/DankMaterialShell/core/cmd/dms/main.go:41 +0x6a
```