### PR TITLE
nix: match upstream package format

### DIFF
--- a/distro/nix/common.nix
+++ b/distro/nix/common.nix
@@ -7,7 +7,7 @@
 }: let
     cfg = config.programs.dankMaterialShell;
 in {
-    qmlPath = "${dmsPkgs.dankMaterialShell}/etc/xdg/quickshell/dms";
+    qmlPath = "${dmsPkgs.dms-shell}/share/quickshell/dms";
 
     packages =
         [
@@ -19,7 +19,7 @@ in {
             pkgs.libsForQt5.qt5ct
             pkgs.kdePackages.qt6ct
 
-            dmsPkgs.dmsCli
+            dmsPkgs.dms-shell
         ]
         ++ lib.optional cfg.enableSystemMonitoring dmsPkgs.dgop
         ++ lib.optionals cfg.enableClipboard [pkgs.cliphist pkgs.wl-clipboard]

--- a/distro/nix/greeter.nix
+++ b/distro/nix/greeter.nix
@@ -20,7 +20,7 @@
             "--command"
             cfg.compositor.name
             "-p"
-            "${dmsPkgs.dankMaterialShell}/etc/xdg/quickshell/dms"
+            "${dmsPkgs.dms-shell}/share/quickshell/dms"
         ]
         ++ lib.optionals (cfg.compositor.customConfig != "") [
             "-C"

--- a/distro/nix/home.nix
+++ b/distro/nix/home.nix
@@ -66,7 +66,7 @@ in {
             };
 
             Service = {
-                ExecStart = lib.getExe dmsPkgs.dmsCli + " run --session";
+                ExecStart = lib.getExe dmsPkgs.dms-shell + " run --session";
                 Restart = "on-failure";
             };
 
@@ -89,6 +89,6 @@ in {
             }
         ];
 
-        home.packages = common.packages ++ [dmsPkgs.dankMaterialShell];
+        home.packages = common.packages;
     };
 }

--- a/distro/nix/nixos.nix
+++ b/distro/nix/nixos.nix
@@ -14,7 +14,7 @@ in {
 
     config = lib.mkIf cfg.enable
     {
-        environment.etc."xdg/quickshell/dms".source = "${dmsPkgs.dankMaterialShell}/etc/xdg/quickshell/dms";
+        environment.etc."xdg/quickshell/dms".source = "${dmsPkgs.dms-shell}/share/quickshell/dms";
 
         systemd.user.services.dms = lib.mkIf cfg.systemd.enable {
             description = "DankMaterialShell";
@@ -26,11 +26,11 @@ in {
             restartTriggers = lib.optional cfg.systemd.restartIfChanged common.qmlPath;
 
             serviceConfig = {
-                ExecStart = lib.getExe dmsPkgs.dmsCli + " run --session";
+                ExecStart = lib.getExe dmsPkgs.dms-shell + " run --session";
                 Restart = "on-failure";
             };
         };
 
-        environment.systemPackages = [cfg.quickshell.package dmsPkgs.dankMaterialShell] ++ common.packages;
+        environment.systemPackages = [cfg.quickshell.package] ++ common.packages;
     };
 }


### PR DESCRIPTION
Updates the flake to match the same format as the upstream `nixpkgs`, so the users can use the NixOS upstream module instead with overriding the package. This should not affect current flake NixOS or home-manager module users.