### PR TITLE
nix: use by default quickshell from source

### DIFF
--- a/distro/nix/home.nix
+++ b/distro/nix/home.nix
@@ -4,13 +4,13 @@
     lib,
     dmsPkgs,
     ...
-}: let
+} @ args: let
     cfg = config.programs.dankMaterialShell;
     jsonFormat = pkgs.formats.json {};
     common = import ./common.nix {inherit config pkgs lib dmsPkgs;};
 in {
     imports = [
-        ./options.nix
+        (import ./options.nix args)
         (lib.mkRemovedOptionModule ["programs" "dankMaterialShell" "enableNightMode"] "Night mode is now always available.")
         (lib.mkRenamedOptionModule ["programs" "dankMaterialShell" "enableSystemd"] ["programs" "dankMaterialShell" "systemd" "enable"])
     ];

--- a/distro/nix/nixos.nix
+++ b/distro/nix/nixos.nix
@@ -4,12 +4,12 @@
     lib,
     dmsPkgs,
     ...
-}: let
+} @ args: let
     cfg = config.programs.dankMaterialShell;
     common = import ./common.nix {inherit config pkgs lib dmsPkgs;};
 in {
     imports = [
-        ./options.nix
+        (import ./options.nix args)
     ];
 
     config = lib.mkIf cfg.enable

--- a/distro/nix/options.nix
+++ b/distro/nix/options.nix
@@ -1,6 +1,6 @@
 {
-    pkgs,
     lib,
+    dmsPkgs,
     ...
 }: let
     inherit (lib) types;
@@ -62,7 +62,9 @@ in {
             description = "Add needed dependencies to have system sound support";
         };
         quickshell = {
-            package = lib.mkPackageOption pkgs "quickshell" {};
+            package = lib.mkPackageOption dmsPkgs "quickshell" {
+                extraDescription = "The quickshell package to use (defaults to be built from source, in the commit 26531f due to unreleased features used by DMS).";
+            };
         };
     };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762435535,
-        "narHash": "sha256-QhzRn7pYN35IFpKjjxJAj3GPJECuC+VLhoGem3ezycc=",
+        "lastModified": 1762835999,
+        "narHash": "sha256-UykYGrGFOFTmDpKTLNxj1wvd1gbDG4TkqLNSbV0TYwk=",
         "owner": "AvengeMedia",
         "repo": "dgop",
-        "rev": "6cf638dde818f9f8a2e26d0243179c43cb3458d7",
+        "rev": "799301991cd5dcea9b64245f9d500dcc76615653",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762363567,
-        "narHash": "sha256-YRqMDEtSMbitIMj+JLpheSz0pwEr0Rmy5mC7myl17xs=",
+        "lastModified": 1764950072,
+        "narHash": "sha256-BmPWzogsG2GsXZtlT+MTcAWeDK5hkbGRZTeZNW42fwA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ae814fd3904b621d8ab97418f1d0f2eb0d3716f4",
+        "rev": "f61125a668a320878494449750330ca58b78c557",
         "type": "github"
       },
       "original": {
@@ -36,10 +36,32 @@
         "type": "github"
       }
     },
+    "quickshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1764663772,
+        "narHash": "sha256-sHqLmm0wAt3PC4vczJeBozI1/f4rv9yp3IjkClHDXDs=",
+        "ref": "refs/heads/master",
+        "rev": "26531fc46ef17e9365b03770edd3fb9206fcb460",
+        "revCount": 713,
+        "type": "git",
+        "url": "https://git.outfoxxed.me/quickshell/quickshell"
+      },
+      "original": {
+        "rev": "26531fc46ef17e9365b03770edd3fb9206fcb460",
+        "type": "git",
+        "url": "https://git.outfoxxed.me/quickshell/quickshell"
+      }
+    },
     "root": {
       "inputs": {
         "dgop": "dgop",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "quickshell": "quickshell"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,12 +7,17 @@
             url = "github:AvengeMedia/dgop";
             inputs.nixpkgs.follows = "nixpkgs";
         };
+        quickshell = {
+            url = "git+https://git.outfoxxed.me/quickshell/quickshell?rev=26531fc46ef17e9365b03770edd3fb9206fcb460";
+            inputs.nixpkgs.follows = "nixpkgs";
+        };
     };
 
     outputs = {
         self,
         nixpkgs,
         dgop,
+        quickshell,
         ...
     }: let
         forEachSystem = fn:
@@ -22,6 +27,7 @@
         buildDmsPkgs = pkgs: {
             dms-shell = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
             dgop = dgop.packages.${pkgs.stdenv.hostPlatform.system}.dgop;
+            quickshell = quickshell.packages.${pkgs.stdenv.hostPlatform.system}.default;
         };
         mkModuleWithDmsPkgs = path: args @ {pkgs, ...}: {
             imports = [


### PR DESCRIPTION
Use by default quickshell from their flake (locked in `26531f`) to match the other danklinux distributions that uses the same version. Users can still use the one from `nixpkgs` or another one, if desired.