### PR TITLE
nix: refactor module structure and flake output

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ quickshell -p quickshell/
   inputs.dms.url = "github:AvengeMedia/DankMaterialShell";
 
   # Use in home-manager or NixOS configuration
-  imports = [ inputs.dms.homeModules.dankMaterialShell.default ];
+  imports = [ inputs.dms.homeModules.dank-material-shell ];
 }
 ```
 

--- a/distro/nix/common.nix
+++ b/distro/nix/common.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  cfg = config.programs.dankMaterialShell;
+  cfg = config.programs.dank-material-shell;
 in
 {
   packages = [

--- a/distro/nix/dms-rename.nix
+++ b/distro/nix/dms-rename.nix
@@ -1,0 +1,15 @@
+{ lib, ... }:
+{
+  imports = [
+    (lib.mkRenamedOptionModule
+      [
+        "programs"
+        "dankMaterialShell"
+      ]
+      [
+        "programs"
+        "dank-material-shell"
+      ]
+    )
+  ];
+}

--- a/distro/nix/greeter.nix
+++ b/distro/nix/greeter.nix
@@ -7,7 +7,7 @@
 }:
 let
   inherit (lib) types;
-  cfg = config.programs.dankMaterialShell.greeter;
+  cfg = config.programs.dank-material-shell.greeter;
 
   inherit (config.services.greetd.settings.default_session) user;
 
@@ -44,19 +44,20 @@ in
 {
   imports =
     let
-      msg = "The option 'programs.dankMaterialShell.greeter.compositor.extraConfig' is deprecated. Please use 'programs.dankMaterialShell.greeter.compositor.customConfig' instead.";
+      msg = "The option 'programs.dank-material-shell.greeter.compositor.extraConfig' is deprecated. Please use 'programs.dank-material-shell.greeter.compositor.customConfig' instead.";
     in
     [
       (lib.mkRemovedOptionModule [
         "programs"
-        "dankMaterialShell"
+        "dank-material-shell"
         "greeter"
         "compositor"
         "extraConfig"
       ] msg)
+      ./dms-rename.nix
     ];
 
-  options.programs.dankMaterialShell.greeter = {
+  options.programs.dank-material-shell.greeter = {
     enable = lib.mkEnableOption "DankMaterialShell greeter";
     compositor.name = lib.mkOption {
       type = types.enum [
@@ -177,7 +178,7 @@ in
       mv dms-colors.json colors.json || :
       chown ${user}: * || :
     '';
-    programs.dankMaterialShell.greeter.configFiles = lib.mkIf (cfg.configHome != null) [
+    programs.dank-material-shell.greeter.configFiles = lib.mkIf (cfg.configHome != null) [
       "${cfg.configHome}/.config/DankMaterialShell/settings.json"
       "${cfg.configHome}/.local/state/DankMaterialShell/session.json"
       "${cfg.configHome}/.cache/DankMaterialShell/dms-colors.json"

--- a/distro/nix/home.nix
+++ b/distro/nix/home.nix
@@ -6,7 +6,7 @@
   ...
 }@args:
 let
-  cfg = config.programs.dankMaterialShell;
+  cfg = config.programs.dank-material-shell;
   jsonFormat = pkgs.formats.json { };
   common = import ./common.nix {
     inherit
@@ -22,16 +22,16 @@ in
     (import ./options.nix args)
     (lib.mkRemovedOptionModule [
       "programs"
-      "dankMaterialShell"
+      "dank-material-shell"
       "enableNightMode"
     ] "Night mode is now always available.")
     (lib.mkRenamedOptionModule
-      [ "programs" "dankMaterialShell" "enableSystemd" ]
-      [ "programs" "dankMaterialShell" "systemd" "enable" ]
+      [ "programs" "dank-material-shell" "enableSystemd" ]
+      [ "programs" "dank-material-shell" "systemd" "enable" ]
     )
   ];
 
-  options.programs.dankMaterialShell = with lib.types; {
+  options.programs.dank-material-shell = with lib.types; {
     default = {
       settings = lib.mkOption {
         type = jsonFormat.type;

--- a/distro/nix/niri.nix
+++ b/distro/nix/niri.nix
@@ -4,10 +4,14 @@
   ...
 }:
 let
-  cfg = config.programs.dankMaterialShell;
+  cfg = config.programs.dank-material-shell;
 in
 {
-  options.programs.dankMaterialShell = {
+  imports = [
+    ./dms-rename.nix
+  ];
+
+  options.programs.dank-material-shell = {
     niri = {
       enableKeybinds = lib.mkEnableOption "DankMaterialShell niri keybinds";
       enableSpawn = lib.mkEnableOption "DankMaterialShell niri spawn-at-startup";

--- a/distro/nix/nixos.nix
+++ b/distro/nix/nixos.nix
@@ -6,7 +6,7 @@
   ...
 }@args:
 let
-  cfg = config.programs.dankMaterialShell;
+  cfg = config.programs.dank-material-shell;
   common = import ./common.nix {
     inherit
       config

--- a/distro/nix/options.nix
+++ b/distro/nix/options.nix
@@ -7,7 +7,7 @@ let
   inherit (lib) types;
   path = [
     "programs"
-    "dankMaterialShell"
+    "dank-material-shell"
   ];
 
   builtInRemovedMsg = "This is now built-in in DMS and doesn't need additional dependencies.";
@@ -20,16 +20,17 @@ in
     (lib.mkRemovedOptionModule (
       path ++ [ "enableSystemSound" ]
     ) "qtmultimedia is now included on dms-shell package.")
+    ./dms-rename.nix
   ];
 
-  options.programs.dankMaterialShell = {
+  options.programs.dank-material-shell = {
     enable = lib.mkEnableOption "DankMaterialShell";
     systemd = {
       enable = lib.mkEnableOption "DankMaterialShell systemd startup";
       restartIfChanged = lib.mkOption {
         type = types.bool;
         default = true;
-        description = "Auto-restart dms.service when dankMaterialShell changes";
+        description = "Auto-restart dms.service when dank-material-shell changes";
       };
     };
     enableSystemMonitoring = lib.mkOption {

--- a/flake.nix
+++ b/flake.nix
@@ -149,13 +149,23 @@
         }
       );
 
-      homeModules.dankMaterialShell.default = mkModuleWithDmsPkgs ./distro/nix/home.nix;
+      homeModules.dank-material-shell = mkModuleWithDmsPkgs ./distro/nix/home.nix;
 
-      homeModules.dankMaterialShell.niri = import ./distro/nix/niri.nix;
+      homeModules.default = self.homeModules.dank-material-shell;
 
-      nixosModules.dankMaterialShell = mkModuleWithDmsPkgs ./distro/nix/nixos.nix;
+      homeModules.niri = import ./distro/nix/niri.nix;
+
+      homeModules.dankMaterialShell.default = builtins.warn "dank-material-shell: flake output `homeModules.dankMaterialShell.default` has been renamed to `homeModules.dank-material-shell`" self.homeModules.dank-material-shell;
+
+      homeModules.dankMaterialShell.niri = builtins.warn "dank-material-shell: flake output `homeModules.dankMaterialShell.niri` has been renamed to `homeModules.niri`" self.homeModules.niri;
+
+      nixosModules.dank-material-shell = mkModuleWithDmsPkgs ./distro/nix/nixos.nix;
+
+      nixosModules.default = self.nixosModules.dank-material-shell;
 
       nixosModules.greeter = mkModuleWithDmsPkgs ./distro/nix/greeter.nix;
+
+      nixosModules.dankMaterialShell = builtins.warn "dank-material-shell: flake output `nixosModules.dankMaterialShell` has been renamed to `nixosModules.dank-material-shell`" self.nixosModules.dank-material-shell;
 
       devShells = forEachSystem (
         system: pkgs:

--- a/quickshell/Modules/Greetd/README.md
+++ b/quickshell/Modules/Greetd/README.md
@@ -177,13 +177,13 @@ If you prefer the old method with separate shell scripts and config files:
 To install the greeter on NixOS add the repo to your flake inputs as described in the readme. Then somewhere in your NixOS config add this to imports:
 ```nix
 imports = [
-  inputs.dankMaterialShell.nixosModules.greeter
+  inputs.dank-material-shell.nixosModules.greeter
 ]
 ```
 
 Enable the greeter with this in your NixOS config:
 ```nix
-programs.dankMaterialShell.greeter = {
+programs.dank-material-shell.greeter = {
   enable = true;
   compositor.name = "niri"; # or set to hyprland
   configHome = "/home/user"; # optionally copyies that users DMS settings (and wallpaper if set) to the greeters data directory as root before greeter starts


### PR DESCRIPTION
I've noticed that the structure and naming convention of the Nix modules currently breaks a few standard conventions:

1. `camelCase` for top-level program modules

   Using `kebab-case` for program module names is a universally-agreed convention. You can verify it by looking at how they name modules upstream.

   <details>
   <summary><b>All program names from NixOS</b></summary>

   ```json
   [
     "_1password"
     "_1password-gui"
     "adb"
     "alvr"
     "amnezia-vpn"
     "appgate-sdp"
     "appimage"
     "arp-scan"
     "atop"
     "ausweisapp"
     "autoenv"
     "autojump"
     "bandwhich"
     "bash"
     "bash-my-aws"
     "bat"
     "bazecor"
     "bcc"
     "benchexec"
     "browserpass"
     "calls"
     "captive-browser"
     "cardboard"
     "ccache"
     "cdemu"
     "cfs-zen-tweaks"
     "chromium"
     "chrysalis"
     "clash-verge"
     "cnping"
     "command-not-found"
     "coolercontrol"
     "corectrl"
     "corefreq"
     "cpu-energy-meter"
     "criu"
     "dconf"
     "digitalbitbox"
     "direnv"
     "dmrconfig"
     "dms-shell"
     "droidcam"
     "dsearch"
     "dublin-traceroute"
     "dwl"
     "ecryptfs"
     "envision"
     "evince"
     "evolution"
     "extra-container"
     "fcast-receiver"
     "feedbackd"
     "file-roller"
     "firefox"
     "firejail"
     "fish"
     "flashprog"
     "flashrom"
     "flexoptix-app"
     "foot"
     "fuse"
     "fzf"
     "gamemode"
     "gamescope"
     "gdk-pixbuf"
     "geary"
     "ghidra"
     "git"
     "git-worktree-switcher"
     "gnome-disks"
     "gnome-documents"
     "gnome-terminal"
     "gnupg"
     "goldwarden"
     "gpaste"
     "gphoto2"
     "gpu-screen-recorder"
     "gtklock"
     "haguichi"
     "hamster"
     "htop"
     "hyprland"
     "hyprlock"
     "i3lock"
     "iay"
     "ibus"
     "iftop"
     "iio-hyprland"
     "immersed"
     "immersed-vr"
     "info"
     "iotop"
     "java"
     "joycond-cemuhook"
     "k3b"
     "k40-whisperer"
     "kbdlight"
     "kclock"
     "kde-pim"
     "kdeconnect"
     "kubeswitch"
     "labwc"
     "ladybird"
     "lazygit"
     "less"
     "liboping"
     "light"
     "localsend"
     "man"
     "mdevctl"
     "mepo"
     "mininet"
     "minipro"
     "miriway"
     "mosh"
     "mouse-actions"
     "msmtp"
     "mtr"
     "nano"
     "nautilus-open-any-terminal"
     "nbd"
     "nekoray"
     "neovim"
     "nethoscope"
     "nexttrace"
     "nh"
     "niri"
     "nix-index"
     "nix-ld"
     "nix-required-mounts"
     "nixbit"
     "nm-applet"
     "nncp"
     "noisetorch"
     "npm"
     "ns-usbloader"
     "oblogout"
     "obs-studio"
     "oddjobd"
     "opengamepadui"
     "openvpn3"
     "pantheon-tweaks"
     "partition-manager"
     "pay-respects"
     "plotinus"
     "pmount"
     "pqos-wrapper"
     "projecteur"
     "proxychains"
     "pulseview"
     "qdmr"
     "qgroundcontrol"
     "qt5ct"
     "quark-goldleaf"
     "regreet"
     "river"
     "river-classic"
     "rog-control-center"
     "rush"
     "rust-motd"
     "ryzen-monitor-ng"
     "schroot"
     "screen"
     "seahorse"
     "sedutil"
     "sharing"
     "singularity"
     "skim"
     "slock"
     "sniffnet"
     "soundmodem"
     "spacefm"
     "ssh"
     "starship"
     "steam"
     "streamcontroller"
     "streamdeck-ui"
     "sway"
     "sysdig"
     "system-config-printer"
     "systemtap"
     "tcpdump"
     "television"
     "thefuck"
     "throne"
     "thunar"
     "thunderbird"
     "tilp2"
     "tmux"
     "traceroute"
     "trippy"
     "tsmClient"
     "turbovnc"
     "tuxclocker"
     "udevil"
     "unity3d"
     "usbtop"
     "uwsm"
     "vim"
     "virt-manager"
     "vivid"
     "vscode"
     "wavemon"
     "way-cooler"
     "waybar"
     "wayfire"
     "wayland"
     "wayvnc"
     "weylus"
     "winbox"
     "wireshark"
     "wshowkeys"
     "x2goserver"
     "xastir"
     "xfconf"
     "xfs_quota"
     "xonsh"
     "xppen"
     "xss-lock"
     "xwayland"
     "yabar"
     "yazi"
     "ydotool"
     "yubikey-manager"
     "yubikey-touch-detector"
     "zmap"
     "zoom-us"
     "zoxide"
     "zsh"
   ]
   ```
   </details>
   
   <details>
   <summary><b>All program names from home-manager</b></summary>
   
   ```json
   [
     "abaddon"
     "abook"
     "acd-cli"
     "aerc"
     "aerospace"
     "afew"
     "ahoviewer"
     "aiac"
     "aichat"
     "aider-chat"
     "airlift"
     "alacritty"
     "algia"
     "aliae"
     "alistral"
     "alot"
     "am2rlauncher"
     "amber"
     "amfora"
     "amoco"
     "amp"
     "andcli"
     "animdl"
     "anime-downloader"
     "anki"
     "anup"
     "anvil-editor"
     "anyrun"
     "aria2"
     "asciinema"
     "ashell"
     "astroid"
     "atuin"
     "autojump"
     "autorandr"
     "awscli"
     "bacon"
     "bash"
     "bashmount"
     "bat"
     "beets"
     "bemenu"
     "bluetuith"
     "borgmatic"
     "bottom"
     "boxxy"
     "brave"
     "broot"
     "browserpass"
     "btop"
     "bun"
     "calibre"
     "carapace"
     "cargo"
     "cava"
     "cavalier"
     "chawan"
     "chromium"
     "claude-code"
     "clock-rs"
     "cmus"
     "codex"
     "command-not-found"
     "comodoro"
     "cudatext"
     "darcs"
     "delta"
     "desktoppr"
     "diff-highlight"
     "diff-so-fancy"
     "difftastic"
     "dircolors"
     "direnv"
     "discocss"
     "discord"
     "distrobox"
     "docker-cli"
     "earthly"
     "eclipse"
     "element-desktop"
     "emacs"
     "eww"
     "exa"
     "eza"
     "fabric-ai"
     "fastfetch"
     "fd"
     "feh"
     "firefox"
     "firefoxpwa"
     "fish"
     "floorp"
     "foliate"
     "foot"
     "formiko"
     "freetube"
     "fuzzel"
     "fzf"
     "gallery-dl"
     "gcc"
     "gemini-cli"
     "gh"
     "gh-dash"
     "ghostty"
     "git"
     "git-cliff"
     "git-credential-keepassxc"
     "git-credential-oauth"
     "git-worktree-switcher"
     "gitui"
     "glab"
     "glamour"
     "gnome-shell"
     "gnome-terminal"
     "go"
     "google-chrome"
     "google-chrome-beta"
     "google-chrome-dev"
     "goto"
     "gpg"
     "gradle"
     "granted"
     "grep"
     "gurk-rs"
     "halloy"
     "havoc"
     "helix"
     "hexchat"
     "himalaya"
     "home-manager"
     "hstr"
     "htop"
     "hwatch"
     "hyfetch"
     "hyprlock"
     "hyprpanel"
     "hyprshot"
     "i3bar-river"
     "i3blocks"
     "i3status"
     "i3status-rust"
     "iamb"
     "imv"
     "infat"
     "info"
     "inori"
     "intelli-shell"
     "ion"
     "irssi"
     "java"
     "jetbrains-remote"
     "jjui"
     "joplin-desktop"
     "joshuto"
     "jq"
     "jqp"
     "jrnl"
     "jujutsu"
     "just"
     "k9s"
     "kakoune"
     "keepassxc"
     "keychain"
     "khal"
     "khard"
     "kickoff"
     "kitty"
     "kodi"
     "kraftkit"
     "kubecolor"
     "kubeswitch"
     "lapce"
     "lazydocker"
     "lazygit"
     "lazysql"
     "ledger"
     "less"
     "lesspipe"
     "lf"
     "librewolf"
     "lieer"
     "looking-glass-client"
     "lsd"
     "lutris"
     "man"
     "mangohud"
     "matplotlib"
     "mbsync"
     "mc"
     "mcfly"
     "mcp"
     "meli"
     "mercurial"
     "mergiraf"
     "micro"
     "mise"
     "mods"
     "mpv"
     "mpvpaper"
     "mr"
     "msmtp"
     "mu"
     "mujmap"
     "mullvad-vpn"
     "mypy"
     "navi"
     "ncmpcpp"
     "ncspot"
     "ne"
     "neomutt"
     "neovide"
     "neovim"
     "newsboat"
     "nh"
     "nheko"
     "niriswitcher"
     "nix-index"
     "nix-index-database"
     "nix-init"
     "nix-search-tv"
     "nix-your-shell"
     "nnn"
     "noti"
     "notmuch"
     "numbat"
     "nushell"
     "nvchecker"
     "nyxt"
     "obs-studio"
     "obsidian"
     "octant"
     "offlineimap"
     "oh-my-posh"
     "onagre"
     "onedrive"
     "onlyoffice"
     "opam"
     "opencode"
     "openstackclient"
     "opkssh"
     "pandoc"
     "papis"
     "parallel"
     "password-store"
     "patdiff"
     "pay-respects"
     "pazi"
     "pet"
     "pgcli"
     "pianobar"
     "pidgin"
     "pimsync"
     "pistol"
     "piston-cli"
     "pls"
     "poetry"
     "powerline-go"
     "pqiv"
     "ptyxis"
     "pubs"
     "pyenv"
     "pylint"
     "pywal"
     "qcal"
     "quickshell"
     "qutebrowser"
     "radicle"
     "radio-active"
     "radio-cli"
     "ranger"
     "rbenv"
     "rbw"
     "rclone"
     "readline"
     "retext"
     "retroarch"
     "riff"
     "rio"
     "ripgrep"
     "ripgrep-all"
     "rmpc"
     "rofi"
     "rtorrent"
     "rtx"
     "ruff"
     "sagemath"
     "sapling"
     "satty"
     "sbt"
     "scmpuff"
     "screen"
     "script-directory"
     "senpai"
     "sesh"
     "sftpman"
     "sheldon"
     "sherlock"
     "sioyek"
     "sketchybar"
     "skim"
     "sm64ex"
     "smug"
     "spotify-player"
     "sqls"
     "ssh"
     "starship"
     "streamlink"
     "superfile"
     "swappy"
     "sway-easyfocus"
     "swayimg"
     "swaylock"
     "swayr"
     "taskwarrior"
     "tealdeer"
     "television"
     "terminator"
     "termite"
     "tex-fmt"
     "texlive"
     "thefuck"
     "thunderbird"
     "timidity"
     "tint2"
     "tiny"
     "tmate"
     "tmux"
     "todoman"
     "tofi"
     "topgrade"
     "translate-shell"
     "tray-tui"
     "trippy"
     "twitch-tui"
     "ty"
     "urxvt"
     "uv"
     "vdirsyncer"
     "vesktop"
     "vicinae"
     "vifm"
     "vim"
     "vim-vint"
     "vinegar"
     "visidata"
     "vivaldi"
     "vivid"
     "vscode"
     "wallust"
     "watson"
     "waveterm"
     "waybar"
     "waylogout"
     "wayprompt"
     "wezterm"
     "wleave"
     "wlogout"
     "wofi"
     "wpaperd"
     "xmobar"
     "xplr"
     "yambar"
     "yarn"
     "yazi"
     "yofi"
     "yt-dlp"
     "z-lua"
     "zapzap"
     "zathura"
     "zed-editor"
     "zellij"
     "zk"
     "zoxide"
     "zsh"
   ]
   ```
   </details>

   To correct this, I've renamed `programs.dankMaterialShell` to `programs.dank-material-shell`.

2. `camelCase` for output module names

   Output module names should also generally be `kebab-case`. Some examples from the community:

   - [`nixosModules`](https://github.com/search?q=org%3Anix-community%20nixosModules&type=code)
   - [`homeModules`](https://github.com/search?q=org%3Anix-community+homeModules&type=code)

   The modules are now called:

   - `nixosModules.dankMaterialShell` -> `nixosModules.dank-material-shell`
   - `homeModules.dankMaterialShell` -> `homeModules.dank-material-shell`

3. Nested `homeModules`

   Neither `nixosModules` nor `homeModules` should ever be nested. So I've flattened the structure of `homeModules`:

   - `homeModules.dankMaterialShell.default` -> `homeModules.dank-material-shell`
   - `homeModules.dankMaterialShell.niri` -> `homeModules.niri`

   I also find it misleading that the home-manager module is called `default`, in the sense that it provides the [default settings](https://danklinux.com/docs/dankmaterialshell/nixos#default-settings-home-manager-only) functionality. The module provides complete functionality beyond just the default settings, so it should have a more general name.

4. Proper `default` module convention

   Both the NixOS and home-manager modules now have a proper `default` attribute, following the established standard. `default` here refers to the *default module of choice* as in the module that the typical user should install by default. It is not related to the [default settings](https://danklinux.com/docs/dankmaterialshell/nixos#default-settings-home-manager-only) functionality.

   - `nixosModules.default` is now an alias for `nixosModules.dank-material-shell`
   - `homeModules.default` is now an alias for `homeModules.dank-material-shell`

All the changes I've made here is 100% *backwards-compatible*, so all existing configurations will continue to function but with a deprecation warning printed to the console.