### PR TITLE
Wifi QR code generation (requires testing)

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -16,6 +16,8 @@ require (
 	github.com/sblinch/kdl-go v0.0.0-20260121213736-8b7053306ca6
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	github.com/yeqown/go-qrcode/v2 v2.2.5
+	github.com/yeqown/go-qrcode/writer/standard v1.3.0
 	github.com/yuin/goldmark v1.7.16
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc
 	go.etcd.io/bbolt v1.4.3
@@ -32,15 +34,19 @@ require (
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/fogleman/gg v1.3.0 // indirect
 	github.com/go-git/gcfg/v2 v2.0.2 // indirect
 	github.com/go-git/go-billy/v6 v6.0.0-20260209124918-37866f83c2d3 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/kevinburke/ssh_config v1.6.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/pjbgf/sha1cd v0.5.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
+	github.com/yeqown/reedsolomon v1.0.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
 )

--- a/core/go.sum
+++ b/core/go.sum
@@ -58,6 +58,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
+github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
@@ -75,6 +77,8 @@ github.com/go-logfmt/logfmt v0.6.1/go.mod h1:EV2pOAQoZaT1ZXZbqDl5hrymndi4SY9ED9/
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -115,6 +119,8 @@ github.com/pilebones/go-udev v0.9.1 h1:uN72M1C1fgzhsVmBGEM8w9RD1JY4iVsPZpr+Z6rb3
 github.com/pilebones/go-udev v0.9.1/go.mod h1:Bgcl07crebF3JSeS4+nuaRvhWFdCeFoBhXXeAp93XNo=
 github.com/pjbgf/sha1cd v0.5.0 h1:a+UkboSi1znleCDUNT3M5YxjOnN1fz2FhN48FlwCxs0=
 github.com/pjbgf/sha1cd v0.5.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
@@ -142,6 +148,12 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/yeqown/go-qrcode/v2 v2.2.5 h1:HCOe2bSjkhZyYoyyNaXNzh4DJZll6inVJQQw+8228Zk=
+github.com/yeqown/go-qrcode/v2 v2.2.5/go.mod h1:uHpt9CM0V1HeXLz+Wg5MN50/sI/fQhfkZlOM+cOTHxw=
+github.com/yeqown/go-qrcode/writer/standard v1.3.0 h1:chdyhEfRtUPgQtuPeaWVGQ/TQx4rE1PqeoW3U+53t34=
+github.com/yeqown/go-qrcode/writer/standard v1.3.0/go.mod h1:O4MbzsotGCvy8upYPCR91j81dr5XLT7heuljcNXW+oQ=
+github.com/yeqown/reedsolomon v1.0.0 h1:x1h/Ej/uJnNu8jaX7GLHBWmZKCAWjEJTetkqaabr4B0=
+github.com/yeqown/reedsolomon v1.0.0/go.mod h1:P76zpcn2TCuL0ul1Fso373qHRc69LKwAw/Iy6g1WiiM=
 github.com/yuin/goldmark v1.4.15/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
 github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=

--- a/core/internal/mocks/network/mock_Backend.go
+++ b/core/internal/mocks/network/mock_Backend.go
@@ -1062,6 +1062,62 @@ func (_c *MockBackend_GetWiFiNetworkDetails_Call) RunAndReturn(run func(string) 
 	return _c
 }
 
+// GetWiFiQRCodeContent provides a mock function with given fields: ssid
+func (_m *MockBackend) GetWiFiQRCodeContent(ssid string) (string, error) {
+	ret := _m.Called(ssid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetWiFiQRCodeContent")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return rf(ssid)
+	}
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(ssid)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(ssid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockBackend_GetWiFiQRCodeContent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetWiFiQRCodeContent'
+type MockBackend_GetWiFiQRCodeContent_Call struct {
+	*mock.Call
+}
+
+// GetWiFiQRCodeContent is a helper method to define mock.On call
+//   - ssid string
+func (_e *MockBackend_Expecter) GetWiFiQRCodeContent(ssid interface{}) *MockBackend_GetWiFiQRCodeContent_Call {
+	return &MockBackend_GetWiFiQRCodeContent_Call{Call: _e.mock.On("GetWiFiQRCodeContent", ssid)}
+}
+
+func (_c *MockBackend_GetWiFiQRCodeContent_Call) Run(run func(ssid string)) *MockBackend_GetWiFiQRCodeContent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockBackend_GetWiFiQRCodeContent_Call) Return(_a0 string, _a1 error) *MockBackend_GetWiFiQRCodeContent_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockBackend_GetWiFiQRCodeContent_Call) RunAndReturn(run func(string) (string, error)) *MockBackend_GetWiFiQRCodeContent_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetWiredConnections provides a mock function with no fields
 func (_m *MockBackend) GetWiredConnections() ([]network.WiredConnection, error) {
 	ret := _m.Called()

--- a/core/internal/server/network/backend.go
+++ b/core/internal/server/network/backend.go
@@ -10,6 +10,7 @@ type Backend interface {
 	ScanWiFi() error
 	ScanWiFiDevice(device string) error
 	GetWiFiNetworkDetails(ssid string) (*NetworkInfoResponse, error)
+	GetWiFiQRCodeContent(ssid string) (string, error)
 	GetWiFiDevices() []WiFiDevice
 
 	ConnectWiFi(req ConnectionRequest) error

--- a/core/internal/server/network/backend_hybrid_iwd_networkd.go
+++ b/core/internal/server/network/backend_hybrid_iwd_networkd.go
@@ -111,6 +111,10 @@ func (b *HybridIwdNetworkdBackend) GetWiFiNetworkDetails(ssid string) (*NetworkI
 	return b.wifi.GetWiFiNetworkDetails(ssid)
 }
 
+func (b *HybridIwdNetworkdBackend) GetWiFiQRCodeContent(ssid string) (string, error) {
+	return b.wifi.GetWiFiQRCodeContent(ssid)
+}
+
 func (b *HybridIwdNetworkdBackend) ConnectWiFi(req ConnectionRequest) error {
 	if err := b.wifi.ConnectWiFi(req); err != nil {
 		return err

--- a/core/internal/server/network/backend_iwd_unimplemented.go
+++ b/core/internal/server/network/backend_iwd_unimplemented.go
@@ -1,6 +1,9 @@
 package network
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 func (b *IWDBackend) GetWiredConnections() ([]WiredConnection, error) {
 	return nil, fmt.Errorf("wired connections not supported by iwd")
@@ -114,5 +117,17 @@ func (b *IWDBackend) getWiFiDevicesLocked() []WiFiDevice {
 }
 
 func (b *IWDBackend) GetWiFiQRCodeContent(ssid string) (string, error) {
-	return "", fmt.Errorf("WiFi QR code not supported by iwd backend")
+	path := iwdConfigPath(ssid)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("no saved iwd config for `%s`: %w", ssid, err)
+	}
+
+	passphrase, err := parseIWDPassphrase(string(data))
+	if err != nil {
+		return "", fmt.Errorf("failed to read passphrase for `%s`: %w", ssid, err)
+	}
+
+	return FormatWiFiQRString("WPA", ssid, passphrase), nil
 }

--- a/core/internal/server/network/backend_iwd_unimplemented.go
+++ b/core/internal/server/network/backend_iwd_unimplemented.go
@@ -112,3 +112,7 @@ func (b *IWDBackend) getWiFiDevicesLocked() []WiFiDevice {
 		Networks:  b.state.WiFiNetworks,
 	}}
 }
+
+func (b *IWDBackend) GetWiFiQRCodeContent(ssid string) (string, error) {
+	return "", fmt.Errorf("WiFi QR code not supported by iwd backend")
+}

--- a/core/internal/server/network/backend_networkd_unimplemented.go
+++ b/core/internal/server/network/backend_networkd_unimplemented.go
@@ -18,6 +18,10 @@ func (b *SystemdNetworkdBackend) GetWiFiNetworkDetails(ssid string) (*NetworkInf
 	return nil, fmt.Errorf("WiFi details not supported by networkd backend")
 }
 
+func (b *SystemdNetworkdBackend) GetWiFiQRCodeContent(ssid string) (string, error) {
+	return "", fmt.Errorf("WiFi QR Code not supported by networkd backend")
+}
+
 func (b *SystemdNetworkdBackend) ConnectWiFi(req ConnectionRequest) error {
 	return fmt.Errorf("WiFi connect not supported by networkd backend")
 }

--- a/core/internal/server/network/handlers.go
+++ b/core/internal/server/network/handlers.go
@@ -348,8 +348,12 @@ func handleDeleteQRCode(conn net.Conn, req models.Request, _ *Manager) {
 		return
 	}
 
-	err = os.Remove(path)
-	if err != nil {
+	if !isValidQRCodePath(path) {
+		models.RespondError(conn, req.ID, "invalid QR code path")
+		return
+	}
+
+	if err := os.Remove(path); err != nil {
 		models.RespondError(conn, req.ID, err.Error())
 		return
 	}

--- a/core/internal/server/network/handlers.go
+++ b/core/internal/server/network/handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/log"
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/models"
@@ -40,6 +41,10 @@ func HandleRequest(conn net.Conn, req models.Request, manager *Manager) {
 		handleSetPreference(conn, req, manager)
 	case "network.info":
 		handleGetNetworkInfo(conn, req, manager)
+	case "network.qrcode":
+		handleGetNetworkQRCode(conn, req, manager)
+	case "network.delete-qrcode":
+		handleDeleteQRCode(conn, req, manager)
 	case "network.ethernet.info":
 		handleGetWiredNetworkInfo(conn, req, manager)
 	case "network.subscribe":
@@ -318,6 +323,38 @@ func handleGetNetworkInfo(conn net.Conn, req models.Request, manager *Manager) {
 	}
 
 	models.Respond(conn, req.ID, network)
+}
+
+func handleGetNetworkQRCode(conn net.Conn, req models.Request, manager *Manager) {
+	ssid, err := params.String(req.Params, "ssid")
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+
+	content, err := manager.GetNetworkQRCode(ssid)
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+
+	models.Respond(conn, req.ID, content)
+}
+
+func handleDeleteQRCode(conn net.Conn, req models.Request, _ *Manager) {
+	path, err := params.String(req.Params, "path")
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+
+	err = os.Remove(path)
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+
+	models.Respond(conn, req.ID, models.SuccessResult{Success: true, Message: "QR code file deleted"})
 }
 
 func handleGetWiredNetworkInfo(conn net.Conn, req models.Request, manager *Manager) {

--- a/core/internal/server/network/manager.go
+++ b/core/internal/server/network/manager.go
@@ -443,16 +443,15 @@ func (m *Manager) GetNetworkInfoDetailed(ssid string) (*NetworkInfoResponse, err
 func (m *Manager) GetNetworkQRCode(ssid string) ([2]string, error) {
 	content, err := m.backend.GetWiFiQRCodeContent(ssid)
 	if err != nil {
-		return [2]string{"", ""}, err
+		return [2]string{}, err
 	}
 
 	qrc, err := qrcode.New(content)
 	if err != nil {
-		return [2]string{"", ""}, fmt.Errorf("failed to create QR code for `%s`: %w", ssid, err)
+		return [2]string{}, fmt.Errorf("failed to create QR code for `%s`: %w", ssid, err)
 	}
 
-	pathThemed := "/tmp/dank-wifi-qrcode-themed.png"
-	pathNormal := "/tmp/dank-wifi-qrcode-normal.png"
+	pathThemed, pathNormal := qrCodePaths(ssid)
 
 	wThemed, err := standard.New(
 		pathThemed,
@@ -461,18 +460,18 @@ func (m *Manager) GetNetworkQRCode(ssid string) ([2]string, error) {
 		standard.WithFgColorRGBHex("#ffffff"),
 	)
 	if err != nil {
-		return [2]string{"", ""}, fmt.Errorf("failed to create QR code writer: %w", err)
+		return [2]string{}, fmt.Errorf("failed to create QR code writer: %w", err)
 	}
 	if err := qrc.Save(wThemed); err != nil {
-		return [2]string{"", ""}, fmt.Errorf("failed to save QR code for `%s`: %w", ssid, err)
+		return [2]string{}, fmt.Errorf("failed to save QR code for `%s`: %w", ssid, err)
 	}
 
 	wNormal, err := standard.New(pathNormal, standard.WithBuiltinImageEncoder(standard.PNG_FORMAT))
 	if err != nil {
-		return [2]string{"", ""}, fmt.Errorf("failed to create QR code writer: %w", err)
+		return [2]string{}, fmt.Errorf("failed to create QR code writer: %w", err)
 	}
 	if err := qrc.Save(wNormal); err != nil {
-		return [2]string{"", ""}, fmt.Errorf("failed to save QR code for `%s`: %w", ssid, err)
+		return [2]string{}, fmt.Errorf("failed to save QR code for `%s`: %w", ssid, err)
 	}
 
 	return [2]string{pathThemed, pathNormal}, nil

--- a/core/internal/server/network/manager.go
+++ b/core/internal/server/network/manager.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/log"
+	"github.com/yeqown/go-qrcode/v2"
+	"github.com/yeqown/go-qrcode/writer/standard"
 )
 
 func NewManager() (*Manager, error) {
@@ -436,6 +438,44 @@ func (m *Manager) GetNetworkInfo(ssid string) (*WiFiNetwork, error) {
 
 func (m *Manager) GetNetworkInfoDetailed(ssid string) (*NetworkInfoResponse, error) {
 	return m.backend.GetWiFiNetworkDetails(ssid)
+}
+
+func (m *Manager) GetNetworkQRCode(ssid string) ([2]string, error) {
+	content, err := m.backend.GetWiFiQRCodeContent(ssid)
+	if err != nil {
+		return [2]string{"", ""}, err
+	}
+
+	qrc, err := qrcode.New(content)
+	if err != nil {
+		return [2]string{"", ""}, fmt.Errorf("failed to create QR code for `%s`: %w", ssid, err)
+	}
+
+	pathThemed := "/tmp/dank-wifi-qrcode-themed.png"
+	pathNormal := "/tmp/dank-wifi-qrcode-normal.png"
+
+	wThemed, err := standard.New(
+		pathThemed,
+		standard.WithBuiltinImageEncoder(standard.PNG_FORMAT),
+		standard.WithBgTransparent(),
+		standard.WithFgColorRGBHex("#ffffff"),
+	)
+	if err != nil {
+		return [2]string{"", ""}, fmt.Errorf("failed to create QR code writer: %w", err)
+	}
+	if err := qrc.Save(wThemed); err != nil {
+		return [2]string{"", ""}, fmt.Errorf("failed to save QR code for `%s`: %w", ssid, err)
+	}
+
+	wNormal, err := standard.New(pathNormal, standard.WithBuiltinImageEncoder(standard.PNG_FORMAT))
+	if err != nil {
+		return [2]string{"", ""}, fmt.Errorf("failed to create QR code writer: %w", err)
+	}
+	if err := qrc.Save(wNormal); err != nil {
+		return [2]string{"", ""}, fmt.Errorf("failed to save QR code for `%s`: %w", ssid, err)
+	}
+
+	return [2]string{pathThemed, pathNormal}, nil
 }
 
 func (m *Manager) ToggleWiFi() error {

--- a/core/internal/server/network/wifi_qrcode.go
+++ b/core/internal/server/network/wifi_qrcode.go
@@ -1,0 +1,59 @@
+package network
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const qrCodeTmpPrefix = "/tmp/dank-wifi-qrcode-"
+
+func FormatWiFiQRString(securityType, ssid, password string) string {
+	return fmt.Sprintf("WIFI:T:%s;S:%s;P:%s;;", securityType, ssid, password)
+}
+
+func qrCodePaths(ssid string) (themed, normal string) {
+	safe := sanitizeSSIDForPath(ssid)
+	themed = fmt.Sprintf("%s%s-themed.png", qrCodeTmpPrefix, safe)
+	normal = fmt.Sprintf("%s%s-normal.png", qrCodeTmpPrefix, safe)
+	return
+}
+
+func isValidQRCodePath(path string) bool {
+	clean := filepath.Clean(path)
+	return strings.HasPrefix(clean, qrCodeTmpPrefix) && strings.HasSuffix(clean, ".png")
+}
+
+var safePathChar = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
+
+func sanitizeSSIDForPath(ssid string) string {
+	return safePathChar.ReplaceAllString(ssid, "_")
+}
+
+var iwdVerbatimSSID = regexp.MustCompile(`^[a-zA-Z0-9 _-]+$`)
+
+func iwdConfigPath(ssid string) string {
+	switch {
+	case iwdVerbatimSSID.MatchString(ssid):
+		return fmt.Sprintf("/var/lib/iwd/%s.psk", ssid)
+	default:
+		return fmt.Sprintf("/var/lib/iwd/=%x.psk", []byte(ssid))
+	}
+}
+
+func parseIWDPassphrase(data string) (string, error) {
+	inSecurity := false
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case line == "[Security]":
+			inSecurity = true
+		case strings.HasPrefix(line, "["):
+			inSecurity = false
+		case inSecurity && strings.HasPrefix(line, "Passphrase="):
+			return strings.TrimPrefix(line, "Passphrase="), nil
+		}
+	}
+	return "", fmt.Errorf("no passphrase found in iwd config")
+}

--- a/flake.nix
+++ b/flake.nix
@@ -182,6 +182,7 @@
               with pkgs;
               [
                 go_1_25
+                go-mockery_2
                 gopls
                 delve
                 go-tools

--- a/quickshell/DMSShell.qml
+++ b/quickshell/DMSShell.qml
@@ -342,6 +342,23 @@ Item {
     }
 
     LazyLoader {
+        id: wifiQRCodeModalLoader
+        active: false
+
+        Component.onCompleted: {
+            PopoutService.wifiQRCodeModalLoader = wifiQRCodeModalLoader;
+        }
+
+        WifiQRCodeModal {
+            id: wifiQRCodeModalItem
+
+            Component.onCompleted: {
+                PopoutService.wifiQRCodeModal = wifiQRCodeModalItem;
+            }
+        }
+    }
+
+    LazyLoader {
         id: polkitAuthModalLoader
         active: false
 

--- a/quickshell/Modals/WifiQRCodeModal.qml
+++ b/quickshell/Modals/WifiQRCodeModal.qml
@@ -40,7 +40,7 @@ DankModal {
             deleteQRCodeFile(themedQrCodePath);
         }
         if (normalQrCodePath !== "") {
-            // deleteQRCodeFile(normalQrCodePath);
+            deleteQRCodeFile(normalQrCodePath);
         }
         close();
     }

--- a/quickshell/Modals/WifiQRCodeModal.qml
+++ b/quickshell/Modals/WifiQRCodeModal.qml
@@ -1,0 +1,170 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Effects
+import Quickshell
+import Quickshell.Io
+import qs.Modals.Common
+import qs.Modals.FileBrowser
+import qs.Common
+import qs.Services
+import qs.Widgets
+
+DankModal {
+    id: root
+    visible: false
+    layerNamespace: "dms:wifi-qrcode"
+
+    property bool disablePopupTransparency: true
+    property string wifiSSID: ""
+    property string themedQrCodePath: ""
+    property string normalQrCodePath: ""
+    modalWidth: 420
+    modalHeight: 480
+    onBackgroundClicked: hide()
+    onOpened: {
+        Qt.callLater(() => {
+            modalFocusScope.forceActiveFocus();
+            contentLoader.item.wifiSSID = wifiSSID;
+            contentLoader.item.themedQrCodePath = themedQrCodePath;
+            contentLoader.item.saveBrowserLoader = saveBrowserLoader;
+        });
+    }
+
+    function show(ssid) {
+        wifiSSID = ssid;
+        fetchNetworkQRCode(ssid);
+    }
+
+    function hide() {
+        if (themedQrCodePath !== "") {
+            deleteQRCodeFile(themedQrCodePath);
+        }
+        if (normalQrCodePath !== "") {
+            // deleteQRCodeFile(normalQrCodePath);
+        }
+        close();
+    }
+
+    function fetchNetworkQRCode(ssid) {
+        // TODO: Add loading UI?
+
+        DMSService.sendRequest("network.qrcode", {
+            ssid: ssid
+        }, response => {
+            if (response.error) {
+                ToastService.showError("Failed to fetch network QR code: ", JSON.stringify(response.error));
+            } else if (response.result) {
+                themedQrCodePath = response.result[0];
+                normalQrCodePath = response.result[1];
+                open();
+            }
+        });
+    }
+
+    function deleteQRCodeFile(path) {
+        DMSService.sendRequest("network.delete-qrcode", {
+            path: path
+        }, response => {
+            if (response.error) {
+                ToastService.showError(`Failed to remove QR code at ${path}: `, JSON.stringify(response.error));
+            }
+        })
+    }
+
+    LazyLoader {
+        id: saveBrowserLoader
+        active: false
+
+        FileBrowserSurfaceModal {
+            id: saveBrowser
+
+            browserTitle: I18n.tr("Save QR Code")
+            browserIcon: "qr_code"
+            browserType: "default"
+            fileExtensions: ["*.png"]
+            allowStacking: true
+            saveMode: true
+            defaultFileName: `${root.wifiSSID ?? "wifi-qrcode"}.png`
+            onFileSelected: path => {
+                const cleanPath = decodeURI(path.toString().replace(/^file:\/\//, ''));
+                const fileName = cleanPath.split('/').pop();
+                const fileUrl = "file://" + cleanPath;
+
+                copyQrCodeProcess.exec(["cp", root.normalQrCodePath, cleanPath, "-f"])
+            }
+
+            Process {
+                id: copyQrCodeProcess
+                stdout: StdioCollector {
+                    onStreamFinished: {
+                        saveBrowser.close();
+                    }
+                }
+            }
+        }
+    }
+
+    content: Component {
+        Item {
+            id: theItem
+            property alias themedQrCodePath: qrCodeImg.source
+            property var saveBrowserLoader: null
+            property string wifiSSID: ""
+            anchors.fill: parent
+
+            Column {
+                anchors.fill: parent
+                anchors.margins: Theme.spacingL
+                spacing: Theme.spacingL
+
+                RowLayout {
+                    id: modalTitle
+                    width: parent.width
+
+                    StyledText {
+                        text: I18n.tr("WiFi QR code for ") + theItem.wifiSSID
+                        font.pixelSize: Theme.fontSizeLarge
+                        color: Theme.surfaceText
+                        font.weight: Font.Bold
+                        Layout.alignment: Qt.AlignLeft
+                    }
+
+                    DankActionButton {
+                        iconName: "save"
+                        iconSize: Theme.iconSize - 4
+                        iconColor: Theme.surfaceText
+                        onClicked: {
+                            saveBrowserLoader.active = true;
+                            if (saveBrowserLoader.item) {
+                                saveBrowserLoader.item.open();
+                            }
+                        }
+                        Layout.alignment: Qt.AlignRight
+                    }
+
+                    DankActionButton {
+                        iconName: "close"
+                        iconSize: Theme.iconSize - 4
+                        iconColor: Theme.surfaceText
+                        onClicked: root.hide()
+                        Layout.alignment: Qt.AlignRight
+                    }
+                }
+
+                Image {
+                    id: qrCodeImg
+                    height: parent.height - parent.spacing - modalTitle.height
+                    width: height
+                    anchors.horizontalCenter: parent.horizontalCenter
+
+                    MultiEffect {
+                        source: qrCodeImg
+                        anchors.fill: source
+                        colorization: 1.0
+                        colorizationColor: Theme.primary
+                    }
+                }
+            }
+        }
+    }
+}

--- a/quickshell/Modules/ControlCenter/Details/NetworkDetail.qml
+++ b/quickshell/Modules/ControlCenter/Details/NetworkDetail.qml
@@ -651,6 +651,7 @@ Rectangle {
             }
 
             Rectangle {
+                id: pinButton
                 anchors.right: parent.right
                 anchors.rightMargin: optionsButton.width + Theme.spacingM + Theme.spacingS
                 anchors.verticalCenter: parent.verticalCenter
@@ -711,6 +712,19 @@ Rectangle {
                 }
             }
 
+            DankActionButton {
+                id: qrCodeButton
+                visible: modelData.secured && modelData.saved
+                anchors.right: parent.right
+                anchors.rightMargin: optionsButton.width + pinWifiRow.width + 3 * Theme.spacingM + Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+                iconName: "qr_code"
+                buttonSize: 28
+                onClicked: {
+                    PopoutService.showWifiQRCodeModal(modelData.ssid);
+                }
+            }
+
             DankRipple {
                 id: wifiRipple
                 cornerRadius: parent.radius
@@ -719,7 +733,7 @@ Rectangle {
             MouseArea {
                 id: networkMouseArea
                 anchors.fill: parent
-                anchors.rightMargin: optionsButton.width + Theme.spacingM + Theme.spacingS + pinWifiRow.width + Theme.spacingS * 4
+                anchors.rightMargin: optionsButton.width + pinWifiRow.width + (qrCodeButton.visible ? qrCodeButton.width : 0) + Theme.spacingS * 5 + Theme.spacingM
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
                 onPressed: mouse => wifiRipple.trigger(mouse.x, mouse.y)

--- a/quickshell/Modules/Settings/NetworkTab.qml
+++ b/quickshell/Modules/Settings/NetworkTab.qml
@@ -1282,6 +1282,15 @@ Item {
                                                 }
 
                                                 DankActionButton {
+                                                    iconName: "qr_code"
+                                                    buttonSize: 28
+                                                    visible: modelData.secured && modelData.saved
+                                                    onClicked: {
+                                                        PopoutService.showWifiQRCodeModal(modelData.ssid);
+                                                    }
+                                                }
+
+                                                DankActionButton {
                                                     iconName: isPinned ? "push_pin" : "push_pin"
                                                     buttonSize: 28
                                                     iconColor: isPinned ? Theme.primary : Theme.surfaceVariantText

--- a/quickshell/Services/PopoutService.qml
+++ b/quickshell/Services/PopoutService.qml
@@ -31,6 +31,8 @@ Singleton {
     property var notificationModal: null
     property var wifiPasswordModal: null
     property var wifiPasswordModalLoader: null
+    property var wifiQRCodeModal: null
+    property var wifiQRCodeModalLoader: null
     property var polkitAuthModal: null
     property var polkitAuthModalLoader: null
     property var bluetoothPairingModal: null
@@ -579,6 +581,13 @@ Singleton {
             wifiPasswordModalLoader.active = true;
         if (wifiPasswordModal)
             wifiPasswordModal.show(ssid);
+    }
+
+    function showWifiQRCodeModal(ssid) {
+        if (wifiQRCodeModalLoader)
+            wifiQRCodeModalLoader.active = true;
+        if (wifiQRCodeModal)
+            wifiQRCodeModal.show(ssid);
     }
 
     function showHiddenNetworkModal() {


### PR DESCRIPTION
Attempts to solve #1592. This is a somewhat incomplete and best effort implementation, and I might not be able to do anything more than that for now.

I only added support for NetworkManager backend (I would not have been able to test the others). I also only could implement WPA-PSK security type. I did not find a way to know for sure where the password is to be found in all circumstances. Also, although I did extract a text snippet that seemed correct from my phone, I cannot be sure that it actually unlocks the WiFi network as I have no device recent enough to support this feature. Someone will have to check on his/her side...

There might be quite a few clunky blocks of code in there. It is my first time coding in Go and it is not like I have much more experience in QML. I might have not done all of what I had to do for the I18n support either. My apologies for that.

For every WiFi network that is saved and secured, a QR code icon is added on the network info panels. Upon clicking it, two QR codes are generated: one white on transparent background (to be displayed in a popout, as it is easy to colorize it with the theme's palette), and one more standard, black on white background. When the user asks for saving the code, the latter is copied with a rough `cp` command called in a `Quickshell.Io.Process`.

For some reason, I cannot edit the file name in the file browser that opens. I did not find the reason for that, maybe a maintainer will?

I also thought about adding a setting to display the standard code rather than the themed one. That could be done later I guess.

Thanks in advance for reviewing this!