### PR TITLE
zen: add more commands to detection

### DIFF
--- a/core/internal/matugen/matugen.go
+++ b/core/internal/matugen/matugen.go
@@ -54,7 +54,7 @@ var templateRegistry = []TemplateDef{
 	{ID: "qt6ct", Commands: []string{"qt6ct"}, ConfigFile: "qt6ct.toml"},
 	{ID: "firefox", Commands: []string{"firefox"}, ConfigFile: "firefox.toml"},
 	{ID: "pywalfox", Commands: []string{"pywalfox"}, ConfigFile: "pywalfox.toml"},
-	{ID: "zenbrowser", Commands: []string{"zen", "zen-browser"}, Flatpaks: []string{"app.zen_browser.zen"}, ConfigFile: "zenbrowser.toml"},
+	{ID: "zenbrowser", Commands: []string{"zen", "zen-browser", "zen-beta", "zen-twilight"}, Flatpaks: []string{"app.zen_browser.zen"}, ConfigFile: "zenbrowser.toml"},
 	{ID: "vesktop", Commands: []string{"vesktop"}, Flatpaks: []string{"dev.vencord.Vesktop"}, ConfigFile: "vesktop.toml"},
 	{ID: "equibop", Commands: []string{"equibop"}, ConfigFile: "equibop.toml"},
 	{ID: "ghostty", Commands: []string{"ghostty"}, ConfigFile: "ghostty.toml", Kind: TemplateKindTerminal},


### PR DESCRIPTION
Update zen-browser commands list for detection (added `zen-beta` and `zen-twilight`).