### PR TITLE
Use `volume_mute` icon for `volume===0`

### DIFF
--- a/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
+++ b/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
@@ -248,8 +248,10 @@ Column {
                             return "volume_off";
                         let volume = AudioService.sink.audio.volume;
                         let muted = AudioService.sink.audio.muted;
-                        if (muted || volume === 0.0)
+                        if (muted)
                             return "volume_off";
+                        if (volume === 0.0)
+                            return "volume_mute";
                         if (volume <= 0.33)
                             return "volume_down";
                         if (volume <= 0.66)

--- a/quickshell/Modules/ControlCenter/Details/AudioOutputDetail.qml
+++ b/quickshell/Modules/ControlCenter/Details/AudioOutputDetail.qml
@@ -77,8 +77,10 @@ Rectangle {
                         return "volume_off";
                     let muted = AudioService.sink.audio.muted;
                     let volume = AudioService.sink.audio.volume;
-                    if (muted || volume === 0.0)
+                    if (muted)
                         return "volume_off";
+                    if (volume === 0.0)
+                        return "volume_mute";
                     if (volume <= 0.33)
                         return "volume_down";
                     if (volume <= 0.66)
@@ -417,8 +419,10 @@ Rectangle {
                                         let volume = modelData.audio.volume;
                                         let muted = modelData.audio.muted;
 
-                                        if (muted || volume === 0.0)
+                                        if (muted)
                                             return "volume_off";
+                                        if (volume === 0.0)
+                                            return "volume_mute";
                                         if (volume <= 0.33)
                                             return "volume_down";
                                         if (volume <= 0.66)

--- a/quickshell/Modules/ControlCenter/Widgets/AudioSliderRow.qml
+++ b/quickshell/Modules/ControlCenter/Widgets/AudioSliderRow.qml
@@ -42,8 +42,10 @@ Row {
                 let volume = defaultSink.audio.volume;
                 let muted = defaultSink.audio.muted;
 
-                if (muted || volume === 0.0)
+                if (muted)
                     return "volume_off";
+                if (volume === 0.0)
+                    return "volume_mute";
                 if (volume <= 0.33)
                     return "volume_down";
                 if (volume <= 0.66)

--- a/quickshell/Modules/DankBar/Widgets/ControlCenterButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/ControlCenterButton.qml
@@ -57,8 +57,10 @@ BasePill {
     function getVolumeIconName() {
         if (!AudioService.sink?.audio)
             return "volume_up";
-        if (AudioService.sink.audio.muted || AudioService.sink.audio.volume === 0)
+        if (AudioService.sink.audio.muted)
             return "volume_off";
+        if (AudioService.sink.audio.volume === 0)
+            return "volume_mute";
         if (AudioService.sink.audio.volume * 100 < 33)
             return "volume_down";
         return "volume_up";

--- a/quickshell/Modules/Greetd/GreeterContent.qml
+++ b/quickshell/Modules/Greetd/GreeterContent.qml
@@ -824,9 +824,10 @@ Item {
                         if (!AudioService.sink?.audio) {
                             return "volume_up";
                         }
-                        if (AudioService.sink.audio.muted || AudioService.sink.audio.volume === 0) {
+                        if (AudioService.sink.audio.muted)
                             return "volume_off";
-                        }
+                        if (AudioService.sink.audio.volume === 0)
+                            return "volume_mute";
                         if (AudioService.sink.audio.volume * 100 < 33) {
                             return "volume_down";
                         }

--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -1142,9 +1142,10 @@ Item {
                         if (!AudioService.sink?.audio) {
                             return "volume_up";
                         }
-                        if (AudioService.sink.audio.muted || AudioService.sink.audio.volume === 0) {
+                        if (AudioService.sink.audio.muted)
                             return "volume_off";
-                        }
+                        if (AudioService.sink.audio.volume === 0)
+                            return "volume_mute";
                         if (AudioService.sink.audio.volume * 100 < 33) {
                             return "volume_down";
                         }


### PR DESCRIPTION
Currently, the same `volume_off` icon is used both when the volume is muted, and when the volume is unmuted but set to 0%:
<img width="24" height="24" alt="volume_off_24dp_E3E3E3_FILL0_wght400_GRAD0_opsz24" src="https://github.com/user-attachments/assets/85c2e563-e686-4c90-9ff9-563a3553e7f7" />

The Material Icons library also contains the `volume_mute` icon which is often used to represent a volume of 0, but not muted:
<img width="24" height="24" alt="volume_mute_24dp_E3E3E3_FILL0_wght400_GRAD0_opsz24" src="https://github.com/user-attachments/assets/85bdbacd-f4f7-4c94-949b-7a1b4a25f784" />

This PR adds the `volume_mute` icon for cases where `volume === 0`, as opposed to `muted`.