### PR TITLE
keyboard-layout: fixed hyprland keyboard layout widget compact mode

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/KeyboardLayoutName.qml
+++ b/quickshell/Modules/DankBar/Widgets/KeyboardLayoutName.qml
@@ -164,7 +164,7 @@ BasePill {
                         const variant = mainKeyboard.variant;
                         const index = mainKeyboard.active_layout_index;
 
-                        if (root.compactMode && layout && variant && index !== undefined) {
+                        if (root.compactMode && layout && index !== undefined) {
                             const layouts = mainKeyboard.layout.split(",");
                             const variants = mainKeyboard.variant.split(",");
                             const index = mainKeyboard.active_layout_index;
@@ -176,7 +176,7 @@ BasePill {
                                     root.currentLayout = layouts[index] + "-" + variants[index];
                                 }
                             } else {
-                                root.currentLayout = "Unknown";
+                                root.currentLayout = layouts[index];
                             }
                         } else if (mainKeyboard && mainKeyboard.active_keymap) {
                             root.currentLayout = mainKeyboard.active_keymap;


### PR DESCRIPTION
on Hyprland when not setting a variant for the keyboard trying to show compact layout on the keyboard widget won't work. it should be now fixed i tested it and so far works as intended now with both full and compact widget setting