### PR TITLE
fix(notepad): decode path URI when saving/creating a file

### DIFF
--- a/quickshell/Modules/Notepad/Notepad.qml
+++ b/quickshell/Modules/Notepad/Notepad.qml
@@ -282,7 +282,7 @@ Item {
 
             onFileSelected: path => {
                 root.fileDialogOpen = false;
-                const cleanPath = path.toString().replace(/^file:\/\//, '');
+                const cleanPath = decodeURI(path.toString().replace(/^file:\/\//, ''));
                 const fileName = cleanPath.split('/').pop();
                 const fileUrl = "file://" + cleanPath;
 

--- a/quickshell/Services/NotepadStorageService.qml
+++ b/quickshell/Services/NotepadStorageService.qml
@@ -358,7 +358,7 @@ Singleton {
     }
 
     function createEmptyFile(path, callback) {
-        var cleanPath = path.toString()
+        var cleanPath = decodeURI(path.toString())
 
         if (!cleanPath.startsWith("/")) {
             cleanPath = baseDir + "/" + cleanPath


### PR DESCRIPTION
When I was trying to save a new note file with the notepad using some characters like é or è, I would get a bunch of other characters starting with a % instead. I think this solves it.