### PR TITLE
feat: Keybinds cheatsheet search

### DIFF
--- a/quickshell/Modals/KeybindsModal.qml
+++ b/quickshell/Modals/KeybindsModal.qml
@@ -170,6 +170,8 @@ DankModal {
                         return 40 + bindCount * 28;
                     }
 
+                    property var categoryKeys: Object.keys(categories);
+
                     function distributeCategories(cols) {
                         const columns = [];
                         const heights = [];
@@ -177,7 +179,7 @@ DankModal {
                             columns.push([]);
                             heights.push(0);
                         }
-                        const sorted = [...Object.keys(categories)].sort((a, b) => estimateCategoryHeight(b) - estimateCategoryHeight(a));
+                        const sorted = [...categoryKeys].sort((a, b) => estimateCategoryHeight(b) - estimateCategoryHeight(a));
                         for (const cat of sorted) {
                             let minIdx = 0;
                             for (let i = 1; i < cols; i++) {


### PR DESCRIPTION
Attempts to solve #1699. I first tried to reuse the Fzf logic in DankDropDown without success. Reusing the inclusion criterion in the official DankLauncherKeys plugin turned out to be better. Also, I haven't run the precommit hooks, somehow my NixOS system does not want to... Since I just edited one QML file, I guess anyone with a working development setup can check if it breaks any rules.

https://github.com/user-attachments/assets/756842e9-17c6-4355-96d9-56e5fcc1b3a5