### PR TITLE
fix(matugen): use single quotes for zed template paths

### DIFF
--- a/quickshell/matugen/configs/zed.toml
+++ b/quickshell/matugen/configs/zed.toml
@@ -1,3 +1,3 @@
 [templates.dmszed]
-input_path = "SHELL_DIR/matugen/templates/dank-zed.json"
-output_path = "CONFIG_DIR/zed/themes/dank-zed-theme.json"
+input_path = 'SHELL_DIR/matugen/templates/dank-zed.json'
+output_path = 'CONFIG_DIR/zed/themes/dank-zed-theme.json'


### PR DESCRIPTION
Fixes #1971 