### PR TITLE
feat(icons): support file path substitutions for PWA icons

### DIFF
--- a/quickshell/Common/Paths.qml
+++ b/quickshell/Common/Paths.qml
@@ -78,6 +78,10 @@ Singleton {
 
         const moddedId = moddedAppId(appId);
         if (moddedId !== appId) {
+            if (moddedId.startsWith("~") || moddedId.startsWith("/"))
+                return toFileUrl(expandTilde(moddedId));
+            if (moddedId.startsWith("file://"))
+                return moddedId;
             return Quickshell.iconPath(moddedId, true);
         }
 


### PR DESCRIPTION
## Summary

Allow App ID Substitutions to resolve to file paths, bypassing `Quickshell.iconPath` theme lookup.

This is a 4-line addition to `getAppIcon()` in `Paths.qml` — when a substitution returns a path (`/`, `~`, or `file://`), it's used directly as an image source instead of passing through the Qt icon theme engine.

## Problem

Chrome, Chromium, and Edge PWAs install icons to `~/.local/share/icons/hicolor/` with names matching their app ID (e.g. `chrome-agimnkijcaahngcdmfeangaknmldooml-Default`). However, Qt's `QIcon::fromTheme()` often fails to find these icons due to stale or missing icon theme caches in the user's hicolor directory. The workspace widget then falls back to the browser icon or a letter.

## Approach

This follows the same pattern DMS already uses for Steam — app IDs that don't resolve through Qt's theme lookup are handled via regex substitutions in `SettingsSpec.js`:

```js
// Existing — Steam games
{ pattern: "^steam_app_(\\d+)$", replacement: "steam_icon_$1", type: "regex" }

// Proposed — Chrome/Chromium PWAs
{ pattern: "^(chrome|msedge|chromium)-(.+)$", replacement: "~/.local/share/icons/hicolor/128x128/apps/$1-$2.png", type: "regex" }

// Proposed — Edge PWAs (extra _ in app ID not present in icon filename)
{ pattern: "^msedge-_(.+)$", replacement: "~/.local/share/icons/hicolor/128x128/apps/msedge-$1.png", type: "regex" }
```

The Steam substitution works because `steam_icon_*` is a valid icon theme name. PWA icon names aren't in Qt's theme index, so the substitution needs to resolve to a file path instead — which is what this PR enables.

The Edge-specific rule handles a quirk where Edge adds an extra `_` in the app ID (`msedge-_hash-Default`) that doesn't appear in the icon filename (`msedge-hash-Default`).

Users can also add these substitutions manually via **Settings → Running Apps → App ID Substitutions** without waiting for a release.

## Change

```diff
         const moddedId = moddedAppId(appId);
         if (moddedId !== appId) {
+            if (moddedId.startsWith("~") || moddedId.startsWith("/"))
+                return toFileUrl(expandTilde(moddedId));
+            if (moddedId.startsWith("file://"))
+                return moddedId;
             return Quickshell.iconPath(moddedId, true);
         }
```

## Tested with

- Chrome PWAs: YouTube, Twitch, ai-ta
- Edge PWAs: Microsoft Teams, Outlook
- Regular Chromium/Edge windows (unaffected — no hyphen in app ID)
- Steam games (existing substitution unaffected)
- Compositor: niri/Wayland, DMS 1.4.3