### PR TITLE
feat: FileBrowser video thumbnail

### DIFF
--- a/quickshell/Common/Paths.qml
+++ b/quickshell/Common/Paths.qml
@@ -10,6 +10,7 @@ Singleton {
 
     readonly property url home: StandardPaths.standardLocations(StandardPaths.HomeLocation)[0]
     readonly property url pictures: StandardPaths.standardLocations(StandardPaths.PicturesLocation)[0]
+    readonly property url xdgCache: StandardPaths.standardLocations(StandardPaths.GenericCacheLocation)[0]
 
     readonly property url data: `${StandardPaths.standardLocations(StandardPaths.GenericDataLocation)[0]}/DankMaterialShell`
     readonly property url state: `${StandardPaths.standardLocations(StandardPaths.GenericStateLocation)[0]}/DankMaterialShell`

--- a/quickshell/Modals/FileBrowser/FileBrowserGridDelegate.qml
+++ b/quickshell/Modals/FileBrowser/FileBrowserGridDelegate.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Effects
-import Quickshell
 import qs.Common
 import qs.Widgets
 
@@ -86,7 +85,7 @@ StyledRect {
     property bool isImage: isImageFile(delegateRoot.fileName)
     property bool isVideo: isVideoFile(delegateRoot.fileName)
 
-    property string _xdgCacheHome: Quickshell.env("XDG_CACHE_HOME") || (Paths.strip(Paths.home) + "/.cache")
+    property string _xdgCacheHome: Paths.strip(Paths.xdgCache)
     property string _thumbnailSize: iconSizeIndex >= 2 ? "x-large" : "large"
     property int _thumbnailPx: iconSizeIndex >= 2 ? 512 : 256
     property string videoThumbnailPath: {

--- a/quickshell/Modals/FileBrowser/FileBrowserListDelegate.qml
+++ b/quickshell/Modals/FileBrowser/FileBrowserListDelegate.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Effects
-import Quickshell
 import qs.Common
 import qs.Widgets
 
@@ -85,7 +84,7 @@ StyledRect {
     property bool isImage: isImageFile(listDelegateRoot.fileName)
     property bool isVideo: isVideoFile(listDelegateRoot.fileName)
 
-    property string _xdgCacheHome: Quickshell.env("XDG_CACHE_HOME") || (Paths.strip(Paths.home) + "/.cache")
+    property string _xdgCacheHome: Paths.strip(Paths.xdgCache)
     property string videoThumbnailPath: {
         if (!listDelegateRoot.fileIsDir && isVideo) {
             const hash = Qt.md5("file://" + listDelegateRoot.filePath);


### PR DESCRIPTION
This PR adds support for video files' thumbnail generation with `ffmpegthumbnailer`

## Features
- thumbnail lookup and generation
  - find thumbnails in XDG_CACHE_HOME first, generate with `Proc.runCommand` when not found.
- fallback to video icon placeholder if `ffmpegthumbnailer` not found in PATH. 

## Demo

https://github.com/user-attachments/assets/d20d6a5a-2f4f-4e17-b7e8-f2ece2e8ddd0

## Notes
This PR is mainly for support with [dms-mpvpaper](https://github.com/kanghengliu/dms-mpvpaper) plugin; It reuses the filebrowser for wallpaper selector. 