### PR TITLE
fix: use prefer-light and dconf for GTK4 color-scheme refresh (niri compatibility)

### DIFF
--- a/core/internal/matugen/matugen.go
+++ b/core/internal/matugen/matugen.go
@@ -810,17 +810,17 @@ func refreshGTK4() {
 
 	var toggle string
 	if current == "prefer-dark" {
-		toggle = "default"
+		toggle = "prefer-light"
 	} else {
 		toggle = "prefer-dark"
 	}
 
-	if err := utils.GsettingsSet("org.gnome.desktop.interface", "color-scheme", toggle); err != nil {
+	if err := utils.DconfSet("org.gnome.desktop.interface", "color-scheme", toggle); err != nil {
 		log.Warnf("Failed to toggle color-scheme for GTK4 refresh: %v", err)
 		return
 	}
 	time.Sleep(50 * time.Millisecond)
-	if err := utils.GsettingsSet("org.gnome.desktop.interface", "color-scheme", current); err != nil {
+	if err := utils.DconfSet("org.gnome.desktop.interface", "color-scheme", current); err != nil {
 		log.Warnf("Failed to restore color-scheme for GTK4 refresh: %v", err)
 	}
 }
@@ -867,10 +867,10 @@ func signalByName(name string, sig syscall.Signal) {
 func syncColorScheme(mode ColorMode) {
 	scheme := "prefer-dark"
 	if mode == ColorModeLight {
-		scheme = "default"
+		scheme = "prefer-light"
 	}
 
-	if err := utils.GsettingsSet("org.gnome.desktop.interface", "color-scheme", scheme); err != nil {
+	if err := utils.DconfSet("org.gnome.desktop.interface", "color-scheme", scheme); err != nil {
 		log.Warnf("Failed to sync color-scheme: %v", err)
 	}
 }

--- a/core/internal/utils/gsettings.go
+++ b/core/internal/utils/gsettings.go
@@ -29,3 +29,13 @@ func GsettingsSet(schema, key, value string) error {
 	}
 	return exec.Command("dconf", "write", dconfPath(schema, key), "'"+value+"'").Run()
 }
+
+// DconfSet writes a value using dconf write, falling back to gsettings.
+// Prefer this for settings like color-scheme where dconf is more universally
+// available (e.g. on niri, NixOS) and does not require GSettings schema setup.
+func DconfSet(schema, key, value string) error {
+	if err := exec.Command("dconf", "write", dconfPath(schema, key), "'"+value+"'").Run(); err == nil {
+		return nil
+	}
+	return exec.Command("gsettings", "set", schema, key, value).Run()
+}


### PR DESCRIPTION
Fixes #2140

## Summary

- Replace `"default"` with `"prefer-light"` as the intermediate toggle value in `refreshGTK4()` — avoids ambiguity on compositors like niri where `default` may not trigger a style reload
- Replace `"default"` with `"prefer-light"` in `syncColorScheme()` for light mode — explicit value is safer across environments
- Add `utils.DconfSet()` which tries `dconf write` first (falling back to `gsettings`), and use it for all `color-scheme` writes — `dconf` is more universal and does not require GSettings schema setup (niri, NixOS, minimal distros)

## Test plan

- [ ] Apply theme in dark mode on niri — GTK4 apps should reload their color scheme
- [ ] Apply theme in light mode on niri — GTK4 apps should reload their color scheme
- [ ] Verify behavior is unchanged on a standard GNOME session
- [ ] Verify `dconf` is tried before `gsettings` for `color-scheme` writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)