### PR TITLE
nix: remove wl-clipboard and cliphist dependencies

### DIFF
--- a/distro/nix/common.nix
+++ b/distro/nix/common.nix
@@ -13,10 +13,6 @@ in
     dmsPkgs.dms-shell
   ]
   ++ lib.optional cfg.enableSystemMonitoring dmsPkgs.dgop
-  ++ lib.optionals cfg.enableClipboard [
-    pkgs.cliphist
-    pkgs.wl-clipboard
-  ]
   ++ lib.optionals cfg.enableVPN [
     pkgs.glib
     pkgs.networkmanager

--- a/distro/nix/niri.nix
+++ b/distro/nix/niri.nix
@@ -76,17 +76,15 @@ in
               action = dms-ipc "night" "toggle";
               hotkey-overlay.title = "Toggle Night Mode";
             };
+            "Mod+V" = {
+              action = dms-ipc "clipboard" "toggle";
+              hotkey-overlay.title = "Toggle Clipboard Manager";
+            };
           }
           // lib.attrsets.optionalAttrs cfg.enableSystemMonitoring {
             "Mod+M" = {
               action = dms-ipc "processlist" "toggle";
               hotkey-overlay.title = "Toggle Process List";
-            };
-          }
-          // lib.attrsets.optionalAttrs cfg.enableClipboard {
-            "Mod+V" = {
-              action = dms-ipc "clipboard" "toggle";
-              hotkey-overlay.title = "Toggle Clipboard Manager";
             };
           };
       })
@@ -97,16 +95,6 @@ in
             command = [
               "dms"
               "run"
-            ];
-          }
-        ]
-        ++ lib.optionals cfg.enableClipboard [
-          {
-            command = [
-              "wl-paste"
-              "--watch"
-              "cliphist"
-              "store"
             ];
           }
         ];

--- a/distro/nix/options.nix
+++ b/distro/nix/options.nix
@@ -16,6 +16,7 @@ in
   imports = [
     (lib.mkRemovedOptionModule (path ++ [ "enableBrightnessControl" ]) builtInRemovedMsg)
     (lib.mkRemovedOptionModule (path ++ [ "enableColorPicker" ]) builtInRemovedMsg)
+    (lib.mkRemovedOptionModule (path ++ [ "enableClipboard" ]) builtInRemovedMsg)
     (lib.mkRemovedOptionModule (
       path ++ [ "enableSystemSound" ]
     ) "qtmultimedia is now included on dms-shell package.")
@@ -35,11 +36,6 @@ in
       type = types.bool;
       default = true;
       description = "Add needed dependencies to use system monitoring widgets";
-    };
-    enableClipboard = lib.mkOption {
-      type = types.bool;
-      default = true;
-      description = "Add needed dependencies to use the clipboard widget";
     };
     enableVPN = lib.mkOption {
       type = types.bool;


### PR DESCRIPTION
Removes wl-clipboard and cliphist from the Flake's dependencies since they're not used anymore