### PR TITLE
Add media control bindings using playerctl

### DIFF
--- a/core/internal/config/embedded/niri-binds.kdl
+++ b/core/internal/config/embedded/niri-binds.kdl
@@ -45,6 +45,15 @@ binds {
     XF86AudioLowerVolume allow-when-locked=true {
         spawn "dms" "ipc" "call" "audio" "decrement" "3";
     }
+    XF86AudioPlay allow-when-locked=true { 
+        spawn "playerctl" "play-pause"; 
+    }
+    XF86AudioNext allow-when-locked=true { 
+        spawn "playerctl" "next"; 
+    }
+    XF86AudioPrev allow-when-locked=true { 
+        spawn "playerctl" "previous"; 
+    }
     XF86AudioMute allow-when-locked=true {
         spawn "dms" "ipc" "call" "audio" "mute";
     }


### PR DESCRIPTION
* Added `XF86AudioPlay`, `XF86AudioNext`, and `XF86AudioPrev` key bindings to control media playback (play/pause, next, previous) via `playerctl`.