### PR TITLE
feat: highlight active workspace app tiles

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -280,6 +280,7 @@ Singleton {
     property bool showOccupiedWorkspacesOnly: false
     property bool reverseScrolling: false
     property bool dwlShowAllTags: false
+    property bool workspaceActiveAppHighlightEnabled: false
     property string workspaceColorMode: "default"
     property string workspaceOccupiedColorMode: "none"
     property string workspaceUnfocusedColorMode: "default"

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -123,6 +123,7 @@ var SPEC = {
     showOccupiedWorkspacesOnly: { def: false },
     reverseScrolling: { def: false },
     dwlShowAllTags: { def: false },
+    workspaceActiveAppHighlightEnabled: { def: false },
     workspaceColorMode: { def: "default" },
     workspaceOccupiedColorMode: { def: "none" },
     workspaceUnfocusedColorMode: { def: "default" },

--- a/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
+++ b/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
@@ -1470,8 +1470,9 @@ Item {
                                         delegate: Item {
                                             width: root.appIconSize
                                             height: root.appIconSize
-                                            readonly property color appBorderColor: modelData.active ? focusedBorderColor : Theme.primarySelected
-                                            readonly property color appGlyphColor: modelData.active ? focusedBorderColor : Theme.primary
+                                            readonly property bool appHighlightActive: SettingsData.workspaceActiveAppHighlightEnabled && modelData.active
+                                            readonly property color appBorderColor: appHighlightActive ? focusedBorderColor : Theme.primarySelected
+                                            readonly property color appGlyphColor: appHighlightActive ? focusedBorderColor : Theme.primary
                                             readonly property real appOpacity: (modelData.active || isActive) ? 1.0 : rowAppMouseArea.containsMouse ? 0.8 : 0.6
 
                                             IconImage {
@@ -1526,7 +1527,7 @@ Item {
                                                 layer.effect: MultiEffect {
                                                     saturation: 0
                                                     colorization: 1
-                                                    colorizationColor: modelData.active ? focusedBorderColor : (isActive ? quickshellIconActiveColor : quickshellIconInactiveColor)
+                                                    colorizationColor: appHighlightActive ? focusedBorderColor : (isActive ? quickshellIconActiveColor : quickshellIconInactiveColor)
                                                 }
                                             }
 
@@ -1542,14 +1543,14 @@ Item {
                                                 anchors.centerIn: parent
                                                 size: root.appIconSize
                                                 name: "sports_esports"
-                                                color: modelData.active ? focusedBorderColor : Theme.widgetTextColor
+                                                color: appHighlightActive ? focusedBorderColor : Theme.widgetTextColor
                                                 opacity: modelData.active ? 1.0 : rowAppMouseArea.containsMouse ? 0.8 : 0.6
                                                 visible: modelData.isSteamApp && !modelData.icon
                                             }
 
                                             Rectangle {
                                                 anchors.fill: parent
-                                                visible: (rowAppIcon.visible || rowSteamIcon.visible || modelData.isQuickshell) && modelData.active
+                                                visible: (rowAppIcon.visible || rowSteamIcon.visible || modelData.isQuickshell) && appHighlightActive
                                                 color: "transparent"
                                                 radius: Theme.cornerRadius * (root.appIconSize / 40)
                                                 border.width: 1
@@ -1638,8 +1639,9 @@ Item {
                                         delegate: Item {
                                             width: root.appIconSize
                                             height: root.appIconSize
-                                            readonly property color appBorderColor: modelData.active ? focusedBorderColor : Theme.primarySelected
-                                            readonly property color appGlyphColor: modelData.active ? focusedBorderColor : Theme.primary
+                                            readonly property bool appHighlightActive: SettingsData.workspaceActiveAppHighlightEnabled && modelData.active
+                                            readonly property color appBorderColor: appHighlightActive ? focusedBorderColor : Theme.primarySelected
+                                            readonly property color appGlyphColor: appHighlightActive ? focusedBorderColor : Theme.primary
                                             readonly property real appOpacity: (modelData.active || isActive) ? 1.0 : colAppMouseArea.containsMouse ? 0.8 : 0.6
 
                                             IconImage {
@@ -1694,7 +1696,7 @@ Item {
                                                 layer.effect: MultiEffect {
                                                     saturation: 0
                                                     colorization: 1
-                                                    colorizationColor: modelData.active ? focusedBorderColor : (isActive ? quickshellIconActiveColor : quickshellIconInactiveColor)
+                                                    colorizationColor: appHighlightActive ? focusedBorderColor : (isActive ? quickshellIconActiveColor : quickshellIconInactiveColor)
                                                 }
                                             }
 
@@ -1710,14 +1712,14 @@ Item {
                                                 anchors.centerIn: parent
                                                 size: root.appIconSize
                                                 name: "sports_esports"
-                                                color: modelData.active ? focusedBorderColor : Theme.widgetTextColor
+                                                color: appHighlightActive ? focusedBorderColor : Theme.widgetTextColor
                                                 opacity: modelData.active ? 1.0 : colAppMouseArea.containsMouse ? 0.8 : 0.6
                                                 visible: modelData.isSteamApp && !modelData.icon
                                             }
 
                                             Rectangle {
                                                 anchors.fill: parent
-                                                visible: (colAppIcon.visible || colSteamIcon.visible || modelData.isQuickshell) && modelData.active
+                                                visible: (colAppIcon.visible || colSteamIcon.visible || modelData.isQuickshell) && appHighlightActive
                                                 color: "transparent"
                                                 radius: Theme.cornerRadius * (root.appIconSize / 40)
                                                 border.width: 1

--- a/quickshell/Modules/Settings/WorkspacesTab.qml
+++ b/quickshell/Modules/Settings/WorkspacesTab.qml
@@ -126,6 +126,16 @@ Item {
                 }
 
                 SettingsToggleRow {
+                    settingKey: "workspaceActiveAppHighlightEnabled"
+                    tags: ["workspace", "apps", "icons", "highlight", "active", "focused"]
+                    text: I18n.tr("Highlight Active Workspace App")
+                    description: I18n.tr("Highlight the currently focused app inside workspace indicators")
+                    checked: SettingsData.workspaceActiveAppHighlightEnabled
+                    visible: SettingsData.showWorkspaceApps
+                    onToggled: checked => SettingsData.set("workspaceActiveAppHighlightEnabled", checked)
+                }
+
+                SettingsToggleRow {
                     settingKey: "workspaceFollowFocus"
                     tags: ["workspace", "focus", "follow", "monitor"]
                     text: I18n.tr("Follow Monitor Focus")


### PR DESCRIPTION
<img width="354" height="125" alt="image" src="https://github.com/user-attachments/assets/39eaaba3-eae3-410d-949f-ca7f790d2c96" />

<img width="354" height="125" alt="image" src="https://github.com/user-attachments/assets/d9ed9b04-d278-4da9-8a86-2cd61a4f7372" />


Adds outline for active column. I can make a follow-up to make it toggleable  from settings