### PR TITLE
applications: filter out Hidden and NoDisplay applications

### DIFF
--- a/quickshell/Services/AppSearchService.qml
+++ b/quickshell/Services/AppSearchService.qml
@@ -38,7 +38,7 @@ Singleton {
     ]
 
     function refreshApplications() {
-        applications = DesktopEntries.applications.values;
+        applications = DesktopEntries.applications.values.filter(app => !app.noDisplay && !app.hidden);
         _cachedCategories = null;
     }
 


### PR DESCRIPTION
Filter out applications that are set as Hidden or NoDisplay in the .desktop file. Quickshell documentation lacks the `hidden` field for some reason, but it exists in the source code. NoDisplay applications were filtered before, but this just got removed in the last commit.

Note that hidden are supposed to never show anyway, but I'm not completely sure if we should also ignore NoDisplay in the app picker modal (that also uses this service). Per the specification:

> `NoDisplay` means "this application exists, but don't display it in the menus". This can be useful to e.g. associate this application with MIME types, so that it gets launched from a file manager (or other apps), without having a menu entry for it (there are tons of good reasons for this, including e.g. the `netscape -remote`, or `kfmclient openURL` kind of stuff). 
