### PR TITLE
nix: add `package` option for `dms-shell`

### DIFF
--- a/distro/nix/common.nix
+++ b/distro/nix/common.nix
@@ -2,7 +2,6 @@
   config,
   lib,
   pkgs,
-  dmsPkgs,
   ...
 }:
 let
@@ -10,7 +9,7 @@ let
 in
 {
   packages = [
-    dmsPkgs.dms-shell
+    cfg.package
   ]
   ++ lib.optional cfg.enableSystemMonitoring cfg.dgop.package
   ++ lib.optionals cfg.enableVPN [

--- a/distro/nix/greeter.nix
+++ b/distro/nix/greeter.nix
@@ -8,6 +8,7 @@
 let
   inherit (lib) types;
   cfg = config.programs.dank-material-shell.greeter;
+  cfgDms = config.programs.dank-material-shell;
 
   inherit (config.services.greetd.settings.default_session) user;
 
@@ -29,13 +30,13 @@ let
       lib.escapeShellArgs (
         [
           "sh"
-          "${../../quickshell/Modules/Greetd/assets/dms-greeter}"
+          "${cfg.package}/share/quickshell/dms/Modules/Greetd/assets/dms-greeter"
           "--cache-dir"
           cacheDir
           "--command"
           cfg.compositor.name
           "-p"
-          "${dmsPkgs.dms-shell}/share/quickshell/dms"
+          "${cfg.package}/share/quickshell/dms"
         ]
         ++ lib.optionals (cfg.compositor.customConfig != "") [
           "-C"
@@ -65,6 +66,21 @@ in
 
   options.programs.dank-material-shell.greeter = {
     enable = lib.mkEnableOption "DankMaterialShell greeter";
+    package = lib.mkOption {
+      type = types.package;
+      default = if cfgDms.enable or false then cfgDms.package else dmsPkgs.dms-shell;
+      defaultText = lib.literalExpression ''
+        if config.programs.dank-material-shell.enable
+        then config.programs.dank-material-shell.package
+        else built from source;
+      '';
+      description = ''
+        The DankMaterialShell package to use for the greeter.
+
+        Defaults to the package from `programs.dank-material-shell` if it is enabled,
+        otherwise defaults to building from source.
+      '';
+    };
     compositor.name = lib.mkOption {
       type = types.enum [
         "niri"

--- a/distro/nix/home.nix
+++ b/distro/nix/home.nix
@@ -2,7 +2,6 @@
   config,
   pkgs,
   lib,
-  dmsPkgs,
   ...
 }@args:
 let
@@ -13,7 +12,6 @@ let
       config
       pkgs
       lib
-      dmsPkgs
       ;
   };
   hasPluginSettings = lib.any (plugin: plugin.settings != { }) (
@@ -96,7 +94,7 @@ in
       };
 
       Service = {
-        ExecStart = lib.getExe dmsPkgs.dms-shell + " run --session";
+        ExecStart = lib.getExe cfg.package + " run --session";
         Restart = "on-failure";
       };
 

--- a/distro/nix/nixos.nix
+++ b/distro/nix/nixos.nix
@@ -2,7 +2,6 @@
   config,
   pkgs,
   lib,
-  dmsPkgs,
   ...
 }@args:
 let
@@ -12,7 +11,6 @@ let
       config
       pkgs
       lib
-      dmsPkgs
       ;
   };
 in
@@ -36,7 +34,7 @@ in
       restartIfChanged = cfg.systemd.restartIfChanged;
 
       serviceConfig = {
-        ExecStart = lib.getExe dmsPkgs.dms-shell + " run --session";
+        ExecStart = lib.getExe cfg.package + " run --session";
         Restart = "on-failure";
       };
     };

--- a/distro/nix/options.nix
+++ b/distro/nix/options.nix
@@ -26,6 +26,9 @@ in
 
   options.programs.dank-material-shell = {
     enable = lib.mkEnableOption "DankMaterialShell";
+    package = lib.mkPackageOption dmsPkgs "dms-shell" {
+      extraDescription = "The DankMaterialShell package to use (defaults to be built from source)";
+    };
 
     systemd = {
       enable = lib.mkEnableOption "DankMaterialShell systemd startup";


### PR DESCRIPTION
... to make it configurable when using nix modules.

As an example, this would allow one to overcome #1831 with:
```nix
  programs.dank-material-shell = {
    enable = true;
    package = inputs.dms.packages.x86_64-linux.dms-shell.overrideAttrs { vendorHash = "sha256-cVUJXgzYMRSM0od1xzDVkMTdxHu3OIQX2bQ8AJbGQ1Q="; };
  }
```

when using [v1.4.3](https://github.com/AvengeMedia/DankMaterialShell/releases/tag/v1.4.3).

https://github.com/ilkecan/config/commit/f1bf1eecfd5b772abbe3d1a65ceaca7336ea5d89