### PR TITLE
fix: correct preview centering with scaling

### DIFF
--- a/quickshell/Modules/Settings/DisplayConfig/MonitorCanvas.qml
+++ b/quickshell/Modules/Settings/DisplayConfig/MonitorCanvas.qml
@@ -21,8 +21,9 @@ Rectangle {
                 continue;
             const x = output.logical.x;
             const y = output.logical.y;
-            const w = output.logical.width || 1920;
-            const h = output.logical.height || 1080;
+            const size = DisplayConfigState.getLogicalSize(output);
+            const w = size.w || 1920;
+            const h = size.h || 1080;
             minX = Math.min(minX, x);
             minY = Math.min(minY, y);
             maxX = Math.max(maxX, x + w);


### PR DESCRIPTION
In MonitorCanvas this update makes sure the monitor's position and size are calculated using the same method. This stops the preview from jumping to the top-left corner when you change the display scale.

Please check on your machine