### PR TITLE
Add getDoNotDisturb to IPC

### DIFF
--- a/quickshell/Modals/NotificationModal.qml
+++ b/quickshell/Modals/NotificationModal.qml
@@ -112,6 +112,10 @@ DankModal {
             return "NOTIFICATION_MODAL_TOGGLE_DND_SUCCESS";
         }
 
+        function getDoNotDisturb(): bool {
+            return SessionData.doNotDisturb;
+        }
+
         function clearAll(): string {
             notificationModal.clearAll();
             return "NOTIFICATION_MODAL_CLEAR_ALL_SUCCESS";


### PR DESCRIPTION
This PR adds a new function to the IPC interface for fetching current Do Not Disturb status.