### PR TITLE
Allow toggling mute with right-click on control center items

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/ControlCenterButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/ControlCenterButton.qml
@@ -212,10 +212,13 @@ BasePill {
 
                     MouseArea {
                         anchors.fill: parent
-                        acceptedButtons: Qt.NoButton
+                        acceptedButtons: Qt.RightButton
                         onWheel: function (wheelEvent) {
                             root.handleVolumeWheel(wheelEvent.angleDelta.y);
                             wheelEvent.accepted = true;
+                        }
+                        onClicked: {
+                            AudioService.toggleMute();
                         }
                     }
                 }
@@ -237,10 +240,13 @@ BasePill {
 
                     MouseArea {
                         anchors.fill: parent
-                        acceptedButtons: Qt.NoButton
+                        acceptedButtons: Qt.RightButton
                         onWheel: function (wheelEvent) {
                             root.handleMicWheel(wheelEvent.angleDelta.y);
                             wheelEvent.accepted = true;
+                        }
+                        onClicked: {
+                            AudioService.toggleMicMute();
                         }
                     }
                 }
@@ -346,10 +352,13 @@ BasePill {
                     MouseArea {
                         id: audioWheelArea
                         anchors.fill: parent
-                        acceptedButtons: Qt.NoButton
+                        acceptedButtons: Qt.RightButton
                         onWheel: function (wheelEvent) {
                             root.handleVolumeWheel(wheelEvent.angleDelta.y);
                             wheelEvent.accepted = true;
+                        }
+                        onClicked: {
+                            AudioService.toggleMute();
                         }
                     }
                 }
@@ -372,10 +381,13 @@ BasePill {
                     MouseArea {
                         id: micWheelArea
                         anchors.fill: parent
-                        acceptedButtons: Qt.NoButton
+                        acceptedButtons: Qt.RightButton
                         onWheel: function (wheelEvent) {
                             root.handleMicWheel(wheelEvent.angleDelta.y);
                             wheelEvent.accepted = true;
+                        }
+                        onClicked: {
+                            AudioService.toggleMicMute();
                         }
                     }
                 }


### PR DESCRIPTION
This is another feature I'm looking to bring over from my prior setup. Combined with #1146, it gives full volume control without having to open any menus. I don't think it needs a config option, as right click currently has no other purpose.