### PR TITLE
dock: resolve icons for pre-substituted app IDs

### DIFF
--- a/quickshell/Common/Paths.qml
+++ b/quickshell/Common/Paths.qml
@@ -80,7 +80,10 @@ Singleton {
             return Quickshell.iconPath(moddedId, true);
         }
 
-        return desktopEntry && desktopEntry.icon ? Quickshell.iconPath(desktopEntry.icon, true) : "";
+        if (desktopEntry && desktopEntry.icon) {
+            return Quickshell.iconPath(desktopEntry.icon, true);
+        }
+        return Quickshell.iconPath(appId, true);
     }
 
     function getAppName(appId: string, desktopEntry: var): string {


### PR DESCRIPTION
fixes dock icons not resolving for apps whose IDs have been subbed out by appIdSubstitutions. e.g. steam_app_123 -> steam_icon_123.