### PR TITLE
feat(dms-greeter): add Niri override kdl includes

### DIFF
--- a/quickshell/Modules/Greetd/assets/dms-greeter
+++ b/quickshell/Modules/Greetd/assets/dms-greeter
@@ -125,6 +125,7 @@ case "$COMPOSITOR" in
     niri)
         if [[ -z "$COMPOSITOR_CONFIG" ]]; then
             TEMP_CONFIG=$(mktemp)
+			# base/default config
             cat > "$TEMP_CONFIG" << NIRI_EOF
 hotkey-overlay {
     skip-at-startup
@@ -133,8 +134,6 @@ hotkey-overlay {
 environment {
     DMS_RUN_GREETER "1"
 }
-
-spawn-at-startup "sh" "-c" "$QS_CMD; niri msg action quit --skip-confirmation"
 
 debug {
   keep-max-bpc-unchanged
@@ -154,12 +153,27 @@ NIRI_EOF
         else
             TEMP_CONFIG=$(mktemp)
             cat "$COMPOSITOR_CONFIG" > "$TEMP_CONFIG"
+        fi
+		# Append includes if override_files exist
+		OVERRIDE_FILES=(
+			/usr/share/greetd/niri_overrides.kdl # for building into a system image
+			/etc/greetd/niri_overrides.kdl # for local overrides
+			)
+		for override_file in "${OVERRIDE_FILES[@]}"; do
+			if [[ -e "$override_file" ]]; then
+		# TODO: maybe move to optional=true when Niri Next drops, so we can avoid these checks ;-)
+				cat >> "$TEMP_CONFIG" << NIRI_EOF
+
+include "$override_file"
+NIRI_EOF
+			fi
+		done
+		# Append spawn command
             cat >> "$TEMP_CONFIG" << NIRI_EOF
 
 spawn-at-startup "sh" "-c" "$QS_CMD; niri msg action quit --skip-confirmation"
 NIRI_EOF
             COMPOSITOR_CONFIG="$TEMP_CONFIG"
-        fi
         exec niri -c "$COMPOSITOR_CONFIG"
         ;;
 


### PR DESCRIPTION
This will optionally include one or two files into the Niri conf for
dms-greeter:
  - `/usr/share/greetd/niri_overrides.kdl` (for building into a system image)
  - `/etc/greetd/niri_overrides.kdl` (for local overrides)

This enables a distro or a system administrator to easily add their own
customizations to the dms-greeter Niri configuration.

Note: Niri next includes https://github.com/YaLTeR/niri/pull/3022 which
can make this a whole lot simpler: we're testing for the existence of
files and optionally adding `include` lines within the dms-greeter shell
script, but in the future it will be possible to simply use `include
optional=true` which we can just append unconditionally.

Lastly, I deduplicated the line that spawns the actual greeter by
appending that unconditionally at the end.
