### PR TITLE
Greetd memory improvements

### DIFF
--- a/quickshell/Modules/Greetd/GreetdMemory.qml
+++ b/quickshell/Modules/Greetd/GreetdMemory.qml
@@ -11,6 +11,8 @@ Singleton {
     readonly property string greetCfgDir: Quickshell.env("DMS_GREET_CFG_DIR") || "/etc/greetd/.dms"
     readonly property string sessionConfigPath: greetCfgDir + "/session.json"
     readonly property string memoryFile: greetCfgDir + "/memory.json"
+    readonly property bool saveUsername: Quickshell.env("DMS_SAVE_USERNAME") === "1" || Quickshell.env("DMS_SAVE_USERNAME") === "true"
+    readonly property bool saveSession: Quickshell.env("DMS_SAVE_SESSION") === "1" || Quickshell.env("DMS_SAVE_SESSION") === "true"
 
     property string lastSessionId: ""
     property string lastSuccessfulUser: ""
@@ -57,10 +59,12 @@ Singleton {
     }
 
     function saveMemory() {
-        memoryFileView.setText(JSON.stringify({
-            "lastSessionId": lastSessionId,
-            "lastSuccessfulUser": lastSuccessfulUser
-        }, null, 2));
+        let memory = {}
+        if (saveSession)
+            memory.lastSessionId = lastSessionId
+        if (saveUsername)
+            memory.lastSuccessfulUser = lastSuccessfulUser
+        memoryFileView.setText(JSON.stringify(memory, null, 2));
     }
 
     function setLastSessionId(id) {

--- a/quickshell/Modules/Greetd/assets/dms-greeter
+++ b/quickshell/Modules/Greetd/assets/dms-greeter
@@ -6,6 +6,8 @@ COMPOSITOR=""
 COMPOSITOR_CONFIG=""
 DMS_PATH="dms-greeter"
 CACHE_DIR="/var/cache/dms-greeter"
+DMS_SAVE_USERNAME=true
+DMS_SAVE_SESSION=true
 
 show_help() {
     cat << EOF
@@ -22,6 +24,8 @@ Options:
                            (default: dms-greeter)
     --cache-dir PATH        Cache directory for greeter data
                            (default: /var/cache/dms-greeter)
+    --no-save-username     Do not save username in greeter data
+    --no-save-session      Do not save session in greeter data
     -h, --help             Show this help message
 
 Examples:
@@ -60,6 +64,14 @@ while [[ $# -gt 0 ]]; do
         --cache-dir)
             CACHE_DIR="$2"
             shift 2
+            ;;
+        --no-save-username)
+            DMS_SAVE_USERNAME=false
+            shift
+            ;;
+        --no-save-session)
+            DMS_SAVE_SESSION=false
+            shift
             ;;
         -h|--help)
             show_help
@@ -112,6 +124,7 @@ export QT_WAYLAND_DISABLE_WINDOWDECORATION=1
 export EGL_PLATFORM=gbm
 export DMS_RUN_GREETER=1
 export DMS_GREET_CFG_DIR="$CACHE_DIR"
+export DMS_SAVE_USERNAME DMS_SAVE_SESSION
 
 mkdir -p "$CACHE_DIR"
 


### PR DESCRIPTION
Allow disabling saving of username and session to greeter data.

This allow for prompting for the username every time.
To enable this, add "--no-save-username" to the dms-greeter line in /etc/greetd/config.toml

This can similarly be done for the session (window manager) by adding "--no-save-session"