### PR TITLE
fix: reverse rotation direction of sync icon in plugin browser

### DIFF
--- a/quickshell/Modules/Settings/PluginBrowser.qml
+++ b/quickshell/Modules/Settings/PluginBrowser.qml
@@ -378,7 +378,7 @@ FloatingWindow {
 
                             RotationAnimator on rotation {
                                 from: 0
-                                to: 360
+                                to: -360
                                 duration: 1000
                                 loops: Animation.Infinite
                                 running: root.isLoading


### PR DESCRIPTION
## Description
 
The loading spinner in the Plugin Browser rotates clockwise, but the `sync` icon's arrows
point counter-clockwise. This makes the animation look visually incorrect.
 
**Fix:** Change `RotationAnimator` target from `360` to `-360` so the icon spins in the
direction its arrows indicate.

## Before / After
 
| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/83cf6dd6-ccab-45b4-9201-f4a8d19c9637) | ![after](https://github.com/user-attachments/assets/509610b4-5634-43e8-969b-bc8652051541) |