### PR TITLE
Add volume and brightness percentages

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -108,9 +108,12 @@ Singleton {
     property bool controlCenterShowNetworkIcon: true
     property bool controlCenterShowBluetoothIcon: true
     property bool controlCenterShowAudioIcon: true
+    property bool controlCenterShowAudioPercent: true
     property bool controlCenterShowVpnIcon: true
     property bool controlCenterShowBrightnessIcon: false
+    property bool controlCenterShowBrightnessPercent: false
     property bool controlCenterShowMicIcon: false
+    property bool controlCenterShowMicPercent: true
     property bool controlCenterShowBatteryIcon: false
     property bool controlCenterShowPrinterIcon: false
     property bool showPrivacyButton: true

--- a/quickshell/Common/settings/Lists.qml
+++ b/quickshell/Common/settings/Lists.qml
@@ -21,9 +21,12 @@ Singleton {
             showNetworkIcon: true,
             showBluetoothIcon: true,
             showAudioIcon: true,
+            showAudioPercent: true,
             showVpnIcon: true,
             showBrightnessIcon: false,
+            showBrightnessPercent: false,
             showMicIcon: false,
+            showMicPercent: true,
             showBatteryIcon: false,
             showPrinterIcon: false
         };
@@ -65,12 +68,18 @@ Singleton {
                 item.showBluetoothIcon = order[i].showBluetoothIcon;
             if (isObj && order[i].showAudioIcon !== undefined)
                 item.showAudioIcon = order[i].showAudioIcon;
+            if (isObj && order[i].showAudioPercent !== undefined)
+                item.showAudioPercent = order[i].showAudioPercent;
             if (isObj && order[i].showVpnIcon !== undefined)
                 item.showVpnIcon = order[i].showVpnIcon;
             if (isObj && order[i].showBrightnessIcon !== undefined)
                 item.showBrightnessIcon = order[i].showBrightnessIcon;
+            if (isObj && order[i].showBrightnessPercent !== undefined)
+                item.showBrightnessPercent = order[i].showBrightnessPercent;
             if (isObj && order[i].showMicIcon !== undefined)
                 item.showMicIcon = order[i].showMicIcon;
+            if (isObj && order[i].showMicPercent !== undefined)
+                item.showMicPercent = order[i].showMicPercent;
             if (isObj && order[i].showBatteryIcon !== undefined)
                 item.showBatteryIcon = order[i].showBatteryIcon;
             if (isObj && order[i].showPrinterIcon !== undefined)

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -54,9 +54,12 @@ var SPEC = {
     controlCenterShowNetworkIcon: { def: true },
     controlCenterShowBluetoothIcon: { def: true },
     controlCenterShowAudioIcon: { def: true },
+    controlCenterShowAudioPercent: { def: false },
     controlCenterShowVpnIcon: { def: true },
     controlCenterShowBrightnessIcon: { def: false },
+    controlCenterShowBrightnessPercent: { def: false },
     controlCenterShowMicIcon: { def: false },
+    controlCenterShowMicPercent: { def: false },
     controlCenterShowBatteryIcon: { def: false },
     controlCenterShowPrinterIcon: { def: false },
 

--- a/quickshell/Modules/DankBar/Widgets/ControlCenterButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/ControlCenterButton.qml
@@ -16,9 +16,12 @@ BasePill {
     property bool showNetworkIcon: widgetData?.showNetworkIcon !== undefined ? widgetData.showNetworkIcon : SettingsData.controlCenterShowNetworkIcon
     property bool showBluetoothIcon: widgetData?.showBluetoothIcon !== undefined ? widgetData.showBluetoothIcon : SettingsData.controlCenterShowBluetoothIcon
     property bool showAudioIcon: widgetData?.showAudioIcon !== undefined ? widgetData.showAudioIcon : SettingsData.controlCenterShowAudioIcon
+    property bool showAudioPercent: widgetData?.showAudioPercent !== undefined ? widgetData.showAudioPercent : SettingsData.controlCenterShowAudioPercent
     property bool showVpnIcon: widgetData?.showVpnIcon !== undefined ? widgetData.showVpnIcon : SettingsData.controlCenterShowVpnIcon
     property bool showBrightnessIcon: widgetData?.showBrightnessIcon !== undefined ? widgetData.showBrightnessIcon : SettingsData.controlCenterShowBrightnessIcon
+    property bool showBrightnessPercent: widgetData?.showBrightnessPercent !== undefined ? widgetData.showBrightnessPercent : SettingsData.controlCenterShowBrightnessPercent
     property bool showMicIcon: widgetData?.showMicIcon !== undefined ? widgetData.showMicIcon : SettingsData.controlCenterShowMicIcon
+    property bool showMicPercent: widgetData?.showMicPercent !== undefined ? widgetData.showMicPercent : SettingsData.controlCenterShowMicPercent
     property bool showBatteryIcon: widgetData?.showBatteryIcon !== undefined ? widgetData.showBatteryIcon : SettingsData.controlCenterShowBatteryIcon
     property bool showPrinterIcon: widgetData?.showPrinterIcon !== undefined ? widgetData.showPrinterIcon : SettingsData.controlCenterShowPrinterIcon
     property real touchpadThreshold: 100
@@ -185,6 +188,14 @@ BasePill {
         DisplayService.setBrightness(newBrightness, deviceName);
     }
 
+    function getBrightness() {
+        const deviceName = getPinnedBrightnessDevice();
+        if (!deviceName) {
+            return;
+        }
+        return DisplayService.getDeviceBrightness(deviceName) / 100;
+    }
+
     function getBatteryIconColor() {
         if (!BatteryService.batteryAvailable)
             return Theme.widgetIconColor;
@@ -240,7 +251,7 @@ BasePill {
 
                 Rectangle {
                     width: audioIconV.implicitWidth + 4
-                    height: audioIconV.implicitHeight + 4
+                    height: audioIconV.implicitHeight + (root.showAudioPercent ? audioPercentV.implicitHeight : 0) + 4
                     color: "transparent"
                     anchors.horizontalCenter: parent.horizontalCenter
                     visible: root.showAudioIcon
@@ -250,7 +261,20 @@ BasePill {
                         name: root.getVolumeIconName()
                         size: Theme.barIconSize(root.barThickness, -4)
                         color: Theme.widgetIconColor
-                        anchors.centerIn: parent
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.top: parent
+                        anchors.topMargin: 2
+                    }
+
+                    StyledText {
+                        id: audioPercentV
+                        visible: root.showAudioPercent
+                        text: Math.round(AudioService.sink.audio.volume * 100) + "%"
+                        font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale)
+                        color: Theme.widgetTextColor
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.top: audioIconV.bottom
+                        anchors.topMargin: 2
                     }
 
                     MouseArea {
@@ -268,7 +292,7 @@ BasePill {
 
                 Rectangle {
                     width: micIconV.implicitWidth + 4
-                    height: micIconV.implicitHeight + 4
+                    height: micIconV.implicitHeight + (root.showAudioPercent ? micPercentV.implicitHeight : 0) + 4
                     color: "transparent"
                     anchors.horizontalCenter: parent.horizontalCenter
                     visible: root.showMicIcon
@@ -278,7 +302,20 @@ BasePill {
                         name: root.getMicIconName()
                         size: Theme.barIconSize(root.barThickness, -4)
                         color: root.getMicIconColor()
-                        anchors.centerIn: parent
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.top: parent
+                        anchors.topMargin: 2
+                    }
+
+                    StyledText {
+                        id: micPercentV
+                        visible: root.showMicPercent
+                        text: Math.round(AudioService.source.audio.volume * 100) + "%"
+                        font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale)
+                        color: Theme.widgetTextColor
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.top: micIconV.bottom
+                        anchors.topMargin: 2
                     }
 
                     MouseArea {
@@ -296,7 +333,7 @@ BasePill {
 
                 Rectangle {
                     width: brightnessIconV.implicitWidth + 4
-                    height: brightnessIconV.implicitHeight + 4
+                    height: brightnessIconV.implicitHeight + (root.showBrightnessPercent ? brightnessPercentV.implicitHeight : 0) + 4
                     color: "transparent"
                     anchors.horizontalCenter: parent.horizontalCenter
                     visible: root.showBrightnessIcon && DisplayService.brightnessAvailable && root.hasPinnedBrightnessDevice()
@@ -306,7 +343,20 @@ BasePill {
                         name: root.getBrightnessIconName()
                         size: Theme.barIconSize(root.barThickness, -4)
                         color: Theme.widgetIconColor
-                        anchors.centerIn: parent
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.top: parent
+                        anchors.topMargin: 2
+                    }
+
+                    StyledText {
+                        id: brightnessPercentV
+                        visible: root.showBrightnessPercent
+                        text: Math.round(getBrightness() * 100) + "%"
+                        font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale)
+                        color: Theme.widgetTextColor
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.top: brightnessIconV.bottom
+                        anchors.topMargin: 2
                     }
 
                     MouseArea {
@@ -378,7 +428,7 @@ BasePill {
                 }
 
                 Rectangle {
-                    width: audioIcon.implicitWidth + 4
+                    width: audioIcon.implicitWidth + (root.showAudioPercent ? audioPercent.implicitWidth : 0) + 4
                     height: audioIcon.implicitHeight + 4
                     color: "transparent"
                     anchors.verticalCenter: parent.verticalCenter
@@ -389,7 +439,20 @@ BasePill {
                         name: root.getVolumeIconName()
                         size: Theme.barIconSize(root.barThickness, -4)
                         color: Theme.widgetIconColor
-                        anchors.centerIn: parent
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: parent
+                        anchors.leftMargin: 2
+                    }
+
+                    StyledText {
+                        id: audioPercent
+                        visible: root.showAudioPercent
+                        text: Math.round(AudioService.sink.audio.volume * 100) + "%"
+                        font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale)
+                        color: Theme.widgetTextColor
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: audioIcon.right
+                        anchors.leftMargin: 2
                     }
 
                     MouseArea {
@@ -407,7 +470,7 @@ BasePill {
                 }
 
                 Rectangle {
-                    width: micIcon.implicitWidth + 4
+                    width: micIcon.implicitWidth + (root.showMicPercent ? micPercent.implicitWidth : 0) + 4
                     height: micIcon.implicitHeight + 4
                     color: "transparent"
                     anchors.verticalCenter: parent.verticalCenter
@@ -418,7 +481,20 @@ BasePill {
                         name: root.getMicIconName()
                         size: Theme.barIconSize(root.barThickness, -4)
                         color: root.getMicIconColor()
-                        anchors.centerIn: parent
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: parent
+                        anchors.leftMargin: 2
+                    }
+
+                    StyledText {
+                        id: micPercent
+                        visible: root.showMicPercent
+                        text: Math.round(AudioService.source.audio.volume * 100) + "%"
+                        font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale)
+                        color: Theme.widgetTextColor
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: micIcon.right
+                        anchors.leftMargin: 2
                     }
 
                     MouseArea {
@@ -436,7 +512,7 @@ BasePill {
                 }
 
                 Rectangle {
-                    width: brightnessIcon.implicitWidth + 4
+                    width: brightnessIcon.implicitWidth + (root.showBrightnessPercent ? brightnessPercent.implicitWidth : 0) + 4
                     height: brightnessIcon.implicitHeight + 4
                     color: "transparent"
                     anchors.verticalCenter: parent.verticalCenter
@@ -447,7 +523,20 @@ BasePill {
                         name: root.getBrightnessIconName()
                         size: Theme.barIconSize(root.barThickness, -4)
                         color: Theme.widgetIconColor
-                        anchors.centerIn: parent
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: parent
+                        anchors.leftMargin: 2
+                    }
+
+                    StyledText {
+                        id: brightnessPercent
+                        visible: root.showBrightnessPercent
+                        text: Math.round(getBrightness() * 100) + "%"
+                        font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale)
+                        color: Theme.widgetTextColor
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: brightnessIcon.right
+                        anchors.leftMargin: 2
                     }
 
                     MouseArea {

--- a/quickshell/Modules/Settings/WidgetsTab.qml
+++ b/quickshell/Modules/Settings/WidgetsTab.qml
@@ -374,9 +374,12 @@ Item {
             widgetObj.showNetworkIcon = SettingsData.controlCenterShowNetworkIcon;
             widgetObj.showBluetoothIcon = SettingsData.controlCenterShowBluetoothIcon;
             widgetObj.showAudioIcon = SettingsData.controlCenterShowAudioIcon;
+            widgetObj.showAudioPercent = SettingsData.controlCenterShowAudioPercent;
             widgetObj.showVpnIcon = SettingsData.controlCenterShowVpnIcon;
             widgetObj.showBrightnessIcon = SettingsData.controlCenterShowBrightnessIcon;
+            widgetObj.showBrightnessPercent = SettingsData.controlCenterShowBrightnessPercent;
             widgetObj.showMicIcon = SettingsData.controlCenterShowMicIcon;
+            widgetObj.showMicPercent = SettingsData.controlCenterShowMicPercent;
             widgetObj.showBatteryIcon = SettingsData.controlCenterShowBatteryIcon;
             widgetObj.showPrinterIcon = SettingsData.controlCenterShowPrinterIcon;
         }
@@ -431,9 +434,12 @@ Item {
                 newWidget.showNetworkIcon = widget.showNetworkIcon ?? SettingsData.controlCenterShowNetworkIcon;
                 newWidget.showBluetoothIcon = widget.showBluetoothIcon ?? SettingsData.controlCenterShowBluetoothIcon;
                 newWidget.showAudioIcon = widget.showAudioIcon ?? SettingsData.controlCenterShowAudioIcon;
+                newWidget.showAudioPercent = widget.showAudioPercent ?? SettingsData.controlCenterShowAudioPercent;
                 newWidget.showVpnIcon = widget.showVpnIcon ?? SettingsData.controlCenterShowVpnIcon;
                 newWidget.showBrightnessIcon = widget.showBrightnessIcon ?? SettingsData.controlCenterShowBrightnessIcon;
+                newWidget.showBrightnessPercent = widget.showBrightnessPercent ?? SettingsData.controlCenterShowBrightnessPercent;
                 newWidget.showMicIcon = widget.showMicIcon ?? SettingsData.controlCenterShowMicIcon;
+                newWidget.showMicPercent = widget.showMicPercent ?? SettingsData.controlCenterShowMicPercent;
                 newWidget.showBatteryIcon = widget.showBatteryIcon ?? SettingsData.controlCenterShowBatteryIcon;
                 newWidget.showPrinterIcon = widget.showPrinterIcon ?? SettingsData.controlCenterShowPrinterIcon;
             }
@@ -484,9 +490,12 @@ Item {
             newWidget.showNetworkIcon = widget.showNetworkIcon ?? SettingsData.controlCenterShowNetworkIcon;
             newWidget.showBluetoothIcon = widget.showBluetoothIcon ?? SettingsData.controlCenterShowBluetoothIcon;
             newWidget.showAudioIcon = widget.showAudioIcon ?? SettingsData.controlCenterShowAudioIcon;
+            newWidget.showAudioPercent = widget.showAudioPercent ?? SettingsData.controlCenterShowAudioPercent;
             newWidget.showVpnIcon = widget.showVpnIcon ?? SettingsData.controlCenterShowVpnIcon;
             newWidget.showBrightnessIcon = widget.showBrightnessIcon ?? SettingsData.controlCenterShowBrightnessIcon;
+            newWidget.showBrightnessPercent = widget.showBrightnessPercent ?? SettingsData.controlCenterShowBrightnessPercent;
             newWidget.showMicIcon = widget.showMicIcon ?? SettingsData.controlCenterShowMicIcon;
+            newWidget.showMicPercent = widget.showMicPercent ?? SettingsData.controlCenterShowMicPercent;
             newWidget.showBatteryIcon = widget.showBatteryIcon ?? SettingsData.controlCenterShowBatteryIcon;
             newWidget.showPrinterIcon = widget.showPrinterIcon ?? SettingsData.controlCenterShowPrinterIcon;
         }
@@ -559,9 +568,12 @@ Item {
             newWidget.showNetworkIcon = widget.showNetworkIcon ?? SettingsData.controlCenterShowNetworkIcon;
             newWidget.showBluetoothIcon = widget.showBluetoothIcon ?? SettingsData.controlCenterShowBluetoothIcon;
             newWidget.showAudioIcon = widget.showAudioIcon ?? SettingsData.controlCenterShowAudioIcon;
+            newWidget.showAudioPercent = widget.showAudioPercent ?? SettingsData.controlCenterShowAudioPercent;
             newWidget.showVpnIcon = widget.showVpnIcon ?? SettingsData.controlCenterShowVpnIcon;
             newWidget.showBrightnessIcon = widget.showBrightnessIcon ?? SettingsData.controlCenterShowBrightnessIcon;
+            newWidget.showBrightnessPercent = widget.showBrightnessPercent ?? SettingsData.controlCenterShowBrightnessPercent;
             newWidget.showMicIcon = widget.showMicIcon ?? SettingsData.controlCenterShowMicIcon;
+            newWidget.showMicPercent = widget.showMicPercent ?? SettingsData.controlCenterShowMicPercent;
             newWidget.showBatteryIcon = widget.showBatteryIcon ?? SettingsData.controlCenterShowBatteryIcon;
             newWidget.showPrinterIcon = widget.showPrinterIcon ?? SettingsData.controlCenterShowPrinterIcon;
         }
@@ -588,9 +600,12 @@ Item {
             "showNetworkIcon": widget.showNetworkIcon ?? SettingsData.controlCenterShowNetworkIcon,
             "showBluetoothIcon": widget.showBluetoothIcon ?? SettingsData.controlCenterShowBluetoothIcon,
             "showAudioIcon": widget.showAudioIcon ?? SettingsData.controlCenterShowAudioIcon,
+            "showAudioPercent": widget.showAudioPercent ?? SettingsData.controlCenterShowAudioPercent,
             "showVpnIcon": widget.showVpnIcon ?? SettingsData.controlCenterShowVpnIcon,
             "showBrightnessIcon": widget.showBrightnessIcon ?? SettingsData.controlCenterShowBrightnessIcon,
+            "showBrightnessPercent": widget.showBrightnessPercent ?? SettingsData.controlCenterShowBrightnessPercent,
             "showMicIcon": widget.showMicIcon ?? SettingsData.controlCenterShowMicIcon,
+            "showMicPercent": widget.showMicPercent ?? SettingsData.controlCenterShowMicPercent,
             "showBatteryIcon": widget.showBatteryIcon ?? SettingsData.controlCenterShowBatteryIcon,
             "showPrinterIcon": widget.showPrinterIcon ?? SettingsData.controlCenterShowPrinterIcon
         };
@@ -651,9 +666,12 @@ Item {
             newWidget.showNetworkIcon = widget.showNetworkIcon ?? SettingsData.controlCenterShowNetworkIcon;
             newWidget.showBluetoothIcon = widget.showBluetoothIcon ?? SettingsData.controlCenterShowBluetoothIcon;
             newWidget.showAudioIcon = widget.showAudioIcon ?? SettingsData.controlCenterShowAudioIcon;
+            newWidget.showAudioPercent = widget.showAudioPercent ?? SettingsData.controlCenterShowAudioPercent;
             newWidget.showVpnIcon = widget.showVpnIcon ?? SettingsData.controlCenterShowVpnIcon;
             newWidget.showBrightnessIcon = widget.showBrightnessIcon ?? SettingsData.controlCenterShowBrightnessIcon;
+            newWidget.showBrightnessPercent = widget.showBrightnessPercent ?? SettingsData.controlCenterShowBrightnessPercent;
             newWidget.showMicIcon = widget.showMicIcon ?? SettingsData.controlCenterShowMicIcon;
+            newWidget.showMicPercent = widget.showMicPercent ?? SettingsData.controlCenterShowMicPercent;
             newWidget.showBatteryIcon = widget.showBatteryIcon ?? SettingsData.controlCenterShowBatteryIcon;
             newWidget.showPrinterIcon = widget.showPrinterIcon ?? SettingsData.controlCenterShowPrinterIcon;
         }
@@ -708,9 +726,12 @@ Item {
             newWidget.showNetworkIcon = widget.showNetworkIcon ?? SettingsData.controlCenterShowNetworkIcon;
             newWidget.showBluetoothIcon = widget.showBluetoothIcon ?? SettingsData.controlCenterShowBluetoothIcon;
             newWidget.showAudioIcon = widget.showAudioIcon ?? SettingsData.controlCenterShowAudioIcon;
+            newWidget.showAudioPercent = widget.showAudioPercent ?? SettingsData.controlCenterShowAudioPercent;
             newWidget.showVpnIcon = widget.showVpnIcon ?? SettingsData.controlCenterShowVpnIcon;
             newWidget.showBrightnessIcon = widget.showBrightnessIcon ?? SettingsData.controlCenterShowBrightnessIcon;
+            newWidget.showBrightnessPercent = widget.showBrightnessPercent ?? SettingsData.controlCenterShowBrightnessPercent;
             newWidget.showMicIcon = widget.showMicIcon ?? SettingsData.controlCenterShowMicIcon;
+            newWidget.showMicPercent = widget.showMicPercent ?? SettingsData.controlCenterShowMicPercent;
             newWidget.showBatteryIcon = widget.showBatteryIcon ?? SettingsData.controlCenterShowBatteryIcon;
             newWidget.showPrinterIcon = widget.showPrinterIcon ?? SettingsData.controlCenterShowPrinterIcon;
         }
@@ -765,9 +786,12 @@ Item {
                     newWidget.showNetworkIcon = widget.showNetworkIcon ?? SettingsData.controlCenterShowNetworkIcon;
                     newWidget.showBluetoothIcon = widget.showBluetoothIcon ?? SettingsData.controlCenterShowBluetoothIcon;
                     newWidget.showAudioIcon = widget.showAudioIcon ?? SettingsData.controlCenterShowAudioIcon;
+                    newWidget.showAudioPercent = widget.showAudioPercent ?? SettingsData.controlCenterShowAudioPercent;
                     newWidget.showVpnIcon = widget.showVpnIcon ?? SettingsData.controlCenterShowVpnIcon;
                     newWidget.showBrightnessIcon = widget.showBrightnessIcon ?? SettingsData.controlCenterShowBrightnessIcon;
+                    newWidget.showBrightnessPercent = widget.showBrightnessPercent ?? SettingsData.controlCenterShowBrightnessPercent;
                     newWidget.showMicIcon = widget.showMicIcon ?? SettingsData.controlCenterShowMicIcon;
+                    newWidget.showMicPercent = widget.showMicPercent ?? SettingsData.controlCenterShowMicPercent;
                     newWidget.showBatteryIcon = widget.showBatteryIcon ?? SettingsData.controlCenterShowBatteryIcon;
                     newWidget.showPrinterIcon = widget.showPrinterIcon ?? SettingsData.controlCenterShowPrinterIcon;
                 }
@@ -826,12 +850,18 @@ Item {
                     item.showBluetoothIcon = widget.showBluetoothIcon;
                 if (widget.showAudioIcon !== undefined)
                     item.showAudioIcon = widget.showAudioIcon;
+                if (widget.showAudioPercent !== undefined)
+                    item.showAudioPercent = widget.showAudioPercent;
                 if (widget.showVpnIcon !== undefined)
                     item.showVpnIcon = widget.showVpnIcon;
                 if (widget.showBrightnessIcon !== undefined)
                     item.showBrightnessIcon = widget.showBrightnessIcon;
+                if (widget.showBrightnessPercent !== undefined)
+                    item.showBrightnessPercent = widget.showBrightnessPercent;
                 if (widget.showMicIcon !== undefined)
                     item.showMicIcon = widget.showMicIcon;
+                if (widget.showMicPercent !== undefined)
+                    item.showMicPercent = widget.showMicPercent;
                 if (widget.showBatteryIcon !== undefined)
                     item.showBatteryIcon = widget.showBatteryIcon;
                 if (widget.showPrinterIcon !== undefined)

--- a/quickshell/Modules/Settings/WidgetsTabSection.qml
+++ b/quickshell/Modules/Settings/WidgetsTabSection.qml
@@ -824,14 +824,29 @@ Column {
                             setting: "showAudioIcon"
                         },
                         {
+                            icon: "percent",
+                            label: I18n.tr("Volume"),
+                            setting: "showAudioPercent"
+                        },
+                        {
                             icon: "mic",
                             label: I18n.tr("Microphone"),
                             setting: "showMicIcon"
                         },
                         {
+                            icon: "percent",
+                            label: I18n.tr("Microphone Volume"),
+                            setting: "showMicPercent"
+                        },
+                        {
                             icon: "brightness_high",
                             label: I18n.tr("Brightness"),
                             setting: "showBrightnessIcon"
+                        },
+                        {
+                            icon: "percent",
+                            label: I18n.tr("Brightness Value"),
+                            setting: "showBrightnessPercent"
                         },
                         {
                             icon: "battery_full",
@@ -860,10 +875,16 @@ Column {
                                 return wd?.showBluetoothIcon ?? SettingsData.controlCenterShowBluetoothIcon;
                             case "showAudioIcon":
                                 return wd?.showAudioIcon ?? SettingsData.controlCenterShowAudioIcon;
+                            case "showAudioPercent":
+                                return wd?.showAudioPercent ?? SettingsData.controlCenterShowAudioPercent;
                             case "showMicIcon":
                                 return wd?.showMicIcon ?? SettingsData.controlCenterShowMicIcon;
+                            case "showMicPercent":
+                                return wd?.showMicPercent ?? SettingsData.controlCenterShowMicPercent;
                             case "showBrightnessIcon":
                                 return wd?.showBrightnessIcon ?? SettingsData.controlCenterShowBrightnessIcon;
+                            case "showBrightnessPercent":
+                                return wd?.showBrightnessPercent ?? SettingsData.controlCenterShowBrightnessPercent;
                             case "showBatteryIcon":
                                 return wd?.showBatteryIcon ?? SettingsData.controlCenterShowBatteryIcon;
                             case "showPrinterIcon":

--- a/quickshell/translations/en.json
+++ b/quickshell/translations/en.json
@@ -1026,6 +1026,12 @@
     "comment": ""
   },
   {
+    "term": "Brightness Value",
+    "context": "Brightness Value",
+    "reference": "Modules/Settings/WidgetsTabSection.qml:848",
+    "comment": ""
+  },
+  {
     "term": "Brightness control not available",
     "context": "Brightness control not available",
     "reference": "Modules/ControlCenter/Details/BrightnessDetail.qml:144, Modules/ControlCenter/Models/WidgetModel.qml:148",
@@ -4299,6 +4305,12 @@
     "term": "Microphone Mute",
     "context": "Microphone Mute",
     "reference": "Modules/Settings/OSDTab.qml:125",
+    "comment": ""
+  },
+  {
+    "term": "Microphone Volume",
+    "context": "Microphone Volume",
+    "reference": "Modules/Settings/WidgetsTabSection.qml:838",
     "comment": ""
   },
   {

--- a/quickshell/translations/template.json
+++ b/quickshell/translations/template.json
@@ -1197,6 +1197,13 @@
     "comment": ""
   },
   {
+    "term": "Brightness Value",
+    "translation": "",
+    "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Brightness control not available",
     "translation": "",
     "context": "",
@@ -5013,6 +5020,13 @@
   },
   {
     "term": "Microphone Mute",
+    "translation": "",
+    "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Microphone Volume",
     "translation": "",
     "context": "",
     "reference": "",


### PR DESCRIPTION
This PR adds options for the Control Center widget to show the percentage values for the current system volume, microphone volume, and screen brightness, next to the existing icons for each. By default they are all disabled so as not to change behavior on existing installations. They are positioned to the right of each icon for horizontal layouts, or below the icon for vertical layouts. Because they are tied to the existing icons, the icon must be enabled before the new option will have any effect.