### PR TITLE
evdev: improve capslock detection for no led device

### DIFF
--- a/core/internal/server/evdev/manager.go
+++ b/core/internal/server/evdev/manager.go
@@ -306,14 +306,14 @@ func (m *Manager) readAndUpdateCapsLockState(deviceIndex int) {
 		return
 	}
 
-    if len(ledStates) == 0 {
-        log.Debug("No LED state available (empty map)")
+	if len(ledStates) == 0 {
+		log.Debug("No LED state available (empty map)")
 
-        // This means the device either:
-        // - doesn't support LED reporting at all, or
-        // - the kernel returned an empty state
-        return
-    }
+		// This means the device either:
+		// - doesn't support LED reporting at all, or
+		// - the kernel returned an empty state
+		return
+	}
 
 	capsLockState := ledStates[ledCapslockKey]
 	m.updateCapsLockStateDirect(capsLockState)


### PR DESCRIPTION
The current Caps Lock detection does not work correctly on my Sofle keyboard: the state instantly flips from true back to false.  

After checking the logs, the cause is clear:

```go
if event.Type == evKeyType && event.Code == keyCapslockKey && event.Value == keyStateOn {
    time.Sleep(50 * time.Millisecond)
    m.readAndUpdateCapsLockState(deviceIndex) // triggered here
} else if event.Type == evLedType && event.Code == ledCapslockKey {
    capsLockState := event.Value == keyStateOn
    m.updateCapsLockStateDirect(capsLockState)
}
```

and inside the called function:

```go
ledStates, err := device.State(evLedType)
...
capsLockState := ledStates[ledCapslockKey] // root cause
```

My keyboard has no physical Caps Lock LED, so `device.State(EV_LED)` returns an empty map.  
Accessing it yields `false`, which forces the state back to off every time.

This PR adds a simple check: if `ledStates` is completely empty, we skip the update entirely instead of treating Caps Lock as off.

The change has minimal impact on other devices:
- When `ledStates` is non-empty (normal case), behaviour is unchanged.
- When it is empty, we now avoid the incorrect forced-off state that some keyboards currently suffer from.

---

Another alternative to the current fix would be to fall back to using `event.Value` directly whenever the LED map is detected to be empty.