### PR TITLE
notifications: add modal IPC command to dismiss all popups

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1088,7 +1088,7 @@ Singleton {
         updateBarConfigs();
 
         if (positionChanged) {
-            NotificationService.clearAllPopups();
+            NotificationService.dismissAllPopups();
         }
     }
 
@@ -1233,7 +1233,7 @@ Singleton {
     }
 
     function sendTestNotifications() {
-        NotificationService.clearAllPopups();
+        NotificationService.dismissAllPopups();
         sendTestNotification(0);
         testNotifTimer1.start();
         testNotifTimer2.start();

--- a/quickshell/Modals/NotificationModal.qml
+++ b/quickshell/Modals/NotificationModal.qml
@@ -61,6 +61,10 @@ DankModal {
         NotificationService.clearAllNotifications();
     }
 
+    function dismissAllPopups () {
+        NotificationService.dismissAllPopups();
+    }
+
     modalWidth: 500
     modalHeight: 700
     backgroundColor: Theme.withAlpha(Theme.surfaceContainer, Theme.popupTransparency)
@@ -111,6 +115,11 @@ DankModal {
         function clearAll(): string {
             notificationModal.clearAll();
             return "NOTIFICATION_MODAL_CLEAR_ALL_SUCCESS";
+        }
+
+        function dismissAllPopups(): string {
+            notificationModal.dismissAllPopups();
+            return "NOTIFICATION_MODAL_DISMISS_ALL_POPUPS_SUCCESS";
         }
 
         target: "notifications"

--- a/quickshell/Services/NotificationService.qml
+++ b/quickshell/Services/NotificationService.qml
@@ -403,7 +403,7 @@ Singleton {
         NotifWrapper {}
     }
 
-    function clearAllPopups() {
+    function dismissAllPopups() {
         for (const w of visibleNotifications) {
             if (w) {
                 w.popup = false;


### PR DESCRIPTION
Add function to notifications IPC modal for dismissing all popups to the notification center. I renamed the existing clearAllPopups() function to dismissAllPopups(), since the clearAllNotifications function actually deletes the notifications but the clearAllPopups function simply sends them to the notification center. This addresses #1093.
