### PR TITLE
fix(osd): coerce optional chain to bool in VolumeOSD enabled bindings

### DIFF
--- a/quickshell/Modules/OSD/VolumeOSD.qml
+++ b/quickshell/Modules/OSD/VolumeOSD.qml
@@ -95,7 +95,7 @@ DankOSD {
                 anchors.verticalCenter: parent.verticalCenter
                 minimum: 0
                 maximum: AudioService.sinkMaxVolume
-                enabled: AudioService.sink?.audio
+                enabled: AudioService.sink?.audio ?? false
                 showValue: true
                 unit: "%"
                 thumbOutlineColor: Theme.surfaceContainer
@@ -207,7 +207,7 @@ DankOSD {
                     id: vertSliderArea
                     anchors.fill: parent
                     anchors.margins: -12
-                    enabled: AudioService.sink?.audio
+                    enabled: AudioService.sink?.audio ?? false
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
 


### PR DESCRIPTION
Fixes #2100

`AudioService.sink?.audio` evaluates to `undefined` when the default sink is destroyed during audio device hotplug. Assigning `undefined` to `property bool enabled` crashes quickshell. Adding `?? false` matches the pattern already used in `MediaVolumeOSD.qml`.