### PR TITLE
Add hide option for updater widget

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -352,6 +352,7 @@ Singleton {
     property string customPowerActionReboot: ""
     property string customPowerActionPowerOff: ""
 
+    property bool updaterHideWidget: false
     property bool updaterUseCustomCommand: false
     property string updaterCustomCommand: ""
     property string updaterTerminalAdditionalParams: ""

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -250,6 +250,7 @@ var SPEC = {
     customPowerActionReboot: { def: "" },
     customPowerActionPowerOff: { def: "" },
 
+    updaterHideWidget: { def: false },
     updaterUseCustomCommand: { def: false },
     updaterCustomCommand: { def: "" },
     updaterTerminalAdditionalParams: { def: "" },

--- a/quickshell/Modules/DankBar/Widgets/SystemUpdate.qml
+++ b/quickshell/Modules/DankBar/Widgets/SystemUpdate.qml
@@ -11,6 +11,9 @@ BasePill {
     readonly property bool hasUpdates: SystemUpdateService.updateCount > 0
     readonly property bool isChecking: SystemUpdateService.isChecking
 
+    readonly property real horizontalPadding: (barConfig?.noBackground ?? false) ? 2 : Theme.spacingS
+    width : (SettingsData.updaterHideWidget && !hasUpdates) ? 0 : (18 + horizontalPadding * 2)
+
     Ref {
         service: SystemUpdateService
     }

--- a/quickshell/Modules/Settings/SystemUpdaterTab.qml
+++ b/quickshell/Modules/Settings/SystemUpdaterTab.qml
@@ -24,6 +24,15 @@ Item {
                 title: I18n.tr("System Updater")
 
                 SettingsToggleRow {
+                    text: I18n.tr("Hide Updater Widget", "When updater widget is used, then hide it if no update found")
+                    description: I18n.tr("When updater widget is used, then hide it if no update found")
+                    checked: SettingsData.updaterHideWidget
+                    onToggled: checked => {
+                        SettingsData.set("updaterHideWidget", checked);
+                    }
+                }
+
+                SettingsToggleRow {
                     text: I18n.tr("Use Custom Command")
                     description: I18n.tr("Use custom command for update your system")
                     checked: SettingsData.updaterUseCustomCommand


### PR DESCRIPTION
In the menu "Workspaces & Widgets -> System Updater", add an option to hide the widget if no update are found

@bbedward hope internalisation are correct as I think a description is needed