### PR TITLE
clipboard: fix html elements get parsed in clipboard entry

### DIFF
--- a/quickshell/Modals/Clipboard/ClipboardEntry.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEntry.qml
@@ -135,6 +135,7 @@ Rectangle {
                 wrapMode: Text.WordWrap
                 maximumLineCount: entryType === "long_text" ? 3 : 1
                 elide: Text.ElideRight
+                textFormat: Text.PlainText
             }
         }
     }


### PR DESCRIPTION
This pull request fix the issue in https://github.com/AvengeMedia/DankMaterialShell/issues/1793