### PR TITLE
feat(battery): show power rate (W) in DankBar battery widget.

### DIFF
--- a/quickshell/Modules/DankBar/Popouts/BatteryPopout.qml
+++ b/quickshell/Modules/DankBar/Popouts/BatteryPopout.qml
@@ -201,9 +201,22 @@ DankPopout {
                     }
 
                     Column {
+                        id: headerInfoColumn
                         spacing: Theme.spacingXS
                         anchors.verticalCenter: parent.verticalCenter
                         width: parent.width - Theme.iconSizeLarge - 32 - Theme.spacingM * 2
+                        readonly property string timeInfoText: {
+                            if (!BatteryService.batteryAvailable)
+                                return "Power profile management available";
+                            const time = BatteryService.formatTimeRemaining();
+                            if (time !== "Unknown") {
+                                return BatteryService.isCharging ? `Time until full: ${time}` : `Time remaining: ${time}`;
+                            }
+                            return "";
+                        }
+                        readonly property bool showPowerRate: BatteryService.batteryAvailable && Math.abs(BatteryService.changeRate) > 0.05
+                        readonly property bool isOnAC: BatteryService.batteryAvailable && (BatteryService.isCharging || BatteryService.isPluggedIn)
+                        readonly property bool isDischarging: BatteryService.batteryAvailable && !BatteryService.isCharging && !BatteryService.isPluggedIn
 
                         Row {
                             spacing: Theme.spacingS
@@ -241,21 +254,35 @@ DankPopout {
                             }
                         }
 
-                        StyledText {
-                            text: {
-                                if (!BatteryService.batteryAvailable)
-                                    return "Power profile management available";
-                                const time = BatteryService.formatTimeRemaining();
-                                if (time !== "Unknown") {
-                                    return BatteryService.isCharging ? `Time until full: ${time}` : `Time remaining: ${time}`;
-                                }
-                                return "";
-                            }
-                            font.pixelSize: Theme.fontSizeSmall
-                            color: Theme.surfaceTextMedium
-                            visible: text.length > 0
-                            elide: Text.ElideRight
+                        Row {
                             width: parent.width
+                            spacing: Theme.spacingS
+                            visible: headerInfoColumn.timeInfoText.length > 0
+
+                            StyledText {
+                                id: powerRateText
+                                text: `${headerInfoColumn.isOnAC ? "+" : (headerInfoColumn.isDischarging ? "-" : "")}${Math.abs(BatteryService.changeRate).toFixed(1)}W`
+                                font.pixelSize: Theme.fontSizeSmall
+                                color: {
+                                    if (headerInfoColumn.isOnAC) {
+                                        return Theme.primary;
+                                    }
+                                    if (headerInfoColumn.isDischarging) {
+                                        return Theme.warning;
+                                    }
+                                    return Theme.surfaceTextMedium;
+                                }
+                                font.weight: Font.Medium
+                                visible: headerInfoColumn.showPowerRate
+                            }
+
+                            StyledText {
+                                text: headerInfoColumn.timeInfoText
+                                font.pixelSize: Theme.fontSizeSmall
+                                color: Theme.surfaceTextMedium
+                                elide: Text.ElideRight
+                                width: parent.width - (powerRateText.visible ? (powerRateText.implicitWidth + parent.spacing) : 0)
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Summary
  This PR adds real-time battery power rate (W) to the Battery popout header in DankBar.


  The rate is shown to the left of the existing time message (`Time remaining` / `Time until full`) when the value is available.

  ## What Changed
  - Updated `quickshell/Modules/DankBar/Popouts/BatteryPopout.qml`
  - Refactored the header subtext area into a row:
    - Left: power rate display (e.g. `+23.1W`, `-11.4W`)
    - Right: existing time text
  - Added state-based formatting:
    - `+` and `Theme.primary` when on AC power (charging or plugged in)
    - `-` and `Theme.warning` when discharging
  - Hide power rate when `changeRate` is effectively unavailable (`<= 0.05`)
  - No backend changes; this uses existing `BatteryService.changeRate`.

  ## Screenshots
<img width="592" height="324" alt="screenshot_2026-02-24_17-24-42" src="https://github.com/user-attachments/assets/43a1feb7-574b-4ab3-a6a3-f2e26eb1ada8" />
<img width="593" height="325" alt="screenshot_2026-02-24_17-25-44" src="https://github.com/user-attachments/assets/ba11842d-c22d-4df2-a63a-2f26c89b732d" />