### PR TITLE
Feature/better keybinds

### DIFF
--- a/quickshell/Modals/DankLauncherV2/ActionPanel.qml
+++ b/quickshell/Modals/DankLauncherV2/ActionPanel.qml
@@ -207,9 +207,12 @@ Rectangle {
         selectedActionIndex = 0;
     }
 
-    function cycleAction() {
+    function cycleAction(reverse = false) {
         if (actions.length > 0) {
-            selectedActionIndex = (selectedActionIndex + 1) % actions.length;
+            if (! reverse)
+                selectedActionIndex = (selectedActionIndex + 1) % actions.length;
+            else
+                selectedActionIndex = (selectedActionIndex - 1) % actions.length;
             ensureSelectedVisible();
         }
     }

--- a/quickshell/Modals/DankLauncherV2/LauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/LauncherContent.qml
@@ -200,13 +200,19 @@ FocusScope {
             event.accepted = false;
             return;
         case Qt.Key_Tab:
-            if (actionPanel.hasActions) {
+            if (hasCtrl && actionPanel.hasActions) {
                 actionPanel.expanded ? actionPanel.cycleAction() : actionPanel.show();
+                return;
             }
+            controller.selectNext();
             return;
         case Qt.Key_Backtab:
-            if (actionPanel.expanded)
-                actionPanel.hide();
+            if (hasCtrl && actionPanel.expanded) {
+                const reverse = true
+                actionPanel.expanded ? actionPanel.cycleAction(reverse) : actionPanel.show();
+                return;
+            }
+            controller.selectPrevious();
             return;
         case Qt.Key_Return:
         case Qt.Key_Enter:
@@ -388,7 +394,7 @@ FocusScope {
 
                 StyledText {
                     anchors.verticalCenter: parent.verticalCenter
-                    text: "Tab " + I18n.tr("actions")
+                    text: "Ctrl-Tab " + I18n.tr("actions")
                     font.pixelSize: Theme.fontSizeSmall - 1
                     color: Theme.surfaceVariantText
                     visible: actionPanel.hasActions


### PR DESCRIPTION
With programs like rofi, pressing the tab key advances to the next item in the list. This change makes the Launcher behave in the same way, moving the action cycling to Ctrl+Tab (and Ctrl+Shift+Tab for reverse.