### PR TITLE
fix(system-update): popout first-click and AUR package listing

### DIFF
--- a/quickshell/Modules/DankBar/DankBarContent.qml
+++ b/quickshell/Modules/DankBar/DankBarContent.qml
@@ -1438,12 +1438,21 @@ Item {
             parentScreen: barWindow.screen
             onClicked: {
                 systemUpdateLoader.active = true;
+                if (!systemUpdateLoader.item)
+                    return;
+                const popout = systemUpdateLoader.item;
                 const effectiveBarConfig = topBarContent.barConfig;
                 const barPosition = barWindow.axis?.edge === "left" ? 2 : (barWindow.axis?.edge === "right" ? 3 : (barWindow.axis?.edge === "top" ? 0 : 1));
-                if (systemUpdateLoader.item && systemUpdateLoader.item.setBarContext) {
-                    systemUpdateLoader.item.setBarContext(barPosition, effectiveBarConfig?.bottomGap ?? 0);
+                if (popout.setBarContext) {
+                    popout.setBarContext(barPosition, effectiveBarConfig?.bottomGap ?? 0);
                 }
-                systemUpdateLoader.item?.toggle();
+                if (popout.setTriggerPosition) {
+                    const globalPos = visualContent.mapToItem(null, 0, 0);
+                    const currentScreen = parentScreen || Screen;
+                    const pos = SettingsData.getPopupTriggerPosition(globalPos, currentScreen, barWindow.effectiveBarThickness, visualWidth, effectiveBarConfig?.spacing ?? 4, barPosition, effectiveBarConfig);
+                    popout.setTriggerPosition(pos.x, pos.y, pos.width, section, currentScreen, barPosition, barWindow.effectiveBarThickness, effectiveBarConfig?.spacing ?? 4, effectiveBarConfig);
+                }
+                PopoutManager.requestPopout(popout, undefined, "systemUpdate");
             }
         }
     }

--- a/quickshell/Services/SystemUpdateService.qml
+++ b/quickshell/Services/SystemUpdateService.qml
@@ -231,7 +231,10 @@ Singleton {
             return;
         isChecking = true;
         hasError = false;
-        if (updChecker.length > 0) {
+        if (pkgManager === "paru" || pkgManager === "yay") {
+            const repoCmd = updChecker.length > 0 ? updChecker : `${pkgManager} -Qu`;
+            updateChecker.command = ["sh", "-c", `(${repoCmd} 2>/dev/null; ${pkgManager} -Qua 2>/dev/null) || true`];
+        } else if (updChecker.length > 0) {
             updateChecker.command = [updChecker].concat(updateCheckerParams[updChecker].listUpdatesSettings.params);
         } else {
             updateChecker.command = [pkgManager].concat(packageManagerParams[pkgManager].listUpdatesSettings.params);


### PR DESCRIPTION
## Summary

Two fixes for the SystemUpdate bar widget:

- **Popout requires double-click to open:** On the first click, the LazyLoader was activated but `popoutTarget` (bound to the loader's item) was still `null` in the MouseArea handler, so `setTriggerPosition` was never called. The popout's `open()` then returned early because `screen` was unset. Restructured the `onClicked` handler to call `setTriggerPosition` directly on the loaded item and use `PopoutManager.requestPopout()` — matching the pattern used by Clock, Clipboard, and other bar widgets.

- **AUR packages missing from update list:** When paru or yay is the package manager, the update list only showed official repo packages (via `checkupdates`) while the upgrade command (`paru/yay -Syu`) also processes AUR packages. This meant AUR updates appeared as a surprise during the upgrade. Now combines the repo listing with the AUR helper's `-Qua` flag so both official and AUR packages are shown before the user triggers the upgrade.