### PR TITLE
media : add scroll wheel behavior configuration

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -176,6 +176,7 @@ Singleton {
     property bool waveProgressEnabled: true
     property bool scrollTitleEnabled: true
     property bool audioVisualizerEnabled: true
+    property bool audioScrollEnabled: true
     property bool clockCompactMode: false
     property bool focusedWindowCompactMode: false
     property bool runningAppsCompactMode: true

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -91,6 +91,7 @@ var SPEC = {
     waveProgressEnabled: { def: true },
     scrollTitleEnabled: { def: true },
     audioVisualizerEnabled: { def: true },
+    audioScrollEnabled: { def: true },
     clockCompactMode: { def: false },
     focusedWindowCompactMode: { def: false },
     runningAppsCompactMode: { def: true },

--- a/quickshell/Modules/DankBar/Widgets/Media.qml
+++ b/quickshell/Modules/DankBar/Widgets/Media.qml
@@ -52,9 +52,12 @@ BasePill {
     property real touchpadThreshold: 100
 
     onWheel: function (wheelEvent) {
-        wheelEvent.accepted = true;
         if (!usePlayerVolume)
             return;
+        if (!SettingsData.audioScrollEnabled)
+            return;
+
+        wheelEvent.accepted = true;
 
         const deltaY = wheelEvent.angleDelta.y;
         const isMouseWheelY = Math.abs(deltaY) >= 120 && (Math.abs(deltaY) % 120) === 0;

--- a/quickshell/Modules/Settings/MediaPlayerTab.qml
+++ b/quickshell/Modules/Settings/MediaPlayerTab.qml
@@ -43,6 +43,13 @@ Item {
                     checked: SettingsData.audioVisualizerEnabled
                     onToggled: checked => SettingsData.set("audioVisualizerEnabled", checked)
                 }
+
+                SettingsToggleRow {
+                    text: I18n.tr("Scroll Wheel")
+                    description: I18n.tr("Scroll on widget changes media volume")
+                    checked: SettingsData.audioScrollEnabled
+                    onToggled: checked => SettingsData.set("audioScrollEnabled", checked)
+                }
             }
         }
     }


### PR DESCRIPTION
This removes the need to avoid media weight when switching workspaces with the mouse wheel.