### PR TITLE
Fixed having to click twice to exit out of Spotlight/Cliphist/Powermenu

### DIFF
--- a/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
@@ -13,7 +13,7 @@ DankModal {
     layerNamespace: "dms:clipboard"
 
     HyprlandFocusGrab {
-        windows: [clipboardHistoryModal.contentWindow]
+        windows: [clipboardHistoryModal.contentWindow, clipboardHistoryModal.backgroundWindow]
         active: clipboardHistoryModal.useHyprlandFocusGrab && clipboardHistoryModal.shouldHaveFocus
     }
 

--- a/quickshell/Modals/PowerMenuModal.qml
+++ b/quickshell/Modals/PowerMenuModal.qml
@@ -14,7 +14,7 @@ DankModal {
     keepPopoutsOpen: true
 
     HyprlandFocusGrab {
-        windows: [root.contentWindow]
+        windows: [root.contentWindow, root.backgroundWindow]
         active: root.useHyprlandFocusGrab && root.shouldHaveFocus
     }
 

--- a/quickshell/Modals/Spotlight/SpotlightModal.qml
+++ b/quickshell/Modals/Spotlight/SpotlightModal.qml
@@ -11,7 +11,7 @@ DankModal {
     layerNamespace: "dms:spotlight"
 
     HyprlandFocusGrab {
-        windows: [spotlightModal.contentWindow]
+        windows: [spotlightModal.contentWindow, spotlightModal.backgroundWindow]
         active: spotlightModal.useHyprlandFocusGrab && spotlightModal.shouldHaveFocus
     }
 


### PR DESCRIPTION
fix the need of having to click the background twice to close those modals.
not sure if this is intentional behavior