### PR TITLE
bar(ws): add option to show name

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -168,6 +168,7 @@ Singleton {
     ]
 
     property bool showWorkspaceIndex: false
+    property bool showWorkspaceName: false
     property bool showWorkspacePadding: false
     property bool workspaceScrolling: false
     property bool showWorkspaceApps: false

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -81,6 +81,7 @@ var SPEC = {
     ]},
 
     showWorkspaceIndex: { def: false },
+    showWorkspaceName: { def: false },
     showWorkspacePadding: { def: false },
     workspaceScrolling: { def: false },
     showWorkspaceApps: { def: false },

--- a/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
+++ b/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
@@ -565,6 +565,17 @@ Item {
         if (isPlaceholder)
             return index + 1;
 
+        if (SettingsData.showWorkspaceName) {
+            let workspaceName = modelData?.name;
+
+            if (workspaceName && workspaceName !== "") {
+                if (root.isVertical) {
+                    return workspaceName.charAt(0);
+                }
+                return workspaceName;
+            }
+        }
+
         if (root.useExtWorkspace)
             return index + 1;
         if (CompositorService.isHyprland)
@@ -942,7 +953,7 @@ Item {
                                 id: rowLayout
                                 Row {
                                     spacing: 4
-                                    visible: loadedIcons.length > 0 || SettingsData.showWorkspaceIndex || loadedHasIcon
+                                    visible: loadedIcons.length > 0 || SettingsData.showWorkspaceIndex || SettingsData.showWorkspaceName || loadedHasIcon
 
                                     Item {
                                         visible: loadedHasIcon && loadedIconData?.type === "icon"
@@ -975,7 +986,7 @@ Item {
                                     }
 
                                     Item {
-                                        visible: SettingsData.showWorkspaceIndex && !loadedHasIcon
+                                        visible: (SettingsData.showWorkspaceIndex || SettingsData.showWorkspaceName) && !loadedHasIcon
                                         width: wsIndexText.implicitWidth + (isActive && loadedIcons.length > 0 ? 4 : 0)
                                         height: root.appIconSize
 
@@ -1072,7 +1083,7 @@ Item {
                                 id: columnLayout
                                 Column {
                                     spacing: 4
-                                    visible: loadedIcons.length > 0 || loadedHasIcon
+                                    visible: loadedIcons.length > 0 || SettingsData.showWorkspaceIndex || SettingsData.showWorkspaceName || loadedHasIcon
 
                                     DankIcon {
                                         visible: loadedHasIcon && loadedIconData?.type === "icon"
@@ -1209,7 +1220,7 @@ Item {
                     Loader {
                         id: indexLoader
                         anchors.fill: parent
-                        active: SettingsData.showWorkspaceIndex && !loadedHasIcon && !SettingsData.showWorkspaceApps
+                        active: (SettingsData.showWorkspaceIndex || SettingsData.showWorkspaceName) && !loadedHasIcon && !SettingsData.showWorkspaceApps
                         sourceComponent: Item {
                             StyledText {
                                 anchors.centerIn: parent

--- a/quickshell/Modules/Settings/WorkspacesTab.qml
+++ b/quickshell/Modules/Settings/WorkspacesTab.qml
@@ -36,6 +36,15 @@ Item {
                 }
 
                 SettingsToggleRow {
+                    settingKey: "showWorkspaceName"
+                    tags: ["workspace", "name", "labels"]
+                    text: I18n.tr("Workspace Names")
+                    description: I18n.tr("Show workspace name on horizontal bars, and first letter on vertical bars")
+                    checked: SettingsData.showWorkspaceName
+                    onToggled: checked => SettingsData.set("showWorkspaceName", checked)
+                }
+
+                SettingsToggleRow {
                     settingKey: "showWorkspacePadding"
                     tags: ["workspace", "padding", "minimum"]
                     text: I18n.tr("Workspace Padding")

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -872,6 +872,28 @@
     "description": "Show workspace index numbers in the top bar workspace switcher"
   },
   {
+    "section": "showWorkspaceName",
+    "label": "Workspace Name",
+    "tabIndex": 4,
+    "category": "Workspaces",
+    "keywords": [
+      "desktop",
+      "labels",
+      "panel",
+      "show",
+      "spaces",
+      "statusbar",
+      "switcher",
+      "taskbar",
+      "topbar",
+      "virtual",
+      "virtual desktops",
+      "workspace",
+      "workspaces"
+    ],
+    "description": "Show workspace name on horizontal bars, and first letter on vertical bars"
+  },
+  {
     "section": "showWorkspacePadding",
     "label": "Workspace Padding",
     "tabIndex": 4,


### PR DESCRIPTION
I'd like to show the workspace name instead of the index, as I use `a s d f u i o p` as my 8 workspaces.

I would have preferred to implement the option more elegantly by merging "show index" with it and make it a `SettingsButtonGroupRow`. But that wouldn't be backward compatible.
Maybe something to keep in mind for a future config version.