### PR TITLE
 ipc: update DankBar selection 

### DIFF
--- a/quickshell/DMSShellIPC.qml
+++ b/quickshell/DMSShellIPC.qml
@@ -166,27 +166,33 @@ Item {
             if (!bar)
                 return "DASH_OPEN_FAILED";
 
-            bar.triggerWallpaperBrowser();
+            const dash = root.dankDashPopoutLoader.item;
+            const onSameScreen = dash && dash.shouldBeVisible && dash.triggerScreen?.name === bar.screen?.name;
 
-            if (root.dankDashPopoutLoader.item) {
-                switch (tab.toLowerCase()) {
-                case "media":
-                    root.dankDashPopoutLoader.item.currentTabIndex = 1;
-                    break;
-                case "wallpaper":
-                    root.dankDashPopoutLoader.item.currentTabIndex = 2;
-                    break;
-                case "weather":
-                    root.dankDashPopoutLoader.item.currentTabIndex = SettingsData.weatherEnabled ? 3 : 0;
-                    break;
-                default:
-                    root.dankDashPopoutLoader.item.currentTabIndex = 0;
-                    break;
-                }
-                return "DASH_OPEN_SUCCESS";
+            if (!onSameScreen) {
+                bar.triggerWallpaperBrowser();
             }
 
-            return "DASH_OPEN_FAILED";
+            if (!root.dankDashPopoutLoader.item)
+                return "DASH_OPEN_FAILED";
+
+            switch (tab.toLowerCase()) {
+            case "media":
+                root.dankDashPopoutLoader.item.currentTabIndex = 1;
+                break;
+            case "wallpaper":
+                root.dankDashPopoutLoader.item.currentTabIndex = 2;
+                break;
+            case "weather":
+                root.dankDashPopoutLoader.item.currentTabIndex = SettingsData.weatherEnabled ? 3 : 0;
+                break;
+            default:
+                root.dankDashPopoutLoader.item.currentTabIndex = 0;
+                break;
+            }
+
+            root.dankDashPopoutLoader.item.dashVisible = true;
+            return "DASH_OPEN_SUCCESS";
         }
 
         function close(): string {


### PR DESCRIPTION
Fixes IPC toggle (used in `dash toggle` or `control-center toggle`) bar selection by choosing the bar that has the desired widget (prioritizing the one in the current monitor, if multiple). Currently it was trying to get the first bar, which resulted in some possible breakages (in some systems, the toggle commands were not working at all).

Also updated `dms ipc dash open` to use the widget in the bar instead of spawning it standalone, fixed some wrong positioning issues. 

As a future enhancement, some way to let the popouts still be able to be toggled when the user doesn't have a bar with the desired widget should be added.