### PR TITLE
settings: fix modal not opening on latest quickshell

### DIFF
--- a/quickshell/DMSShell.qml
+++ b/quickshell/DMSShell.qml
@@ -442,16 +442,14 @@ Item {
             PopoutService.settingsModalLoader = settingsModalLoader;
         }
 
-        onActiveChanged: {
-            if (active && item) {
-                PopoutService.settingsModal = item;
-                PopoutService._onSettingsModalLoaded();
-            }
-        }
-
         SettingsModal {
             id: settingsModal
             property bool wasShown: false
+
+            Component.onCompleted: {
+                PopoutService.settingsModal = settingsModal;
+                PopoutService._onSettingsModalLoaded();
+            }
 
             onVisibleChanged: {
                 if (visible) {


### PR DESCRIPTION
Fix for the settings window not opening in latest Quickshell version.

Note that this have a small difference than how it was before, the settings window open instantly now but the menu may only load a bit less than a second later, where before it would only open with the content already loaded. But this works as a quick workaround as seemingly Quickshell after https://github.com/quickshell-mirror/quickshell/commit/de1bfe028d6982ac9dce08e5063ea5611498b204 is not creating the window if it's set visible as false.