### PR TITLE
fix: use UnsetWorkspaceName to fix  empty input in workspace rename

### DIFF
--- a/quickshell/Services/NiriService.qml
+++ b/quickshell/Services/NiriService.qml
@@ -1427,6 +1427,15 @@ Singleton {
     }
 
     function renameWorkspace(name) {
+        if (!name || name.trim() === "") {
+            return send({
+                "Action": {
+                    "UnsetWorkspaceName": {
+                        "workspace": null
+                    }
+                }
+            });
+        }
         return send({
             "Action": {
                 "SetWorkspaceName": {


### PR DESCRIPTION
Problem : previously if we open up workspace renaming dialoag box and press enter without typing anything it would rename the workspace to an empty string . So if we have to remove the name of two workspaces we cant do that because it would set the name of two workspaces to empty strings and duplicate workspace names are not allowed .

Fix : Used unsetWorkspaceName  to unset the workspace name instead of setting it to empty string . 


