### PR TITLE
fix(icons): apply file path substitutions in launcher icon resolution

### DIFF
--- a/quickshell/Widgets/AppIconRenderer.qml
+++ b/quickshell/Widgets/AppIconRenderer.qml
@@ -49,6 +49,14 @@ Item {
     readonly property string iconPath: {
         if (hasSpecialPrefix || !iconValue)
             return "";
+        const moddedId = Paths.moddedAppId(iconValue);
+        if (moddedId !== iconValue) {
+            if (moddedId.startsWith("~") || moddedId.startsWith("/"))
+                return Paths.toFileUrl(Paths.expandTilde(moddedId));
+            if (moddedId.startsWith("file://"))
+                return moddedId;
+            return Quickshell.iconPath(moddedId, true);
+        }
         return Quickshell.iconPath(iconValue, true) || DesktopService.resolveIconPath(iconValue);
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #1867. The launcher's `AppIconRenderer.qml` resolved icons via its own `Quickshell.iconPath()` call without going through `appIdSubstitutions`, so PWA icons configured via regex file path rules were not resolved in the app launcher (only in the taskbar/workspace widget).

This adds the same `Paths.moddedAppId()` check before falling through to the default icon lookup, matching the pattern established in `Paths.getAppIcon()`.

## Test plan
- Configure a regex appIdSubstitution that maps a PWA app_id to a file path (e.g. `^(chrome|msedge|chromium)-(.+)$` → `/home/user/.local/share/icons/hicolor/128x128/apps/$1-$2.png`)
- Open the app launcher and verify PWA icons display correctly
- Verify non-PWA apps are unaffected