### PR TITLE
fix(wallpaper): fix multi-monitor cycling not working

### DIFF
--- a/quickshell/Services/WallpaperCyclingService.qml
+++ b/quickshell/Services/WallpaperCyclingService.qml
@@ -194,10 +194,11 @@ Singleton {
                 var timer = monitorTimers[screenName];
                 if (!timer && monitorTimerComponent && monitorTimerComponent.status === Component.Ready) {
                     var newTimers = Object.assign({}, monitorTimers);
-                    newTimers[screenName] = monitorTimerComponent.createObject(root);
-                    newTimers[screenName].targetScreen = screenName;
+                    var newTimer = monitorTimerComponent.createObject(root);
+                    newTimer.targetScreen = screenName;
+                    newTimers[screenName] = newTimer;
                     monitorTimers = newTimers;
-                    timer = monitorTimers[screenName];
+                    timer = newTimer;
                 }
                 if (timer) {
                     timer.interval = settings.interval * 1000;
@@ -258,9 +259,10 @@ Singleton {
             var process = monitorProcesses[screenName];
             if (!process) {
                 var newProcesses = Object.assign({}, monitorProcesses);
-                newProcesses[screenName] = monitorProcessComponent.createObject(root);
+                var newProcess = monitorProcessComponent.createObject(root);
+                newProcesses[screenName] = newProcess;
                 monitorProcesses = newProcesses;
-                process = monitorProcesses[screenName];
+                process = newProcess;
             }
 
             if (process) {
@@ -290,9 +292,10 @@ Singleton {
             var process = monitorProcesses[screenName];
             if (!process) {
                 var newProcesses = Object.assign({}, monitorProcesses);
-                newProcesses[screenName] = monitorProcessComponent.createObject(root);
+                var newProcess = monitorProcessComponent.createObject(root);
+                newProcesses[screenName] = newProcess;
                 monitorProcesses = newProcesses;
-                process = monitorProcesses[screenName];
+                process = newProcess;
             }
 
             if (process) {


### PR DESCRIPTION
## Summary

Fix multi-monitor wallpaper cycling not working due to QML property binding timing issues when dynamically creating timer and process objects.

## Root Cause

Multi-monitor wallpaper cycling uses dynamically created QML objects (timers and processes) stored in QML property maps (`monitorTimers`, `monitorProcesses`). The original code:

1. Created object with `createObject(root)`
2. Assigned to property map
3. Read back from property to get reference

This caused issues because QML property assignments don't always evaluate synchronously. Reading back immediately could return `undefined` or stale values, causing timers and processes to never start.

Single monitor cycling worked fine because it uses statically declared QML objects accessed by ID (no property assignment path).

## Changes

- `WallpaperCyclingService.qml:startMonitorCycling()` - Fixed timer creation to use local variable reference
- `WallpaperCyclingService.qml:cycleToNextWallpaper()` - Fixed process creation to use local variable reference
- `WallpaperCyclingService.qml:cycleToPrevWallpaper()` - Fixed process creation to use local variable reference

## Verification

Manual testing on NixOS:
- Enabled per-monitor wallpapers
- Enabled automatic cycling for multiple monitors
- Confirmed wallpapers cycle independently on each monitor
- Confirmed cycling continues working after interval changes
- Confirmed settings persist correctly in `session.json`