### PR TITLE
matugen/template: Soothing neovim theme

### DIFF
--- a/quickshell/matugen/templates/neovim.lua
+++ b/quickshell/matugen/templates/neovim.lua
@@ -5,48 +5,81 @@ return {
 		config = function()
 			require('base16-colorscheme').setup({
 				base00 = '{{dank16.color0.default.hex}}',
-				base01 = '{{dank16.color8.default.hex}}',
-				base02 = '{{dank16.color14.default.hex}}',
-				base03 = '{{dank16.color5.default.hex}}',
+				base01 = '{{dank16.color0.default.hex}}',
+				base02 = '{{dank16.color8.default.hex}}',
+				base03 = '{{dank16.color8.default.hex}}',
 				base04 = '{{dank16.color7.default.hex}}',
-				base05 = '{{dank16.color12.default.hex}}',
-				base06 = '{{dank16.color6.default.hex}}',
+				base05 = '{{dank16.color15.default.hex}}',
+				base06 = '{{dank16.color15.default.hex}}',
 				base07 = '{{dank16.color15.default.hex}}',
-
-				base08 = '{{dank16.color4.default.hex}}',
-				base09 = '{{dank16.color3.default.hex}}',
-				base0A = '{{dank16.color11.default.hex}}',
-				base0B = '{{dank16.color2.default.hex}}',
-				base0C = '{{dank16.color10.default.hex}}',
-				base0D = '{{dank16.color9.default.hex}}',
-				base0E = '{{dank16.color1.default.hex}}',
+				base08 = '{{dank16.color9.default.hex}}',
+				base09 = '{{dank16.color9.default.hex}}',
+				base0A = '{{dank16.color12.default.hex}}',
+				base0B = '{{dank16.color10.default.hex}}',
+				base0C = '{{dank16.color14.default.hex}}',
+				base0D = '{{dank16.color12.default.hex}}',
+				base0E = '{{dank16.color13.default.hex}}',
 				base0F = '{{dank16.color13.default.hex}}',
 			})
 
 			vim.api.nvim_set_hl(0, 'Visual', {
-				bg = '{{dank16.color14.default.hex}}',
+				bg = '{{dank16.color8.default.hex}}',
 				fg = '{{dank16.color15.default.hex}}',
 				bold = true
 			})
+			vim.api.nvim_set_hl(0, 'Statusline', {
+				bg = '{{dank16.color12.default.hex}}',
+				fg = '{{dank16.color0.default.hex}}',
+			})
+			vim.api.nvim_set_hl(0, 'LineNr', { fg = '{{dank16.color8.default.hex}}' })
+			vim.api.nvim_set_hl(0, 'CursorLineNr', { fg = '{{dank16.color14.default.hex}}', bold = true })
 
-			vim.api.nvim_set_hl(0, 'LineNr', {
-				fg = '{{dank16.color8.default.hex}}'
+			vim.api.nvim_set_hl(0, 'Statement', {
+				fg = '{{dank16.color13.default.hex}}',
+				bold = true
+			})
+			vim.api.nvim_set_hl(0, 'Keyword', { link = 'Statement' })
+			vim.api.nvim_set_hl(0, 'Repeat', { link = 'Statement' })
+			vim.api.nvim_set_hl(0, 'Conditional', { link = 'Statement' })
+
+			vim.api.nvim_set_hl(0, 'Function', {
+				fg = '{{dank16.color12.default.hex}}',
+				bold = true
+			})
+			vim.api.nvim_set_hl(0, 'Macro', {
+				fg = '{{dank16.color12.default.hex}}',
+				italic = true
+			})
+			vim.api.nvim_set_hl(0, '@function.macro', { link = 'Macro' })
+
+			vim.api.nvim_set_hl(0, 'Type', {
+				fg = '{{dank16.color14.default.hex}}',
+				bold = true,
+				italic = true
+			})
+			vim.api.nvim_set_hl(0, 'Structure', { link = 'Type' })
+
+			vim.api.nvim_set_hl(0, 'String', {
+				fg = '{{dank16.color10.default.hex}}',
+				italic = true
 			})
 
-			vim.api.nvim_set_hl(0, 'CursorLineNr', {
-				fg = '{{dank16.color6.default.hex}}',
-				bold = true
+			vim.api.nvim_set_hl(0, 'Operator', { fg = '{{dank16.color7.default.hex}}' })
+			vim.api.nvim_set_hl(0, 'Delimiter', { fg = '{{dank16.color7.default.hex}}' })
+			vim.api.nvim_set_hl(0, '@punctuation.bracket', { link = 'Delimiter' })
+			vim.api.nvim_set_hl(0, '@punctuation.delimiter', { link = 'Delimiter' })
+
+			vim.api.nvim_set_hl(0, 'Comment', {
+				fg = '{{dank16.color8.default.hex}}',
+				italic = true
 			})
 
 			local current_file_path = vim.fn.stdpath("config") .. "/lua/plugins/dankcolors.lua"
-
 			if not _G._matugen_theme_watcher then
 				local uv = vim.uv or vim.loop
 				_G._matugen_theme_watcher = uv.new_fs_event()
-
 				_G._matugen_theme_watcher:start(current_file_path, {}, vim.schedule_wrap(function()
 					local new_spec = dofile(current_file_path)
-
 					if new_spec and new_spec[1] and new_spec[1].config then
 						new_spec[1].config()
 						print("Theme reload")


### PR DESCRIPTION
- Incremented some changes in the matugen template, _might_ be a little biased.

after(1,2): 
- Neutral
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/444b1d84-e137-400c-aa96-910fec5d710c" />
- Tonal Spot
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/33961023-f9cc-41fa-a79c-7ad81c2eb774" />


Before(3,2): 
- Tonal Spot
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3895b0bb-3f9e-41e7-81c0-3229a32c1352" />
- Neutral
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/086e6cd5-6e76-4c2d-96e3-de5602c541ac" />



