### PR TITLE
feat: steam game icons

### DIFF
--- a/quickshell/Common/Paths.qml
+++ b/quickshell/Common/Paths.qml
@@ -59,6 +59,9 @@ Singleton {
                 return "transmission";
             return "transmission-gtk";
         }
+        const steamMatch = appId.match(/^steam_app_(\d+)$/);
+        if (steamMatch)
+            return `steam_icon_${steamMatch[1]}`;
         return appId;
     }
 
@@ -68,8 +71,8 @@ Singleton {
         }
 
         const moddedId = moddedAppId(appId);
-        if (moddedId.toLowerCase().includes("steam_app")) {
-            return "";
+        if (moddedId.startsWith("steam_icon_")) {
+            return Quickshell.iconPath(moddedId, true);
         }
 
         return desktopEntry && desktopEntry.icon ? Quickshell.iconPath(desktopEntry.icon, true) : "";

--- a/quickshell/Modules/DankBar/Widgets/FocusedApp.qml
+++ b/quickshell/Modules/DankBar/Widgets/FocusedApp.qml
@@ -148,29 +148,9 @@ BasePill {
                 }
             }
 
-            DankIcon {
-                anchors.centerIn: parent
-                size: 18
-                name: "sports_esports"
-                color: Theme.widgetTextColor
-                visible: {
-                    if (!root.isVerticalOrientation || !activeWindow || !activeWindow.appId)
-                        return false;
-                    const moddedId = Paths.moddedAppId(activeWindow.appId);
-                    return moddedId.toLowerCase().includes("steam_app");
-                }
-            }
-
             Text {
                 anchors.centerIn: parent
-                visible: {
-                    if (!root.isVerticalOrientation || !activeWindow || !activeWindow.appId)
-                        return false;
-                    if (appIcon.status === Image.Ready)
-                        return false;
-                    const moddedId = Paths.moddedAppId(activeWindow.appId);
-                    return !moddedId.toLowerCase().includes("steam_app");
-                }
+                visible: root.isVerticalOrientation && activeWindow && activeWindow.appId && appIcon.status !== Image.Ready
                 text: {
                     if (!activeWindow || !activeWindow.appId)
                         return "?";

--- a/quickshell/Modules/DankBar/Widgets/RunningApps.qml
+++ b/quickshell/Modules/DankBar/Widgets/RunningApps.qml
@@ -384,27 +384,9 @@ Item {
                             }
                         }
 
-                        DankIcon {
-                            anchors.left: parent.left
-                            anchors.leftMargin: (widgetData?.runningAppsCompactMode !== undefined ? widgetData.runningAppsCompactMode : SettingsData.runningAppsCompactMode) ? Math.round((parent.width - Theme.barIconSize(root.barThickness)) / 2) : Theme.spacingXS
-                            anchors.verticalCenter: parent.verticalCenter
-                            size: Theme.barIconSize(root.barThickness)
-                            name: "sports_esports"
-                            color: Theme.widgetTextColor
-                            visible: {
-                                const moddedId = Paths.moddedAppId(appId);
-                                return moddedId.toLowerCase().includes("steam_app");
-                            }
-                        }
-
-                        // Fallback text if no icon found
                         Text {
                             anchors.centerIn: parent
-                            visible: {
-                                const moddedId = Paths.moddedAppId(appId);
-                                const isSteamApp = moddedId.toLowerCase().includes("steam_app");
-                                return !iconImg.visible && !isSteamApp;
-                            }
+                            visible: !iconImg.visible
                             text: {
                                 root._desktopEntriesUpdateTrigger;
                                 if (!appId)
@@ -634,26 +616,9 @@ Item {
                             }
                         }
 
-                        DankIcon {
-                            anchors.left: parent.left
-                            anchors.leftMargin: (widgetData?.runningAppsCompactMode !== undefined ? widgetData.runningAppsCompactMode : SettingsData.runningAppsCompactMode) ? Math.round((parent.width - Theme.barIconSize(root.barThickness)) / 2) : Theme.spacingXS
-                            anchors.verticalCenter: parent.verticalCenter
-                            size: Theme.barIconSize(root.barThickness)
-                            name: "sports_esports"
-                            color: Theme.widgetTextColor
-                            visible: {
-                                const moddedId = Paths.moddedAppId(appId);
-                                return moddedId.toLowerCase().includes("steam_app");
-                            }
-                        }
-
                         Text {
                             anchors.centerIn: parent
-                            visible: {
-                                const moddedId = Paths.moddedAppId(appId);
-                                const isSteamApp = moddedId.toLowerCase().includes("steam_app");
-                                return !iconImg.visible && !isSteamApp;
-                            }
+                            visible: !iconImg.visible
                             text: {
                                 root._desktopEntriesUpdateTrigger;
                                 if (!appId)

--- a/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
+++ b/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
@@ -264,15 +264,12 @@ Item {
             const key = isActiveWs || !SettingsData.groupWorkspaceApps ? `${keyBase}_${i}` : keyBase;
 
             if (!byApp[key]) {
-                const moddedId = Paths.moddedAppId(keyBase);
-                const isSteamApp = moddedId.toLowerCase().includes("steam_app");
                 const isQuickshell = keyBase === "org.quickshell";
                 const desktopEntry = DesktopEntries.heuristicLookup(keyBase);
-                const icon = isSteamApp ? "" : Paths.getAppIcon(keyBase, desktopEntry);
+                const icon = Paths.getAppIcon(keyBase, desktopEntry);
                 byApp[key] = {
                     "type": "icon",
                     "icon": icon,
-                    "isSteamApp": isSteamApp,
                     "isQuickshell": isQuickshell,
                     "active": !!((w.activated || w.is_focused) || (CompositorService.isNiri && w.is_focused)),
                     "count": 1,
@@ -1137,7 +1134,7 @@ Item {
                                                 anchors.fill: parent
                                                 source: modelData.icon
                                                 opacity: modelData.active ? 1.0 : rowAppMouseArea.containsMouse ? 0.8 : 0.6
-                                                visible: !modelData.isSteamApp && !modelData.isQuickshell
+                                                visible: !modelData.isQuickshell
                                             }
 
                                             IconImage {
@@ -1151,15 +1148,6 @@ Item {
                                                     colorization: 1
                                                     colorizationColor: isActive ? quickshellIconActiveColor : quickshellIconInactiveColor
                                                 }
-                                            }
-
-                                            DankIcon {
-                                                anchors.centerIn: parent
-                                                size: root.appIconSize
-                                                name: "sports_esports"
-                                                color: Theme.widgetTextColor
-                                                opacity: modelData.active ? 1.0 : rowAppMouseArea.containsMouse ? 0.8 : 0.6
-                                                visible: modelData.isSteamApp
                                             }
 
                                             MouseArea {
@@ -1240,7 +1228,7 @@ Item {
                                                 anchors.fill: parent
                                                 source: modelData.icon
                                                 opacity: modelData.active ? 1.0 : colAppMouseArea.containsMouse ? 0.8 : 0.6
-                                                visible: !modelData.isSteamApp && !modelData.isQuickshell
+                                                visible: !modelData.isQuickshell
                                             }
 
                                             IconImage {
@@ -1254,15 +1242,6 @@ Item {
                                                     colorization: 1
                                                     colorizationColor: isActive ? quickshellIconActiveColor : quickshellIconInactiveColor
                                                 }
-                                            }
-
-                                            DankIcon {
-                                                anchors.centerIn: parent
-                                                size: root.appIconSize
-                                                name: "sports_esports"
-                                                color: Theme.widgetTextColor
-                                                opacity: modelData.active ? 1.0 : colAppMouseArea.containsMouse ? 0.8 : 0.6
-                                                visible: modelData.isSteamApp
                                             }
 
                                             MouseArea {

--- a/quickshell/Modules/Dock/DockAppButton.qml
+++ b/quickshell/Modules/Dock/DockAppButton.qml
@@ -392,20 +392,6 @@ Item {
             }
         }
 
-        DankIcon {
-            anchors.centerIn: parent
-            size: actualIconSize
-            name: "sports_esports"
-            color: Theme.surfaceText
-            visible: {
-                if (!appData || !appData.appId || appData.appId === "__SEPARATOR__") {
-                    return false;
-                }
-                const moddedId = Paths.moddedAppId(appData.appId);
-                return moddedId.toLowerCase().includes("steam_app");
-            }
-        }
-
         Rectangle {
             width: actualIconSize
             height: actualIconSize


### PR DESCRIPTION
steam proton games now show their actual game icons instead of the generic controller. maps steam_app_XXXXX window class to steam_icon_XXXXX which is what steam installs.