### PR TITLE
nix: fix typo in flake. Closes #946

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
 
                         nativeBuildInputs = with pkgs; [
                             installShellFiles
-                            .makeWrapper
+                            makeWrapper
                         ];
 
                         postInstall = ''


### PR DESCRIPTION
we should probably add a simple job that does `nix flake check` to github to catch stuff like this.