### PR TITLE
fix: correct parameter name in Hyprland windowrule (no_initial_focus)

### DIFF
--- a/core/internal/config/embedded/hyprland.conf
+++ b/core/internal/config/embedded/hyprland.conf
@@ -100,7 +100,7 @@ windowrule = float on, match:class ^(blueman-manager)$
 windowrule = float on, match:class ^(org\.gnome\.Nautilus)$
 windowrule = float on, match:class ^(xdg-desktop-portal)$
 
-windowrule = noinitialfocus on, match:class ^(steam)$, match:title ^(notificationtoasts)
+windowrule = no_initial_focus on, match:class ^(steam)$, match:title ^(notificationtoasts)
 windowrule = pin on, match:class ^(steam)$, match:title ^(notificationtoasts)
 
 windowrule = float on, match:class ^(firefox)$, match:title ^(Picture-in-Picture)$


### PR DESCRIPTION
## Description
This PR corrects the parameter name to match new Hyprland standard.

## Changes
- **Before:**  'noinitialfocus'
- **After:** 'no_initial_focus'