### PR TITLE
Remove rpkg from BuildRequires

### DIFF
--- a/distro/fedora/dms.spec
+++ b/distro/fedora/dms.spec
@@ -16,7 +16,6 @@ VCS:            {{{ git_repo_vcs }}}
 Source0:        {{{ git_repo_pack }}}
 
 BuildRequires:  git-core
-BuildRequires:  rpkg
 BuildRequires:  gzip
 BuildRequires:  golang >= 1.24
 BuildRequires:  make


### PR DESCRIPTION
Removed rpkg from BuildRequires in dms.spec

Enables CentOS