### PR TITLE
nix: remove leading dot in nativeBuildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
 
                         nativeBuildInputs = with pkgs; [
                             installShellFiles
-                            .makeWrapper
+                            makeWrapper
                         ];
 
                         postInstall = ''


### PR DESCRIPTION
the leading dot in nativeBuildInputs for the `makeWrapper` causes `nixos-rebuild switch` to fail with a '"attribute 'makeWrapper' missing" error.

this was introduced in #944 