### PR TITLE
feat(distros): allow CatOS to run DMS installer

### DIFF
--- a/core/internal/distros/arch.go
+++ b/core/internal/distros/arch.go
@@ -26,6 +26,9 @@ func init() {
 	Register("cachyos", "#08A283", FamilyArch, func(config DistroConfig, logChan chan<- string) Distribution {
 		return NewArchDistribution(config, logChan)
 	})
+	Register("catos", "#1793D1", FamilyArch, func(config DistroConfig, logChan chan<- string) Distribution {
+		return NewArchDistribution(config, logChan)
+	})
 	Register("endeavouros", "#7F3FBF", FamilyArch, func(config DistroConfig, logChan chan<- string) Distribution {
 		return NewArchDistribution(config, logChan)
 	})


### PR DESCRIPTION
### Description
This PR adds support for **CatOS** (a famous Chinese Arch-based beginner-friendly Linux distribution) to `core/internal/distros/arch.go`.

CatOS is fully compatible with Arch Linux, this commit allows it to utilize the existing `NewArchDistribution` logic.

### Testing
- [x] Compiled locally and verified that the TUI launches successfully.
- [x] Finished the full installation process on CatOS and it worked great.