### PR TITLE
fix(shell): cover edge cases of compact focused app widget

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/FocusedApp.qml
+++ b/quickshell/Modules/DankBar/Widgets/FocusedApp.qml
@@ -211,16 +211,17 @@ BasePill {
                     text: {
                         const title = activeWindow && activeWindow.title ? activeWindow.title : "";
                         const appName = appText.text;
+
+                        if (compactMode && title === appName) {
+                            return title;
+                        }
+
                         if (!title || !appName) {
                             return title;
                         }
 
-                        if (title.endsWith(" - " + appName)) {
-                            return title.substring(0, title.length - (" - " + appName).length);
-                        }
-
                         if (title.endsWith(appName)) {
-                            return title.substring(0, title.length - appName.length).replace(/ - $/, "");
+                            return title.substring(0, title.length - appName.length).replace(/ (-|—) $/, "");
                         }
 
                         return title;


### PR DESCRIPTION
Fixes two cases for compact mode (screenshots show BEFORE at the top and AFTER at the bottom)

- some apps (e.g., Zen browser) use the "—" character at the end of webpage name)
<img width="159" height="114" alt="image" src="https://github.com/user-attachments/assets/32cb4db2-4f5b-4df4-9eb4-21ae39387c7a" />


- when app has only appName, and not window name, we should display the appName to avoid empty title.
<img width="209" height="110" alt="image" src="https://github.com/user-attachments/assets/a9130bdf-8298-44f9-a650-4d83f9d669c5" />


- removes some unneeded code - the regex matching already covers the conditional that I removed.
