### PR TITLE
Systray: call context menu fallback for legacy protocol

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
+++ b/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
@@ -41,24 +41,10 @@ BasePill {
         return `${id}::${tooltipTitle}`;
     }
 
+    // ! TODO - replace with either native dbus client (like plugins use) or just a DMS cli or something
     function callContextMenuFallback(trayItemId, globalX, globalY) {
-        const script = [
-            'ITEMS=$(dbus-send --session --print-reply --dest=org.kde.StatusNotifierWatcher /StatusNotifierWatcher org.freedesktop.DBus.Properties.Get string:org.kde.StatusNotifierWatcher string:RegisteredStatusNotifierItems 2>/dev/null)',
-            'while IFS= read -r line; do',
-            '  line="${line#*\\\"}"',
-            '  line="${line%\\\"*}"',
-            '  [ -z "$line" ] && continue',
-            '  BUS="${line%%/*}"',
-            '  OBJ="/${line#*/}"',
-            '  ID=$(dbus-send --session --print-reply --dest="$BUS" "$OBJ" org.freedesktop.DBus.Properties.Get string:org.kde.StatusNotifierItem string:Id 2>/dev/null | grep -oP "(?<=\\\")(.*?)(?=\\\")" | tail -1)',
-            '  if [ "$ID" = "$1" ]; then',
-            '    dbus-send --session --type=method_call --dest="$BUS" "$OBJ" org.kde.StatusNotifierItem.ContextMenu int32:"$2" int32:"$3"',
-            '    exit 0',
-            '  fi',
-            'done <<< "$ITEMS"',
-        ].join("\n");
-        Quickshell.execDetached(["bash", "-c", script, "_",
-            trayItemId, String(globalX), String(globalY)]);
+        const script = ['ITEMS=$(dbus-send --session --print-reply --dest=org.kde.StatusNotifierWatcher /StatusNotifierWatcher org.freedesktop.DBus.Properties.Get string:org.kde.StatusNotifierWatcher string:RegisteredStatusNotifierItems 2>/dev/null)', 'while IFS= read -r line; do', '  line="${line#*\\\"}"', '  line="${line%\\\"*}"', '  [ -z "$line" ] && continue', '  BUS="${line%%/*}"', '  OBJ="/${line#*/}"', '  ID=$(dbus-send --session --print-reply --dest="$BUS" "$OBJ" org.freedesktop.DBus.Properties.Get string:org.kde.StatusNotifierItem string:Id 2>/dev/null | grep -oP "(?<=\\\")(.*?)(?=\\\")" | tail -1)', '  if [ "$ID" = "$1" ]; then', '    dbus-send --session --type=method_call --dest="$BUS" "$OBJ" org.kde.StatusNotifierItem.ContextMenu int32:"$2" int32:"$3"', '    exit 0', '  fi', 'done <<< "$ITEMS"',].join("\n");
+        Quickshell.execDetached(["bash", "-c", script, "_", trayItemId, String(globalX), String(globalY)]);
     }
 
     property int _trayOrderTrigger: 0


### PR DESCRIPTION
# Issue
Wine apps that integrate their tray menu via `xembedsniproxy` (done in plasma desktop) don't have working context menu. 

# Fix
This is a poc that calls the dbus interface directly as a fallback for the wineapps to render X11 context menus.

# Showcase
Excuse the double bar, the bottom one is the working branch. 
 
https://github.com/user-attachments/assets/90e9b8a2-084d-44e5-876c-c57ed7d68f8e

# Improvement
Good to put the script at the GO backend, I'm not familiar with go programming.

# Bugs
Seems to be a `wine`/`xembedsniproxy` issue, the tray icon would require **two** clicks to activate, both left click and right clicks. The signal sends correctly on qml side, it just needs to be sent twice. 