### PR TITLE
fix(bar): exclude niri from fullscreen toplevel detection

### DIFF
--- a/quickshell/Modules/DankBar/DankBarWindow.qml
+++ b/quickshell/Modules/DankBar/DankBarWindow.qml
@@ -181,7 +181,7 @@ PanelWindow {
     }
 
     function _updateHasFullscreenToplevel() {
-        if (!CompositorService.isHyprland && !CompositorService.isNiri) {
+        if (!CompositorService.isHyprland) {
             hasFullscreenToplevel = false;
             return;
         }


### PR DESCRIPTION
Niri already renders fullscreen windows above the top layer-shell layer (see render_above_top_layer() in niri's scrolling.rs). Aside from redundancy, this check also hides the bar for windowed-fullscreen windows (aka fake fullscreen), since the Wayland protocol reports identical state for both.