### PR TITLE
fix(matugen): detect Zed Linux binary aliases

### DIFF
--- a/core/internal/matugen/matugen.go
+++ b/core/internal/matugen/matugen.go
@@ -71,7 +71,7 @@ var templateRegistry = []TemplateDef{
 	{ID: "kcolorscheme", ConfigFile: "kcolorscheme.toml", RunUnconditionally: true},
 	{ID: "vscode", Kind: TemplateKindVSCode},
 	{ID: "emacs", Commands: []string{"emacs"}, ConfigFile: "emacs.toml", Kind: TemplateKindEmacs},
-	{ID: "zed", Commands: []string{"zed"}, ConfigFile: "zed.toml"},
+	{ID: "zed", Commands: []string{"zed", "zeditor", "zedit"}, ConfigFile: "zed.toml"},
 }
 
 func (c *ColorMode) GTKTheme() string {


### PR DESCRIPTION
## Summary

The matugen Zed template currently checks only for `zed` in `PATH`.

On some Linux distributions and community-maintained packages, including NixOS setups, Zed may be installed as `zeditor` or `zedit` instead. The [Zed Linux docs](https://zed.dev/docs/linux) call this out explicitly.

This PR expands Zed detection so the template is enabled when any documented Linux binary name is present.

## Changes

- add `zeditor` and `zedit` to the Zed template command detection list

## Why

Without this change, users can have Zed installed and working normally, but the matugen Zed template is still treated as unavailable because only `zed` is probed.

That causes the Zed theme integration to be skipped unnecessarily on distros/packages that ship one of the alternate executable names.
