### PR TITLE
chore(niri): use satty screenshot tool as default

### DIFF
--- a/quickshell/Services/NiriService.qml
+++ b/quickshell/Services/NiriService.qml
@@ -629,9 +629,9 @@ Singleton {
         if (pendingScreenshotPath && data.path === pendingScreenshotPath) {
             const editor = Quickshell.env("DMS_SCREENSHOT_EDITOR");
             let command;
-            if (editor === "satty") {
+            if (editor === "satty" || !editor) {
                 command = ["satty", "-f", data.path];
-            } else if (editor === "swappy" || !editor) {
+            } else if (editor === "swappy") {
                 command = ["swappy", "-f", data.path];
             } else {
                 // Custom command with %path% placeholder


### PR DESCRIPTION
Swappy seems to not be quite as well maintained as satty, latest commit (https://github.com/jtheoof/swappy/commit/ff7d641b8c0d461b8a90448a5893e4aa3a0533b1) is a translation, before that the latest commit was in august 2025. Latest release is also from Aug 27 2025.

Satty however has had commits quite recently and releases as well.
- https://github.com/Satty-org/Satty/commit/590253c8bba01f5c559808dd432cbb80bc4bd7c8 - This was from yesterday
- https://github.com/Satty-org/Satty/releases/tag/v0.20.1 - Febuary 6th