### PR TITLE
Not everyone uses paru or yay on Arch: Support pacman command

### DIFF
--- a/quickshell/Services/SystemUpdateService.qml
+++ b/quickshell/Services/SystemUpdateService.qml
@@ -185,7 +185,7 @@ Singleton {
 
     Process {
         id: pkgManagerDetection
-        command: ["sh", "-c", "which which paru || which yay || which pacman || which dnf"]
+        command: ["sh", "-c", "which paru || which yay || which pacman || which dnf"]
 
         onExited: exitCode => {
             if (exitCode === 0) {


### PR DESCRIPTION
Allow the System Update widget to work on Arch systems without paru or yay installed