### PR TITLE
tweak background and popout colors

### DIFF
--- a/quickshell/matugen/templates/gtk-colors.css
+++ b/quickshell/matugen/templates/gtk-colors.css
@@ -18,7 +18,7 @@
 @define-color window_bg_color {{colors.surface.default.hex}};
 @define-color window_fg_color {{colors.on_surface.default.hex}};
 /* Make it more similar to Adwaita */
-@define-color view_bg_color {{colors.surface_container_lowest.default.hex}};
+@define-color view_bg_color {{colors.surface.default.hex}};
 @define-color view_fg_color {{colors.on_surface.default.hex}};
 @define-color headerbar_bg_color {{colors.surface.default.hex}};
 @define-color headerbar_fg_color {{colors.on_surface.default.hex}};
@@ -32,9 +32,9 @@ a color between surface and surface container so I think just giving this surfac
 @define-color card_fg_color {{colors.on_surface.default.hex}};
 @define-color overview_bg_color {{colors.surface_container.default.hex}};
 @define-color overview_fg_color {{colors.on_surface.default.hex}};
-@define-color popover_bg_color {{colors.surface_container_lowest.default.hex}};
+@define-color popover_bg_color {{colors.surface_container.default.hex}};
 @define-color popover_fg_color {{colors.on_surface.default.hex}};
-@define-color dialog_bg_color {{colors.surface_container_lowest.default.hex}};
+@define-color dialog_bg_color {{colors.surface.default.hex}};
 @define-color dialog_fg_color {{colors.on_surface.default.hex}};
 
 /* Backdrop/unfocused states - prevents white flash on window unfocus */


### PR DESCRIPTION
Tweak background and popout colors to be brighter and more similar to Adwaita.

Before and after:
<img width="369" height="337" alt="image" src="https://github.com/user-attachments/assets/8523bf3f-960e-4ef1-b834-0d975c32c16a" /> <img width="369" height="337" alt="image" src="https://github.com/user-attachments/assets/659f55a7-77fb-4bfd-91f8-c835285a7699" />
