### PR TITLE
Fix light mode/dark mode switch for stock themes

### DIFF
--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -918,6 +918,7 @@ Singleton {
 
     function buildMatugenColorsFromTheme(darkTheme, lightTheme) {
         const colors = {};
+        const isLight = SessionData !== "undefined" && SessionData.isLightMode;
 
         function addColor(matugenKey, darkVal, lightVal) {
             if (!darkVal && !lightVal)
@@ -930,7 +931,7 @@ Singleton {
                     "color": String(lightVal || darkVal)
                 },
                 "default": {
-                    "color": String(darkVal || lightVal)
+                    "color": String((isLight && lightVal) ? lightVal : darkVal)
                 }
             };
         }


### PR DESCRIPTION
When using stock themes, the switch between light mode and dark mode does not seem to work properly. Specifically, the ".default" color property in the matugen templates is not substituted by the right color variant (for me it always uses the dark color variant). This PR fixes this issue by selecting the right color value for the .default color.