### PR TITLE
nix: Support specifying systemd target

### DIFF
--- a/distro/nix/home.nix
+++ b/distro/nix/home.nix
@@ -73,6 +73,12 @@ in
       default = hasPluginSettings;
       description = ''Whether to manage plugin settings. Automatically enabled if any plugins have settings configured.'';
     };
+
+    systemd.target = lib.mkOption {
+      type = lib.types.str;
+      default = config.wayland.systemd.target;
+      defaultText = lib.literalExpression "config.wayland.systemd.target";
+      description = "Systemd target to bind to.";
   };
 
   config = lib.mkIf cfg.enable {
@@ -84,8 +90,8 @@ in
     systemd.user.services.dms = lib.mkIf cfg.systemd.enable {
       Unit = {
         Description = "DankMaterialShell";
-        PartOf = [ config.wayland.systemd.target ];
-        After = [ config.wayland.systemd.target ];
+        PartOf = [ cfg.systemd.target ];
+        After = [ cfg.systemd.target ];
       };
 
       Service = {
@@ -93,7 +99,7 @@ in
         Restart = "on-failure";
       };
 
-      Install.WantedBy = [ config.wayland.systemd.target ];
+      Install.WantedBy = [ cfg.systemd.target ];
     };
 
     xdg.stateFile."DankMaterialShell/session.json" = lib.mkIf (cfg.session != { }) {

--- a/distro/nix/nixos.nix
+++ b/distro/nix/nixos.nix
@@ -20,15 +20,19 @@ in
   imports = [
     (import ./options.nix args)
   ];
-
+  options.programs.dank-material-shell.systemd.target = lib.mkOption {
+    type = lib.types.str;
+    description = "Systemd target to bind to.";
+    default = "graphical-session.target";
+  };
   config = lib.mkIf cfg.enable {
     systemd.user.services.dms = lib.mkIf cfg.systemd.enable {
       description = "DankMaterialShell";
       path = lib.mkForce [ ];
 
-      partOf = [ "graphical-session.target" ];
-      after = [ "graphical-session.target" ];
-      wantedBy = [ "graphical-session.target" ];
+      partOf = [ cfg.systemd.target ];
+      after = [ cfg.systemd.target ];
+      wantedBy = [ cfg.systemd.target ];
       restartIfChanged = cfg.systemd.restartIfChanged;
 
       serviceConfig = {


### PR DESCRIPTION
This is a pretty common pattern in home manager: https://home-manager-options.extranix.com/?query=systemd.target

It's not necessarily true that one will always want to bind to the default target, like in the case that one is running DMS in Niri but sometimes running other compositor sessions where one doesn't want to run DMS. This supports that case in a cleaner way than `mkForce`ing the unit configuration. I opted to just duplicate the option between the home manager module and the NixOS module due to NixOS not having anything analogous to `config.wayland.systemd.target`.