### PR TITLE
fix(nix/greeter): skip invalid customThemeFile in preStart

### DIFF
--- a/distro/nix/greeter.nix
+++ b/distro/nix/greeter.nix
@@ -196,7 +196,7 @@ in
 
       if [ -f settings.json ]; then
           theme_file="$(${jq} -r '.customThemeFile // empty' settings.json)"
-          if [ -r "$theme_file" ]; then
+          if [ -f "$theme_file" ] && [ -r "$theme_file" ]; then
               cp "$theme_file" custom-theme.json
               mv settings.json settings.orig.json
               ${jq} '.customThemeFile = "${cacheDir}/custom-theme.json"' settings.orig.json > settings.json


### PR DESCRIPTION
Avoid attempting to copy a null/empty/missing customThemeFile path by validating the jq result and file existence before cp.

The default implementation of wrap systemd script in Nix is "set -e", so the code is interrupted here.