### PR TITLE
fixed lambda issue on nixos

### DIFF
--- a/distro/nix/options.nix
+++ b/distro/nix/options.nix
@@ -37,7 +37,7 @@ in
     };
 
     dgop = {
-      package = lib.mkPackageOption pkgs "dgop";
+      package = lib.mkPackageOption pkgs "dgop" {};
     };
 
     enableSystemMonitoring = lib.mkOption {


### PR DESCRIPTION
Because of missing brackets the error:
```
       error: An option declaration for `home-manager.users.matthias.programs.dank-material-shell.dgop.package' has type
       `lambda' rather than an attribute set.
```
occured. Fixed by adding missing brackets in options.nix