### PR TITLE
fix(Scorer): honour _preScored for no-query when value exceeds typeBonus

### DIFF
--- a/quickshell/Modals/DankLauncherV2/Scorer.js
+++ b/quickshell/Modals/DankLauncherV2/Scorer.js
@@ -152,7 +152,7 @@ function scoreItems(items, query, getFrecencyFn) {
         var item = items[i]
         var itemScore
 
-        if (query && item._preScored !== undefined) {
+        if (item._preScored !== undefined && (query || item._preScored > 900)) {
             itemScore = item._preScored
         } else {
             var frecencyData = getFrecencyFn ? getFrecencyFn(item) : null


### PR DESCRIPTION
## Summary

- `_preScored` was only respected by the Scorer when an active search query existed. In no-query (default) mode all plugin items fell back to `typeBonus + frecency` scoring (900 for plugins), making plugin-controlled ordering of the default list impossible.
- Change the condition to also honour `_preScored` in no-query mode **when the value exceeds 900** (the plugin typeBonus). Values ≤ 900 continue to use the existing formula, so items whose `_preScored` is set to `900 - j` by the controller in "all" mode are unaffected.

## Change

```js
// Before
if (query && item._preScored !== undefined) {

// After
if (item._preScored !== undefined && (query || item._preScored > 900)) {
```

## Motivation

This unblocks plugins that want to surface priority items (e.g. recently-used) at the top of their default no-query list. Without this fix a plugin can sort its `getItems("")` return value correctly but DMS will re-score everything equally and discard that ordering.

The specific use-case is the [dms-emoji-launcher](https://github.com/devnullvoid/dms-emoji-launcher) plugin surfacing recently-used emojis at the top of the `:e` trigger default list.

## Test plan

- [ ] Open launcher with no query — plugin items with `_preScored > 900` appear above other plugin items
- [ ] Open launcher and type a search query — existing scoring behaviour unchanged
- [ ] Verify "all" mode default list (apps, files) is unaffected (their `_preScored ≤ 900` or `undefined`)