### PR TITLE
Change DPMS off to DPMS toggle in hyprland.conf

### DIFF
--- a/core/internal/config/embedded/hyprland.conf
+++ b/core/internal/config/embedded/hyprland.conf
@@ -276,4 +276,4 @@ bind = CTRL, Print, exec, dms screenshot full
 bind = ALT, Print, exec, dms screenshot window
 
 # === System Controls ===
-bind = $mod SHIFT, P, dpms, off
+bind = $mod SHIFT, P, dpms, toggle


### PR DESCRIPTION
Allow recovery if dpms toggled and no way to recover system on single monitor without reboot (or when escaping to another tty don't work)