### PR TITLE
False error Fix

### DIFF
--- a/quickshell/Services/NiriService.qml
+++ b/quickshell/Services/NiriService.qml
@@ -99,15 +99,14 @@ Singleton {
                 const lines = text.split('\n');
                 const trimmedLines = lines.map(line => line.replace(/\s+$/, '')).filter(line => line.length > 0);
                 configValidationOutput = trimmedLines.join('\n').trim();
-                if (hasInitialConnection) {
-                    ToastService.showError("niri: failed to load config", configValidationOutput, "", "niri-config");
-                }
             }
         }
 
         onExited: exitCode => {
             if (exitCode === 0) {
                 configValidationOutput = "";
+            } else if (hasInitialConnection && configValidationOutput.length > 0) {
+                ToastService.showError("niri: failed to load config", configValidationOutput, "", "niri-config");
             }
         }
     }


### PR DESCRIPTION
Issue : when users set window rules via GUI it gives some false positive because error function check error for each appended line . 

FIx : prevent false "failed to load config" toast on niri validation
Move error toast logic from StdioCollector.onStreamFinished to Process.onExited
so it only displays when niri validate actually fails (non-zero exit code),
not when stderr outputs early progress messages during config processing.

Closes #2102 