### PR TITLE
distro: add cups-pk-helper to recommended dependencies

### DIFF
--- a/distro/debian/dms-git/debian/control
+++ b/distro/debian/dms-git/debian/control
@@ -29,6 +29,7 @@ Depends: ${misc:Depends},
          qml6-module-qtquick-templates,
          qml6-module-qtquick-window,
          qt6ct
+Suggests: cups-pk-helper
 Provides: dms
 Conflicts: dms
 Replaces: dms

--- a/distro/debian/dms/debian/control
+++ b/distro/debian/dms/debian/control
@@ -28,6 +28,7 @@ Depends: ${misc:Depends},
          qml6-module-qtquick-templates,
          qml6-module-qtquick-window,
          qt6ct
+Suggests: cups-pk-helper
 Conflicts: dms-git
 Replaces: dms-git
 Description: DankMaterialShell - Modern Wayland Desktop Shell

--- a/distro/fedora/dms-git.spec
+++ b/distro/fedora/dms-git.spec
@@ -37,6 +37,7 @@ Recommends:     quickshell-git
 # Recommended system packages
 Recommends:     NetworkManager
 Recommends:     qt6-qtmultimedia
+Suggests:       cups-pk-helper
 Suggests:       qt6ct
 
 %description

--- a/distro/fedora/dms.spec
+++ b/distro/fedora/dms.spec
@@ -28,6 +28,7 @@ Recommends:     danksearch
 Recommends:     matugen
 Recommends:     NetworkManager
 Recommends:     qt6-qtmultimedia
+Suggests:       cups-pk-helper
 Suggests:       qt6ct
 
 %description

--- a/distro/opensuse/dms-git.spec
+++ b/distro/opensuse/dms-git.spec
@@ -25,6 +25,7 @@ Recommends:     matugen
 Recommends:     quickshell-git
 Recommends:     NetworkManager
 Recommends:     qt6-qtmultimedia
+Suggests:       cups-pk-helper
 Suggests:       qt6ct
 
 Provides:       dms

--- a/distro/opensuse/dms.spec
+++ b/distro/opensuse/dms.spec
@@ -27,6 +27,7 @@ Recommends:     danksearch
 Recommends:     matugen
 Recommends:     NetworkManager
 Recommends:     qt6-qtmultimedia
+Suggests:       cups-pk-helper
 Suggests:       qt6ct
 
 %description


### PR DESCRIPTION
Was getting "The name is not activatable" when trying to interact/add/delete a printer. Noticed the dbus call in core/internal/server/cups/pkhelper.go.

Some distro's might have the pk-helper by default, I honestly don't know.

This commit is only a half measure.. the docs, AUR packages and system doctor would also need updating. I wanted to flag it first. 