### PR TITLE
fix: pywalfox output name is wrong

### DIFF
--- a/quickshell/matugen/configs/pywalfox.toml
+++ b/quickshell/matugen/configs/pywalfox.toml
@@ -1,4 +1,4 @@
 [templates.dmspywalfox]
 input_path = 'SHELL_DIR/matugen/templates/pywalfox-colors.json'
-output_path = 'CACHE_DIR/wal/dank-pywalfox.json'
+output_path = 'CACHE_DIR/wal/colors.json'
 post_hook = 'sh -c "command -v pywalfox && test -f ~/.cache/wal/colors.json && pywalfox update"'


### PR DESCRIPTION
Resolves errors caused by inconsistencies between the names `output_path` and `post_hook`.