### PR TITLE
fix volume osd sliding ui update for vertical layout

### DIFF
--- a/quickshell/Modules/OSD/VolumeOSD.qml
+++ b/quickshell/Modules/OSD/VolumeOSD.qml
@@ -262,9 +262,7 @@ DankOSD {
                     target: AudioService.sink && AudioService.sink.audio ? AudioService.sink.audio : null
 
                     function onVolumeChanged() {
-                        if (!vertSlider.dragging) {
-                            vertSlider.value = Math.min(100, Math.round(AudioService.sink.audio.volume * 100));
-                        }
+                        vertSlider.value = Math.min(100, Math.round(AudioService.sink.audio.volume * 100));
                     }
                 }
             }


### PR DESCRIPTION
Fixes the volume ui bug mentioned in #1378 not sure if hover for percentage should be shown or not in vertical layout. 