### PR TITLE
feature: Add clipboard editor

### DIFF
--- a/quickshell/Modals/Clipboard/ClipboardContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContent.qml
@@ -145,6 +145,7 @@ Item {
                 onDeleteRequested: clipboardContent.modal.deleteEntry(modelData)
                 onPinRequested: clipboardContent.modal.pinEntry(modelData)
                 onUnpinRequested: clipboardContent.modal.unpinEntry(modelData)
+                onEditRequested: clipboardContent.modal.editEntry(modelData)
             }
         }
 
@@ -204,6 +205,7 @@ Item {
                 onDeleteRequested: clipboardContent.modal.deletePinnedEntry(modelData)
                 onPinRequested: clipboardContent.modal.pinEntry(modelData)
                 onUnpinRequested: clipboardContent.modal.unpinEntry(modelData)
+                onEditRequested: clipboardContent.modal.editEntry(modelData)
             }
         }
 

--- a/quickshell/Modals/Clipboard/ClipboardEntry.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEntry.qml
@@ -17,6 +17,7 @@ Rectangle {
     signal deleteRequested
     signal pinRequested
     signal unpinRequested
+    signal editRequested
 
     readonly property string entryType: modal ? modal.getEntryType(entry) : "text"
     readonly property string entryPreview: modal ? modal.getEntryPreview(entry) : ""
@@ -68,6 +69,20 @@ Rectangle {
             iconColor: (entry.pinned || hasPinnedDuplicate) ? Theme.primary : Theme.surfaceText
             backgroundColor: (entry.pinned || hasPinnedDuplicate) ? Theme.primarySelected : "transparent"
             onClicked: entry.pinned ? unpinRequested() : pinRequested()
+        }
+
+        DankActionButton {
+            iconName: "edit"
+            iconSize: Theme.iconSize - 6
+            iconColor: Theme.surfaceText
+
+            onClicked: {
+                if (entryType === "image") {
+                    // TODO - forward to editing software
+                } else {
+                    editRequested();
+                }
+            }
         }
 
         DankActionButton {
@@ -142,8 +157,11 @@ Rectangle {
 
     MouseArea {
         id: mouseArea
-        anchors.fill: parent
-        anchors.rightMargin: 80
+        anchors.left: parent.left
+        anchors.right: actionButtons.left
+        anchors.rightMargin: Theme.spacingS
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
         hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
         onPressed: mouse => {

--- a/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
@@ -6,6 +6,7 @@ import qs.Common
 import qs.Modals.Clipboard
 import qs.Modals.Common
 import qs.Services
+import qs.Widgets
 
 DankModal {
     id: clipboardHistoryModal
@@ -22,6 +23,7 @@ DankModal {
         ClipboardService.selectedIndex = 0;
         ClipboardService.keyboardNavigationActive = false;
     }
+    property var editClipboardModal: null
     property bool showKeyboardHints: false
     property Component clipboardContent
     property int activeImageLoads: 0
@@ -42,6 +44,8 @@ DankModal {
     Ref {
         service: ClipboardService
     }
+
+    property string mode: "history"
 
     function updateFilteredModel() {
         ClipboardService.updateFilteredModel();
@@ -65,6 +69,7 @@ DankModal {
             return;
         }
         open();
+        mode = "history";
         activeImageLoads = 0;
         shouldHaveFocus = true;
         ClipboardService.reset();
@@ -125,6 +130,21 @@ DankModal {
         return ClipboardService.getEntryType(entry);
     }
 
+    function editEntry(entry) {
+        if (!entry) {
+            return;
+        }
+        if (entry.isImage) {
+            return;
+        }
+        const editor = contentLoader.item?.editorView;
+        if (!editor) {
+            return;
+        }
+        editor.setEntry(entry);
+        mode = "editor";
+    }
+
     visible: false
     modalWidth: ClipboardConstants.modalWidth
     modalHeight: ClipboardConstants.modalHeight
@@ -169,9 +189,254 @@ DankModal {
     property var confirmDialog: clearConfirmDialog
 
     clipboardContent: Component {
-        ClipboardContent {
-            modal: clipboardHistoryModal
-            clearConfirmDialog: clipboardHistoryModal.confirmDialog
+        Item {
+            id: viewContainer
+
+            property alias editorView: editorView
+            property alias searchField: historyContent.searchField
+
+            anchors.fill: parent
+
+            Item {
+                id: historyView
+
+                anchors.fill: parent
+                opacity: 1
+                scale: 1
+                visible: opacity > 0.01
+                enabled: clipboardHistoryModal.mode === "history"
+
+                ClipboardContent {
+                    id: historyContent
+                    anchors.fill: parent
+                    modal: clipboardHistoryModal
+                    clearConfirmDialog: clipboardHistoryModal.confirmDialog
+                }
+            }
+
+            Item {
+                id: editorView
+
+                anchors.fill: parent
+                opacity: 0
+                scale: 0.98
+                visible: opacity > 0.01
+                enabled: clipboardHistoryModal.mode === "editor"
+
+                property var entry: null
+                property string editorText: ""
+
+                function setEntry(newEntry) {
+                    entry = newEntry;
+                    editorText = newEntry?.text ?? newEntry?.preview ?? "";
+                    if (editField) {
+                        editField.text = editorText;
+                    }
+                    Qt.callLater(function () {
+                        if (editField) {
+                            editField.forceActiveFocus();
+                        }
+                    });
+                }
+
+                Column {
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingM
+                    spacing: Theme.spacingM
+
+                    Item {
+                        width: parent.width
+                        height: ClipboardConstants.headerHeight
+
+                        DankActionButton {
+                            iconName: "arrow_back"
+                            iconSize: Theme.iconSize - 4
+                            iconColor: Theme.surfaceText
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            onClicked: clipboardHistoryModal.mode = "history"
+                        }
+
+                        StyledText {
+                            text: I18n.tr("Edit Clipboard")
+                            font.pixelSize: Theme.fontSizeLarge
+                            color: Theme.surfaceText
+                            font.weight: Font.Medium
+                            anchors.centerIn: parent
+                        }
+
+                        DankActionButton {
+                            iconName: "close"
+                            iconSize: Theme.iconSize - 4
+                            iconColor: Theme.surfaceText
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            onClicked: clipboardHistoryModal.mode = "history"
+                        }
+                    }
+
+                    StyledRect {
+                        id: editFieldContainer
+                        width: parent.width
+                        height: Math.max(Theme.fontSizeMedium * 8, Theme.fontSizeMedium * 3)
+                        radius: Theme.cornerRadius
+                        color: Theme.withAlpha(Theme.surfaceContainerHigh, Theme.popupTransparency)
+                        border.color: editField.activeFocus ? Theme.primary : Theme.outlineMedium
+                        border.width: editField.activeFocus ? 2 : 1
+                        clip: true
+
+                        DankIcon {
+                            id: editIcon
+                            name: "edit"
+                            size: Theme.iconSize
+                            color: editField.activeFocus ? Theme.primary : Theme.surfaceVariantText
+                            anchors.left: parent.left
+                            anchors.leftMargin: Theme.spacingM
+                            anchors.top: parent.top
+                            anchors.topMargin: Theme.spacingM
+                        }
+
+                        TextEdit {
+                            id: editField
+                            anchors.left: editIcon.right
+                            anchors.leftMargin: Theme.spacingS
+                            anchors.right: parent.right
+                            anchors.top: parent.top
+                            anchors.bottom: parent.bottom
+                            anchors.rightMargin: Theme.spacingM
+                            anchors.topMargin: Theme.spacingS
+                            anchors.bottomMargin: Theme.spacingS
+                            text: editorView.editorText
+                            font.pixelSize: Theme.fontSizeMedium
+                            color: Theme.surfaceText
+                            wrapMode: TextEdit.Wrap
+                            selectByMouse: true
+                            Keys.forwardTo: [clipboardHistoryModal.modalFocusScope]
+                            onTextChanged: editorView.editorText = text
+                            Keys.onEscapePressed: function (event) {
+                                clipboardHistoryModal.mode = "history";
+                                event.accepted = true;
+                            }
+                        }
+
+                        StyledText {
+                            text: I18n.tr("Edit clipboard text")
+                            font.pixelSize: Theme.fontSizeMedium
+                            color: Theme.outlineButton
+                            anchors.left: editField.left
+                            anchors.right: editField.right
+                            anchors.top: editField.top
+                            anchors.bottom: editField.bottom
+                            visible: editField.text.length === 0 && !editField.activeFocus
+                            wrapMode: Text.WordWrap
+                        }
+                    }
+
+                    Row {
+                        width: parent.width
+                        spacing: Theme.spacingS
+
+                        Item {
+                            id: buttonSpacer
+                            width: Math.max(0, parent.width - cancelButton.width - saveButton.width - Theme.spacingS)
+                            height: 1
+                        }
+
+                        DankButton {
+                            id: cancelButton
+                            text: I18n.tr("Cancel")
+                            backgroundColor: Theme.surfaceContainerHigh
+                            textColor: Theme.surfaceText
+                            onClicked: clipboardHistoryModal.mode = "history"
+                        }
+
+                        DankButton {
+                            id: saveButton
+                            text: I18n.tr("Save")
+                            backgroundColor: Theme.primary
+                            textColor: Theme.onPrimary
+                            onClicked: {
+                                DMSService.sendRequest("clipboard.copy", {
+                                    "text": editorView.editorText
+                                }, function (response) {
+                                    if (response.error) {
+                                        ToastService.showError(I18n.tr("Failed to update clipboard"));
+                                        return;
+                                    }
+                                    clipboardHistoryModal.mode = "history";
+                                    clipboardHistoryModal.refreshClipboard();
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+
+            states: [
+                State {
+                    name: "history"
+                    when: clipboardHistoryModal.mode === "history"
+                    PropertyChanges {
+                        target: historyView
+                        opacity: 1
+                        scale: 1
+                    }
+                    PropertyChanges {
+                        target: editorView
+                        opacity: 0
+                        scale: 0.98
+                    }
+                },
+                State {
+                    name: "editor"
+                    when: clipboardHistoryModal.mode === "editor"
+                    PropertyChanges {
+                        target: historyView
+                        opacity: 0
+                        scale: 0.98
+                    }
+                    PropertyChanges {
+                        target: editorView
+                        opacity: 1
+                        scale: 1
+                    }
+                }
+            ]
+
+            transitions: [
+                Transition {
+                    from: "history"
+                    to: "editor"
+                    ParallelAnimation {
+                        NumberAnimation {
+                            property: "opacity"
+                            duration: Theme.shortDuration
+                            easing.type: Theme.standardEasing
+                        }
+                        NumberAnimation {
+                            property: "scale"
+                            duration: Theme.shortDuration
+                            easing.type: Theme.emphasizedEasing
+                        }
+                    }
+                },
+                Transition {
+                    from: "editor"
+                    to: "history"
+                    ParallelAnimation {
+                        NumberAnimation {
+                            property: "opacity"
+                            duration: Theme.shortDuration
+                            easing.type: Theme.standardEasing
+                        }
+                        NumberAnimation {
+                            property: "scale"
+                            duration: Theme.shortDuration
+                            easing.type: Theme.emphasizedEasing
+                        }
+                    }
+                }
+            ]
         }
     }
 }

--- a/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
@@ -284,6 +284,47 @@ DankModal {
                             editField.forceActiveFocus();
                         }
                     });
+
+                    if (!newEntry || newEntry.isImage) {
+                        return;
+                    }
+
+                    const requestedId = newEntry.id;
+                    DMSService.sendRequest("clipboard.getEntry", {
+                        "id": requestedId
+                    }, function (response) {
+                        if (response.error) {
+                            return;
+                        }
+                        if (!editorView.entry || editorView.entry.id !== requestedId) {
+                            return;
+                        }
+                        const rawText = response.result?.text ?? response.result?.content ?? response.result?.data ?? "";
+                        let fullText = rawText;
+                        try {
+                            const sanitized = rawText.replace(/\s+/g, "");
+                            const decoder = (typeof Qt !== "undefined" && typeof Qt.atob === "function") ? Qt.atob : (typeof atob === "function" ? atob : null);
+                            if (decoder) {
+                                const decoded = decoder(sanitized);
+                                fullText = decoded;
+                                try {
+                                    fullText = decodeURIComponent(escape(decoded));
+                                } catch (e) {
+                                    fullText = decoded;
+                                }
+                            }
+                        } catch (e) {
+                            fullText = rawText;
+                        }
+
+                        if (!fullText || fullText.length === 0) {
+                            return;
+                        }
+                        editorView.editorText = fullText;
+                        if (editField) {
+                            editField.text = fullText;
+                        }
+                    });
                 }
 
                 function saveEntry(action) {
@@ -297,7 +338,11 @@ DankModal {
                         }
                         if (saveAction === "history") {
                             clipboardHistoryModal.mode = "history";
-                            clipboardHistoryModal.refreshClipboard();
+                            Qt.callLater(function () {
+                                ClipboardService.reset();
+                                ClipboardService.refresh();
+                                keyboardController.reset();
+                            });
                             return;
                         }
                         if (saveAction === "close") {
@@ -341,6 +386,7 @@ DankModal {
                     spacing: Theme.spacingM
 
                     Item {
+                        id: editorHeader
                         width: parent.width
                         height: ClipboardConstants.headerHeight
 
@@ -374,7 +420,7 @@ DankModal {
                     StyledRect {
                         id: editFieldContainer
                         width: parent.width
-                        height: Math.max(Theme.fontSizeMedium * 8, Theme.fontSizeMedium * 3)
+                        height: Math.max(Theme.fontSizeMedium * 8, parent.height - editorHeader.height - editorActions.height - Theme.spacingM * 2)
                         radius: Theme.cornerRadius
                         color: Theme.withAlpha(Theme.surfaceContainerHigh, Theme.popupTransparency)
                         border.color: editField.activeFocus ? Theme.primary : Theme.outlineMedium
@@ -392,8 +438,8 @@ DankModal {
                             anchors.topMargin: Theme.spacingM
                         }
 
-                        TextEdit {
-                            id: editField
+                        DankFlickable {
+                            id: editScroll
                             anchors.left: editIcon.right
                             anchors.leftMargin: Theme.spacingS
                             anchors.right: parent.right
@@ -402,26 +448,34 @@ DankModal {
                             anchors.rightMargin: Theme.spacingM
                             anchors.topMargin: Theme.spacingS
                             anchors.bottomMargin: Theme.spacingS
-                            text: editorView.editorText
-                            font.pixelSize: Theme.fontSizeMedium
-                            color: Theme.surfaceText
-                            wrapMode: TextEdit.Wrap
-                            selectByMouse: true
-                            Keys.forwardTo: [clipboardHistoryModal.modalFocusScope]
-                            onTextChanged: editorView.editorText = text
-                            Keys.onPressed: function (event) {
-                                const hasCtrl = (event.modifiers & Qt.ControlModifier) !== 0;
-                                const hasShift = (event.modifiers & Qt.ShiftModifier) !== 0;
+                            clip: true
+                            contentWidth: width
+                            contentHeight: editField.height
 
-                                if (hasCtrl && event.key === Qt.Key_S) {
-                                    editorView.saveEntry(hasShift ? "close" : "history");
-                                    event.accepted = true;
-                                    return;
-                                }
-                                if (hasCtrl && hasShift && event.key === Qt.Key_V) {
-                                    editorView.saveEntry("paste");
-                                    event.accepted = true;
-                                    return;
+                            TextEdit {
+                                id: editField
+                                width: editScroll.width
+                                height: Math.max(editScroll.height, contentHeight)
+                                text: editorView.editorText
+                                font.pixelSize: Theme.fontSizeMedium
+                                color: Theme.surfaceText
+                                wrapMode: TextEdit.Wrap
+                                selectByMouse: true
+                                onTextChanged: editorView.editorText = text
+                                Keys.onPressed: function (event) {
+                                    const hasCtrl = (event.modifiers & Qt.ControlModifier) !== 0;
+                                    const hasShift = (event.modifiers & Qt.ShiftModifier) !== 0;
+
+                                    if (hasCtrl && event.key === Qt.Key_S) {
+                                        editorView.saveEntry(hasShift ? "close" : "history");
+                                        event.accepted = true;
+                                        return;
+                                    }
+                                    if (hasCtrl && hasShift && event.key === Qt.Key_V) {
+                                        editorView.saveEntry("paste");
+                                        event.accepted = true;
+                                        return;
+                                    }
                                 }
                             }
                         }
@@ -430,16 +484,17 @@ DankModal {
                             text: I18n.tr("Edit clipboard text")
                             font.pixelSize: Theme.fontSizeMedium
                             color: Theme.outlineButton
-                            anchors.left: editField.left
-                            anchors.right: editField.right
-                            anchors.top: editField.top
-                            anchors.bottom: editField.bottom
+                            anchors.left: editScroll.left
+                            anchors.right: editScroll.right
+                            anchors.top: editScroll.top
+                            anchors.bottom: editScroll.bottom
                             visible: editField.text.length === 0 && !editField.activeFocus
                             wrapMode: Text.WordWrap
                         }
                     }
 
                     Row {
+                        id: editorActions
                         width: parent.width
                         spacing: Theme.spacingS
 

--- a/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtQuick.Controls
 import Quickshell.Hyprland
 import qs.Common
 import qs.Modals.Clipboard
@@ -46,6 +47,16 @@ DankModal {
     }
 
     property string mode: "history"
+    onModeChanged: {
+        if (mode !== "history") {
+            return;
+        }
+        Qt.callLater(function () {
+            if (contentLoader.item?.searchField) {
+                contentLoader.item.searchField.forceActiveFocus();
+            }
+        });
+    }
 
     function updateFilteredModel() {
         ClipboardService.updateFilteredModel();
@@ -239,6 +250,55 @@ DankModal {
                     });
                 }
 
+                function saveEntry(action) {
+                    const saveAction = action ?? "history";
+                    DMSService.sendRequest("clipboard.copy", {
+                        "text": editorView.editorText
+                    }, function (response) {
+                        if (response.error) {
+                            ToastService.showError(I18n.tr("Failed to update clipboard"));
+                            return;
+                        }
+                        if (saveAction === "history") {
+                            clipboardHistoryModal.mode = "history";
+                            clipboardHistoryModal.refreshClipboard();
+                            return;
+                        }
+                        if (saveAction === "close") {
+                            clipboardHistoryModal.hide();
+                            return;
+                        }
+                        if (saveAction === "paste") {
+                            ClipboardService.pasteClipboard(clipboardHistoryModal.hide);
+                        }
+                    });
+                }
+
+                function toggleSaveMenu() {
+                    if (saveMenu.visible) {
+                        saveMenu.close();
+                        return;
+                    }
+                    saveMenu.open();
+                    const pos = saveButton.mapToItem(Overlay.overlay, 0, 0);
+                    const popupW = saveMenu.width;
+                    const popupH = saveMenu.height;
+                    const overlayW = Overlay.overlay.width;
+                    const overlayH = Overlay.overlay.height;
+
+                    let x = pos.x + (saveButton.width - popupW) / 2;
+                    let y = pos.y + saveButton.height + 4;
+                    if (y + popupH > overlayH) {
+                        y = pos.y - popupH - 4;
+                    }
+
+                    x = Math.max(8, Math.min(x, overlayW - popupW - 8));
+                    y = Math.max(8, y);
+
+                    saveMenu.x = x;
+                    saveMenu.y = y;
+                }
+
                 Column {
                     anchors.fill: parent
                     anchors.margins: Theme.spacingM
@@ -350,22 +410,207 @@ DankModal {
                             onClicked: clipboardHistoryModal.mode = "history"
                         }
 
-                        DankButton {
+                        Item {
                             id: saveButton
-                            text: I18n.tr("Save")
-                            backgroundColor: Theme.primary
-                            textColor: Theme.onPrimary
-                            onClicked: {
-                                DMSService.sendRequest("clipboard.copy", {
-                                    "text": editorView.editorText
-                                }, function (response) {
-                                    if (response.error) {
-                                        ToastService.showError(I18n.tr("Failed to update clipboard"));
-                                        return;
+                            property int arrowWidth: 32
+                            property int horizontalPadding: Theme.spacingL
+                            width: cancelButton.width
+                            height: 40
+
+                            Rectangle {
+                                anchors.fill: parent
+                                radius: Theme.cornerRadius
+                                color: Theme.primary
+                            }
+
+                            Item {
+                                id: saveMainArea
+                                anchors.left: parent.left
+                                anchors.right: saveArrowArea.left
+                                anchors.top: parent.top
+                                anchors.bottom: parent.bottom
+                            }
+
+                            StyledText {
+                                id: saveLabel
+                                text: I18n.tr("Save")
+                                font.pixelSize: Theme.fontSizeMedium
+                                font.weight: Font.Medium
+                                color: Theme.onPrimary
+                                anchors.centerIn: saveMainArea
+                            }
+
+                            Item {
+                                id: saveArrowArea
+                                width: saveButton.arrowWidth
+                                anchors.right: parent.right
+                                anchors.top: parent.top
+                                anchors.bottom: parent.bottom
+                            }
+
+                            Rectangle {
+                                width: 1
+                                height: parent.height - Theme.spacingM
+                                color: Theme.withAlpha(Theme.onPrimary, 0.2)
+                                anchors.right: saveArrowArea.left
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            DankIcon {
+                                name: saveMenu.visible ? "expand_less" : "expand_more"
+                                size: Theme.iconSizeSmall
+                                color: Theme.onPrimary
+                                anchors.centerIn: saveArrowArea
+                            }
+
+                            StateLayer {
+                                anchors.fill: saveMainArea
+                                stateColor: Theme.onPrimary
+                                onClicked: editorView.saveEntry("history")
+                            }
+
+                            StateLayer {
+                                anchors.fill: saveArrowArea
+                                stateColor: Theme.onPrimary
+                                onClicked: editorView.toggleSaveMenu()
+                            }
+                        }
+                    }
+
+                    Popup {
+                        id: saveMenu
+                        parent: Overlay.overlay
+                        width: 220
+                        padding: Theme.spacingM
+                        modal: false
+                        focus: true
+                        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+                        background: StyledRect {
+                            radius: Theme.cornerRadius
+                            color: Theme.surfaceContainer
+                            border.color: Theme.outlineMedium
+                            border.width: 1
+                        }
+
+                        contentItem: Column {
+                            id: saveMenuColumn
+                            spacing: Theme.spacingXS
+
+                            StyledRect {
+                                width: saveMenu.width - saveMenu.padding * 2
+                                height: 32
+                                radius: Theme.cornerRadius
+                                color: saveMenuSaveArea.containsMouse ? Theme.surfaceVariant : "transparent"
+
+                                Row {
+                                    anchors.fill: parent
+                                    anchors.leftMargin: Theme.spacingS
+                                    spacing: Theme.spacingS
+
+                                    DankIcon {
+                                        name: "save"
+                                        size: Theme.iconSizeSmall
+                                        color: Theme.surfaceText
+                                        anchors.verticalCenter: parent.verticalCenter
                                     }
-                                    clipboardHistoryModal.mode = "history";
-                                    clipboardHistoryModal.refreshClipboard();
-                                });
+
+                                    StyledText {
+                                        text: I18n.tr("Save")
+                                        font.pixelSize: Theme.fontSizeMedium
+                                        color: Theme.surfaceText
+                                        anchors.verticalCenter: parent.verticalCenter
+                                    }
+                                }
+
+                                MouseArea {
+                                    id: saveMenuSaveArea
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: {
+                                        saveMenu.close();
+                                        editorView.saveEntry("history");
+                                    }
+                                }
+                            }
+
+                            StyledRect {
+                                width: saveMenu.width - saveMenu.padding * 2
+                                height: 32
+                                radius: Theme.cornerRadius
+                                color: saveMenuCloseArea.containsMouse ? Theme.surfaceVariant : "transparent"
+
+                                Row {
+                                    anchors.fill: parent
+                                    anchors.leftMargin: Theme.spacingS
+                                    spacing: Theme.spacingS
+
+                                    DankIcon {
+                                        name: "close"
+                                        size: Theme.iconSizeSmall
+                                        color: Theme.surfaceText
+                                        anchors.verticalCenter: parent.verticalCenter
+                                    }
+
+                                    StyledText {
+                                        text: I18n.tr("Save and close")
+                                        font.pixelSize: Theme.fontSizeMedium
+                                        color: Theme.surfaceText
+                                        anchors.verticalCenter: parent.verticalCenter
+                                    }
+                                }
+
+                                MouseArea {
+                                    id: saveMenuCloseArea
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: {
+                                        saveMenu.close();
+                                        editorView.saveEntry("close");
+                                    }
+                                }
+                            }
+
+                            StyledRect {
+                                width: saveMenu.width - saveMenu.padding * 2
+                                height: 32
+                                radius: Theme.cornerRadius
+                                color: saveMenuPasteArea.containsMouse ? Theme.surfaceVariant : "transparent"
+                                opacity: clipboardHistoryModal.wtypeAvailable ? 1 : 0.5
+
+                                Row {
+                                    anchors.fill: parent
+                                    anchors.leftMargin: Theme.spacingS
+                                    spacing: Theme.spacingS
+
+                                    DankIcon {
+                                        name: "content_paste"
+                                        size: Theme.iconSizeSmall
+                                        color: Theme.surfaceText
+                                        anchors.verticalCenter: parent.verticalCenter
+                                    }
+
+                                    StyledText {
+                                        text: I18n.tr("Save and paste")
+                                        font.pixelSize: Theme.fontSizeMedium
+                                        color: Theme.surfaceText
+                                        anchors.verticalCenter: parent.verticalCenter
+                                    }
+                                }
+
+                                MouseArea {
+                                    id: saveMenuPasteArea
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    enabled: clipboardHistoryModal.wtypeAvailable
+                                    cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                                    onClicked: {
+                                        saveMenu.close();
+                                        editorView.saveEntry("paste");
+                                    }
+                                }
                             }
                         }
                     }

--- a/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
@@ -164,8 +164,37 @@ DankModal {
     borderColor: Theme.outlineMedium
     borderWidth: 1
     enableShadow: true
+    closeOnEscapeKey: mode !== "editor"
     onBackgroundClicked: hide()
     modalFocusScope.Keys.onPressed: function (event) {
+        if (mode === "history" && (event.modifiers & Qt.ControlModifier) && (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab)) {
+            activeTab = activeTab === "recents" ? "saved" : "recents";
+            event.accepted = true;
+            return;
+        }
+        if (mode === "history" && (event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_S) {
+            const entries = activeTab === "saved" ? pinnedEntries : unpinnedEntries;
+            if (entries && entries.length > 0) {
+                const index = ClipboardService.selectedIndex >= 0 && ClipboardService.selectedIndex < entries.length ? ClipboardService.selectedIndex : 0;
+                const entry = entries[index];
+                if (activeTab === "saved") {
+                    unpinEntry(entry);
+                } else {
+                    pinEntry(entry);
+                }
+            }
+            event.accepted = true;
+            return;
+        }
+        if (mode === "history" && (event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_E) {
+            const entries = activeTab === "saved" ? pinnedEntries : unpinnedEntries;
+            if (entries && entries.length > 0) {
+                const index = ClipboardService.selectedIndex >= 0 && ClipboardService.selectedIndex < entries.length ? ClipboardService.selectedIndex : 0;
+                editEntry(entries[index]);
+            }
+            event.accepted = true;
+            return;
+        }
         keyboardController.handleKey(event);
     }
     content: clipboardContent
@@ -233,6 +262,13 @@ DankModal {
                 scale: 0.98
                 visible: opacity > 0.01
                 enabled: clipboardHistoryModal.mode === "editor"
+                focus: clipboardHistoryModal.mode === "editor"
+
+                Shortcut {
+                    sequences: ["Escape"]
+                    enabled: clipboardHistoryModal.mode === "editor"
+                    onActivated: clipboardHistoryModal.mode = "history"
+                }
 
                 property var entry: null
                 property string editorText: ""
@@ -373,9 +409,20 @@ DankModal {
                             selectByMouse: true
                             Keys.forwardTo: [clipboardHistoryModal.modalFocusScope]
                             onTextChanged: editorView.editorText = text
-                            Keys.onEscapePressed: function (event) {
-                                clipboardHistoryModal.mode = "history";
-                                event.accepted = true;
+                            Keys.onPressed: function (event) {
+                                const hasCtrl = (event.modifiers & Qt.ControlModifier) !== 0;
+                                const hasShift = (event.modifiers & Qt.ShiftModifier) !== 0;
+
+                                if (hasCtrl && event.key === Qt.Key_S) {
+                                    editorView.saveEntry(hasShift ? "close" : "history");
+                                    event.accepted = true;
+                                    return;
+                                }
+                                if (hasCtrl && hasShift && event.key === Qt.Key_V) {
+                                    editorView.saveEntry("paste");
+                                    event.accepted = true;
+                                    return;
+                                }
                             }
                         }
 

--- a/quickshell/Modals/Clipboard/ClipboardKeyboardController.qml
+++ b/quickshell/Modals/Clipboard/ClipboardKeyboardController.qml
@@ -56,7 +56,9 @@ QtObject {
     function handleKey(event) {
         switch (event.key) {
         case Qt.Key_Escape:
-            if (ClipboardService.keyboardNavigationActive) {
+            if (modal.mode === "editor") {
+                modal.mode = "history";
+            } else if (ClipboardService.keyboardNavigationActive) {
                 ClipboardService.keyboardNavigationActive = false;
             } else {
                 modal.hide();

--- a/quickshell/Modals/Clipboard/ClipboardKeyboardHints.qml
+++ b/quickshell/Modals/Clipboard/ClipboardKeyboardHints.qml
@@ -10,7 +10,7 @@ Rectangle {
     readonly property string hintsText: {
         if (!wtypeAvailable)
             return I18n.tr("Shift+Del: Clear All • Esc: Close");
-        return enterToPaste ? I18n.tr("Shift+Enter: Copy • Shift+Del: Clear All • Esc: Close", "Keyboard hints when enter-to-paste is enabled") : I18n.tr("Shift+Enter: Paste • Shift+Del: Clear All • Esc: Close");
+        return enterToPaste ? I18n.tr("Ctrl+Tab: Switch Tabs • Shift+Enter: Copy • Shift+Del: Clear All • F10: Help • Esc: Close", "Keyboard hints when enter-to-paste is enabled") : I18n.tr("Ctrl+Tab: Switch Tabs • Shift+Enter: Paste • Shift+Del: Clear All • F10: Help • Esc: Close");
     }
 
     height: ClipboardConstants.keyboardHintsHeight
@@ -22,13 +22,17 @@ Rectangle {
     z: 100
 
     Column {
+        width: parent.width - Theme.spacingL * 2
         anchors.centerIn: parent
         spacing: 2
 
         StyledText {
-            text: keyboardHints.enterToPaste ? I18n.tr("↑/↓: Navigate • Enter: Paste • Del: Delete • F10: Help", "Keyboard hints when enter-to-paste is enabled") : "↑/↓: Navigate • Enter/Ctrl+C: Copy • Del: Delete • F10: Help"
+            text: keyboardHints.enterToPaste ? I18n.tr("↑/↓: Navigate • Enter: Paste • Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin", "Keyboard hints when enter-to-paste is enabled") : I18n.tr("↑/↓: Navigate • Enter/Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin")
             font.pixelSize: Theme.fontSizeSmall
             color: Theme.surfaceText
+            width: parent.width
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
             anchors.horizontalCenter: parent.horizontalCenter
         }
 
@@ -36,6 +40,9 @@ Rectangle {
             text: keyboardHints.hintsText
             font.pixelSize: Theme.fontSizeSmall
             color: Theme.surfaceText
+            width: parent.width
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
             anchors.horizontalCenter: parent.horizontalCenter
         }
     }

--- a/quickshell/Services/ClipboardService.qml
+++ b/quickshell/Services/ClipboardService.qml
@@ -113,6 +113,17 @@ Singleton {
         });
     }
 
+    function pasteClipboard(closeCallback) {
+        if (!wtypeAvailable) {
+            ToastService.showError(I18n.tr("wtype not available - install wtype for paste support"));
+            return;
+        }
+        if (closeCallback) {
+            closeCallback();
+        }
+        pasteTimer.start();
+    }
+
     function pasteEntry(entry, closeCallback) {
         if (!wtypeAvailable) {
             ToastService.showError(I18n.tr("wtype not available - install wtype for paste support"));


### PR DESCRIPTION
## Summary
Enhance the clipboard history modal with a basic text editor. It works both for short and long entries (with base64 decode), a split save menu with multiple save actions, new keyboard shortcuts and hints. Usefull when pasting the same thing multiple times with small edits (terminal commands, IM messages), or for sanitizing text before pasting into the terminal.

## Changes
- **Editor UX**
  - Add an editor view to the modal
  - Fetches full clipboard entry content (`clipboard.getEntry`) and decodes base64 via `Qt.atob`/`atob` (needed for long text)
  - Editor fills available modal space and is scrollable
  - `Esc` in editor reliably returns to history
- **Save actions**
  - Split Save button with dropdown:
    - Save
    - Save and close
    - Save and paste
- **Clipboard entry UI**
  - Fixed action button hit‑area overlap after adding the edit button.
- **Keyboard shortcuts**
  - History view:
    - `Ctrl+Tab` / `Ctrl+Shift+Tab`: switch Recents/Saved
    - `Ctrl+S`: pin/unpin selected entry
    - `Ctrl+E`: edit selected entry
  - Editor view:
    - `Ctrl+S`: save
    - `Ctrl+Shift+S`: save & close
    - `Ctrl+Shift+V`: save & paste
    - `Esc`: return to history
- **Keyboard hints**
  - Updated to include new shortcuts and wrap to prevent overflow.
- **Focus & refresh**
  - Restores search field focus when returning to history.
  - Refreshes history after saving to show updated entries immediately.

## Testing
- Open clipboard modal, edit entries (including long text).
- Verify full text loads in editor and scrolls.
- Verify all shortcuts in history/editor modes.
- Verify save dropdown actions (save, save & close, save & paste).
- Confirm search field regains focus when returning to history view.
- Confirm pin/unpin and tab switching shortcuts.

## Todo
- [ ] Start an external editor for images (gradia/satty)
- [ ] Add configuration options in DMS settings for default image editor and for default save action
- [ ] New clip button from creating items in clipboard from scratch (?)

## Screenshots / Videos
### Added "edit" button
<img width="1158" height="995" alt="image" src="https://github.com/user-attachments/assets/5e3d2bce-b598-497b-9719-21acc54ed05f" />

### Edit UI
<img width="1186" height="997" alt="image" src="https://github.com/user-attachments/assets/c9c7682d-ea08-4e58-88ce-197126333146" />

### Save button
<img width="562" height="422" alt="image" src="https://github.com/user-attachments/assets/88b03529-ab98-4eba-8a1b-4e52c085114b" />

### Keyboard hints
<img width="1153" height="182" alt="image" src="https://github.com/user-attachments/assets/d4bc4c74-ecdd-4013-af0d-fa00f478ace6" />

https://github.com/user-attachments/assets/5574f824-5ab7-49b8-b0bb-93878faedf6a



