### PR TITLE
Implement ability to cycle through launcher modes

### DIFF
--- a/quickshell/Modals/DankLauncherV2/Controller.qml
+++ b/quickshell/Modals/DankLauncherV2/Controller.qml
@@ -353,10 +353,13 @@ Item {
         performSearch();
     }
 
-    function cycleMode() {
+    function cycleMode(reverse = false) {
         var modes = ["all", "apps", "files", "plugins"];
         var currentIndex = modes.indexOf(searchMode);
-        var nextIndex = (currentIndex + 1) % modes.length;
+        if (!reverse)
+            var nextIndex = (currentIndex + 1) % modes.length;
+        else
+            var nextIndex = (currentIndex - 1 + modes.length) % modes.length;
         setMode(modes[nextIndex]);
     }
 

--- a/quickshell/Modals/DankLauncherV2/LauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/LauncherContent.qml
@@ -158,6 +158,10 @@ FocusScope {
             controller.selectPageUp(8);
             return;
         case Qt.Key_Right:
+            if (hasCtrl) {
+                controller.cycleMode();
+                return;
+            }
             if (controller.getCurrentSectionViewMode() !== "list") {
                 controller.selectRight();
                 return;
@@ -165,8 +169,21 @@ FocusScope {
             event.accepted = false;
             return;
         case Qt.Key_Left:
+            if (hasCtrl) {
+                const reverse = true;
+                controller.cycleMode(reverse);
+                return;
+            }
             if (controller.getCurrentSectionViewMode() !== "list") {
                 controller.selectLeft();
+                return;
+            }
+            event.accepted = false;
+            return;
+        case Qt.Key_H:
+            if (hasCtrl) {
+                const reverse = true;
+                controller.cycleMode(reverse);
                 return;
             }
             event.accepted = false;
@@ -181,6 +198,13 @@ FocusScope {
         case Qt.Key_K:
             if (hasCtrl) {
                 controller.selectPrevious();
+                return;
+            }
+            event.accepted = false;
+            return;
+        case Qt.Key_L:
+            if (hasCtrl) {
+                controller.cycleMode();
                 return;
             }
             event.accepted = false;


### PR DESCRIPTION
Use Ctrl+Left/Right and Ctrl+H/L to move back and forward through the modes of the Launcher