### PR TITLE
fix: new dgop package option is missing function call

### DIFF
--- a/distro/nix/options.nix
+++ b/distro/nix/options.nix
@@ -37,7 +37,7 @@ in
     };
 
     dgop = {
-      package = lib.mkPackageOption pkgs "dgop";
+      package = lib.mkPackageOption pkgs "dgop" { };
     };
 
     enableSystemMonitoring = lib.mkOption {


### PR DESCRIPTION
has type 'lambda' rather than attribute set.
