### PR TITLE
labwc support for greetd

### DIFF
--- a/distro/nix/greeter.nix
+++ b/distro/nix/greeter.nix
@@ -11,12 +11,18 @@ let
 
   inherit (config.services.greetd.settings.default_session) user;
 
+  compositorPackage =
+    let
+      configured = lib.attrByPath [ "programs" cfg.compositor.name "package" ] null config;
+    in
+    if configured != null then configured else builtins.getAttr cfg.compositor.name pkgs;
+
   cacheDir = "/var/lib/dms-greeter";
   greeterScript = pkgs.writeShellScriptBin "dms-greeter" ''
     export PATH=$PATH:${
       lib.makeBinPath [
         cfg.quickshell.package
-        config.programs.${cfg.compositor.name}.package
+        compositorPackage
       ]
     }
     ${
@@ -64,6 +70,7 @@ in
         "niri"
         "hyprland"
         "sway"
+        "labwc"
       ];
       description = "Compositor to run greeter in";
     };

--- a/quickshell/Modules/Greetd/assets/dms-greeter
+++ b/quickshell/Modules/Greetd/assets/dms-greeter
@@ -16,7 +16,7 @@ dms-greeter - DankMaterialShell greeter launcher
 Usage: dms-greeter --command COMPOSITOR [OPTIONS]
 
 Required:
-    --command COMPOSITOR    Compositor to use (niri, hyprland, sway, scroll or mangowc)
+    --command COMPOSITOR    Compositor to use (niri, hyprland, sway, scroll, mangowc, or labwc)
 
 Options:
     -C, --config PATH       Custom compositor config file
@@ -33,6 +33,7 @@ Examples:
     dms-greeter --command scroll -p /home/user/.config/quickshell/custom-dms
     dms-greeter --command niri --cache-dir /tmp/dmsgreeter
     dms-greeter --command mangowc
+    dms-greeter --command labwc
 EOF
 }
 
@@ -231,6 +232,15 @@ SCROLL_EOF
         exec scroll -c "$COMPOSITOR_CONFIG"
         ;;
 
+
+    labwc)
+        if [[ -n "$COMPOSITOR_CONFIG" ]]; then
+            exec labwc --config "$COMPOSITOR_CONFIG" --session "$QS_CMD"
+        else
+            exec labwc --session "$QS_CMD"
+        fi
+        ;;
+
     mangowc)
         if [[ -n "$COMPOSITOR_CONFIG" ]]; then
             exec mango -c "$COMPOSITOR_CONFIG" -s "$QS_CMD && mmsg -d quit"
@@ -241,7 +251,7 @@ SCROLL_EOF
 
     *)
         echo "Error: Unsupported compositor: $COMPOSITOR" >&2
-        echo "Supported compositors: niri, hyprland, sway, mangowc" >&2
+        echo "Supported compositors: niri, hyprland, sway, scroll, mangowc, labwc" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
I wanted greetd to run on my labwc on NixOS but it was not supported (also see #1250) so I had the clanker look into the labwc sourcecode and suggest how to fix it.

Tested the patched .nix module on NixOS 26.05 unstable.

<img width="1297" height="963" alt="image" src="https://github.com/user-attachments/assets/c7c434f0-d320-410d-8c57-97cb5bcb33a7" />