### PR TITLE
fix: changing UI width was shifted due to the clock widget

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/Clock.qml
+++ b/quickshell/Modules/DankBar/Widgets/Clock.qml
@@ -211,6 +211,20 @@ BasePill {
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale)
                     color: Theme.widgetTextColor
                     anchors.baseline: dateText.baseline
+                    width: timeTextMetrics.width
+                    horizontalAlignment: Text.AlignHCenter
+                    TextMetrics {
+                        id: timeTextMetrics
+                        font: timeText.font
+                        text: {
+                            const format = SettingsData.getEffectiveTimeFormat();
+                            if (SettingsData.use24HourClock) {
+                                return SettingsData.showSeconds ? "88:88:88" : "88:88";
+                            } else {
+                                return SettingsData.showSeconds ? "88:88:88 PM" : "88:88 PM";
+                            }
+                        }
+                    }
                 }
 
                 StyledText {


### PR DESCRIPTION
### Description
  This PR addresses an issue where the Clock widget's width would fluctuate as the time updated, causing the surrounding UI to shift. This was particularly noticeable when using non-monospaced fonts, where different digits have varying widths.

  Similar logic to stabilize width is already implemented in other modules like the Network and CPU monitors. This change brings that same consistency to the Clock widget.


### Changes
   - Introduced `TextMetrics` in `quickshell/Modules/DankBar/Widgets/Clock.qml` to calculate the maximum possible width of the time string (e.g., using
     "88:88:88").
   - Set a fixed width based on these metrics and applied Text.AlignHCenter to the time display.

  This ensures the clock widget maintains a stable width regardless of the current time digits, preventing layout jitter.

### ScreenShots

https://github.com/user-attachments/assets/921f4f9f-d1c7-4238-a9ec-971361b4dee7

↑AS IS
↓Fixed
(Font: SF Pro Rounded)