### PR TITLE
fix: pass query string to launcher v2 during IPC toggle

### DIFF
--- a/quickshell/DMSShellIPC.qml
+++ b/quickshell/DMSShellIPC.qml
@@ -1063,7 +1063,7 @@ Item {
         }
 
         function toggleQuery(query: string): string {
-            PopoutService.toggleDankLauncherV2();
+            PopoutService.toggleDankLauncherV2WithQuery(query);
             return "LAUNCHER_TOGGLE_QUERY_SUCCESS";
         }
 
@@ -1107,7 +1107,7 @@ Item {
         }
 
         function toggleQuery(query: string): string {
-            PopoutService.toggleDankLauncherV2();
+            PopoutService.toggleDankLauncherV2WithQuery(query);
             return "SPOTLIGHT_TOGGLE_QUERY_SUCCESS";
         }
 

--- a/quickshell/Modals/DankLauncherV2/DankLauncherV2Modal.qml
+++ b/quickshell/Modals/DankLauncherV2/DankLauncherV2Modal.qml
@@ -186,6 +186,14 @@ Item {
         }
     }
 
+    function toggleWithQuery(query) {
+        if (spotlightOpen) {
+            hide();
+        } else {
+            showWithQuery(query);
+        }
+    }
+
     Timer {
         id: closeCleanupTimer
         interval: Theme.expressiveDurations.expressiveFastSpatial + 50

--- a/quickshell/Services/PopoutService.qml
+++ b/quickshell/Services/PopoutService.qml
@@ -416,6 +416,17 @@ Singleton {
         }
     }
 
+    function toggleDankLauncherV2WithQuery(query: string) {
+        if (dankLauncherV2Modal) {
+            dankLauncherV2Modal.toggleWithQuery(query);
+        } else if (dankLauncherV2ModalLoader) {
+            _dankLauncherV2PendingQuery = query;
+            _dankLauncherV2WantsOpen = true;
+            _dankLauncherV2WantsToggle = false;
+            dankLauncherV2ModalLoader.active = true;
+        }
+    }
+
     function _onDankLauncherV2ModalLoaded() {
         if (_dankLauncherV2WantsOpen) {
             _dankLauncherV2WantsOpen = false;


### PR DESCRIPTION
### Description 
This PR fixes #1476

### Changes
- Added toggleWithQuery() to DankLauncherV2Modal to handle query-specific toggling.

- Extended PopoutService with toggleDankLauncherV2WithQuery() to bridge the IPC call and the modal state.

- Updated both spotlight and launcher IPC targets to utilize the new query-aware toggle function.

### Verification
- [x] Ran dms ipc call launcher toggleQuery "test query" and verified the launcher opened with the text "test query".

- [x] Verified openQuery still functions correctly.

- [x] Tested spotlight call target to ensure the fix applies there as well.