### PR TITLE
matugen/template: Pasterizing neovim.

### DIFF
--- a/quickshell/matugen/templates/neovim.lua
+++ b/quickshell/matugen/templates/neovim.lua
@@ -4,25 +4,23 @@ return {
 		priority = 1000,
 		config = function()
 			require('base16-colorscheme').setup({
-				base00 = '{{colors.background.default.hex}}',
 
-				base01 = '{{colors.surface_container.default.hex}}',
-				base02 = '{{colors.surface_container_high.default.hex}}',
-				base03 = '{{colors.outline_variant.default.hex}}',
-
-				base04 = '{{colors.on_surface_variant.default.hex}}',
-				base05 = '{{colors.on_surface.default.hex}}',
-				base06 = '{{colors.inverse_on_surface.default.hex}}',
-				base07 = '{{colors.inverse_surface.default.hex}}',
-
-				base08 = '{{colors.error.default.hex}}',
-				base09 = '{{colors.tertiary_fixed_dim.default.hex}}',
-				base0A = '{{colors.secondary_fixed.default.hex}}',
-				base0B = '{{colors.primary_fixed.default.hex}}',
-				base0C = '{{colors.tertiary.default.hex}}',
-				base0D = '{{colors.primary.default.hex}}',
-				base0E = '{{colors.secondary.default.hex}}',
-				base0F = '{{colors.outline.default.hex}}',
+				base00 = '{{colors.background.dark.hex}}',
+				base01 = '{{colors.surface_container_low.dark.hex}}',
+				base02 = '{{colors.surface_container.dark.hex}}',
+				base03 = '{{dank16.color8.dark.hex}}',
+				base0B = '{{dank16.color3.dark.hex}}',
+				base04 = '{{dank16.color7.default.hex}}',
+				base05 = '{{dank16.color15.default.hex}}',
+				base06 = '{{dank16.color15.default.hex}}',
+				base07 = '{{dank16.color15.default.hex}}',
+				base08 = '{{dank16.color9.default.hex}}',
+				base09 = '{{dank16.color9.default.hex}}',
+				base0A = '{{dank16.color12.default.hex}}',
+				base0C = '{{dank16.color14.default.hex}}',
+				base0D = '{{dank16.color12.default.hex}}',
+				base0E = '{{dank16.color13.default.hex}}',
+				base0F = '{{dank16.color13.default.hex}}',
 			})
 
 			local current_file_path = vim.fn.stdpath("config") .. "/lua/plugins/dankcolors.lua"


### PR DESCRIPTION
The original template start burning my eyes... Anyway, its more an opinion than anything, so check yourself:

- New template:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6aa60a05-f34a-4768-ae57-17ab78d06070" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3c6e8af5-c69c-4afa-9776-79ee826c5edc" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fb56933a-25e4-4f4a-b967-3e648ec64f35" />


- Old template (As reference.)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b9d568e7-92cd-4110-83c1-8c95793e1c08" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d9b5703d-408a-420c-bd82-511bd1467c93" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/434dcb30-4b78-435e-bd31-e1d3940932c7" />

