### PR TITLE
fix: redraw wallpaper after DMS lock screen is dismissed

### DIFF
--- a/quickshell/Modules/Lock/Lock.qml
+++ b/quickshell/Modules/Lock/Lock.qml
@@ -14,6 +14,7 @@ Scope {
     property bool shouldLock: false
 
     onShouldLockChanged: {
+        IdleService.isShellLocked = shouldLock;
         if (shouldLock && lockPowerOffArmed) {
             lockStateCheck.restart();
         }

--- a/quickshell/Modules/WallpaperBackground.qml
+++ b/quickshell/Modules/WallpaperBackground.qml
@@ -151,6 +151,16 @@ Variants {
                 }
             }
 
+            Connections {
+                target: IdleService
+                function onIsShellLockedChanged() {
+                    if (!IdleService.isShellLocked) {
+                        root._renderSettling = true;
+                        renderSettleTimer.restart();
+                    }
+                }
+            }
+
             Timer {
                 id: renderSettleTimer
                 interval: 1000

--- a/quickshell/Services/IdleService.qml
+++ b/quickshell/Services/IdleService.qml
@@ -64,6 +64,7 @@ Singleton {
     property var suspendMonitor: null
     property var lockComponent: null
     property bool monitorsOff: false
+    property bool isShellLocked: false
 
     function wake() {
         requestMonitorOn();


### PR DESCRIPTION
After unlocking the screen (startup lock or wake from sleep), the desktop showed Hyprland's background color instead of the wallpaper.

WallpaperBackground disables QML updates via updatesEnabled after a 1-second settle timer. While WlSessionLock is active, Hyprland does not composite the background layer, so when the lock is released it needs a fresh Wayland buffer — but none is committed because the render loop is already paused.

The previous attempt used SessionService.sessionUnlocked, which is unreliable for the startup lock case: DMSService is not yet connected when lock() is called at startup, so notifyLoginctl is a no-op and the loginctl state never transitions, meaning sessionUnlocked never fires.

Fix by tracking the shell lock state directly from Lock.qml's shouldLock via a new IdleService.isShellLocked property. WallpaperBackground watches this and re-enables rendering for 1 second on unlock, ensuring a fresh buffer is committed to Wayland before the compositor resumes displaying the layer.