### PR TITLE
Enable printer device and driver search

### DIFF
--- a/quickshell/Modules/Settings/PrinterTab.qml
+++ b/quickshell/Modules/Settings/PrinterTab.qml
@@ -287,6 +287,7 @@ Item {
                                     id: deviceDropdown
                                     dropdownWidth: parent.width - 80 - scanDevicesBtn.width - Theme.spacingS * 2
                                     popupWidth: parent.width - 80 - scanDevicesBtn.width - Theme.spacingS * 2
+                                    enableFuzzySearch: true
                                     currentValue: {
                                         if (CupsService.loadingDevices)
                                             return I18n.tr("Scanning...");
@@ -365,6 +366,7 @@ Item {
                                     id: ppdDropdown
                                     dropdownWidth: parent.width - 80 - refreshPpdsBtn.width - Theme.spacingS * 2
                                     popupWidth: parent.width - 80 - refreshPpdsBtn.width - Theme.spacingS * 2
+                                    enableFuzzySearch: true
                                     currentValue: {
                                         if (CupsService.loadingPPDs)
                                             return I18n.tr("Loading...");


### PR DESCRIPTION
It can often be impossible to select your desired printer driver when there is a lot of them installed, for example when using [Gutenprint](https://gimp-print.sourceforge.io/)

https://github.com/user-attachments/assets/04075c53-9f82-4040-a6b5-cbddedc1b399

https://github.com/user-attachments/assets/ec5c8018-fc0c-4db2-91fe-9585abab8f77

Draft because:
-  Performance could be better, as shown in the video. Every keystroke generates a small, noticeable lag. 
- It would make sense to hide the search field when there is only a small number of devices/drivers