### PR TITLE
core: add dynamic completion for ipc command

### DIFF
--- a/core/cmd/dms/commands_common.go
+++ b/core/cmd/dms/commands_common.go
@@ -66,6 +66,10 @@ var ipcCmd = &cobra.Command{
 	Short:   "Send IPC commands to running DMS shell",
 	Long:    "Send IPC commands to running DMS shell (qs -c dms ipc <args>)",
 	PreRunE: findConfig,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		_ = findConfig(cmd, args)
+		return getShellIPCCompletions(args, toComplete), cobra.ShellCompDirectiveNoFileComp
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		runShellIPCCommand(args)
 	},


### PR DESCRIPTION
Calls qs to get the available targets and functions from the QML. The function arguments could probably also be parsed, but in this initial implementation I'm stripping them.