### PR TITLE
feat: animate dock apps on entry addition/deletion

### DIFF
--- a/quickshell/Modules/Dock/DockApps.qml
+++ b/quickshell/Modules/Dock/DockApps.qml
@@ -73,6 +73,20 @@ Item {
         id: appLayout
         width: layoutFlow.width
         height: layoutFlow.height
+
+        Behavior on width {
+            NumberAnimation {
+                duration: Theme.shortDuration
+                easing.type: Easing.OutCubic
+            }
+        }
+
+        Behavior on height {
+            NumberAnimation {
+                duration: Theme.shortDuration
+                easing.type: Easing.OutCubic
+            }
+        }
         anchors.horizontalCenter: root.isVertical ? undefined : parent.horizontalCenter
         anchors.verticalCenter: root.isVertical ? parent.verticalCenter : undefined
         anchors.left: root.isVertical && SettingsData.dockPosition === SettingsData.Position.Left ? parent.left : undefined


### PR DESCRIPTION
Current head only has [dock mouse area animated](https://github.com/AvengeMedia/DankMaterialShell/blob/e7ffa23016a7d0e32203f820bd271fe564243120/quickshell/Modules/Dock/Dock.qml#L473-L485) on width and height changes. The dock apps lack animation. This PR enables it.


https://github.com/user-attachments/assets/993dbdb8-3fef-4844-b2ed-2ae6ed12e075

