### PR TITLE
fix(nix): patch U2F PAM config with full Nix store path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,9 @@
                   substituteInPlace $out/share/quickshell/dms/assets/pam/fprint \
                     --replace-fail pam_fprintd.so ${pkgs.fprintd}/lib/security/pam_fprintd.so
 
+                  substituteInPlace $out/share/quickshell/dms/assets/pam/u2f \
+                    --replace-fail pam_u2f.so ${pkgs.pam_u2f}/lib/security/pam_u2f.so
+
                   installShellCompletion --cmd dms \
                     --bash <($out/bin/dms completion bash) \
                     --fish <($out/bin/dms completion fish) \


### PR DESCRIPTION
## Summary
The Nix flake build patches `assets/pam/fprint` with the full Nix store path to `pam_fprintd.so`, but the same patch is missing for `assets/pam/u2f`. This causes `pam_u2f.so` to fail with "Module is unknown" on NixOS because PAM can't resolve the short module name.

This adds the matching `substituteInPlace` for the U2F PAM config.

Related: #1910,  #1911, #2050,
## Test plan
- [ ] NixOS user with a FIDO2/U2F security key: rebuild with this branch and test lock screen U2F

cc @HirschBerge or any other Nix user can any of you test and quickly confirm that this fixes everything? Point your flake input to `github:xPathin/DankMaterialShell/fix/nixos-u2f-pam-path` and update + rebuild?