### PR TITLE
Add IPC modal command to clear all notifications

### DIFF
--- a/quickshell/Modals/NotificationModal.qml
+++ b/quickshell/Modals/NotificationModal.qml
@@ -57,6 +57,10 @@ DankModal {
         }
     }
 
+    function clearAll() {
+        NotificationService.clearAllNotifications();
+    }
+
     modalWidth: 500
     modalHeight: 700
     backgroundColor: Theme.withAlpha(Theme.surfaceContainer, Theme.popupTransparency)
@@ -102,6 +106,11 @@ DankModal {
             SessionData.setDoNotDisturb(!SessionData.doNotDisturb);
 
             return "NOTIFICATION_MODAL_TOGGLE_DND_SUCCESS";
+        }
+
+        function clearAll(): string {
+            notificationModal.clearAll();
+            return "NOTIFICATION_MODAL_CLEAR_ALL_SUCCESS";
         }
 
         target: "notifications"

--- a/quickshell/Services/NotificationService.qml
+++ b/quickshell/Services/NotificationService.qml
@@ -414,6 +414,9 @@ Singleton {
     }
 
     function clearAllNotifications() {
+        if (!notifications.length) {
+            return;
+        }
         bulkDismissing = true;
         popupsDisabled = true;
         addGate.stop();


### PR DESCRIPTION
Add function to the notifications IPC modal for clearing all notifications. I also edited the notification service clearAllNotifications function to avoid running when there are no notifications, because when testing I found that calling the original function with no notifications caused notifications to fail to display until the notification center was opened and closed. I assume this was not previously an issue when the only way to clear was using the button in the notification center.  

I'm happy to fix any issues, thanks for the great project!