### PR TITLE
dankbar: allow disabling title scrolling in the music display

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -168,6 +168,7 @@ Singleton {
     property bool dwlShowAllTags: false
     property var workspaceNameIcons: ({})
     property bool waveProgressEnabled: true
+    property bool scrollTitleEnabled: true
     property bool clockCompactMode: false
     property bool focusedWindowCompactMode: false
     property bool runningAppsCompactMode: true

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -83,6 +83,7 @@ var SPEC = {
     dwlShowAllTags: { def: false },
     workspaceNameIcons: { def: {} },
     waveProgressEnabled: { def: true },
+    scrollTitleEnabled: {def: true},
     clockCompactMode: { def: false },
     focusedWindowCompactMode: { def: false },
     runningAppsCompactMode: { def: true },

--- a/quickshell/Modules/DankBar/Widgets/Media.qml
+++ b/quickshell/Modules/DankBar/Widgets/Media.qml
@@ -232,7 +232,7 @@ BasePill {
 
                         StyledText {
                             id: mediaText
-                            property bool needsScrolling: implicitWidth > textContainer.width
+                            property bool needsScrolling: implicitWidth > textContainer.width && SettingsData.scrollTitleEnabled
                             property real scrollOffset: 0
 
                             anchors.verticalCenter: parent.verticalCenter

--- a/quickshell/Modules/Settings/WidgetTweaksTab.qml
+++ b/quickshell/Modules/Settings/WidgetTweaksTab.qml
@@ -203,6 +203,15 @@ Item {
                             return SettingsData.set("waveProgressEnabled", checked);
                         }
                     }
+                    DankToggle {
+                        width: parent.width
+                        text: I18n.tr("Scroll song title")
+                        description: I18n.tr("Scroll title if it doesn't fit in widget")
+                        checked: SettingsData.scrollTitleEnabled
+                        onToggled: checked => {
+                            return SettingsData.set("scrollTitleEnabled", checked);
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
I find the motion a bit distracting, could we allow disabling it?