### PR TITLE
fix(icons): apply appIdSubstitutions across all icon resolution paths

### DIFF
--- a/quickshell/Modals/DankLauncherV2/LauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/LauncherContent.qml
@@ -789,7 +789,19 @@ FocusScope {
                 Image {
                     width: 40
                     height: 40
-                    source: editingApp?.icon ? "image://icon/" + editingApp.icon : "image://icon/application-x-executable"
+                    source: {
+                        const icon = editingApp?.icon;
+                        if (!icon) return "image://icon/application-x-executable";
+                        const moddedIcon = Paths.moddedAppId(icon);
+                        if (moddedIcon !== icon) {
+                            if (moddedIcon.startsWith("~") || moddedIcon.startsWith("/"))
+                                return Paths.toFileUrl(Paths.expandTilde(moddedIcon));
+                            if (moddedIcon.startsWith("file://"))
+                                return moddedIcon;
+                            return "image://icon/" + moddedIcon;
+                        }
+                        return "image://icon/" + icon;
+                    }
                     sourceSize.width: 40
                     sourceSize.height: 40
                     fillMode: Image.PreserveAspectFit

--- a/quickshell/Modules/DankBar/Widgets/AppsDockContextMenu.qml
+++ b/quickshell/Modules/DankBar/Widgets/AppsDockContextMenu.qml
@@ -273,7 +273,18 @@ PanelWindow {
 
                             IconImage {
                                 anchors.fill: parent
-                                source: modelData.icon ? Quickshell.iconPath(modelData.icon, true) : ""
+                                source: {
+                                    if (!modelData.icon) return "";
+                                    const moddedIcon = Paths.moddedAppId(modelData.icon);
+                                    if (moddedIcon !== modelData.icon) {
+                                        if (moddedIcon.startsWith("~") || moddedIcon.startsWith("/"))
+                                            return Paths.toFileUrl(Paths.expandTilde(moddedIcon));
+                                        if (moddedIcon.startsWith("file://"))
+                                            return moddedIcon;
+                                        return Quickshell.iconPath(moddedIcon, true);
+                                    }
+                                    return Quickshell.iconPath(modelData.icon, true);
+                                }
                                 smooth: true
                                 asynchronous: true
                                 visible: status === Image.Ready

--- a/quickshell/Modules/Dock/DockContextMenu.qml
+++ b/quickshell/Modules/Dock/DockContextMenu.qml
@@ -329,7 +329,18 @@ PanelWindow {
 
                             IconImage {
                                 anchors.fill: parent
-                                source: modelData.icon ? Quickshell.iconPath(modelData.icon, true) : ""
+                                source: {
+                                    if (!modelData.icon) return "";
+                                    const moddedIcon = Paths.moddedAppId(modelData.icon);
+                                    if (moddedIcon !== modelData.icon) {
+                                        if (moddedIcon.startsWith("~") || moddedIcon.startsWith("/"))
+                                            return Paths.toFileUrl(Paths.expandTilde(moddedIcon));
+                                        if (moddedIcon.startsWith("file://"))
+                                            return moddedIcon;
+                                        return Quickshell.iconPath(moddedIcon, true);
+                                    }
+                                    return Quickshell.iconPath(modelData.icon, true);
+                                }
                                 smooth: true
                                 asynchronous: true
                                 visible: status === Image.Ready

--- a/quickshell/Modules/Notifications/Center/HistoryNotificationCard.qml
+++ b/quickshell/Modules/Notifications/Center/HistoryNotificationCard.qml
@@ -142,6 +142,14 @@ Rectangle {
                     return appIcon;
                 if (appIcon.startsWith("material:") || appIcon.startsWith("svg:") || appIcon.startsWith("unicode:") || appIcon.startsWith("image:"))
                     return "";
+                const moddedIcon = Paths.moddedAppId(appIcon);
+                if (moddedIcon !== appIcon) {
+                    if (moddedIcon.startsWith("~") || moddedIcon.startsWith("/"))
+                        return Paths.toFileUrl(Paths.expandTilde(moddedIcon));
+                    if (moddedIcon.startsWith("file://"))
+                        return moddedIcon;
+                    return Quickshell.iconPath(moddedIcon, true);
+                }
                 return Quickshell.iconPath(appIcon, true);
             }
 

--- a/quickshell/Modules/Notifications/Center/NotificationCard.qml
+++ b/quickshell/Modules/Notifications/Center/NotificationCard.qml
@@ -220,6 +220,14 @@ Rectangle {
                     return appIcon;
                 if (appIcon.startsWith("material:") || appIcon.startsWith("svg:") || appIcon.startsWith("unicode:") || appIcon.startsWith("image:"))
                     return "";
+                const moddedIcon = Paths.moddedAppId(appIcon);
+                if (moddedIcon !== appIcon) {
+                    if (moddedIcon.startsWith("~") || moddedIcon.startsWith("/"))
+                        return Paths.toFileUrl(Paths.expandTilde(moddedIcon));
+                    if (moddedIcon.startsWith("file://"))
+                        return moddedIcon;
+                    return Quickshell.iconPath(moddedIcon, true);
+                }
                 return Quickshell.iconPath(appIcon, true);
             }
 
@@ -557,6 +565,14 @@ Rectangle {
                                         return appIcon;
                                     if (appIcon.startsWith("material:") || appIcon.startsWith("svg:") || appIcon.startsWith("unicode:") || appIcon.startsWith("image:"))
                                         return "";
+                                    const moddedIcon = Paths.moddedAppId(appIcon);
+                                    if (moddedIcon !== appIcon) {
+                                        if (moddedIcon.startsWith("~") || moddedIcon.startsWith("/"))
+                                            return Paths.toFileUrl(Paths.expandTilde(moddedIcon));
+                                        if (moddedIcon.startsWith("file://"))
+                                            return moddedIcon;
+                                        return Quickshell.iconPath(moddedIcon, true);
+                                    }
                                     return Quickshell.iconPath(appIcon, true);
                                 }
 

--- a/quickshell/Modules/Notifications/Popup/NotificationPopup.qml
+++ b/quickshell/Modules/Notifications/Popup/NotificationPopup.qml
@@ -524,6 +524,14 @@ PanelWindow {
                             return appIcon;
                         if (appIcon.startsWith("material:") || appIcon.startsWith("svg:") || appIcon.startsWith("unicode:") || appIcon.startsWith("image:"))
                             return "";
+                        const moddedIcon = Paths.moddedAppId(appIcon);
+                        if (moddedIcon !== appIcon) {
+                            if (moddedIcon.startsWith("~") || moddedIcon.startsWith("/"))
+                                return Paths.toFileUrl(Paths.expandTilde(moddedIcon));
+                            if (moddedIcon.startsWith("file://"))
+                                return moddedIcon;
+                            return Quickshell.iconPath(moddedIcon, true);
+                        }
                         return Quickshell.iconPath(appIcon, true);
                     }
 

--- a/quickshell/Modules/Settings/LauncherTab.qml
+++ b/quickshell/Modules/Settings/LauncherTab.qml
@@ -897,7 +897,19 @@ Item {
                                 Image {
                                     width: 24
                                     height: 24
-                                    source: modelData.icon ? "image://icon/" + modelData.icon : "image://icon/application-x-executable"
+                                    source: {
+                                        const icon = modelData.icon;
+                                        if (!icon) return "image://icon/application-x-executable";
+                                        const moddedIcon = Paths.moddedAppId(icon);
+                                        if (moddedIcon !== icon) {
+                                            if (moddedIcon.startsWith("~") || moddedIcon.startsWith("/"))
+                                                return Paths.toFileUrl(Paths.expandTilde(moddedIcon));
+                                            if (moddedIcon.startsWith("file://"))
+                                                return moddedIcon;
+                                            return "image://icon/" + moddedIcon;
+                                        }
+                                        return "image://icon/" + icon;
+                                    }
                                     sourceSize.width: 24
                                     sourceSize.height: 24
                                     fillMode: Image.PreserveAspectFit
@@ -1008,7 +1020,19 @@ Item {
                                 Image {
                                     width: 24
                                     height: 24
-                                    source: modelData.icon ? "image://icon/" + modelData.icon : "image://icon/application-x-executable"
+                                    source: {
+                                        const icon = modelData.icon;
+                                        if (!icon) return "image://icon/application-x-executable";
+                                        const moddedIcon = Paths.moddedAppId(icon);
+                                        if (moddedIcon !== icon) {
+                                            if (moddedIcon.startsWith("~") || moddedIcon.startsWith("/"))
+                                                return Paths.toFileUrl(Paths.expandTilde(moddedIcon));
+                                            if (moddedIcon.startsWith("file://"))
+                                                return moddedIcon;
+                                            return "image://icon/" + moddedIcon;
+                                        }
+                                        return "image://icon/" + icon;
+                                    }
                                     sourceSize.width: 24
                                     sourceSize.height: 24
                                     fillMode: Image.PreserveAspectFit
@@ -1154,7 +1178,19 @@ Item {
                                 Image {
                                     width: 24
                                     height: 24
-                                    source: modelData.icon ? "image://icon/" + modelData.icon : "image://icon/application-x-executable"
+                                    source: {
+                                        const icon = modelData.icon;
+                                        if (!icon) return "image://icon/application-x-executable";
+                                        const moddedIcon = Paths.moddedAppId(icon);
+                                        if (moddedIcon !== icon) {
+                                            if (moddedIcon.startsWith("~") || moddedIcon.startsWith("/"))
+                                                return Paths.toFileUrl(Paths.expandTilde(moddedIcon));
+                                            if (moddedIcon.startsWith("file://"))
+                                                return moddedIcon;
+                                            return "image://icon/" + moddedIcon;
+                                        }
+                                        return "image://icon/" + icon;
+                                    }
                                     sourceSize.width: 24
                                     sourceSize.height: 24
                                     fillMode: Image.PreserveAspectFit


### PR DESCRIPTION
## Summary
Follow-up to #1867 and #1877. An audit of all icon resolution paths in the codebase found **7 additional components** that resolve icons via `Quickshell.iconPath()` or `image://icon/` URLs without checking `appIdSubstitutions` first.

This means file path substitutions (e.g. for PWA icons that Qt's icon theme system can't reliably resolve — see background below) only worked in the taskbar (#1867) and launcher (#1877), but not in notifications, dock context menus, or settings UI.

### Background: why substitutions are needed for PWAs

Qt6's `QIcon::fromTheme()` has a limitation where it silently resolves PWA icon names (e.g. `chrome-xxx-Default`) to the **generic browser icon** instead of the actual PWA-specific icon installed in `~/.local/share/icons/hicolor/`. This was confirmed via pixel-level comparison — the rendered pixmap is byte-identical to `google-chrome`. PWA icons that happen to be bundled in the active system theme (e.g. Qogir ships YouTube) work correctly; others don't. This is a Qt upstream issue that can't be fixed at the DMS level.

The `appIdSubstitutions` feature (Settings → Running Apps) lets users map these broken icon names to direct file paths, bypassing Qt's theme lookup entirely. This PR ensures that mapping works consistently everywhere icons are displayed.

### Zero cost for non-users

When no substitutions match, `Paths.moddedAppId()` returns the original icon name unchanged (identity), so the existing `Quickshell.iconPath()` / `image://icon/` path executes exactly as before. There is no behavioral change for users who don't configure substitutions.

### Audit results

| Component | File | Issue |
|-----------|------|-------|
| Notification card (grouped + expanded) | `NotificationCard.qml` | `Quickshell.iconPath(appIcon, true)` without substitution |
| Notification popup | `NotificationPopup.qml` | Same |
| Notification history | `HistoryNotificationCard.qml` | Same |
| Dock context menu | `DockContextMenu.qml` | Same |
| Bar dock context menu | `AppsDockContextMenu.qml` | Same |
| Launcher edit dialog | `LauncherContent.qml` | `"image://icon/" + icon` without substitution |
| Launcher settings | `LauncherTab.qml` (×3) | Same |

All now route through `Paths.moddedAppId()` before falling through to the default icon lookup, matching the pattern in `Paths.getAppIcon()` and `AppIconRenderer.iconPath`.

## Test plan
- Configure a regex appIdSubstitution mapping a PWA app_id to a file path
- Verify PWA icons display correctly in: taskbar, launcher, notifications, dock right-click menu, launcher settings
- Verify non-PWA apps are unaffected (no substitution match → original path unchanged)