### PR TITLE
remove hardcoded width and padding fixing overlap

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/SystemUpdate.qml
+++ b/quickshell/Modules/DankBar/Widgets/SystemUpdate.qml
@@ -11,17 +11,14 @@ BasePill {
     readonly property bool hasUpdates: SystemUpdateService.updateCount > 0
     readonly property bool isChecking: SystemUpdateService.isChecking
 
-    readonly property real horizontalPadding: (barConfig?.noBackground ?? false) ? 2 : Theme.spacingS
-    width: (SettingsData.updaterHideWidget && !hasUpdates) ? 0 : (18 + horizontalPadding * 2)
-
     Ref {
         service: SystemUpdateService
     }
 
     content: Component {
         Item {
-            implicitWidth: root.isVerticalOrientation ? (root.widgetThickness - root.horizontalPadding * 2) : updaterIcon.implicitWidth
-            implicitHeight: root.widgetThickness - root.horizontalPadding * 2
+            implicitWidth: root.isVerticalOrientation ? root.widgetThickness : updaterIcon.implicitWidth
+            implicitHeight: root.widgetThickness
 
             DankIcon {
                 id: statusIcon


### PR DESCRIPTION
Fixes this:
<img width="219" height="98" alt="image" src="https://github.com/user-attachments/assets/10b5cf6e-ddb8-4e80-9974-c7a85fa65771" />
<img width="219" height="98" alt="image" src="https://github.com/user-attachments/assets/f12b7f4d-e30c-4338-bb2b-bf1a3ead1c81" />
