### PR TITLE
fix: preserve _preScored from plugin items to allow ordering control

### DIFF
--- a/quickshell/Modals/DankLauncherV2/ItemTransformers.js
+++ b/quickshell/Modals/DankLauncherV2/ItemTransformers.js
@@ -112,7 +112,7 @@ function transformBuiltInLauncherItem(item, pluginId, openLabel) {
         _hName: "",
         _hSub: "",
         _hRich: false,
-        _preScored: undefined
+        _preScored: item._preScored
     };
 }
 
@@ -186,7 +186,7 @@ function transformPluginItem(item, pluginId, selectLabel) {
         _hName: "",
         _hSub: "",
         _hRich: false,
-        _preScored: undefined
+        _preScored: item._preScored
     };
 }
 


### PR DESCRIPTION
## Problem

DMS launcher ignores plugin item ordering and re-sorts results using fuzzy matching. This prevents plugins from controlling which item appears first in search results.

Specifically, the _preScored property set by plugins was being overwritten with \undefined\ during item transformation, effectively discarding any ordering hints from plugins.

## Solution

Preserve the _preScored property from plugin items in:
- transformBuiltInLauncherItem()
- transformPluginItem()

This allows plugins to set _preScored on their items to control result ordering, with higher values appearing first.

## Testing

Tested with dms-web-search plugin:
- Plugin sets _preScored: 10000 for primary/default engine
- Plugin sets _preScored: 1000, 999, 998... for secondary engines
- Results now correctly show primary engine first

## Related Issues

Required for: https://github.com/devnullvoid/dms-web-search/issues/7