### PR TITLE
feat: add option to change occupied workspace color

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -206,6 +206,7 @@ Singleton {
     property bool reverseScrolling: false
     property bool dwlShowAllTags: false
     property string workspaceColorMode: "default"
+    property string workspaceOccupiedColorMode: "default"
     property string workspaceUnfocusedColorMode: "default"
     property string workspaceUrgentColorMode: "default"
     property bool workspaceFocusedBorderEnabled: false

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -100,6 +100,7 @@ var SPEC = {
     reverseScrolling: { def: false },
     dwlShowAllTags: { def: false },
     workspaceColorMode: { def: "default" },
+    workspaceOccupiedColorMode: { def: "default" },
     workspaceUnfocusedColorMode: { def: "default" },
     workspaceUrgentColorMode: { def: "default" },
     workspaceFocusedBorderEnabled: { def: false },

--- a/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
+++ b/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
@@ -754,6 +754,16 @@ Item {
                         return !!(modelData && modelData.num === root.currentWorkspace);
                     return modelData === root.currentWorkspace;
                 }
+                property bool isOccupied: {
+                    if (CompositorService.isHyprland)
+                        return Array.from(Hyprland.toplevels?.values || [])
+                            .some(tl => tl.workspace?.id === modelData?.id);
+                    if (CompositorService.isDwl)
+                        return modelData.clients > 0;
+                    if (CompositorService.isNiri)
+                        return NiriService.windows?.some(win => win.workspace_id === modelData?.id) ?? false;
+                    return false;
+                }
                 property bool isPlaceholder: {
                     if (root.useExtWorkspace)
                         return !!(modelData && modelData.hidden);
@@ -832,6 +842,21 @@ Item {
                         return unfocusedColor;
                     default:
                         return Theme.primary;
+                    }
+                }
+
+                readonly property color occupiedColor: {
+                    switch (SettingsData.workspaceOccupiedColorMode) {
+                    case "s":
+                        return Theme.surface;
+                    case "sc":
+                        return Theme.surfaceContainer;
+                    case "sch":
+                        return Theme.surfaceContainerHigh;
+                    case "none":
+                        return unfocusedColor;
+                    default:
+                        return Theme.secondary;
                     }
                 }
 
@@ -1022,7 +1047,7 @@ Item {
                     height: delegateRoot.visualHeight
                     anchors.centerIn: parent
                     radius: Theme.cornerRadius
-                    color: isActive ? activeColor : isUrgent ? urgentColor : isPlaceholder ? Theme.surfaceTextLight : isHovered ? Theme.withAlpha(unfocusedColor, 0.7) : unfocusedColor
+                    color: isActive ? activeColor : isUrgent ? urgentColor : isPlaceholder ? Theme.surfaceTextLight : isHovered ? Theme.withAlpha(unfocusedColor, 0.7) : isOccupied ? occupiedColor : unfocusedColor
 
                     border.width: isUrgent ? 2 : 0
                     border.color: isUrgent ? urgentColor : "transparent"

--- a/quickshell/Modules/Settings/WorkspacesTab.qml
+++ b/quickshell/Modules/Settings/WorkspacesTab.qml
@@ -200,6 +200,46 @@ Item {
                 }
 
                 SettingsButtonGroupRow {
+                    text: I18n.tr("Occupied Color")
+                    model: ["sec", "s", "sc", "sch", "none"]
+                    visible: CompositorService.isNiri || CompositorService.isHyprland || CompositorService.isDwl
+                    buttonHeight: 22
+                    minButtonWidth: 36
+                    buttonPadding: Theme.spacingS
+                    checkIconSize: Theme.iconSizeSmall - 2
+                    textSize: Theme.fontSizeSmall - 1
+                    spacing: 1
+                    currentIndex: {
+                        switch (SettingsData.wokspaceColorMode) {
+                        case "s":
+                            return 1;
+                        case "sc":
+                            return 2;
+                        case "sch":
+                            return 3;
+                        case "none":
+                            return 4;
+                        default:
+                            return 0;
+                        }
+                    }
+                    onSelectionChanged: (index, selected) => {
+                        if (!selected)
+                            return;
+                        const modes = ["default", "s", "sc", "sch", "none"];
+                        SettingsData.set("workspaceOccupiedColorMode", modes[index]);
+                    }
+                }
+
+                Rectangle {
+                    width: parent.width
+                    height: 1
+                    color: Theme.outline
+                    opacity: 0.15
+                    visible: CompositorService.isNiri || CompositorService.isHyprland || CompositorService.isDwl
+                }
+
+                SettingsButtonGroupRow {
                     text: I18n.tr("Unfocused Color")
                     model: ["def", "s", "sc", "sch"]
                     buttonHeight: 22


### PR DESCRIPTION
this should fix #640 

By default, occupied workspaces in `WorkspaceSwitch` will show as the secondary color.

<img width="243" height="26" alt="image" src="https://github.com/user-attachments/assets/b94ca2c9-70ac-4bdc-8c34-0bb933a58b9c" />

(blue is active, white is occupied, gray is unfocused)

And I only implemented this for Hyprland, Niri, and Dwl, because the first two had ways to detect it already from the "Show Occupied Workspaces Only" option, and someone *probably* has to test this on Dwl to verify it works. I only tested this on Hyprland.

This would be a color change for everyone on these platforms. If it'd make surprises we should maybe change the default value to `none`?