### PR TITLE
fix: multi-monitor wallpaper cycling not working

### DIFF
--- a/quickshell/Services/WallpaperCyclingService.qml
+++ b/quickshell/Services/WallpaperCyclingService.qml
@@ -194,10 +194,11 @@ Singleton {
                 var timer = monitorTimers[screenName];
                 if (!timer && monitorTimerComponent && monitorTimerComponent.status === Component.Ready) {
                     var newTimers = Object.assign({}, monitorTimers);
-                    newTimers[screenName] = monitorTimerComponent.createObject(root);
-                    newTimers[screenName].targetScreen = screenName;
+                    var newTimer = monitorTimerComponent.createObject(root);
+                    newTimer.targetScreen = screenName;
+                    newTimers[screenName] = newTimer;
                     monitorTimers = newTimers;
-                    timer = monitorTimers[screenName];
+                    timer = newTimer;
                 }
                 if (timer) {
                     timer.interval = settings.interval * 1000;
@@ -258,9 +259,10 @@ Singleton {
             var process = monitorProcesses[screenName];
             if (!process) {
                 var newProcesses = Object.assign({}, monitorProcesses);
-                newProcesses[screenName] = monitorProcessComponent.createObject(root);
+                var newProcess = monitorProcessComponent.createObject(root);
+                newProcesses[screenName] = newProcess;
                 monitorProcesses = newProcesses;
-                process = monitorProcesses[screenName];
+                process = newProcess;
             }
 
             if (process) {
@@ -290,9 +292,10 @@ Singleton {
             var process = monitorProcesses[screenName];
             if (!process) {
                 var newProcesses = Object.assign({}, monitorProcesses);
-                newProcesses[screenName] = monitorProcessComponent.createObject(root);
+                var newProcess = monitorProcessComponent.createObject(root);
+                newProcesses[screenName] = newProcess;
                 monitorProcesses = newProcesses;
-                process = monitorProcesses[screenName];
+                process = newProcess;
             }
 
             if (process) {


### PR DESCRIPTION
## Summary
- Fixed QML property binding timing issue in `WallpaperCyclingService.qml` where dynamically created timer and process objects were not being properly assigned when reading back from QML properties
- Changed to store created objects in local variables first before assigning to QML property maps, ensuring reliable references

## Root Cause
Multi-monitor wallpaper cycling used dynamically created objects stored in QML properties (`monitorTimers`, `monitorProcesses`). The code was:
1. Creating object with `createObject(root)`
2. Assigning to property map
3. Reading back from property to get reference

This caused issues because QML property assignments don't always evaluate synchronously, so reading back immediately could return `undefined` or stale values.

Single monitor worked fine because it uses statically declared QML objects accessed by ID (no property assignment path).

## Changes
- `startMonitorCycling()` - line 197: Fixed timer creation
- `cycleToNextWallpaper()` - line 261: Fixed process creation  
- `cycleToPrevWallpaper()` - line 294: Fixed process creation