### PR TITLE
Fix touchpad scrolling behavior

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/ControlCenterButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/ControlCenterButton.qml
@@ -21,7 +21,7 @@ BasePill {
     property bool showMicIcon: widgetData?.showMicIcon !== undefined ? widgetData.showMicIcon : SettingsData.controlCenterShowMicIcon
     property bool showBatteryIcon: widgetData?.showBatteryIcon !== undefined ? widgetData.showBatteryIcon : SettingsData.controlCenterShowBatteryIcon
     property bool showPrinterIcon: widgetData?.showPrinterIcon !== undefined ? widgetData.showPrinterIcon : SettingsData.controlCenterShowPrinterIcon
-    property real touchpadThreshold: 500
+    property real touchpadThreshold: 100
     property real micAccumulator: 0
     property real volumeAccumulator: 0
     property real brightnessAccumulator: 0
@@ -121,8 +121,10 @@ BasePill {
         if (!AudioService.sink?.audio)
             return;
 
+        var step = 5;
         const isMouseWheel = Math.abs(delta) >= 120 && (Math.abs(delta) % 120) === 0;
         if (!isMouseWheel) {
+            step = 1;
             volumeAccumulator += delta;
             if (Math.abs(volumeAccumulator) < touchpadThreshold)
                 return;
@@ -132,7 +134,7 @@ BasePill {
         }
 
         const currentVolume = AudioService.sink.audio.volume * 100;
-        const newVolume = delta > 0 ? Math.min(100, currentVolume + 5) : Math.max(0, currentVolume - 5);
+        const newVolume = delta > 0 ? Math.min(100, currentVolume + step) : Math.max(0, currentVolume - step);
         AudioService.sink.audio.muted = false;
         AudioService.sink.audio.volume = newVolume / 100;
         AudioService.playVolumeChangeSoundIfEnabled();
@@ -142,8 +144,10 @@ BasePill {
         if (!AudioService.source?.audio)
             return;
 
+        var step = 5;
         const isMouseWheel = Math.abs(delta) >= 120 && (Math.abs(delta) % 120) === 0;
         if (!isMouseWheel) {
+            step = 1;
             micAccumulator += delta;
             if (Math.abs(micAccumulator) < touchpadThreshold)
                 return;
@@ -153,7 +157,7 @@ BasePill {
         }
 
         const currentVolume = AudioService.source.audio.volume * 100;
-        const newVolume = delta > 0 ? Math.min(100, currentVolume + 5) : Math.max(0, currentVolume - 5);
+        const newVolume = delta > 0 ? Math.min(100, currentVolume + step) : Math.max(0, currentVolume - step);
         AudioService.source.audio.muted = false;
         AudioService.source.audio.volume = newVolume / 100;
     }
@@ -164,8 +168,10 @@ BasePill {
             return;
         }
 
+        var step = 5;
         const isMouseWheel = Math.abs(delta) >= 120 && (Math.abs(delta) % 120) === 0;
         if (!isMouseWheel) {
+            step = 1;
             brightnessAccumulator += delta;
             if (Math.abs(brightnessAccumulator) < touchpadThreshold)
                 return;
@@ -175,7 +181,7 @@ BasePill {
         }
 
         const currentBrightness = DisplayService.getDeviceBrightness(deviceName);
-        const newBrightness = delta > 0 ? Math.min(100, currentBrightness + 5) : Math.max(1, currentBrightness - 5);
+        const newBrightness = delta > 0 ? Math.min(100, currentBrightness + step) : Math.max(1, currentBrightness - step);
         DisplayService.setBrightness(newBrightness, deviceName);
     }
 

--- a/quickshell/Modules/DankBar/Widgets/Media.qml
+++ b/quickshell/Modules/DankBar/Widgets/Media.qml
@@ -49,7 +49,7 @@ BasePill {
     }
 
     property real scrollAccumulatorY: 0
-    property real touchpadThreshold: 500
+    property real touchpadThreshold: 100
 
     onWheel: function (wheelEvent) {
         wheelEvent.accepted = true;
@@ -72,9 +72,9 @@ BasePill {
             scrollAccumulatorY += deltaY;
             if (Math.abs(scrollAccumulatorY) >= touchpadThreshold) {
                 if (scrollAccumulatorY > 0) {
-                    newVolume = Math.min(100, currentVolume + 5);
+                    newVolume = Math.min(100, currentVolume + 1);
                 } else {
-                    newVolume = Math.max(0, currentVolume - 5);
+                    newVolume = Math.max(0, currentVolume - 1);
                 }
                 scrollAccumulatorY = 0;
             }


### PR DESCRIPTION
Currently, touchpad scrolling on the media widget or the volume/microphone/brightness icons in the control center widget results in very fast and erratic changes to the respective setting. This PR makes all of these elements' scrolling behavior match that from the Workspace Switcher widget.

As an additional benefit, this also fixes #1107 (caused by only checking whether the vertical scroll delta > 0, but when == 0 it still decreases the volume).