### PR TITLE
feat(running-apps): stronger active app highlight

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/RunningApps.qml
+++ b/quickshell/Modules/DankBar/Widgets/RunningApps.qml
@@ -271,7 +271,7 @@ BasePill {
                         radius: Theme.cornerRadius
                         color: {
                             if (isFocused) {
-                                return mouseArea.containsMouse ? Theme.primarySelected : Theme.withAlpha(Theme.primary, 0.2);
+                                return mouseArea.containsMouse ? Theme.primarySelected : Theme.withAlpha(Theme.primary, 0.45);
                             }
                             return mouseArea.containsMouse ? BlurService.hoverColor(Theme.widgetBaseHoverColor) : "transparent";
                         }
@@ -526,7 +526,7 @@ BasePill {
                         radius: Theme.cornerRadius
                         color: {
                             if (isFocused) {
-                                return mouseArea.containsMouse ? Theme.primarySelected : Theme.withAlpha(Theme.primary, 0.2);
+                                return mouseArea.containsMouse ? Theme.primarySelected : Theme.withAlpha(Theme.primary, 0.45);
                             }
                             return mouseArea.containsMouse ? BlurService.hoverColor(Theme.widgetBaseHoverColor) : "transparent";
                         }


### PR DESCRIPTION
@bbedward 

Thanks for this truly great shell.

I really like the running app widget, but I found it difficult to see which app was focused. This increase the primary opacity to 45% to make the active window unambiguous at a glance.

The result:
<img width="81" height="39" alt="image" src="https://github.com/user-attachments/assets/ef891dba-8e5c-40de-990d-754a671afcf2" />
