### PR TITLE
feat(cups): add manual printer by IP/hostname

### DIFF
--- a/core/internal/server/cups/test_connection.go
+++ b/core/internal/server/cups/test_connection.go
@@ -1,0 +1,176 @@
+package cups
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/AvengeMedia/DankMaterialShell/core/pkg/ipp"
+)
+
+var validProtocols = map[string]bool{
+	"ipp":    true,
+	"ipps":   true,
+	"lpd":    true,
+	"socket": true,
+}
+
+func validateTestConnectionParams(host string, port int, protocol string) error {
+	if host == "" {
+		return errors.New("host is required")
+	}
+	if strings.ContainsAny(host, " \t\n\r/\\") {
+		return errors.New("host contains invalid characters")
+	}
+	if port < 1 || port > 65535 {
+		return errors.New("port must be between 1 and 65535")
+	}
+	if protocol != "" && !validProtocols[protocol] {
+		return errors.New("protocol must be one of: ipp, ipps, lpd, socket")
+	}
+	return nil
+}
+
+const probeTimeout = 10 * time.Second
+
+func probeRemotePrinter(host string, port int, useTLS bool) (*RemotePrinterInfo, error) {
+	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+
+	// Fast fail: TCP reachability check
+	conn, err := net.DialTimeout("tcp", addr, probeTimeout)
+	if err != nil {
+		return &RemotePrinterInfo{
+			Reachable: false,
+			Error:     fmt.Sprintf("cannot reach %s: %s", addr, err.Error()),
+		}, nil
+	}
+	conn.Close()
+
+	// Create a temporary IPP client pointing at the remote host.
+	// The TCP dial above provides fast-fail for unreachable hosts.
+	// The IPP adapter's ResponseHeaderTimeout (90s) bounds stalling servers.
+	client := ipp.NewIPPClient(host, port, "", "", useTLS)
+
+	// Try /ipp/print first (modern driverless printers), then / (legacy)
+	info, err := probeIPPEndpoint(client, host, port, useTLS, "/ipp/print")
+	if err != nil {
+		// If we got an auth error, the printer exists but requires credentials.
+		// Report it as reachable with the URI that triggered the auth challenge.
+		if isAuthError(err) {
+			proto := "ipp"
+			if useTLS {
+				proto = "ipps"
+			}
+			return &RemotePrinterInfo{
+				Reachable: true,
+				URI:       fmt.Sprintf("%s://%s:%d/ipp/print", proto, host, port),
+				Info:      "authentication required",
+			}, nil
+		}
+		info, err = probeIPPEndpoint(client, host, port, useTLS, "/")
+	}
+	if err != nil {
+		if isAuthError(err) {
+			proto := "ipp"
+			if useTLS {
+				proto = "ipps"
+			}
+			return &RemotePrinterInfo{
+				Reachable: true,
+				URI:       fmt.Sprintf("%s://%s:%d/", proto, host, port),
+				Info:      "authentication required",
+			}, nil
+		}
+		// TCP reachable but not an IPP printer
+		return &RemotePrinterInfo{
+			Reachable: true,
+			Error:     fmt.Sprintf("host is reachable but does not appear to be an IPP printer: %s", err.Error()),
+		}, nil
+	}
+
+	return info, nil
+}
+
+func probeIPPEndpoint(client *ipp.IPPClient, host string, port int, useTLS bool, resourcePath string) (*RemotePrinterInfo, error) {
+	proto := "ipp"
+	if useTLS {
+		proto = "ipps"
+	}
+	printerURI := fmt.Sprintf("%s://%s:%d%s", proto, host, port, resourcePath)
+
+	httpProto := "http"
+	if useTLS {
+		httpProto = "https"
+	}
+	httpURL := fmt.Sprintf("%s://%s:%d%s", httpProto, host, port, resourcePath)
+
+	req := ipp.NewRequest(ipp.OperationGetPrinterAttributes, 1)
+	req.OperationAttributes[ipp.AttributePrinterURI] = printerURI
+	req.OperationAttributes[ipp.AttributeRequestedAttributes] = []string{
+		ipp.AttributePrinterName,
+		ipp.AttributePrinterMakeAndModel,
+		ipp.AttributePrinterState,
+		ipp.AttributePrinterInfo,
+		ipp.AttributePrinterUriSupported,
+	}
+
+	resp, err := client.SendRequest(httpURL, req, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.PrinterAttributes) == 0 {
+		return nil, errors.New("no printer attributes returned")
+	}
+
+	attrs := resp.PrinterAttributes[0]
+
+	return &RemotePrinterInfo{
+		Reachable: true,
+		MakeModel: getStringAttr(attrs, ipp.AttributePrinterMakeAndModel),
+		Name:      getStringAttr(attrs, ipp.AttributePrinterName),
+		Info:      getStringAttr(attrs, ipp.AttributePrinterInfo),
+		State:     parsePrinterState(attrs),
+		URI:       printerURI,
+	}, nil
+}
+
+// TestRemotePrinter validates inputs and probes a remote printer via IPP.
+// For lpd/socket protocols, only TCP reachability is tested.
+func (m *Manager) TestRemotePrinter(host string, port int, protocol string) (*RemotePrinterInfo, error) {
+	if protocol == "" {
+		protocol = "ipp"
+	}
+
+	if err := validateTestConnectionParams(host, port, protocol); err != nil {
+		return nil, err
+	}
+
+	// For non-IPP protocols, only check TCP reachability
+	if protocol == "lpd" || protocol == "socket" {
+		addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+		conn, err := net.DialTimeout("tcp", addr, probeTimeout)
+		if err != nil {
+			return &RemotePrinterInfo{
+				Reachable: false,
+				Error:     fmt.Sprintf("cannot reach %s: %s", addr, err.Error()),
+			}, nil
+		}
+		conn.Close()
+		return &RemotePrinterInfo{
+			Reachable: true,
+			URI:       fmt.Sprintf("%s://%s:%d", protocol, host, port),
+		}, nil
+	}
+
+	useTLS := protocol == "ipps"
+
+	probeFn := m.probeRemoteFn
+	if probeFn == nil {
+		probeFn = probeRemotePrinter
+	}
+
+	return probeFn(host, port, useTLS)
+}

--- a/core/internal/server/cups/test_connection_test.go
+++ b/core/internal/server/cups/test_connection_test.go
@@ -1,0 +1,397 @@
+package cups
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/models"
+	"github.com/AvengeMedia/DankMaterialShell/core/pkg/ipp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTestConnectionParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		port     int
+		protocol string
+		wantErr  string
+	}{
+		{
+			name:     "valid ipp",
+			host:     "192.168.0.5",
+			port:     631,
+			protocol: "ipp",
+			wantErr:  "",
+		},
+		{
+			name:     "valid ipps",
+			host:     "printer.local",
+			port:     443,
+			protocol: "ipps",
+			wantErr:  "",
+		},
+		{
+			name:     "valid lpd",
+			host:     "10.0.0.1",
+			port:     515,
+			protocol: "lpd",
+			wantErr:  "",
+		},
+		{
+			name:     "valid socket",
+			host:     "10.0.0.1",
+			port:     9100,
+			protocol: "socket",
+			wantErr:  "",
+		},
+		{
+			name:     "empty host",
+			host:     "",
+			port:     631,
+			protocol: "ipp",
+			wantErr:  "host is required",
+		},
+		{
+			name:     "port too low",
+			host:     "192.168.0.5",
+			port:     0,
+			protocol: "ipp",
+			wantErr:  "port must be between 1 and 65535",
+		},
+		{
+			name:     "port too high",
+			host:     "192.168.0.5",
+			port:     70000,
+			protocol: "ipp",
+			wantErr:  "port must be between 1 and 65535",
+		},
+		{
+			name:     "invalid protocol",
+			host:     "192.168.0.5",
+			port:     631,
+			protocol: "ftp",
+			wantErr:  "protocol must be one of: ipp, ipps, lpd, socket",
+		},
+		{
+			name:     "empty protocol treated as ipp",
+			host:     "192.168.0.5",
+			port:     631,
+			protocol: "",
+			wantErr:  "",
+		},
+		{
+			name:     "host with slash",
+			host:     "192.168.0.5/admin",
+			port:     631,
+			protocol: "ipp",
+			wantErr:  "host contains invalid characters",
+		},
+		{
+			name:     "host with space",
+			host:     "192.168.0.5 ",
+			port:     631,
+			protocol: "ipp",
+			wantErr:  "host contains invalid characters",
+		},
+		{
+			name:     "host with newline",
+			host:     "192.168.0.5\n",
+			port:     631,
+			protocol: "ipp",
+			wantErr:  "host contains invalid characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTestConnectionParams(tt.host, tt.port, tt.protocol)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestManager_TestRemotePrinter_Validation(t *testing.T) {
+	m := NewTestManager(nil, nil)
+
+	tests := []struct {
+		name     string
+		host     string
+		port     int
+		protocol string
+		wantErr  string
+	}{
+		{
+			name:     "empty host returns error",
+			host:     "",
+			port:     631,
+			protocol: "ipp",
+			wantErr:  "host is required",
+		},
+		{
+			name:     "invalid port returns error",
+			host:     "192.168.0.5",
+			port:     0,
+			protocol: "ipp",
+			wantErr:  "port must be between 1 and 65535",
+		},
+		{
+			name:     "invalid protocol returns error",
+			host:     "192.168.0.5",
+			port:     631,
+			protocol: "ftp",
+			wantErr:  "protocol must be one of: ipp, ipps, lpd, socket",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := m.TestRemotePrinter(tt.host, tt.port, tt.protocol)
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestManager_TestRemotePrinter_IPP(t *testing.T) {
+	tests := []struct {
+		name      string
+		protocol  string
+		probeRet  *RemotePrinterInfo
+		probeErr  error
+		wantTLS   bool
+		wantReach bool
+		wantModel string
+	}{
+		{
+			name:     "successful ipp probe",
+			protocol: "ipp",
+			probeRet: &RemotePrinterInfo{
+				Reachable: true,
+				MakeModel: "HP OfficeJet 8010",
+				Name:      "OfficeJet",
+				State:     "idle",
+				URI:       "ipp://192.168.0.5:631/ipp/print",
+			},
+			wantTLS:   false,
+			wantReach: true,
+			wantModel: "HP OfficeJet 8010",
+		},
+		{
+			name:     "successful ipps probe",
+			protocol: "ipps",
+			probeRet: &RemotePrinterInfo{
+				Reachable: true,
+				MakeModel: "HP OfficeJet 8010",
+				URI:       "ipps://192.168.0.5:631/ipp/print",
+			},
+			wantTLS:   true,
+			wantReach: true,
+			wantModel: "HP OfficeJet 8010",
+		},
+		{
+			name:     "unreachable host",
+			protocol: "ipp",
+			probeRet: &RemotePrinterInfo{
+				Reachable: false,
+				Error:     "cannot reach 192.168.0.5:631: connection refused",
+			},
+			wantReach: false,
+		},
+		{
+			name:     "empty protocol defaults to ipp",
+			protocol: "",
+			probeRet: &RemotePrinterInfo{
+				Reachable: true,
+				MakeModel: "Test Printer",
+			},
+			wantTLS:   false,
+			wantReach: true,
+			wantModel: "Test Printer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedTLS bool
+			m := NewTestManager(nil, nil)
+			m.probeRemoteFn = func(host string, port int, useTLS bool) (*RemotePrinterInfo, error) {
+				capturedTLS = useTLS
+				return tt.probeRet, tt.probeErr
+			}
+
+			result, err := m.TestRemotePrinter("192.168.0.5", 631, tt.protocol)
+			if tt.probeErr != nil {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantReach, result.Reachable)
+			assert.Equal(t, tt.wantModel, result.MakeModel)
+			assert.Equal(t, tt.wantTLS, capturedTLS)
+		})
+	}
+}
+
+func TestManager_TestRemotePrinter_AuthRequired(t *testing.T) {
+	m := NewTestManager(nil, nil)
+	m.probeRemoteFn = func(host string, port int, useTLS bool) (*RemotePrinterInfo, error) {
+		// Simulate what happens when the printer returns HTTP 401
+		return probeRemotePrinterWithAuthError(host, port, useTLS)
+	}
+
+	result, err := m.TestRemotePrinter("192.168.0.107", 631, "ipp")
+	assert.NoError(t, err)
+	assert.True(t, result.Reachable)
+	assert.Equal(t, "authentication required", result.Info)
+	assert.Contains(t, result.URI, "ipp://192.168.0.107:631")
+}
+
+// probeRemotePrinterWithAuthError simulates a probe where the printer
+// returns HTTP 401 on both endpoints.
+func probeRemotePrinterWithAuthError(host string, port int, useTLS bool) (*RemotePrinterInfo, error) {
+	// This simulates what probeRemotePrinter does when both endpoints
+	// return auth errors. We test the auth detection logic directly.
+	err := ipp.HTTPError{Code: 401}
+	if isAuthError(err) {
+		proto := "ipp"
+		if useTLS {
+			proto = "ipps"
+		}
+		return &RemotePrinterInfo{
+			Reachable: true,
+			URI:       fmt.Sprintf("%s://%s:%d/ipp/print", proto, host, port),
+			Info:      "authentication required",
+		}, nil
+	}
+	return nil, err
+}
+
+func TestManager_TestRemotePrinter_NonIPPProtocol(t *testing.T) {
+	m := NewTestManager(nil, nil)
+	probeCalled := false
+	m.probeRemoteFn = func(host string, port int, useTLS bool) (*RemotePrinterInfo, error) {
+		probeCalled = true
+		return nil, nil
+	}
+
+	// These will fail at TCP dial (no real server), but the important
+	// thing is that probeRemoteFn is NOT called for lpd/socket.
+	m.TestRemotePrinter("192.168.0.5", 9100, "socket")
+	assert.False(t, probeCalled, "probe function should not be called for socket protocol")
+
+	m.TestRemotePrinter("192.168.0.5", 515, "lpd")
+	assert.False(t, probeCalled, "probe function should not be called for lpd protocol")
+}
+
+func TestHandleTestConnection_Success(t *testing.T) {
+	m := NewTestManager(nil, nil)
+	m.probeRemoteFn = func(host string, port int, useTLS bool) (*RemotePrinterInfo, error) {
+		return &RemotePrinterInfo{
+			Reachable: true,
+			MakeModel: "HP OfficeJet 8010",
+			Name:      "OfficeJet",
+			State:     "idle",
+			URI:       "ipp://192.168.0.5:631/ipp/print",
+		}, nil
+	}
+
+	buf := &bytes.Buffer{}
+	conn := &mockConn{Buffer: buf}
+
+	req := models.Request{
+		ID:     1,
+		Method: "cups.testConnection",
+		Params: map[string]any{
+			"host": "192.168.0.5",
+		},
+	}
+
+	handleTestConnection(conn, req, m)
+
+	var resp models.Response[RemotePrinterInfo]
+	err := json.NewDecoder(buf).Decode(&resp)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp.Result)
+	assert.True(t, resp.Result.Reachable)
+	assert.Equal(t, "HP OfficeJet 8010", resp.Result.MakeModel)
+}
+
+func TestHandleTestConnection_MissingHost(t *testing.T) {
+	m := NewTestManager(nil, nil)
+	buf := &bytes.Buffer{}
+	conn := &mockConn{Buffer: buf}
+
+	req := models.Request{
+		ID:     1,
+		Method: "cups.testConnection",
+		Params: map[string]any{},
+	}
+
+	handleTestConnection(conn, req, m)
+
+	var resp models.Response[any]
+	err := json.NewDecoder(buf).Decode(&resp)
+	assert.NoError(t, err)
+	assert.Nil(t, resp.Result)
+	assert.NotNil(t, resp.Error)
+}
+
+func TestHandleTestConnection_CustomPortAndProtocol(t *testing.T) {
+	m := NewTestManager(nil, nil)
+	m.probeRemoteFn = func(host string, port int, useTLS bool) (*RemotePrinterInfo, error) {
+		assert.Equal(t, 9631, port)
+		assert.True(t, useTLS)
+		return &RemotePrinterInfo{Reachable: true, URI: "ipps://192.168.0.5:9631/ipp/print"}, nil
+	}
+
+	buf := &bytes.Buffer{}
+	conn := &mockConn{Buffer: buf}
+
+	req := models.Request{
+		ID:     1,
+		Method: "cups.testConnection",
+		Params: map[string]any{
+			"host":     "192.168.0.5",
+			"port":     float64(9631),
+			"protocol": "ipps",
+		},
+	}
+
+	handleTestConnection(conn, req, m)
+
+	var resp models.Response[RemotePrinterInfo]
+	err := json.NewDecoder(buf).Decode(&resp)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp.Result)
+	assert.True(t, resp.Result.Reachable)
+}
+
+func TestHandleRequest_TestConnection(t *testing.T) {
+	m := NewTestManager(nil, nil)
+	m.probeRemoteFn = func(host string, port int, useTLS bool) (*RemotePrinterInfo, error) {
+		return &RemotePrinterInfo{Reachable: true}, nil
+	}
+
+	buf := &bytes.Buffer{}
+	conn := &mockConn{Buffer: buf}
+
+	req := models.Request{
+		ID:     1,
+		Method: "cups.testConnection",
+		Params: map[string]any{"host": "192.168.0.5"},
+	}
+
+	HandleRequest(conn, req, m)
+
+	var resp models.Response[RemotePrinterInfo]
+	err := json.NewDecoder(buf).Decode(&resp)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp.Result)
+	assert.True(t, resp.Result.Reachable)
+}

--- a/core/internal/server/cups/types.go
+++ b/core/internal/server/cups/types.go
@@ -55,6 +55,16 @@ type PPD struct {
 	Type            string `json:"type"`
 }
 
+type RemotePrinterInfo struct {
+	Reachable bool   `json:"reachable"`
+	MakeModel string `json:"makeModel"`
+	Name      string `json:"name"`
+	Info      string `json:"info"`
+	State     string `json:"state"`
+	URI       string `json:"uri"`
+	Error     string `json:"error,omitempty"`
+}
+
 type PrinterClass struct {
 	Name     string   `json:"name"`
 	URI      string   `json:"uri"`
@@ -77,6 +87,7 @@ type Manager struct {
 	notifierWg        sync.WaitGroup
 	lastNotifiedState *CUPSState
 	baseURL           string
+	probeRemoteFn     func(host string, port int, useTLS bool) (*RemotePrinterInfo, error)
 }
 
 type SubscriptionManagerInterface interface {

--- a/quickshell/Modules/Settings/PrinterTab.qml
+++ b/quickshell/Modules/Settings/PrinterTab.qml
@@ -14,6 +14,12 @@ Item {
     LayoutMirroring.childrenInherit: true
 
     property bool showAddPrinter: false
+    property bool manualEntryMode: false
+    property string manualHost: ""
+    property string manualPort: "631"
+    property string manualProtocol: "ipp"
+    property bool testingConnection: false
+    property var testConnectionResult: null
     property string newPrinterName: ""
     property string selectedDeviceUri: ""
     property var selectedDevice: null
@@ -23,6 +29,12 @@ Item {
     property var suggestedPPDs: []
 
     function resetAddPrinterForm() {
+        manualEntryMode = false;
+        manualHost = "";
+        manualPort = "631";
+        manualProtocol = "ipp";
+        testingConnection = false;
+        testConnectionResult = null;
         newPrinterName = "";
         selectedDeviceUri = "";
         selectedDevice = null;
@@ -30,6 +42,45 @@ Item {
         newPrinterLocation = "";
         newPrinterInfo = "";
         suggestedPPDs = [];
+    }
+
+    Connections {
+        target: CupsService
+        function onPpdsChanged() {
+            if (printerTab.manualEntryMode && printerTab.testConnectionResult?.success)
+                printerTab.selectDriverlessPPD();
+        }
+    }
+
+    function selectDriverlessPPD() {
+        if (printerTab.selectedPpd || CupsService.ppds.length === 0)
+            return;
+
+        const probeModel = printerTab.testConnectionResult?.data?.makeModel || "";
+        let suggested = [];
+
+        // Try to find a model-specific PPD match
+        if (probeModel) {
+            const normalizedModel = probeModel.toLowerCase().replace(/[^a-z0-9]/g, "");
+            const modelMatches = CupsService.ppds.filter(p => {
+                const normalizedPPD = (p.makeModel || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+                return normalizedPPD.includes(normalizedModel) || normalizedModel.includes(normalizedPPD);
+            });
+            if (modelMatches.length > 0)
+                suggested = suggested.concat(modelMatches);
+        }
+
+        // Always include driverless as an option
+        const driverless = CupsService.ppds.filter(p => p.name === "driverless" || p.name === "everywhere");
+        for (const d of driverless) {
+            if (!suggested.find(s => s.name === d.name))
+                suggested.push(d);
+        }
+
+        if (suggested.length > 0) {
+            printerTab.selectedPpd = suggested[0].name;
+            printerTab.suggestedPPDs = suggested;
+        }
     }
 
     function selectDevice(device) {
@@ -276,9 +327,93 @@ Item {
                             color: Qt.rgba(Theme.outline.r, Theme.outline.g, Theme.outline.b, 0.12)
                         }
 
+                        Row {
+                            width: parent.width
+                            spacing: Theme.spacingS
+
+                            Rectangle {
+                                width: discoverRow.width + Theme.spacingM * 2
+                                height: 32
+                                radius: Theme.cornerRadius
+                                color: !printerTab.manualEntryMode ? Theme.primary : (discoverArea.containsMouse ? Theme.primaryHoverLight : Theme.surfaceLight)
+
+                                Row {
+                                    id: discoverRow
+                                    anchors.centerIn: parent
+                                    spacing: Theme.spacingXS
+
+                                    DankIcon {
+                                        name: "search"
+                                        size: 16
+                                        color: !printerTab.manualEntryMode ? Theme.onPrimary : Theme.surfaceText
+                                    }
+
+                                    StyledText {
+                                        text: I18n.tr("Discover Devices", "Toggle button to scan for printers via mDNS/Avahi")
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: !printerTab.manualEntryMode ? Theme.onPrimary : Theme.surfaceText
+                                        font.weight: Font.Medium
+                                    }
+                                }
+
+                                MouseArea {
+                                    id: discoverArea
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: {
+                                        printerTab.manualEntryMode = false;
+                                        printerTab.testConnectionResult = null;
+                                        printerTab.testingConnection = false;
+                                    }
+                                }
+                            }
+
+                            Rectangle {
+                                width: manualRow.width + Theme.spacingM * 2
+                                height: 32
+                                radius: Theme.cornerRadius
+                                color: printerTab.manualEntryMode ? Theme.primary : (manualArea.containsMouse ? Theme.primaryHoverLight : Theme.surfaceLight)
+
+                                Row {
+                                    id: manualRow
+                                    anchors.centerIn: parent
+                                    spacing: Theme.spacingXS
+
+                                    DankIcon {
+                                        name: "edit"
+                                        size: 16
+                                        color: printerTab.manualEntryMode ? Theme.onPrimary : Theme.surfaceText
+                                    }
+
+                                    StyledText {
+                                        text: I18n.tr("Add by Address", "Toggle button to manually add a printer by IP or hostname")
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: printerTab.manualEntryMode ? Theme.onPrimary : Theme.surfaceText
+                                        font.weight: Font.Medium
+                                    }
+                                }
+
+                                MouseArea {
+                                    id: manualArea
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: {
+                                        printerTab.manualEntryMode = true;
+                                        printerTab.selectedDevice = null;
+                                        printerTab.selectedDeviceUri = "";
+                                        if (CupsService.ppds.length === 0)
+                                            CupsService.getPPDs();
+                                    }
+                                }
+                            }
+                        }
+
                         Column {
                             width: parent.width
                             spacing: Theme.spacingS
+                            visible: !printerTab.manualEntryMode
 
                             Row {
                                 width: parent.width
@@ -351,6 +486,202 @@ Item {
                                     elide: Text.ElideRight
                                 }
                             }
+                        }
+
+                        Column {
+                            width: parent.width
+                            spacing: Theme.spacingS
+                            visible: printerTab.manualEntryMode
+
+                            Row {
+                                width: parent.width
+                                spacing: Theme.spacingS
+
+                                StyledText {
+                                    text: I18n.tr("Host", "Label for printer IP address or hostname input field")
+                                    font.pixelSize: Theme.fontSizeMedium
+                                    font.weight: Font.Medium
+                                    color: Theme.surfaceText
+                                    width: 80
+                                    anchors.verticalCenter: parent.verticalCenter
+                                }
+
+                                DankTextField {
+                                    width: parent.width - 80 - Theme.spacingS
+                                    placeholderText: I18n.tr("IP address or hostname", "Placeholder text for manual printer address input")
+                                    text: printerTab.manualHost
+                                    onTextEdited: {
+                                        printerTab.manualHost = text;
+                                        printerTab.testConnectionResult = null;
+                                    }
+                                }
+                            }
+
+                            Row {
+                                width: parent.width
+                                spacing: Theme.spacingS
+
+                                StyledText {
+                                    text: I18n.tr("Port", "Label for printer port number input field")
+                                    font.pixelSize: Theme.fontSizeMedium
+                                    font.weight: Font.Medium
+                                    color: Theme.surfaceText
+                                    width: 80
+                                    anchors.verticalCenter: parent.verticalCenter
+                                }
+
+                                DankTextField {
+                                    width: 80
+                                    placeholderText: "631"
+                                    text: printerTab.manualPort
+                                    onTextEdited: {
+                                        printerTab.manualPort = text;
+                                        printerTab.testConnectionResult = null;
+                                    }
+                                }
+                            }
+
+                            Row {
+                                width: parent.width
+                                spacing: Theme.spacingS
+
+                                StyledText {
+                                    text: I18n.tr("Protocol", "Label for printer protocol selector, e.g. ipp, ipps, lpd, socket")
+                                    font.pixelSize: Theme.fontSizeMedium
+                                    font.weight: Font.Medium
+                                    color: Theme.surfaceText
+                                    width: 80
+                                    anchors.verticalCenter: parent.verticalCenter
+                                }
+
+                                DankDropdown {
+                                    id: protocolDropdown
+                                    dropdownWidth: 120
+                                    popupWidth: 120
+                                    currentValue: printerTab.manualProtocol
+                                    options: ["ipp", "ipps", "lpd", "socket"]
+                                    onValueChanged: value => {
+                                        printerTab.manualProtocol = value;
+                                        printerTab.testConnectionResult = null;
+                                    }
+                                }
+                            }
+
+                            Row {
+                                width: parent.width
+                                spacing: Theme.spacingS
+
+                                Item {
+                                    width: 80
+                                    height: 1
+                                }
+
+                                DankButton {
+                                    text: printerTab.testingConnection ? I18n.tr("Testing...", "Button state while testing printer connection") : I18n.tr("Test Connection", "Button to test connection to a printer by IP address")
+                                    iconName: printerTab.testingConnection ? "sync" : "lan"
+                                    buttonHeight: 36
+                                    enabled: printerTab.manualHost.length > 0 && !printerTab.testingConnection
+                                    onClicked: {
+                                        printerTab.testingConnection = true;
+                                        printerTab.testConnectionResult = null;
+                                        const port = parseInt(printerTab.manualPort) || 631;
+                                        CupsService.testConnection(printerTab.manualHost, port, printerTab.manualProtocol, response => {
+                                            printerTab.testingConnection = false;
+                                            if (response.error) {
+                                                printerTab.testConnectionResult = {
+                                                    "success": false,
+                                                    "error": response.error
+                                                };
+                                            } else if (response.result) {
+                                                printerTab.testConnectionResult = {
+                                                    "success": response.result.reachable === true,
+                                                    "data": response.result
+                                                };
+                                                if (response.result.reachable) {
+                                                    if (response.result.uri)
+                                                        printerTab.selectedDeviceUri = response.result.uri;
+                                                    if (response.result.name && !printerTab.newPrinterName)
+                                                        printerTab.newPrinterName = response.result.name.replace(/[^a-zA-Z0-9_-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "").substring(0, 32) || "Printer";
+                                                    // Load PPDs if not loaded yet, then select driverless
+                                                    if (CupsService.ppds.length === 0) {
+                                                        CupsService.getPPDs();
+                                                    }
+                                                    selectDriverlessPPD();
+                                                }
+                                            }
+                                        });
+                                    }
+                                }
+                            }
+
+                            Column {
+                                width: parent.width
+                                spacing: Theme.spacingXS
+                                visible: printerTab.testConnectionResult !== null
+
+                                Row {
+                                    spacing: Theme.spacingS
+
+                                    Item {
+                                        width: 80
+                                        height: 1
+                                    }
+
+                                    Rectangle {
+                                        width: 8
+                                        height: 8
+                                        radius: 4
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        color: printerTab.testConnectionResult?.success ? Theme.success : Theme.error
+                                    }
+
+                                    StyledText {
+                                        text: printerTab.testConnectionResult?.success ? I18n.tr("Printer reachable", "Status message when test connection to printer succeeds") : I18n.tr("Connection failed", "Status message when test connection to printer fails")
+                                        font.pixelSize: Theme.fontSizeMedium
+                                        font.weight: Font.Medium
+                                        color: printerTab.testConnectionResult?.success ? Theme.success : Theme.error
+                                    }
+                                }
+
+                                Row {
+                                    spacing: Theme.spacingS
+                                    visible: printerTab.testConnectionResult?.success && (printerTab.testConnectionResult?.data?.makeModel || printerTab.testConnectionResult?.data?.info)
+
+                                    Item {
+                                        width: 80
+                                        height: 1
+                                    }
+
+                                    StyledText {
+                                        text: printerTab.testConnectionResult?.data?.makeModel || printerTab.testConnectionResult?.data?.info || ""
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: Theme.surfaceVariantText
+                                    }
+                                }
+
+                                Row {
+                                    spacing: Theme.spacingS
+                                    visible: !printerTab.testConnectionResult?.success && printerTab.testConnectionResult?.data?.error
+
+                                    Item {
+                                        width: 80
+                                        height: 1
+                                    }
+
+                                    StyledText {
+                                        text: printerTab.testConnectionResult?.data?.error || printerTab.testConnectionResult?.error || ""
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: Theme.surfaceVariantText
+                                        width: parent.parent.width - 80 - Theme.spacingS
+                                        wrapMode: Text.WordWrap
+                                    }
+                                }
+                            }
+                        }
+
+                        Column {
+                            width: parent.width
+                            spacing: Theme.spacingS
 
                             Row {
                                 width: parent.width

--- a/quickshell/Services/CupsService.qml
+++ b/quickshell/Services/CupsService.qml
@@ -479,6 +479,21 @@ Singleton {
         });
     }
 
+    function testConnection(host, port, protocol, callback) {
+        if (!cupsAvailable)
+            return;
+        const params = {
+            "host": host,
+            "port": port,
+            "protocol": protocol
+        };
+
+        DMSService.sendRequest("cups.testConnection", params, response => {
+            if (callback)
+                callback(response);
+        });
+    }
+
     function createPrinter(name, deviceURI, ppd, options) {
         if (!cupsAvailable)
             return;

--- a/quickshell/translations/en.json
+++ b/quickshell/translations/en.json
@@ -660,6 +660,12 @@
     "comment": ""
   },
   {
+    "term": "Add by Address",
+    "context": "Toggle button to manually add a printer by IP or hostname",
+    "reference": "Modules/Settings/PrinterTab.qml:351",
+    "comment": ""
+  },
+  {
     "term": "Adjust the number of columns in grid view mode.",
     "context": "Adjust the number of columns in grid view mode.",
     "reference": "Modules/Settings/LauncherTab.qml:349",
@@ -2430,6 +2436,12 @@
     "comment": ""
   },
   {
+    "term": "Connection failed",
+    "context": "Status message when test connection to printer fails",
+    "reference": "Modules/Settings/PrinterTab.qml:603",
+    "comment": ""
+  },
+  {
     "term": "Contains",
     "context": "notification rule match type option",
     "reference": "Modules/Settings/NotificationsTab.qml:101",
@@ -3291,6 +3303,12 @@
     "term": "Disconnected from WiFi",
     "context": "Disconnected from WiFi",
     "reference": "Services/DMSNetworkService.qml:480",
+    "comment": ""
+  },
+  {
+    "term": "Discover Devices",
+    "context": "Toggle button to scan for printers via mDNS/Avahi",
+    "reference": "Modules/Settings/PrinterTab.qml:313",
     "comment": ""
   },
   {
@@ -5268,6 +5286,12 @@
     "comment": ""
   },
   {
+    "term": "Host",
+    "context": "Label for printer IP address or hostname input field",
+    "reference": "Modules/Settings/PrinterTab.qml:462",
+    "comment": ""
+  },
+  {
     "term": "Hostname",
     "context": "system info label",
     "reference": "Modules/ProcessList/SystemView.qml:60",
@@ -5343,6 +5367,12 @@
     "term": "IP Address:",
     "context": "IP Address:",
     "reference": "Modules/Settings/NetworkTab.qml:943",
+    "comment": ""
+  },
+  {
+    "term": "IP address or hostname",
+    "context": "Placeholder text for manual printer address input",
+    "reference": "Modules/Settings/PrinterTab.qml:472",
     "comment": ""
   },
   {
@@ -8262,6 +8292,12 @@
     "comment": ""
   },
   {
+    "term": "Port",
+    "context": "Label for printer port number input field",
+    "reference": "Modules/Settings/PrinterTab.qml:486",
+    "comment": ""
+  },
+  {
     "term": "Portal",
     "context": "wallpaper transition option",
     "reference": "Modules/Settings/WallpaperTab.qml:1175",
@@ -8481,6 +8517,12 @@
     "term": "Printer name (no spaces)",
     "context": "Printer name (no spaces)",
     "reference": "Modules/Settings/PrinterTab.qml:433",
+    "comment": ""
+  },
+  {
+    "term": "Printer reachable",
+    "context": "Status message when test connection to printer succeeds",
+    "reference": "Modules/Settings/PrinterTab.qml:603",
     "comment": ""
   },
   {
@@ -10776,6 +10818,12 @@
     "comment": ""
   },
   {
+    "term": "Test Connection",
+    "context": "Button to test connection to a printer by IP address",
+    "reference": "Modules/Settings/PrinterTab.qml:541",
+    "comment": ""
+  },
+  {
     "term": "Test Page",
     "context": "Test Page",
     "reference": "Modules/Settings/PrinterTab.qml:941",
@@ -10785,6 +10833,12 @@
     "term": "Test page sent to printer",
     "context": "Test page sent to printer",
     "reference": "Services/CupsService.qml:627",
+    "comment": ""
+  },
+  {
+    "term": "Testing...",
+    "context": "Button state while testing printer connection",
+    "reference": "Modules/Settings/PrinterTab.qml:541",
     "comment": ""
   },
   {

--- a/quickshell/translations/template.json
+++ b/quickshell/translations/template.json
@@ -770,6 +770,13 @@
     "comment": ""
   },
   {
+    "term": "Add by Address",
+    "translation": "",
+    "context": "Toggle button to manually add a printer by IP or hostname",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Adjust the number of columns in grid view mode.",
     "translation": "",
     "context": "",
@@ -1995,6 +2002,13 @@
     "comment": ""
   },
   {
+    "term": "Caps Lock is on",
+    "translation": "",
+    "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Center Section",
     "translation": "",
     "context": "",
@@ -2831,6 +2845,13 @@
     "term": "Connecting...",
     "translation": "",
     "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Connection failed",
+    "translation": "",
+    "context": "Status message when test connection to printer fails",
     "reference": "",
     "comment": ""
   },
@@ -3839,6 +3860,13 @@
     "term": "Disconnected from WiFi",
     "translation": "",
     "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Discover Devices",
+    "translation": "",
+    "context": "Toggle button to scan for printers via mDNS/Avahi",
     "reference": "",
     "comment": ""
   },
@@ -5712,6 +5740,13 @@
     "comment": ""
   },
   {
+    "term": "Got It",
+    "translation": "",
+    "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Goth Corner Radius",
     "translation": "",
     "context": "",
@@ -6146,6 +6181,13 @@
     "comment": ""
   },
   {
+    "term": "Host",
+    "translation": "",
+    "context": "Label for printer IP address or hostname input field",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Hostname",
     "translation": "",
     "context": "system info label",
@@ -6233,6 +6275,13 @@
     "term": "IP Address:",
     "translation": "",
     "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "IP address or hostname",
+    "translation": "",
+    "context": "Placeholder text for manual printer address input",
     "reference": "",
     "comment": ""
   },
@@ -9639,6 +9688,13 @@
     "comment": ""
   },
   {
+    "term": "Port",
+    "translation": "",
+    "context": "Label for printer port number input field",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Portal",
     "translation": "",
     "context": "wallpaper transition option",
@@ -9898,6 +9954,13 @@
     "comment": ""
   },
   {
+    "term": "Printer reachable",
+    "translation": "",
+    "context": "Status message when test connection to printer succeeds",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Printers",
     "translation": "",
     "context": "",
@@ -10123,6 +10186,20 @@
   },
   {
     "term": "Rate",
+    "translation": "",
+    "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Read Full Release Notes",
+    "translation": "",
+    "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Read Full Release Notes",
     "translation": "",
     "context": "",
     "reference": "",
@@ -12572,6 +12649,13 @@
     "comment": ""
   },
   {
+    "term": "Test Connection",
+    "translation": "",
+    "context": "Button to test connection to a printer by IP address",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Test Page",
     "translation": "",
     "context": "",
@@ -12582,6 +12666,13 @@
     "term": "Test page sent to printer",
     "translation": "",
     "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Testing...",
+    "translation": "",
+    "context": "Button state while testing printer connection",
     "reference": "",
     "comment": ""
   },
@@ -13923,6 +14014,13 @@
     "comment": ""
   },
   {
+    "term": "What's New",
+    "translation": "",
+    "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "When enabled, apps are sorted alphabetically. When disabled, apps are sorted by usage frequency.",
     "translation": "",
     "context": "",
@@ -14728,51 +14826,16 @@
     "comment": ""
   },
   {
-    "term": "↑/↓: Navigate • Enter: Paste • Del: Delete • F10: Help",
-    "translation": "",
-    "context": "Keyboard hints when enter-to-paste is enabled",
-    "reference": "",
-    "comment": ""
-  },
-  {
-    "term": "What's New",
-    "translation": "",
-    "context": "",
-    "reference": "",
-    "comment": ""
-  },
-  {
-    "term": "Read Full Release Notes",
-    "translation": "",
-    "context": "",
-    "reference": "",
-    "comment": ""
-  },
-  {
-    "term": "Read Full Release Notes",
-    "translation": "",
-    "context": "",
-    "reference": "",
-    "comment": ""
-  },
-  {
-    "term": "Got It",
-    "translation": "",
-    "context": "",
-    "reference": "",
-    "comment": ""
-  },
-  {
-    "term": "Caps Lock is on",
-    "translation": "",
-    "context": "",
-    "reference": "",
-    "comment": ""
-  },
-  {
     "term": "↑/↓: Nav • Space: Expand • Enter: Action/Expand • E: Text",
     "translation": "",
     "context": "",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "↑/↓: Navigate • Enter: Paste • Del: Delete • F10: Help",
+    "translation": "",
+    "context": "Keyboard hints when enter-to-paste is enabled",
     "reference": "",
     "comment": ""
   }


### PR DESCRIPTION
## Summary

- Add manual printer addition by IP address or hostname
- New `cups.testConnection` IPC method probes remote printers via IPP
- QML UI adds "Add by Address" option alongside device discovery
- `lpadmin` CLI fallback when `cups-pk-helper` authorization fails
- Enables printing to printers not visible via mDNS/Avahi (e.g., Tailscale subnet routers, VPNs, cross-network setups)

## Motivation

Printer discovery relies on mDNS/DNS-SD which doesn't work across network boundaries. Users with VPN setups (Tailscale, WireGuard) or printers on remote subnets can reach printers by IP but cannot discover them. This adds a straightforward "add by address" flow.

## Changes

### Go backend
- **New `cups.testConnection` IPC method** that probes a remote host via IPP `Get-Printer-Attributes`, returning make/model/state. Tries `/ipp/print` (modern driverless) then `/` (legacy) with automatic fallback.
- **Input validation** with host sanitization (rejects slashes, spaces, newlines), port range check, protocol allowlist (ipp/ipps/lpd/socket).
- **Auth-aware probing** — printers returning HTTP 401/403 are reported as reachable with "authentication required" rather than "connection failed".
- **`lpadmin` CLI fallback** for `CreatePrinter` and `DeletePrinter` when `cups-pk-helper` polkit authorization fails (e.g., no polkit agent running). This fixes remote printer management on minimal sessions where the user has `sys`/`lpadmin` group membership but no polkit agent.
- **Unit tests** — 20+ new test cases covering validation, probe delegation, TLS flag propagation, auth error detection, handler parameter parsing, and request routing.

### QML frontend
- **"Add by Address" toggle** in PrinterTab alongside existing "Discover Devices"
- **Manual entry form** with host, port, and protocol fields
- **"Test Connection" button** with loading spinner and result display (green/red status with make/model or error details)
- **Smart PPD auto-selection** — matches probed `makeModel` against available PPDs for model-specific drivers, falls back to driverless/everywhere
- **Async PPD loading** — triggers `getPPDs()` on successful test connection with `Connections` handler to auto-select when data arrives
- All strings use `I18n.tr()` with translator context per CONTRIBUTING.md

## Test plan
- [x] Unit tests pass (`make test`, pre-commit hooks pass)
- [x] Test connection to remote printer by IP (HP OfficeJet 8010 via Tailscale subnet router)
- [x] Auth-required printer shows "Printer reachable" with "authentication required" subtitle
- [x] Unreachable host shows clean error message
- [x] Successfully printed to the manually added remote printer
- [x] Printer persists across DMS service restarts
- [x] Printer appears in control center widget
- [x] Delete printer works from the UI

**Tested on:**
- ThinkPad X390, CachyOS (Arch), DMS (git) v1.4.0-3354, niri
- Desktop (RTX 2070S), CachyOS (Arch), DMS (git) v1.4.0-3354, niri