### PR TITLE
Clear lock screen textbox on Escape key press

### DIFF
--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -470,6 +470,10 @@ Item {
                                 return;
                             }
 
+                            if (event.key === Qt.Key_Escape) {
+                                clear();
+                            }
+
                             if (pam.passwd.active) {
                                 console.log("PAM is active, ignoring input");
                                 event.accepted = true;


### PR DESCRIPTION
Currently, pressing the Escape key on the lock screen does nothing if the text box is set to always be visible. This PR makes the Escape key instead clear the password entry textbox, which is useful if you've mistyped your password and want to start over.

Fixes #1103 