### PR TITLE
Open Process List as modal when launched from AppSearch

### DIFF
--- a/quickshell/Services/AppSearchService.qml
+++ b/quickshell/Services/AppSearchService.qml
@@ -322,7 +322,7 @@ Singleton {
             PopoutService.toggleNotepad();
             return true;
         case "processlist":
-            PopoutService.toggleProcessList();
+            PopoutService.toggleProcessListModal();
             return true;
         }
         return false;


### PR DESCRIPTION
### Problem
Opening the Process List from AppSearch calls `toggleProcessList()` without anchor geometry.
This causes `setTriggerPosition()` to receive undefined values, resulting in:

- `Cannot assign [undefined] to double`
- Popout opening at invalid positions

### Fix
Use the fullscreen modal version instead:

- Replace `toggleProcessList()` with `toggleProcessListModal()`

This matches expected behavior when no trigger position is available.

### Testing
- Opened Process List from AppSearch → modal opens correctly with window controls
- Process List popout still works when triggered from anchored widgets (CPU/RAM)
