### PR TITLE
refactor(icons): centralize icon resolution into Paths.resolveIconPath/resolveIconUrl

### DIFF
--- a/quickshell/Common/Paths.qml
+++ b/quickshell/Common/Paths.qml
@@ -71,19 +71,40 @@ Singleton {
         return appId;
     }
 
-    function getAppIcon(appId: string, desktopEntry: var): string {
-        if (appId === "org.quickshell") {
-            return Qt.resolvedUrl("../assets/danklogo.svg");
-        }
-
-        const moddedId = moddedAppId(appId);
-        if (moddedId !== appId) {
+    function resolveIconPath(iconName: string): string {
+        if (!iconName) return "";
+        const moddedId = moddedAppId(iconName);
+        if (moddedId !== iconName) {
             if (moddedId.startsWith("~") || moddedId.startsWith("/"))
                 return toFileUrl(expandTilde(moddedId));
             if (moddedId.startsWith("file://"))
                 return moddedId;
             return Quickshell.iconPath(moddedId, true);
         }
+        return Quickshell.iconPath(iconName, true) || DesktopService.resolveIconPath(iconName);
+    }
+
+    function resolveIconUrl(iconName: string): string {
+        if (!iconName) return "";
+        const moddedId = moddedAppId(iconName);
+        if (moddedId !== iconName) {
+            if (moddedId.startsWith("~") || moddedId.startsWith("/"))
+                return toFileUrl(expandTilde(moddedId));
+            if (moddedId.startsWith("file://"))
+                return moddedId;
+            return "image://icon/" + moddedId;
+        }
+        return "image://icon/" + iconName;
+    }
+
+    function getAppIcon(appId: string, desktopEntry: var): string {
+        if (appId === "org.quickshell") {
+            return Qt.resolvedUrl("../assets/danklogo.svg");
+        }
+
+        const moddedId = moddedAppId(appId);
+        if (moddedId !== appId)
+            return resolveIconPath(appId);
 
         if (desktopEntry && desktopEntry.icon) {
             return Quickshell.iconPath(desktopEntry.icon, true);

--- a/quickshell/Modals/DankLauncherV2/LauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/LauncherContent.qml
@@ -789,7 +789,7 @@ FocusScope {
                 Image {
                     width: 40
                     height: 40
-                    source: editingApp?.icon ? "image://icon/" + editingApp.icon : "image://icon/application-x-executable"
+                    source: Paths.resolveIconUrl(editingApp?.icon || "application-x-executable")
                     sourceSize.width: 40
                     sourceSize.height: 40
                     fillMode: Image.PreserveAspectFit

--- a/quickshell/Modules/DankBar/Widgets/AppsDockContextMenu.qml
+++ b/quickshell/Modules/DankBar/Widgets/AppsDockContextMenu.qml
@@ -273,7 +273,7 @@ PanelWindow {
 
                             IconImage {
                                 anchors.fill: parent
-                                source: modelData.icon ? Quickshell.iconPath(modelData.icon, true) : ""
+                                source: modelData.icon ? Paths.resolveIconPath(modelData.icon) : ""
                                 smooth: true
                                 asynchronous: true
                                 visible: status === Image.Ready

--- a/quickshell/Modules/Dock/DockContextMenu.qml
+++ b/quickshell/Modules/Dock/DockContextMenu.qml
@@ -329,7 +329,7 @@ PanelWindow {
 
                             IconImage {
                                 anchors.fill: parent
-                                source: modelData.icon ? Quickshell.iconPath(modelData.icon, true) : ""
+                                source: modelData.icon ? Paths.resolveIconPath(modelData.icon) : ""
                                 smooth: true
                                 asynchronous: true
                                 visible: status === Image.Ready

--- a/quickshell/Modules/Notifications/Center/HistoryNotificationCard.qml
+++ b/quickshell/Modules/Notifications/Center/HistoryNotificationCard.qml
@@ -142,7 +142,7 @@ Rectangle {
                     return appIcon;
                 if (appIcon.startsWith("material:") || appIcon.startsWith("svg:") || appIcon.startsWith("unicode:") || appIcon.startsWith("image:"))
                     return "";
-                return Quickshell.iconPath(appIcon, true);
+                return Paths.resolveIconPath(appIcon);
             }
 
             hasImage: hasNotificationImage

--- a/quickshell/Modules/Notifications/Center/NotificationCard.qml
+++ b/quickshell/Modules/Notifications/Center/NotificationCard.qml
@@ -220,7 +220,7 @@ Rectangle {
                     return appIcon;
                 if (appIcon.startsWith("material:") || appIcon.startsWith("svg:") || appIcon.startsWith("unicode:") || appIcon.startsWith("image:"))
                     return "";
-                return Quickshell.iconPath(appIcon, true);
+                return Paths.resolveIconPath(appIcon);
             }
 
             hasImage: hasNotificationImage
@@ -557,7 +557,7 @@ Rectangle {
                                         return appIcon;
                                     if (appIcon.startsWith("material:") || appIcon.startsWith("svg:") || appIcon.startsWith("unicode:") || appIcon.startsWith("image:"))
                                         return "";
-                                    return Quickshell.iconPath(appIcon, true);
+                                    return Paths.resolveIconPath(appIcon);
                                 }
 
                                 fallbackIcon: {

--- a/quickshell/Modules/Notifications/Popup/NotificationPopup.qml
+++ b/quickshell/Modules/Notifications/Popup/NotificationPopup.qml
@@ -524,7 +524,7 @@ PanelWindow {
                             return appIcon;
                         if (appIcon.startsWith("material:") || appIcon.startsWith("svg:") || appIcon.startsWith("unicode:") || appIcon.startsWith("image:"))
                             return "";
-                        return Quickshell.iconPath(appIcon, true);
+                        return Paths.resolveIconPath(appIcon);
                     }
 
                     hasImage: hasNotificationImage

--- a/quickshell/Modules/Settings/LauncherTab.qml
+++ b/quickshell/Modules/Settings/LauncherTab.qml
@@ -897,7 +897,7 @@ Item {
                                 Image {
                                     width: 24
                                     height: 24
-                                    source: modelData.icon ? "image://icon/" + modelData.icon : "image://icon/application-x-executable"
+                                    source: Paths.resolveIconUrl(modelData.icon || "application-x-executable")
                                     sourceSize.width: 24
                                     sourceSize.height: 24
                                     fillMode: Image.PreserveAspectFit
@@ -1008,7 +1008,7 @@ Item {
                                 Image {
                                     width: 24
                                     height: 24
-                                    source: modelData.icon ? "image://icon/" + modelData.icon : "image://icon/application-x-executable"
+                                    source: Paths.resolveIconUrl(modelData.icon || "application-x-executable")
                                     sourceSize.width: 24
                                     sourceSize.height: 24
                                     fillMode: Image.PreserveAspectFit
@@ -1154,7 +1154,7 @@ Item {
                                 Image {
                                     width: 24
                                     height: 24
-                                    source: modelData.icon ? "image://icon/" + modelData.icon : "image://icon/application-x-executable"
+                                    source: Paths.resolveIconUrl(modelData.icon || "application-x-executable")
                                     sourceSize.width: 24
                                     sourceSize.height: 24
                                     fillMode: Image.PreserveAspectFit

--- a/quickshell/Widgets/AppIconRenderer.qml
+++ b/quickshell/Widgets/AppIconRenderer.qml
@@ -49,15 +49,7 @@ Item {
     readonly property string iconPath: {
         if (hasSpecialPrefix || !iconValue)
             return "";
-        const moddedId = Paths.moddedAppId(iconValue);
-        if (moddedId !== iconValue) {
-            if (moddedId.startsWith("~") || moddedId.startsWith("/"))
-                return Paths.toFileUrl(Paths.expandTilde(moddedId));
-            if (moddedId.startsWith("file://"))
-                return moddedId;
-            return Quickshell.iconPath(moddedId, true);
-        }
-        return Quickshell.iconPath(iconValue, true) || DesktopService.resolveIconPath(iconValue);
+        return Paths.resolveIconPath(iconValue);
     }
 
     visible: iconValue !== undefined && iconValue !== ""


### PR DESCRIPTION
## Summary
Supersedes #1878. An audit of all icon resolution paths found 8 components that resolve icons via `Quickshell.iconPath()` or `image://icon/` URLs without checking `appIdSubstitutions`. Rather than adding the same 8-line inline pattern to each file (#1878), this PR centralizes the logic into two new functions in `Paths.qml`:

- **`resolveIconPath(iconName)`** — for `Quickshell.iconPath()` callsites, handles substitution + file path detection + `DesktopService.resolveIconPath()` fallback
- **`resolveIconUrl(iconName)`** — for `image://icon/` URL callsites, same substitution logic

All consumer files now use one-line calls instead of duplicated inline blocks.

### Why substitutions are needed

Qt6's `QIcon::fromTheme()` has a limitation where it silently resolves some icon names (e.g. PWA icons like `chrome-xxx-Default`) to the generic browser icon instead of the actual icon installed in `~/.local/share/icons/hicolor/`. This was confirmed via pixel-level comparison. Icons bundled in the active system theme (e.g. Qogir ships YouTube) work; others don't. This is a Qt upstream issue. The `appIdSubstitutions` feature lets users map broken icon names to direct file paths, bypassing Qt's theme lookup.

### Zero cost for non-users

When no substitutions match, `moddedAppId()` returns the original icon name unchanged (identity), so the existing `Quickshell.iconPath()` / `image://icon/` path executes exactly as before.

### Files changed (9)

| File | Change |
|------|--------|
| `Common/Paths.qml` | Add `resolveIconPath()`, `resolveIconUrl()`, simplify `getAppIcon()` |
| `Widgets/AppIconRenderer.qml` | 8 lines inline → `Paths.resolveIconPath()` |
| `Notifications/Center/NotificationCard.qml` (×2) | `Quickshell.iconPath(appIcon, true)` → `Paths.resolveIconPath(appIcon)` |
| `Notifications/Popup/NotificationPopup.qml` | Same |
| `Notifications/Center/HistoryNotificationCard.qml` | Same |
| `Dock/DockContextMenu.qml` | Same |
| `DankBar/Widgets/AppsDockContextMenu.qml` | Same |
| `Modals/DankLauncherV2/LauncherContent.qml` | `"image://icon/" + icon` → `Paths.resolveIconUrl()` |
| `Modules/Settings/LauncherTab.qml` (×3) | Same |

## Test plan
- Configure regex appIdSubstitutions mapping PWA app_ids to file paths
- Verify PWA icons display correctly in: taskbar, launcher, dock right-click menus, launcher settings
- Verify non-PWA apps are unaffected (no substitution → original path unchanged)
- Verify fallback icons still work for apps with no icon