### PR TITLE
Fix charger plugged/unplugged sound playing while the battery is full

### DIFF
--- a/quickshell/Services/BatteryService.qml
+++ b/quickshell/Services/BatteryService.qml
@@ -56,8 +56,8 @@ Singleton {
     }
     readonly property bool isCharging: batteryAvailable && batteries.some(b => b.state === UPowerDeviceState.Charging)
 
-    // Is the system plugged in (none of the batteries are discharging or empty)
-    readonly property bool isPluggedIn: batteryAvailable && batteries.every(b => b.state !== UPowerDeviceState.Discharging)
+    // Is the system plugged in (Is not running on battery)
+    readonly property bool isPluggedIn: !UPower.onBattery
     readonly property bool isLowBattery: batteryAvailable && batteryLevel <= 20
 
     onIsPluggedInChanged: {


### PR DESCRIPTION
This fixes #1837

Instead of checking if the battery is discharging, use Quickshell's `onBattery` property. This fixes the issue, at least on my system.