### PR TITLE
Compositor Pause Hardening

### DIFF
--- a/core/internal/server/wlcontext/context.go
+++ b/core/internal/server/wlcontext/context.go
@@ -2,10 +2,10 @@ package wlcontext
 
 import (
 	"fmt"
+	"golang.org/x/sys/unix"
 	"os"
 	"sync"
-
-	"golang.org/x/sys/unix"
+	"time"
 
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/errdefs"
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/log"
@@ -123,6 +123,9 @@ func (sc *SharedContext) eventDispatcher() {
 		{Fd: int32(sc.wakeR), Events: unix.POLLIN},
 	}
 
+	consecutiveErrors := 0
+	const maxConsecutiveErrors = 20
+
 	for {
 		sc.drainCmdQueue()
 
@@ -153,9 +156,19 @@ func (sc *SharedContext) eventDispatcher() {
 		}
 
 		if err := ctx.Dispatch(); err != nil && !os.IsTimeout(err) {
-			log.Errorf("Wayland connection error: %v", err)
-			return
+			consecutiveErrors++
+			log.Warnf("Wayland connection error (%d/%d): %v", consecutiveErrors, maxConsecutiveErrors, err)
+
+			if consecutiveErrors >= maxConsecutiveErrors {
+				log.Errorf("Fatal: Wayland connection unrecoverable after %d attempts. Exiting dispatcher.", maxConsecutiveErrors)
+				return
+			}
+
+			time.Sleep(100 * time.Millisecond * time.Duration(consecutiveErrors))
+			continue
 		}
+
+		consecutiveErrors = 0
 	}
 }
 


### PR DESCRIPTION
Description:
This PR is to work on #1955 and introduces a retry and backoff mechanism to the main Wayland eventDispatcher in wlcontext.go to prevent the shell from permanently freezing during compositor hardware resets or DPMS power-state transitions.

The Problem:
Currently, if ctx.Dispatch() encounters an error that isn't a standard timeout, the dispatcher logs the error and immediately hits return. This permanently kills the shell's event loop. We discovered that certain hardware configurations (specifically AMD GPUs running the amdgpu driver) emit spurious udev change events when shifting idle power states. Strict compositors (like Niri) react to these events by defensively pausing the entire Wayland session. When the session pauses, the socket becomes unresponsive, ctx.Dispatch() throws an error, and DMS exits the loop—causing a permanent UI freeze even after the compositor resumes.

The Solution:

    Added a consecutiveErrors counter to track consecutive dispatch failures.

    Implemented a progressive time.Sleep backoff to prevent CPU spin-looping while the compositor is unresponsive.

    The shell will now patiently wait out temporary compositor pauses (up to a reasonable threshold) and immediately resume normal operations once ctx.Dispatch() succeeds again.

    If the compositor is genuinely dead (hits maxConsecutiveErrors), the shell will exit gracefully as it did before.