### PR TITLE
nix: fix qt-plugins path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -179,6 +179,10 @@
 
                 prek
                 uv # for prek
+
+                # Nix development tools
+                nixd
+                nil
               ]
               ++ devQmlPkgs;
 


### PR DESCRIPTION
Sets QT_PLUGIN_PATH so Quickshell can recognize QT plugins. This is specifically for qtmultimedia (it was necessary to get it working in my system), but I added the other ones too as a safeguard. Not all of them have plugins (like kirigami), but this should be harmless.

Note: also added nix tools (nil and nixd) in the devshell