### PR TITLE
feature(notification): show notification only on current focused display

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -549,6 +549,7 @@ Singleton {
     property bool notificationHistorySaveNormal: true
     property bool notificationHistorySaveCritical: true
     property var notificationRules: []
+    property bool notificationFocusedMonitor: false
 
     property bool osdAlwaysShowValue: false
     property int osdPosition: SettingsData.Position.BottomCenter

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -363,6 +363,7 @@ var SPEC = {
     notificationHistorySaveNormal: { def: true },
     notificationHistorySaveCritical: { def: true },
     notificationRules: { def: [] },
+    notificationFocusedMonitor: { def: false },
 
     osdAlwaysShowValue: { def: false },
     osdPosition: { def: 5 },

--- a/quickshell/DMSShell.qml
+++ b/quickshell/DMSShell.qml
@@ -313,7 +313,7 @@ Item {
     }
 
     Variants {
-        model: SettingsData.getFilteredScreens("notifications")
+        model: SettingsData.notificationFocusedMonitor ? Quickshell.screens : SettingsData.getFilteredScreens("notifications")
 
         delegate: NotificationPopupManager {
             modelData: item

--- a/quickshell/Modules/Notifications/Popup/NotificationPopupManager.qml
+++ b/quickshell/Modules/Notifications/Popup/NotificationPopupManager.qml
@@ -108,6 +108,13 @@ QtObject {
         return p && p.status !== Component.Null && !p._isDestroying && p.hasValidData;
     }
 
+    function _isFocusedScreen() {
+        if (!SettingsData.notificationFocusedMonitor)
+            return true;
+        const focused = CompositorService.getFocusedScreen();
+        return focused && manager.modelData && focused.name === manager.modelData.name;
+    }
+
     function _sync(newWrappers) {
         for (const p of popupWindows.slice()) {
             if (!_isValidWindow(p) || p.exiting)
@@ -118,7 +125,7 @@ QtObject {
             }
         }
         for (const w of newWrappers) {
-            if (w && !_hasWindowFor(w))
+            if (w && !_hasWindowFor(w) && _isFocusedScreen())
                 _insertAtTop(w);
         }
     }

--- a/quickshell/Modules/Settings/DisplayWidgetsTab.qml
+++ b/quickshell/Modules/Settings/DisplayWidgetsTab.qml
@@ -419,6 +419,15 @@ Item {
 
                                     DankToggle {
                                         width: parent.width
+                                        text: I18n.tr("Focused monitor only")
+                                        description: I18n.tr("Show notifications only on the currently focused monitor")
+                                        visible: parent.componentId === "notifications"
+                                        checked: SettingsData.notificationFocusedMonitor
+                                        onToggled: checked => SettingsData.set("notificationFocusedMonitor", checked)
+                                    }
+
+                                    DankToggle {
+                                        width: parent.width
                                         text: I18n.tr("Show on Last Display")
                                         description: I18n.tr("Always show when there's only one connected display")
                                         checked: root.getShowOnLastDisplay(parent.componentId)

--- a/quickshell/Modules/Settings/NotificationsTab.qml
+++ b/quickshell/Modules/Settings/NotificationsTab.qml
@@ -288,6 +288,15 @@ Item {
                     onToggled: checked => SettingsData.set("notificationPopupPrivacyMode", checked)
                 }
 
+                SettingsToggleRow {
+                    settingKey: "notificationFocusedMonitor"
+                    tags: ["notification", "popup", "focused", "monitor", "display", "screen", "active"]
+                    text: I18n.tr("Focused Monitor Only")
+                    description: I18n.tr("Show notification popups only on the currently focused monitor")
+                    checked: SettingsData.notificationFocusedMonitor
+                    onToggled: checked => SettingsData.set("notificationFocusedMonitor", checked)
+                }
+
                 Item {
                     width: parent.width
                     height: notificationAnimationColumn.implicitHeight + Theme.spacingM * 2


### PR DESCRIPTION
This enables showing the notification only on the current focused display instead of either a static one or all displays.