### PR TITLE
Change Greetd logic to pull accent color

### DIFF
--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -1248,7 +1248,11 @@ Singleton {
             if (themeData.variants.type === "multi" && themeData.variants.flavors && themeData.variants.accents) {
                 const defaults = themeData.variants.defaults || {};
                 const modeDefaults = defaults[colorMode] || defaults.dark || {};
-                const stored = typeof SettingsData !== "undefined" ? SettingsData.getRegistryThemeMultiVariant(themeId, modeDefaults, colorMode) : modeDefaults;
+                const isGreeterMode = typeof SessionData !== "undefined" && SessionData.isGreeterMode;
+		const stored = isGreeterMode ?
+		      (GreetdSettings.registryThemeVariants[themeId]?.[colorMode] || modeDefaults) :
+		      (typeof SettingsData !== "undefined" ?
+		       SettingsData.getRegistryThemeMultiVariant(themeId, modeDefaults, colorMode) : modeDefaults);
                 var flavorId = stored.flavor || modeDefaults.flavor || "";
                 const accentId = stored.accent || modeDefaults.accent || "";
                 var flavor = findVariant(themeData.variants.flavors, flavorId);

--- a/quickshell/Modules/Greetd/GreetdSettings.qml
+++ b/quickshell/Modules/Greetd/GreetdSettings.qml
@@ -24,6 +24,7 @@ Singleton {
     property string currentThemeName: "purple"
     property bool settingsLoaded: false
     property string customThemeFile: ""
+    property var registryThemeVariants: ({})
     property string matugenScheme: "scheme-tonal-spot"
     property bool use24HourClock: true
     property bool showSeconds: false
@@ -80,6 +81,8 @@ Singleton {
 
             currentThemeName = settings.currentThemeName !== undefined ? settings.currentThemeName : "purple";
             customThemeFile = settings.customThemeFile !== undefined ? settings.customThemeFile : "";
+	    registryThemeVariants = settings.registryThemeVariants !== undefined ?
+		settings.registryThemeVariants : ({});
             matugenScheme = settings.matugenScheme !== undefined ? settings.matugenScheme : "scheme-tonal-spot";
             use24HourClock = settings.use24HourClock !== undefined ? settings.use24HourClock : true;
             showSeconds = settings.showSeconds !== undefined ? settings.showSeconds : false;


### PR DESCRIPTION
Greeter wasn't using the accent color from the users set theme. For Issue #1992 

Root cause: Theme.loadCustomTheme was calling 
SettingsData.getRegistryThemeMultiVariant in all contexts including 
greeter mode. In greeter mode SettingsData does not have the user's 
registryThemeVariants populated, so it always fell back to 
modeDefaults.accent from the theme file. GreetdSettings was also 
not reading registryThemeVariants from the synced settings file.

Files Changes:
- GreetdSettings.qml: add registryThemeVariants property and read it 
  in parseSettings
- Theme.qml: loadCustomTheme now uses GreetdSettings.registryThemeVariants 
  in greeter mode instead of SettingsData

Confirmed dms greeter sync already copies the full settings.json 
(commands_greeter.go:1507) so registryThemeVariants is available 
in the greeter cache after sync — no Go changes needed.

Note: Unable to test end-to-end as I don't run greetd. Tested logic 
by code path analysis. Needs verification from someone running greetd 
with a multi-variant theme and non-default accent.