### PR TITLE
feat(color-picker): add --raw flag

### DIFF
--- a/core/cmd/dms/commands_colorpicker.go
+++ b/core/cmd/dms/commands_colorpicker.go
@@ -121,11 +121,7 @@ func runColorPick(cmd *cobra.Command, args []string) {
 	}
 
 	if raw, _ := cmd.Flags().GetBool("raw"); raw {
-		if color.IsDark() {
-			fmt.Printf("%s\n", output)
-		} else {
-			fmt.Printf("%s\n", output)
-		}
+		fmt.Printf("%s\n", output)
 		return
 	}
 


### PR DESCRIPTION
Added --raw flag so output can be piped to other command.

Example usecase: To spawn a standalone color picker cursor then open modal.
dms ipc color-picker openColor "$(dms color pick --raw)"