### PR TITLE
notifications: fix notifications being completely transient if history is disabled

### DIFF
--- a/quickshell/Services/NotificationService.qml
+++ b/quickshell/Services/NotificationService.qml
@@ -491,13 +491,13 @@ Singleton {
 
             if (wrapper) {
                 root.allWrappers.push(wrapper);
-                const shouldSave = !isTransient && _shouldSaveToHistory(notif.urgency);
-                if (shouldSave) {
+                if (!isTransient) {
                     root.notifications.push(wrapper);
                     _trimStored();
-                    root.addToHistory(wrapper);
+                    if (_shouldSaveToHistory(notif.urgency)) {
+                        root.addToHistory(wrapper);
+                    }
                 }
-
                 Qt.callLater(() => {
                     _initWrapperPersistence(wrapper);
                 });


### PR DESCRIPTION
Currently if history is disabled then notifications are completely transient, i.e. they do not wait to be dismissed or show up in notification center if they have not been dismissed. This restores the previous behavior.