### PR TITLE
feat(bar): enlarge bar icons if widget background is off

### DIFF
--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -752,9 +752,9 @@ Singleton {
         return (0.299 * c.r + 0.587 * c.g + 0.114 * c.b) < 0.5;
     }
 
-    function barIconSize(barThickness, offset) {
+    function barIconSize(barThickness, offset, noBackground) {
         const defaultOffset = offset !== undefined ? offset : -6;
-        const size = (SettingsData.barConfigs[0] || SettingsData.getBarConfig("default")).noBackground ? iconSizeLarge : iconSize;
+        const size = (noBackground ?? false) ? iconSizeLarge : iconSize;
 
         return Math.round((barThickness / 48) * (size + defaultOffset));
     }

--- a/quickshell/Modules/DankBar/Widgets/Battery.qml
+++ b/quickshell/Modules/DankBar/Widgets/Battery.qml
@@ -42,7 +42,7 @@ BasePill {
 
                 DankIcon {
                     name: BatteryService.getBatteryIcon()
-                    size: Theme.barIconSize(battery.barThickness)
+                    size: Theme.barIconSize(battery.barThickness, undefined, battery.barConfig?.noBackground)
                     color: {
                         if (!BatteryService.batteryAvailable) {
                             return Theme.widgetIconColor;
@@ -78,7 +78,7 @@ BasePill {
 
                 DankIcon {
                     name: BatteryService.getBatteryIcon()
-                    size: Theme.barIconSize(battery.barThickness, -4)
+                    size: Theme.barIconSize(battery.barThickness, -4, battery.barConfig?.noBackground)
                     color: {
                         if (!BatteryService.batteryAvailable) {
                             return Theme.widgetIconColor;

--- a/quickshell/Modules/DankBar/Widgets/CapsLockIndicator.qml
+++ b/quickshell/Modules/DankBar/Widgets/CapsLockIndicator.qml
@@ -45,7 +45,7 @@ BasePill {
             DankIcon {
                 anchors.centerIn: parent
                 name: "shift_lock"
-                size: Theme.barIconSize(root.barThickness)
+                size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                 color: Theme.primary
             }
         }

--- a/quickshell/Modules/DankBar/Widgets/ClipboardButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/ClipboardButton.qml
@@ -17,7 +17,7 @@ BasePill {
             DankIcon {
                 anchors.centerIn: parent
                 name: "content_paste"
-                size: Theme.barIconSize(root.barThickness, -4)
+                size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                 color: Theme.widgetIconColor
             }
         }

--- a/quickshell/Modules/DankBar/Widgets/ColorPicker.qml
+++ b/quickshell/Modules/DankBar/Widgets/ColorPicker.qml
@@ -18,7 +18,7 @@ BasePill {
             DankIcon {
                 anchors.centerIn: parent
                 name: "palette"
-                size: Theme.barIconSize(root.barThickness, -4)
+                size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                 color: root.isActive ? Theme.primary : Theme.surfaceText
             }
         }

--- a/quickshell/Modules/DankBar/Widgets/ControlCenterButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/ControlCenterButton.qml
@@ -29,7 +29,7 @@ BasePill {
     property real micAccumulator: 0
     property real volumeAccumulator: 0
     property real brightnessAccumulator: 0
-    readonly property real vIconSize: Theme.barIconSize(root.barThickness, -4)
+    readonly property real vIconSize: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
 
     Loader {
         active: root.showPrinterIcon
@@ -459,7 +459,7 @@ BasePill {
 
                 DankIcon {
                     name: "screen_record"
-                    size: Theme.barIconSize(root.barThickness, -4)
+                    size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                     color: NiriService.hasActiveCast ? Theme.primary : Theme.surfaceText
                     anchors.verticalCenter: parent.verticalCenter
                     visible: root.showScreenSharingIcon && NiriService.hasCasts
@@ -468,7 +468,7 @@ BasePill {
                 DankIcon {
                     id: networkIcon
                     name: root.getNetworkIconName()
-                    size: Theme.barIconSize(root.barThickness, -4)
+                    size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                     color: root.getNetworkIconColor()
                     anchors.verticalCenter: parent.verticalCenter
                     visible: root.showNetworkIcon && NetworkService.networkAvailable
@@ -477,7 +477,7 @@ BasePill {
                 DankIcon {
                     id: vpnIcon
                     name: "vpn_lock"
-                    size: Theme.barIconSize(root.barThickness, -4)
+                    size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                     color: NetworkService.vpnConnected ? Theme.primary : Theme.surfaceText
                     anchors.verticalCenter: parent.verticalCenter
                     visible: root.showVpnIcon && NetworkService.vpnAvailable && NetworkService.vpnConnected
@@ -486,7 +486,7 @@ BasePill {
                 DankIcon {
                     id: bluetoothIcon
                     name: "bluetooth"
-                    size: Theme.barIconSize(root.barThickness, -4)
+                    size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                     color: BluetoothService.connected ? Theme.primary : Theme.surfaceText
                     anchors.verticalCenter: parent.verticalCenter
                     visible: root.showBluetoothIcon && BluetoothService.available && BluetoothService.enabled
@@ -502,7 +502,7 @@ BasePill {
                     DankIcon {
                         id: audioIcon
                         name: root.getVolumeIconName()
-                        size: Theme.barIconSize(root.barThickness, -4)
+                        size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                         color: Theme.widgetIconColor
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.left: parent.left
@@ -544,7 +544,7 @@ BasePill {
                     DankIcon {
                         id: micIcon
                         name: root.getMicIconName()
-                        size: Theme.barIconSize(root.barThickness, -4)
+                        size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                         color: root.getMicIconColor()
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.left: parent.left
@@ -586,7 +586,7 @@ BasePill {
                     DankIcon {
                         id: brightnessIcon
                         name: root.getBrightnessIconName()
-                        size: Theme.barIconSize(root.barThickness, -4)
+                        size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                         color: Theme.widgetIconColor
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.left: parent.left
@@ -618,7 +618,7 @@ BasePill {
                 DankIcon {
                     id: batteryIcon
                     name: Theme.getBatteryIcon(BatteryService.batteryLevel, BatteryService.isCharging, BatteryService.batteryAvailable)
-                    size: Theme.barIconSize(root.barThickness, -4)
+                    size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                     color: root.getBatteryIconColor()
                     anchors.verticalCenter: parent.verticalCenter
                     visible: root.showBatteryIcon && BatteryService.batteryAvailable
@@ -627,7 +627,7 @@ BasePill {
                 DankIcon {
                     id: printerIcon
                     name: "print"
-                    size: Theme.barIconSize(root.barThickness, -4)
+                    size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                     color: Theme.primary
                     anchors.verticalCenter: parent.verticalCenter
                     visible: root.showPrinterIcon && CupsService.cupsAvailable && root.hasPrintJobs()
@@ -635,7 +635,7 @@ BasePill {
 
                 DankIcon {
                     name: "settings"
-                    size: Theme.barIconSize(root.barThickness, -4)
+                    size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                     color: root.isActive ? Theme.primary : Theme.widgetIconColor
                     anchors.verticalCenter: parent.verticalCenter
                     visible: root.hasNoVisibleIcons()

--- a/quickshell/Modules/DankBar/Widgets/CpuMonitor.qml
+++ b/quickshell/Modules/DankBar/Widgets/CpuMonitor.qml
@@ -36,7 +36,7 @@ BasePill {
 
                 DankIcon {
                     name: "memory"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: {
                         if (DgopService.cpuUsage > 80) {
                             return Theme.tempDanger;
@@ -74,7 +74,7 @@ BasePill {
                 DankIcon {
                     id: cpuIcon
                     name: "memory"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: {
                         if (DgopService.cpuUsage > 80) {
                             return Theme.tempDanger;

--- a/quickshell/Modules/DankBar/Widgets/CpuTemperature.qml
+++ b/quickshell/Modules/DankBar/Widgets/CpuTemperature.qml
@@ -36,7 +36,7 @@ BasePill {
 
                 DankIcon {
                     name: "device_thermostat"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: {
                         if (DgopService.cpuTemperature > 85) {
                             return Theme.tempDanger;
@@ -74,7 +74,7 @@ BasePill {
                 DankIcon {
                     id: cpuTempIcon
                     name: "device_thermostat"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: {
                         if (DgopService.cpuTemperature > 85) {
                             return Theme.tempDanger;

--- a/quickshell/Modules/DankBar/Widgets/DWLLayout.qml
+++ b/quickshell/Modules/DankBar/Widgets/DWLLayout.qml
@@ -57,7 +57,7 @@ BasePill {
 
                 DankIcon {
                     name: layout.getLayoutIcon(layout.currentLayoutSymbol)
-                    size: Theme.barIconSize(layout.barThickness)
+                    size: Theme.barIconSize(layout.barThickness, undefined, layout.barConfig?.noBackground)
                     color: Theme.widgetTextColor
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
@@ -78,7 +78,7 @@ BasePill {
 
                 DankIcon {
                     name: layout.getLayoutIcon(layout.currentLayoutSymbol)
-                    size: Theme.barIconSize(layout.barThickness, -4)
+                    size: Theme.barIconSize(layout.barThickness, -4, layout.barConfig?.noBackground)
                     color: Theme.widgetTextColor
                     anchors.verticalCenter: parent.verticalCenter
                 }

--- a/quickshell/Modules/DankBar/Widgets/DiskUsage.qml
+++ b/quickshell/Modules/DankBar/Widgets/DiskUsage.qml
@@ -112,7 +112,7 @@ BasePill {
 
                 DankIcon {
                     name: "storage"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: {
                         if (root.diskUsagePercent > 90) {
                             return Theme.tempDanger;
@@ -146,7 +146,7 @@ BasePill {
 
                 DankIcon {
                     name: "storage"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: {
                         if (root.diskUsagePercent > 90) {
                             return Theme.tempDanger;

--- a/quickshell/Modules/DankBar/Widgets/GpuTemperature.qml
+++ b/quickshell/Modules/DankBar/Widgets/GpuTemperature.qml
@@ -104,7 +104,7 @@ BasePill {
 
                 DankIcon {
                     name: "auto_awesome_mosaic"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: {
                         if (root.displayTemp > 80) {
                             return Theme.tempDanger;
@@ -142,7 +142,7 @@ BasePill {
                 DankIcon {
                     id: gpuTempIcon
                     name: "auto_awesome_mosaic"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: {
                         if (root.displayTemp > 80) {
                             return Theme.tempDanger;

--- a/quickshell/Modules/DankBar/Widgets/IdleInhibitor.qml
+++ b/quickshell/Modules/DankBar/Widgets/IdleInhibitor.qml
@@ -17,7 +17,7 @@ BasePill {
             DankIcon {
                 anchors.centerIn: parent
                 name: SessionService.idleInhibited ? "motion_sensor_active" : "motion_sensor_idle"
-                size: Theme.barIconSize(root.barThickness, -4)
+                size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                 color: Theme.widgetTextColor
             }
         }

--- a/quickshell/Modules/DankBar/Widgets/KeyboardLayoutName.qml
+++ b/quickshell/Modules/DankBar/Widgets/KeyboardLayoutName.qml
@@ -61,7 +61,7 @@ BasePill {
 
                 DankIcon {
                     name: "keyboard"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: Theme.widgetTextColor
                     anchors.horizontalCenter: parent.horizontalCenter
                 }

--- a/quickshell/Modules/DankBar/Widgets/LauncherButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/LauncherButton.qml
@@ -21,15 +21,15 @@ BasePill {
                 visible: SettingsData.launcherLogoMode === "apps"
                 anchors.centerIn: parent
                 name: "apps"
-                size: Theme.barIconSize(root.barThickness, -4)
+                size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                 color: Theme.widgetIconColor
             }
 
             SystemLogo {
                 visible: SettingsData.launcherLogoMode === "os"
                 anchors.centerIn: parent
-                width: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset)
-                height: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset)
+                width: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset, root.barConfig?.noBackground)
+                height: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset, root.barConfig?.noBackground)
                 colorOverride: Theme.effectiveLogoColor
                 brightnessOverride: SettingsData.launcherLogoBrightness
                 contrastOverride: SettingsData.launcherLogoContrast
@@ -38,8 +38,8 @@ BasePill {
             IconImage {
                 visible: SettingsData.launcherLogoMode === "dank"
                 anchors.centerIn: parent
-                width: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset)
-                height: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset)
+                width: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset, root.barConfig?.noBackground)
+                height: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset, root.barConfig?.noBackground)
                 smooth: true
                 mipmap: true
                 asynchronous: true
@@ -57,8 +57,8 @@ BasePill {
             IconImage {
                 visible: SettingsData.launcherLogoMode === "compositor" && (CompositorService.isNiri || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isLabwc)
                 anchors.centerIn: parent
-                width: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset)
-                height: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset)
+                width: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset, root.barConfig?.noBackground)
+                height: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset, root.barConfig?.noBackground)
                 smooth: true
                 asynchronous: true
                 source: {
@@ -94,8 +94,8 @@ BasePill {
             IconImage {
                 visible: SettingsData.launcherLogoMode === "custom" && SettingsData.launcherLogoCustomPath !== ""
                 anchors.centerIn: parent
-                width: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset)
-                height: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset)
+                width: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset, root.barConfig?.noBackground)
+                height: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset, root.barConfig?.noBackground)
                 smooth: true
                 asynchronous: true
                 source: SettingsData.launcherLogoCustomPath ? "file://" + SettingsData.launcherLogoCustomPath.replace("file://", "") : ""

--- a/quickshell/Modules/DankBar/Widgets/NetworkMonitor.qml
+++ b/quickshell/Modules/DankBar/Widgets/NetworkMonitor.qml
@@ -41,7 +41,7 @@ BasePill {
 
                 DankIcon {
                     name: "network_check"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: Theme.widgetTextColor
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
@@ -79,7 +79,7 @@ BasePill {
 
                 DankIcon {
                     name: "network_check"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: Theme.widgetTextColor
                     anchors.verticalCenter: parent.verticalCenter
                 }

--- a/quickshell/Modules/DankBar/Widgets/NotepadButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/NotepadButton.qml
@@ -44,7 +44,7 @@ BasePill {
 
                 anchors.centerIn: parent
                 name: "assignment"
-                size: Theme.barIconSize(root.barThickness, -4)
+                size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                 color: root.isActive ? Theme.primary : Theme.surfaceText
             }
         }

--- a/quickshell/Modules/DankBar/Widgets/NotificationCenterButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/NotificationCenterButton.qml
@@ -18,7 +18,7 @@ BasePill {
                 id: notifIcon
                 anchors.centerIn: parent
                 name: SessionData.doNotDisturb ? "notifications_off" : "notifications"
-                size: Theme.barIconSize(root.barThickness, -4)
+                size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                 color: SessionData.doNotDisturb ? Theme.primary : (root.isActive ? Theme.primary : Theme.widgetIconColor)
             }
 

--- a/quickshell/Modules/DankBar/Widgets/PowerMenuButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/PowerMenuButton.qml
@@ -16,7 +16,7 @@ BasePill {
             DankIcon {
                 anchors.centerIn: parent
                 name: "power_settings_new"
-                size: Theme.barIconSize(root.barThickness)
+                size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                 color: Theme.widgetIconColor
             }
         }

--- a/quickshell/Modules/DankBar/Widgets/RamMonitor.qml
+++ b/quickshell/Modules/DankBar/Widgets/RamMonitor.qml
@@ -38,7 +38,7 @@ BasePill {
 
                 DankIcon {
                     name: "developer_board"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: {
                         if (DgopService.memoryUsage > 90) {
                             return Theme.tempDanger;
@@ -84,7 +84,7 @@ BasePill {
                 DankIcon {
                     id: ramIcon
                     name: "developer_board"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                     color: {
                         if (DgopService.memoryUsage > 90) {
                             return Theme.tempDanger;

--- a/quickshell/Modules/DankBar/Widgets/RunningApps.qml
+++ b/quickshell/Modules/DankBar/Widgets/RunningApps.qml
@@ -366,10 +366,10 @@ Item {
                         IconImage {
                             id: iconImg
                             anchors.left: parent.left
-                            anchors.leftMargin: (widgetData?.runningAppsCompactMode !== undefined ? widgetData.runningAppsCompactMode : SettingsData.runningAppsCompactMode) ? Math.round((parent.width - Theme.barIconSize(root.barThickness)) / 2) : Theme.spacingXS
+                            anchors.leftMargin: (widgetData?.runningAppsCompactMode !== undefined ? widgetData.runningAppsCompactMode : SettingsData.runningAppsCompactMode) ? Math.round((parent.width - Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)) / 2) : Theme.spacingXS
                             anchors.verticalCenter: parent.verticalCenter
-                            width: Theme.barIconSize(root.barThickness)
-                            height: Theme.barIconSize(root.barThickness)
+                            width: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
+                            height: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                             source: {
                                 root._desktopEntriesUpdateTrigger;
                                 root._appIdSubstitutionsTrigger;
@@ -395,9 +395,9 @@ Item {
 
                         DankIcon {
                             anchors.left: parent.left
-                            anchors.leftMargin: (widgetData?.runningAppsCompactMode !== undefined ? widgetData.runningAppsCompactMode : SettingsData.runningAppsCompactMode) ? Math.round((parent.width - Theme.barIconSize(root.barThickness)) / 2) : Theme.spacingXS
+                            anchors.leftMargin: (widgetData?.runningAppsCompactMode !== undefined ? widgetData.runningAppsCompactMode : SettingsData.runningAppsCompactMode) ? Math.round((parent.width - Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)) / 2) : Theme.spacingXS
                             anchors.verticalCenter: parent.verticalCenter
-                            size: Theme.barIconSize(root.barThickness)
+                            size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                             name: "sports_esports"
                             color: Theme.widgetTextColor
                             visible: !iconImg.visible && Paths.isSteamApp(appId)
@@ -611,10 +611,10 @@ Item {
                         IconImage {
                             id: iconImg
                             anchors.left: parent.left
-                            anchors.leftMargin: (widgetData?.runningAppsCompactMode !== undefined ? widgetData.runningAppsCompactMode : SettingsData.runningAppsCompactMode) ? Math.round((parent.width - Theme.barIconSize(root.barThickness)) / 2) : Theme.spacingXS
+                            anchors.leftMargin: (widgetData?.runningAppsCompactMode !== undefined ? widgetData.runningAppsCompactMode : SettingsData.runningAppsCompactMode) ? Math.round((parent.width - Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)) / 2) : Theme.spacingXS
                             anchors.verticalCenter: parent.verticalCenter
-                            width: Theme.barIconSize(root.barThickness)
-                            height: Theme.barIconSize(root.barThickness)
+                            width: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
+                            height: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                             source: {
                                 root._desktopEntriesUpdateTrigger;
                                 root._appIdSubstitutionsTrigger;
@@ -640,9 +640,9 @@ Item {
 
                         DankIcon {
                             anchors.left: parent.left
-                            anchors.leftMargin: (widgetData?.runningAppsCompactMode !== undefined ? widgetData.runningAppsCompactMode : SettingsData.runningAppsCompactMode) ? Math.round((parent.width - Theme.barIconSize(root.barThickness)) / 2) : Theme.spacingXS
+                            anchors.leftMargin: (widgetData?.runningAppsCompactMode !== undefined ? widgetData.runningAppsCompactMode : SettingsData.runningAppsCompactMode) ? Math.round((parent.width - Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)) / 2) : Theme.spacingXS
                             anchors.verticalCenter: parent.verticalCenter
-                            size: Theme.barIconSize(root.barThickness)
+                            size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                             name: "sports_esports"
                             color: Theme.widgetTextColor
                             visible: !iconImg.visible && Paths.isSteamApp(appId)

--- a/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
+++ b/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
@@ -198,8 +198,8 @@ Item {
                         IconImage {
                             id: iconImg
                             anchors.centerIn: parent
-                            width: Theme.barIconSize(root.barThickness)
-                            height: Theme.barIconSize(root.barThickness)
+                            width: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
+                            height: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                             source: delegateRoot.iconSource
                             asynchronous: true
                             smooth: true
@@ -262,7 +262,7 @@ Item {
                     DankIcon {
                         anchors.centerIn: parent
                         name: root.menuOpen ? "expand_less" : "expand_more"
-                        size: Theme.barIconSize(root.barThickness)
+                        size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                         color: Theme.widgetTextColor
                     }
 
@@ -331,8 +331,8 @@ Item {
                         IconImage {
                             id: iconImg
                             anchors.centerIn: parent
-                            width: Theme.barIconSize(root.barThickness)
-                            height: Theme.barIconSize(root.barThickness)
+                            width: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
+                            height: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                             source: delegateRoot.iconSource
                             asynchronous: true
                             smooth: true
@@ -402,7 +402,7 @@ Item {
                                 return root.menuOpen ? "chevron_right" : "chevron_left";
                             }
                         }
-                        size: Theme.barIconSize(root.barThickness)
+                        size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                         color: Theme.widgetTextColor
                     }
 
@@ -754,8 +754,8 @@ Item {
                         IconImage {
                             id: menuIconImg
                             anchors.centerIn: parent
-                            width: Theme.barIconSize(root.barThickness)
-                            height: Theme.barIconSize(root.barThickness)
+                            width: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
+                            height: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.noBackground)
                             source: parent.iconSource
                             asynchronous: true
                             smooth: true

--- a/quickshell/Modules/DankBar/Widgets/SystemUpdate.qml
+++ b/quickshell/Modules/DankBar/Widgets/SystemUpdate.qml
@@ -36,7 +36,7 @@ BasePill {
                         return "system_update_alt";
                     return "check_circle";
                 }
-                size: Theme.barIconSize(root.barThickness, -4)
+                size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                 color: {
                     if (SystemUpdateService.hasError)
                         return Theme.error;
@@ -93,7 +93,7 @@ BasePill {
                             return "system_update_alt";
                         return "check_circle";
                     }
-                    size: Theme.barIconSize(root.barThickness, -4)
+                    size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                     color: {
                         if (SystemUpdateService.hasError)
                             return Theme.error;

--- a/quickshell/Modules/DankBar/Widgets/Vpn.qml
+++ b/quickshell/Modules/DankBar/Widgets/Vpn.qml
@@ -41,7 +41,7 @@ BasePill {
                 id: icon
 
                 name: DMSNetworkService.connected ? "vpn_lock" : "vpn_key_off"
-                size: Theme.barIconSize(root.barThickness, -4)
+                size: Theme.barIconSize(root.barThickness, -4, root.barConfig?.noBackground)
                 color: DMSNetworkService.connected ? Theme.primary : Theme.widgetIconColor
                 opacity: DMSNetworkService.isBusy ? 0.5 : 1.0
                 anchors.centerIn: parent

--- a/quickshell/Modules/DankBar/Widgets/Weather.qml
+++ b/quickshell/Modules/DankBar/Widgets/Weather.qml
@@ -30,7 +30,7 @@ BasePill {
 
                 DankIcon {
                     name: WeatherService.getWeatherIcon(WeatherService.weather.wCode)
-                    size: Theme.barIconSize(root.barThickness, -6)
+                    size: Theme.barIconSize(root.barThickness, -6, root.barConfig?.noBackground)
                     color: Theme.widgetIconColor
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
@@ -57,7 +57,7 @@ BasePill {
 
                 DankIcon {
                     name: WeatherService.getWeatherIcon(WeatherService.weather.wCode)
-                    size: Theme.barIconSize(root.barThickness, -6)
+                    size: Theme.barIconSize(root.barThickness, -6, root.barConfig?.noBackground)
                     color: Theme.widgetIconColor
                     anchors.verticalCenter: parent.verticalCenter
                 }

--- a/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
+++ b/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
@@ -467,7 +467,7 @@ Item {
     readonly property real padding: Math.max(Theme.spacingXS, Theme.spacingS * (widgetHeight / 30))
     readonly property real visualWidth: isVertical ? widgetHeight : (workspaceRow.implicitWidth + padding * 2)
     readonly property real visualHeight: isVertical ? (workspaceRow.implicitHeight + padding * 2) : widgetHeight
-    readonly property real appIconSize: Theme.barIconSize(barThickness, -6)
+    readonly property real appIconSize: Theme.barIconSize(barThickness, -6, root.barConfig?.noBackground)
 
     function getRealWorkspaces() {
         return root.workspaceList.filter(ws => {

--- a/quickshell/Modules/Plugins/PluginComponent.qml
+++ b/quickshell/Modules/Plugins/PluginComponent.qml
@@ -59,8 +59,8 @@ Item {
     readonly property bool hasVerticalPill: verticalBarPill !== null
     readonly property bool hasPopout: popoutContent !== null
 
-    readonly property int iconSize: Theme.barIconSize(barThickness, -4)
-    readonly property int iconSizeLarge: Theme.barIconSize(barThickness)
+    readonly property int iconSize: Theme.barIconSize(barThickness, -4, root.barConfig?.noBackground)
+    readonly property int iconSizeLarge: Theme.barIconSize(barThickness, undefined, root.barConfig?.noBackground)
 
     Component.onCompleted: {
         loadPluginData();


### PR DESCRIPTION
After turning off widget background on the bar, the padding becomes empty space, and the icons seem to small:

<img width="201" height="27" alt="image" src="https://github.com/user-attachments/assets/22c9c4be-7e3e-4879-a88a-01218c287ac4" />

So this PR changes the icon size to `iconSizeLarge` if `noBackground` is true.

<img width="211" height="27" alt="image" src="https://github.com/user-attachments/assets/e8bba13b-eb61-4a47-9d0d-ea61eee09529" />
