### PR TITLE
fix(launcher): unload launcher content on close when optional

### DIFF
--- a/quickshell/Modals/DankLauncherV2/DankLauncherV2Modal.qml
+++ b/quickshell/Modals/DankLauncherV2/DankLauncherV2Modal.qml
@@ -284,7 +284,7 @@ Item {
 
     PanelWindow {
         id: launcherWindow
-        visible: root._windowEnabled
+        visible: root._windowEnabled && (!root.unloadContentOnClose || spotlightOpen || isClosing)
         color: "transparent"
         exclusionMode: ExclusionMode.Ignore
 


### PR DESCRIPTION
### Context

Follow-up to PR #1692 (fix(launcher): release DankLauncherV2 resources after close).

Feedback from @AvengeMedia on #1692: full launcher unload was made optional because it introduces a significant keyboard focus delay on reopen; suggested restructuring to unload content while keeping the main window loaded.

### Summary

This PR implements that restructuring.

When unload-on-close is enabled, it unloads only LauncherContent (heavy subtree), while keeping the DankLauncherV2Modal/window object alive.
This preserves optional VRAM savings while reducing reopen/focus latency compared with full modal re-instantiation.

### What changed

- Replaced direct LauncherContent instantiation with a Loader inside DankLauncherV2Modal.
- Added deferred initialization so show(), showWithQuery(), and showWithMode() still initialize correctly after content reload.
- Close cleanup now deactivates only the content loader (when setting is enabled), not the whole modal.

### Why

- Addresses maintainer feedback.
- Keeps behavior/features intact.
- Improves keyboard focus responsiveness on reopen versus full unload.

### File changed

- quickshell/Modals/DankLauncherV2/DankLauncherV2Modal.qml

### Manual validation

1. Enable launcher unload-on-close.
2. Open/close/reopen launcher and verify keyboard focus responsiveness.
3. Verify show, showWithQuery, and showWithMode paths.
4. Confirm heavy launcher content is released after close.