### PR TITLE
Add battery charge limit

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -258,6 +258,7 @@ Singleton {
     property int batterySuspendTimeout: 0
     property int batterySuspendBehavior: SettingsData.SuspendBehavior.Suspend
     property string batteryProfileName: ""
+    property int batteryChargeLimit: 100
     property bool lockBeforeSuspend: false
     property bool loginctlLockIntegration: true
     property bool fadeToLockEnabled: false

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -157,6 +157,7 @@ var SPEC = {
     batterySuspendTimeout: { def: 0 },
     batterySuspendBehavior: { def: 0 },
     batteryProfileName: { def: "" },
+    batteryChargeLimit: { def: 100 },
     lockBeforeSuspend: { def: false },
     loginctlLockIntegration: { def: true },
     fadeToLockEnabled: { def: false },

--- a/quickshell/Modules/Settings/PowerSleepTab.qml
+++ b/quickshell/Modules/Settings/PowerSleepTab.qml
@@ -503,6 +503,24 @@ Item {
                     }
                 }
             }
+
+            SettingsCard {
+                width: parent.width
+                iconName: "tune"
+                title: I18n.tr("Advanced")
+                collapsible: true
+                expanded: false
+
+                SettingsSliderRow {
+                    text: I18n.tr("Battery Charge Limit")
+                    description: I18n.tr("Note: this only changes the percentage, it does not actually limit charging.")
+                    value: SettingsData.batteryChargeLimit
+                    minimum: 50
+                    maximum: 100
+                    defaultValue: 100
+                    onSliderValueChanged: newValue => SettingsData.set("batteryChargeLimit", newValue)
+                }
+            }
         }
     }
 }

--- a/quickshell/Services/BatteryService.qml
+++ b/quickshell/Services/BatteryService.qml
@@ -12,6 +12,8 @@ Singleton {
     property bool suppressSound: true
     property bool previousPluggedState: false
 
+    readonly property var scale: 100 / SettingsData.batteryChargeLimit
+
     Timer {
         id: startupTimer
         interval: 500
@@ -43,14 +45,14 @@ Singleton {
             return 0;
         if (batteryCapacity === 0) {
             if (usePreferred && device && device.ready)
-                return Math.round(device.percentage * 100);
+                return Math.round(device.percentage * 100 * scale);
             const validBatteries = batteries.filter(b => b.ready && b.percentage >= 0);
             if (validBatteries.length === 0)
                 return 0;
             const avgPercentage = validBatteries.reduce((sum, b) => sum + b.percentage, 0) / validBatteries.length;
-            return Math.round(avgPercentage * 100);
+            return Math.round(avgPercentage * 100 * scale);
         }
-        return Math.round((batteryEnergy * 100) / batteryCapacity);
+        return Math.round((batteryEnergy * 100) / batteryCapacity * scale);
     }
     readonly property bool isCharging: batteryAvailable && batteries.some(b => b.state === UPowerDeviceState.Charging)
 

--- a/quickshell/translations/en.json
+++ b/quickshell/translations/en.json
@@ -870,6 +870,12 @@
     "comment": ""
   },
   {
+    "term": "Battery Charge Limit",
+    "context": "Battery Charge Limit",
+    "reference": "Modules/Settings/PowerSleepTab.qml:515",
+    "comment": ""
+  },
+  {
     "term": "Battery and power management",
     "context": "Battery and power management",
     "reference": "Modules/ControlCenter/Models/WidgetModel.qml:162",
@@ -4785,6 +4791,12 @@
     "term": "Not connected",
     "context": "Not connected",
     "reference": "Modules/Settings/NetworkTab.qml:744",
+    "comment": ""
+  },
+  {
+    "term": "Note: this only changes the displayed percentage, it does not actually limit charging.",
+    "context": "Note: this only changes the displayed percentage, it does not actually limit charging.",
+    "reference": "Modules/Settings/PowerSleepTab.qml:516",
     "comment": ""
   },
   {

--- a/quickshell/translations/template.json
+++ b/quickshell/translations/template.json
@@ -1015,6 +1015,13 @@
     "comment": ""
   },
   {
+    "term": "Battery Charge Limit",
+    "translation": "",
+    "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Battery and power management",
     "translation": "",
     "context": "",
@@ -5580,6 +5587,13 @@
   },
   {
     "term": "Not connected",
+    "translation": "",
+    "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Note: this only changes the displayed percentage, it does not actually limit charging.",
     "translation": "",
     "context": "",
     "reference": "",


### PR DESCRIPTION
This PR adds a new setting under Power & Security -> Power & Sleep -> Advanced to set an artificial maximum charge limit for the pinned battery. It only affects the value shown in the bar, Control Center, and on the lock screen, the true value can still be found in the Battery widget and elsewhere. This is useful for people who have set BIOS charge limits to preserve their batteries' health. Note that it does not actually modify any system settings to limit the battery's maximum SoC, it only scales the value displayed to the user.