### PR TITLE
feat(dankdash): add vim keybindings (hjkl) to wallpaper picker navigation

### DIFF
--- a/quickshell/Modules/DankDash/WallpaperTab.qml
+++ b/quickshell/Modules/DankDash/WallpaperTab.qml
@@ -94,7 +94,7 @@ Item {
             return true;
         }
 
-        if (event.key === Qt.Key_Right) {
+        if (event.key === Qt.Key_Right || event.key === Qt.Key_L) {
             if (gridIndex + 1 < visibleCount) {
                 gridIndex++;
             } else if (currentPage < totalPages - 1) {
@@ -104,7 +104,7 @@ Item {
             return true;
         }
 
-        if (event.key === Qt.Key_Left) {
+        if (event.key === Qt.Key_Left || event.key === Qt.Key_H) {
             if (gridIndex > 0) {
                 gridIndex--;
             } else if (currentPage > 0) {
@@ -115,7 +115,7 @@ Item {
             return true;
         }
 
-        if (event.key === Qt.Key_Down) {
+        if (event.key === Qt.Key_Down || event.key === Qt.Key_J) {
             if (gridIndex + columns < visibleCount) {
                 gridIndex += columns;
             } else if (currentPage < totalPages - 1) {
@@ -125,7 +125,7 @@ Item {
             return true;
         }
 
-        if (event.key === Qt.Key_Up) {
+        if (event.key === Qt.Key_Up || event.key === Qt.Key_K) {
             if (gridIndex >= columns) {
                 gridIndex -= columns;
             } else if (currentPage > 0) {


### PR DESCRIPTION
## Summary
Adds vim-style navigation (hjkl) keybindings to the wallpaper picker in DankDash.

## Changes
- Modified WallpaperTab.qml to add h/j/k/l keybindings alongside arrow keys
- h: left navigation
- j: down navigation  
- k: up navigation
- l: right navigation

## Test plan
- Open wallpaper picker
- Verify h/j/k/l keys work for navigation alongside existing arrow keys