### PR TITLE
feat: add support for animated gifs as profile pictures

### DIFF
--- a/quickshell/Widgets/DankCircularImage.qml
+++ b/quickshell/Widgets/DankCircularImage.qml
@@ -30,7 +30,7 @@ Rectangle {
     border.color: "transparent"
     border.width: 0
 
-    Image {
+    AnimatedImage {
         id: internalImage
         anchors.fill: parent
         anchors.margins: 2


### PR DESCRIPTION
Well that's just using QtQuick's `AnimatedImage` to display the profile picture instead of just `Image`. Should answer #1711.