### PR TITLE
feat(screenshot): add --no-confirm and --reset flags

### DIFF
--- a/core/cmd/dms/commands_screenshot.go
+++ b/core/cmd/dms/commands_screenshot.go
@@ -22,6 +22,8 @@ var (
 	ssNoClipboard bool
 	ssNoFile      bool
 	ssNoNotify    bool
+	ssNoConfirm   bool
+	ssReset       bool
 	ssStdout      bool
 )
 
@@ -50,8 +52,10 @@ Examples:
   dms screenshot output -o DP-1      # Specific output
   dms screenshot window              # Focused window (Hyprland)
   dms screenshot last                # Last region (pre-selected)
+  dms screenshot --reset             # Reset last region pre-selection
   dms screenshot --no-clipboard      # Save file only
   dms screenshot --no-file           # Clipboard only
+  dms screenshot --no-confirm        # Region capture on mouse release
   dms screenshot --cursor=on         # Include cursor
   dms screenshot -f jpg -q 85        # JPEG with quality 85`,
 }
@@ -119,6 +123,8 @@ func init() {
 	screenshotCmd.PersistentFlags().BoolVar(&ssNoClipboard, "no-clipboard", false, "Don't copy to clipboard")
 	screenshotCmd.PersistentFlags().BoolVar(&ssNoFile, "no-file", false, "Don't save to file")
 	screenshotCmd.PersistentFlags().BoolVar(&ssNoNotify, "no-notify", false, "Don't show notification")
+	screenshotCmd.PersistentFlags().BoolVar(&ssNoConfirm, "no-confirm", false, "Region mode: capture on mouse release without Enter/Space confirmation")
+	screenshotCmd.PersistentFlags().BoolVar(&ssReset, "reset", false, "Reset saved last-region preselection before capturing")
 	screenshotCmd.PersistentFlags().BoolVar(&ssStdout, "stdout", false, "Output image to stdout (for piping to swappy, etc.)")
 
 	screenshotCmd.AddCommand(ssRegionCmd)
@@ -142,6 +148,8 @@ func getScreenshotConfig(mode screenshot.Mode) screenshot.Config {
 	config.Clipboard = !ssNoClipboard
 	config.SaveFile = !ssNoFile
 	config.Notify = !ssNoNotify
+	config.NoConfirm = ssNoConfirm
+	config.Reset = ssReset
 	config.Stdout = ssStdout
 
 	if ssOutputDir != "" {

--- a/core/internal/screenshot/region.go
+++ b/core/internal/screenshot/region.go
@@ -113,7 +113,11 @@ func NewRegionSelector(s *Screenshoter) *RegionSelector {
 }
 
 func (r *RegionSelector) Run() (*CaptureResult, bool, error) {
-	r.preSelect = GetLastRegion()
+	if r.screenshoter != nil && r.screenshoter.config.Reset {
+		r.preSelect = Region{}
+	} else {
+		r.preSelect = GetLastRegion()
+	}
 
 	if err := r.connect(); err != nil {
 		return nil, false, fmt.Errorf("wayland connect: %w", err)

--- a/core/internal/screenshot/region_input.go
+++ b/core/internal/screenshot/region_input.go
@@ -114,6 +114,9 @@ func (r *RegionSelector) setupPointerHandlers() {
 				for _, os := range r.surfaces {
 					r.redrawSurface(os)
 				}
+				if r.screenshoter != nil && r.screenshoter.config.NoConfirm && r.selection.hasSelection {
+					r.finishSelection()
+				}
 			}
 		default:
 			r.cancelled = true

--- a/core/internal/screenshot/region_render.go
+++ b/core/internal/screenshot/region_render.go
@@ -138,9 +138,13 @@ func (r *RegionSelector) drawHUD(data []byte, stride, bufW, bufH int, format uin
 	if !r.showCapturedCursor {
 		cursorLabel = "show"
 	}
+	captureKey := "Space/Enter"
+	if r.screenshoter != nil && r.screenshoter.config.NoConfirm {
+		captureKey = "Drag+Release"
+	}
 
 	items := []struct{ key, desc string }{
-		{"Space/Enter", "capture"},
+		{captureKey, "capture"},
 		{"P", cursorLabel + " cursor"},
 		{"Esc", "cancel"},
 	}

--- a/core/internal/screenshot/screenshot.go
+++ b/core/internal/screenshot/screenshot.go
@@ -106,6 +106,12 @@ func (s *Screenshoter) captureLastRegion() (*CaptureResult, error) {
 }
 
 func (s *Screenshoter) captureRegion() (*CaptureResult, error) {
+	if s.config.Reset {
+		if err := SaveLastRegion(Region{}); err != nil {
+			log.Debug("failed to reset last region", "err", err)
+		}
+	}
+
 	selector := NewRegionSelector(s)
 	result, cancelled, err := selector.Run()
 	if err != nil {

--- a/core/internal/screenshot/types.go
+++ b/core/internal/screenshot/types.go
@@ -52,6 +52,8 @@ type Config struct {
 	Mode       Mode
 	OutputName string
 	Cursor     CursorMode
+	NoConfirm  bool
+	Reset      bool
 	Format     Format
 	Quality    int
 	OutputDir  string
@@ -66,6 +68,8 @@ func DefaultConfig() Config {
 	return Config{
 		Mode:      ModeRegion,
 		Cursor:    CursorOff,
+		NoConfirm: false,
+		Reset:     false,
 		Format:    FormatPNG,
 		Quality:   90,
 		OutputDir: "",


### PR DESCRIPTION
Adds two opt-in screenshot UX improvements for dms screenshot region mode:

  - --no-confirm: capture immediately on mouse release (no Enter/Space required)
  - --reset: clear the previously saved region so a new interactive capture starts without
    showing the last selection box

These should be default in my opinion, but whatever rocks your boat as long as the option exists :P
  
  