### PR TITLE
fix(wallpaper): preserve per-monitor cycling when changing interval

### DIFF
--- a/quickshell/Common/SessionData.qml
+++ b/quickshell/Common/SessionData.qml
@@ -580,14 +580,7 @@ Singleton {
             }
         }
 
-        if (!newSettings[identifier]) {
-            newSettings[identifier] = {
-                "enabled": false,
-                "mode": "interval",
-                "interval": 300,
-                "time": "06:00"
-            };
-        }
+        newSettings[identifier] = getMonitorCyclingSettings(screenName);
         newSettings[identifier].enabled = enabled;
         monitorCyclingSettings = newSettings;
         saveSettings();
@@ -618,14 +611,7 @@ Singleton {
             }
         }
 
-        if (!newSettings[identifier]) {
-            newSettings[identifier] = {
-                "enabled": false,
-                "mode": "interval",
-                "interval": 300,
-                "time": "06:00"
-            };
-        }
+        newSettings[identifier] = getMonitorCyclingSettings(screenName);
         newSettings[identifier].mode = mode;
         monitorCyclingSettings = newSettings;
         saveSettings();
@@ -656,14 +642,7 @@ Singleton {
             }
         }
 
-        if (!newSettings[identifier]) {
-            newSettings[identifier] = {
-                "enabled": false,
-                "mode": "interval",
-                "interval": 300,
-                "time": "06:00"
-            };
-        }
+        newSettings[identifier] = getMonitorCyclingSettings(screenName);
         newSettings[identifier].interval = interval;
         monitorCyclingSettings = newSettings;
         saveSettings();
@@ -694,14 +673,7 @@ Singleton {
             }
         }
 
-        if (!newSettings[identifier]) {
-            newSettings[identifier] = {
-                "enabled": false,
-                "mode": "interval",
-                "interval": 300,
-                "time": "06:00"
-            };
-        }
+        newSettings[identifier] = getMonitorCyclingSettings(screenName);
         newSettings[identifier].time = time;
         monitorCyclingSettings = newSettings;
         saveSettings();
@@ -1218,7 +1190,7 @@ Singleton {
             "time": "06:00"
         };
         var value = _findMonitorValue(monitorCyclingSettings, screenName);
-        return value !== undefined ? value : defaults;
+        return Object.assign({}, defaults, value !== undefined ? value : {});
     }
 
     FileView {


### PR DESCRIPTION
## Summary

This fixes a bug where changing the automatic wallpaper cycling interval for a specific monitor would disable cycling instead of updating the interval.

The root cause was in `SessionData`: per-monitor cycling updates rebuilt the selected monitor's settings entry from defaults, which reset `enabled` to `false`.

## Changes

- preserve the existing per-monitor cycling settings when updating:
  - interval
  - mode
  - time
  - enabled
- normalize `getMonitorCyclingSettings()` to return a merged copy of defaults plus stored values

## Result

Changing a monitor's wallpaper cycling interval now updates the setting without turning cycling off.

Fixes #1816

## Verification

Manual:
- enabled per-monitor wallpapers
- enabled automatic cycling for one monitor
- changed the cycling interval
- confirmed cycling stayed enabled and the interval remained selected
- confirmed the updated value persisted in `session.json`

## Notes

`make lint-qml` ran with no errors.

(#1816)