### PR TITLE
fix(README): fixes documentation link to include trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ dms plugins search   # Browse plugin registry
 ## Documentation
 
 - **Website:** [danklinux.com](https://danklinux.com)
-- **Docs:** [danklinux.com/docs](https://danklinux.com/docs)
+- **Docs:** [danklinux.com/docs](https://danklinux.com/docs/)
 - **Theming:** [Application themes](https://danklinux.com/docs/dankmaterialshell/application-themes) | [Custom themes](https://danklinux.com/docs/dankmaterialshell/custom-themes)
 - **Plugins:** [Development guide](https://danklinux.com/docs/dankmaterialshell/plugins-overview)
 - **Support:** [Ko-fi](https://ko-fi.com/avengemediallc)


### PR DESCRIPTION
fixes same issue as described in AvengeMedia/DankLinux-Docs#25