### PR TITLE
bar(clock): respect compact mode on vertical bar

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/Clock.qml
+++ b/quickshell/Modules/DankBar/Widgets/Clock.qml
@@ -16,6 +16,8 @@ BasePill {
             implicitWidth: root.isVerticalOrientation ? (root.widgetThickness - root.horizontalPadding * 2) : clockRow.implicitWidth
             implicitHeight: root.isVerticalOrientation ? clockColumn.implicitHeight : (root.widgetThickness - root.horizontalPadding * 2)
 
+            readonly property bool compact: widgetData?.clockCompactMode !== undefined ? widgetData.clockCompactMode : SettingsData.clockCompactMode
+
             Column {
                 id: clockColumn
                 visible: root.isVerticalOrientation
@@ -106,6 +108,7 @@ BasePill {
                     width: parent.width
                     height: Theme.spacingM
                     anchors.horizontalCenter: parent.horizontalCenter
+                    visible: !compact
 
                     Rectangle {
                         width: parent.width * 0.6
@@ -118,6 +121,7 @@ BasePill {
                 Row {
                     spacing: 0
                     anchors.horizontalCenter: parent.horizontalCenter
+                    visible: !compact
 
                     StyledText {
                         text: {
@@ -151,6 +155,7 @@ BasePill {
                 Row {
                     spacing: 0
                     anchors.horizontalCenter: parent.horizontalCenter
+                    visible: !compact
 
                     StyledText {
                         text: {
@@ -204,7 +209,7 @@ BasePill {
                     font.pixelSize: Theme.fontSizeSmall
                     color: Theme.outlineButton
                     anchors.baseline: dateText.baseline
-                    visible: !(widgetData?.clockCompactMode !== undefined ? widgetData.clockCompactMode : SettingsData.clockCompactMode)
+                    visible: !compact
                 }
 
                 StyledText {
@@ -218,7 +223,7 @@ BasePill {
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale)
                     color: Theme.widgetTextColor
                     anchors.verticalCenter: parent.verticalCenter
-                    visible: !(widgetData?.clockCompactMode !== undefined ? widgetData.clockCompactMode : SettingsData.clockCompactMode)
+                    visible: !compact
                 }
             }
 


### PR DESCRIPTION
Re-use compact mode for the clock widget on a vertical bar to only show time.

Tested locally, works great.