### PR TITLE
CpuMonitor.qml: cpuBaseline text as "100%" to reserve enough width - previously "88%"

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/CpuMonitor.qml
+++ b/quickshell/Modules/DankBar/Widgets/CpuMonitor.qml
@@ -102,7 +102,7 @@ BasePill {
                     StyledTextMetrics {
                         id: cpuBaseline
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
-                        text: "88%"
+                        text: "100%"
                     }
 
                     StyledTextMetrics {


### PR DESCRIPTION
My bar layout kept shifting around by a few pixels every time I hit 100% cpu usage - changing the cpuBaseline text in CpuMonitor.qml from "88%" to "100%" fixed that issue.