### PR TITLE
feat: accept numpad's enter key to finish screenshot selection

### DIFF
--- a/core/internal/screenshot/region_input.go
+++ b/core/internal/screenshot/region_input.go
@@ -141,7 +141,7 @@ func (r *RegionSelector) setupKeyboardHandlers() {
 			for _, os := range r.surfaces {
 				r.redrawSurface(os)
 			}
-		case 28, 57:
+		case 28, 57, 96:
 			if r.selection.hasSelection {
 				r.finishSelection()
 			}


### PR DESCRIPTION
When taking a region screenshot, you can press Spacebar or Enter to finish and capture the selected region. This PR adds  the numpad enter key to the accepted keys to finish.