### PR TITLE
nix: add QML dependencies to dms-shell package

### DIFF
--- a/distro/nix/common.nix
+++ b/distro/nix/common.nix
@@ -23,8 +23,7 @@ in
   ]
   ++ lib.optional cfg.enableDynamicTheming pkgs.matugen
   ++ lib.optional cfg.enableAudioWavelength pkgs.cava
-  ++ lib.optional cfg.enableCalendarEvents pkgs.khal
-  ++ lib.optional cfg.enableSystemSound pkgs.kdePackages.qtmultimedia;
+  ++ lib.optional cfg.enableCalendarEvents pkgs.khal;
 
   plugins = lib.mapAttrs (name: plugin: {
     source = plugin.src;

--- a/distro/nix/options.nix
+++ b/distro/nix/options.nix
@@ -16,6 +16,9 @@ in
   imports = [
     (lib.mkRemovedOptionModule (path ++ [ "enableBrightnessControl" ]) builtInRemovedMsg)
     (lib.mkRemovedOptionModule (path ++ [ "enableColorPicker" ]) builtInRemovedMsg)
+    (lib.mkRemovedOptionModule (
+      path ++ [ "enableSystemSound" ]
+    ) "qtmultimedia is now included on dms-shell package.")
   ];
 
   options.programs.dankMaterialShell = {
@@ -57,11 +60,6 @@ in
       type = types.bool;
       default = true;
       description = "Add calendar events support via khal";
-    };
-    enableSystemSound = lib.mkOption {
-      type = types.bool;
-      default = true;
-      description = "Add needed dependencies to have system sound support";
     };
     quickshell = {
       package = lib.mkPackageOption dmsPkgs "quickshell" {


### PR DESCRIPTION
Removes `enableSystemSound` option in the modules and adds `qtmultimedia`, `kirigami` and `sonnet` QML import paths into `dms-shell` package instead. qtmultimedia, in the way it was before, wouldn't work without adding the import path.