### PR TITLE
Bar: Larger option for the media player widget

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/Media.qml
+++ b/quickshell/Modules/DankBar/Widgets/Media.qml
@@ -26,6 +26,8 @@ BasePill {
             return 0;
         case 2:
             return 180;
+        case 3:
+            return 240;
         default:
             return 120;
         }

--- a/quickshell/Modules/Settings/WidgetsTabSection.qml
+++ b/quickshell/Modules/Settings/WidgetsTabSection.qml
@@ -419,6 +419,24 @@ Column {
                             }
 
                             DankActionButton {
+                                id: largerSizeButton
+                                buttonSize: 28
+                                visible: modelData.id === "music"
+                                iconName: "fit_screen"
+                                iconSize: 16
+                                iconColor: (modelData.mediaSize !== undefined ? modelData.mediaSize : SettingsData.mediaSize) === 3 ? Theme.primary : Theme.outline
+                                onClicked: {
+                                    root.compactModeChanged("music", 3);
+                                }
+                                onEntered: {
+                                    sharedTooltip.show("Largest", largerSizeButton, 0, 0, "bottom");
+                                }
+                                onExited: {
+                                    sharedTooltip.hide();
+                                }
+                            }
+
+                            DankActionButton {
                                 id: compactModeButton
                                 buttonSize: 28
                                 visible: modelData.id === "clock" || modelData.id === "focusedWindow" || modelData.id === "runningApps" || modelData.id === "keyboard_layout_name"


### PR DESCRIPTION
I find that the songs in the media player widget need to scroll the majority of the time. I happen to have a lot of real estate so thought this option might be useful to others too.

<img width="645" height="259" alt="image" src="https://github.com/user-attachments/assets/13d98eec-3e88-4d26-bdef-e14405b89a05" />
