### PR TITLE
fix(lock): unlock gnome-keyring after lock screen authentication

### DIFF
--- a/core/internal/server/keyring/handlers.go
+++ b/core/internal/server/keyring/handlers.go
@@ -1,0 +1,32 @@
+package keyring
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/models"
+	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/params"
+)
+
+func HandleRequest(conn net.Conn, req models.Request) {
+	switch req.Method {
+	case "keyring.unlock":
+		handleUnlock(conn, req)
+	default:
+		models.RespondError(conn, req.ID, fmt.Sprintf("unknown method: %s", req.Method))
+	}
+}
+
+func handleUnlock(conn net.Conn, req models.Request) {
+	password, err := params.String(req.Params, "password")
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+
+	if err := Unlock(password); err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+	models.Respond(conn, req.ID, models.SuccessResult{Success: true})
+}

--- a/core/internal/server/keyring/keyring.go
+++ b/core/internal/server/keyring/keyring.go
@@ -1,0 +1,44 @@
+package keyring
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+)
+
+// runner abstracts process execution so the unlock flow can be tested without
+// actually invoking gnome-keyring-daemon.
+type runner func(password string) error
+
+// lookPath is overridable in tests.
+var lookPath = exec.LookPath
+
+// run is the package-level runner. Tests replace it to capture invocations.
+var run runner = defaultRun
+
+func defaultRun(password string) error {
+	path, err := lookPath("gnome-keyring-daemon")
+	if err != nil {
+		return nil // not installed, nothing to do
+	}
+
+	cmd := exec.Command(path, "--unlock")
+	cmd.Stdin = bytes.NewBufferString(password)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gnome-keyring-daemon --unlock failed: %w", err)
+	}
+	return nil
+}
+
+// Unlock pipes the given password to `gnome-keyring-daemon --unlock` via stdin,
+// mirroring what pam_gnome_keyring.so does during pam_open_session. This
+// ensures the login keyring is unlocked after lock-screen authentication
+// without requiring Quickshell to call pam_open_session itself.
+//
+// If gnome-keyring-daemon is not installed, this is a no-op.
+func Unlock(password string) error {
+	return run(password)
+}

--- a/core/internal/server/keyring/keyring_test.go
+++ b/core/internal/server/keyring/keyring_test.go
@@ -1,0 +1,47 @@
+package keyring
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func withRunner(t *testing.T, r runner) {
+	t.Helper()
+	prev := run
+	run = r
+	t.Cleanup(func() { run = prev })
+}
+
+func TestUnlock_PassesPasswordToRunner(t *testing.T) {
+	var got string
+	withRunner(t, func(password string) error {
+		got = password
+		return nil
+	})
+
+	err := Unlock("hunter2")
+	assert.NoError(t, err)
+	assert.Equal(t, "hunter2", got)
+}
+
+func TestUnlock_PropagatesError(t *testing.T) {
+	wantErr := errors.New("boom")
+	withRunner(t, func(password string) error {
+		return wantErr
+	})
+
+	err := Unlock("anything")
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestDefaultRun_NoOpWhenBinaryMissing(t *testing.T) {
+	prevLookPath := lookPath
+	lookPath = func(name string) (string, error) {
+		return "", errors.New("not found")
+	}
+	t.Cleanup(func() { lookPath = prevLookPath })
+
+	assert.NoError(t, defaultRun("anything"))
+}

--- a/core/internal/server/router.go
+++ b/core/internal/server/router.go
@@ -15,6 +15,7 @@ import (
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/evdev"
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/extworkspace"
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/freedesktop"
+	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/keyring"
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/location"
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/loginctl"
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/models"
@@ -61,6 +62,11 @@ func RouteRequest(conn net.Conn, req models.Request) {
 			return
 		}
 		loginctl.HandleRequest(conn, req, loginctlManager)
+		return
+	}
+
+	if strings.HasPrefix(req.Method, "keyring.") {
+		keyring.HandleRequest(conn, req)
 		return
 	}
 

--- a/quickshell/Modules/Lock/Pam.qml
+++ b/quickshell/Modules/Lock/Pam.qml
@@ -59,6 +59,7 @@ Scope {
             u2fPendingTimeout.running = false;
             root.u2fPending = false;
             root.u2fState = "";
+            DMSService.sendRequest("keyring.unlock", {"password": root.buffer});
             unlockRequestTimeout.restart();
             unlockRequested();
         }


### PR DESCRIPTION
## Summary

After lock-screen authentication, DMS never asked `gnome-keyring-daemon` to unlock the login keyring. This is normally handled by `pam_gnome_keyring.so` in the PAM session phase, which DMS does not run. Combined with an upstream race condition in gnome-keyring's Secret Service unlock handling, this caused the daemon to repeatedly crash and left GNOME Online Accounts and Evolution unable to retrieve credentials, especially after suspend/resume.

This PR mirrors what every PAM-based session manager does: pipe the user's password to `gnome-keyring-daemon --unlock` over stdin after successful auth, so the keyring is unlocked through one controlled call instead of through whatever apps happen to race for it next.

## Symptom

After every suspend/resume (sometimes after a plain unlock), Evolution failed with:

> Failed to call tasklists::list: Failed to obtain an access token for \"…\": Failed to retrieve credentials from the keyring

GOA accounts in GNOME Settings showed warning icons. Confusingly, Seahorse showed the keyring as unlocked because it created a fresh D-Bus connection to the (already restarted) daemon, while GOA/Evolution were still holding proxies pointing at the dead one.

The journal showed why:

```
gnome-keyring-daemon[…]: ERROR:daemon/dbus/gkd-secret-unlock.c:243:perform_next_unlock:
                         assertion failed: (!self->current)
systemd[…]: gnome-keyring-daemon.service: Main process exited, code=dumped, status=6/ABRT
systemd[…]: gnome-keyring-daemon.service: Scheduled restart job, restart counter is at …
```

`coredumpctl list /usr/bin/gnome-keyring-daemon` on the affected machine showed **40 core dumps between 2026-03-18 and 2026-04-10**, a mix of SIGTRAP and SIGABRT.

## Root cause

Two things combine into the failure:

**1. Upstream race condition in gnome-keyring** ([GNOME/gnome-keyring#144](https://gitlab.gnome.org/GNOME/gnome-keyring/-/issues/144))

`perform_next_unlock` in `gkd-secret-unlock.c` asserts `!self->current` when starting work on the next queued prompt. The unlock prompt queue logic is faulty in the presence of concurrent `org.freedesktop.Secret.Service.Unlock` requests and aborts the daemon. There is an open MR ([!92](https://gitlab.gnome.org/GNOME/gnome-keyring/-/merge_requests/92)) that serializes prompts via an `ongoing_unlock` guard, opened 2025-03-05 and last updated 2025-09-19; it is still not merged.

**2. DMS never unlocks the keyring after lock-screen auth**

PAM-based session managers run `pam_authenticate()` -> `pam_setcred()` -> `pam_open_session()`. `pam_gnome_keyring.so` is loaded in both the `auth` and `session` stacks: it captures the password during auth, then in `pam_open_session()` it sends an unlock request (with the captured password) to the running gnome-keyring-daemon. By the time apps see the session, the keyring is already unlocked through one controlled call.

DMS uses Quickshell's `PamContext`, which only runs `pam_authenticate()` ([quickshell PamContext](https://quickshell.org/docs/types/Quickshell.Services.Pam/PamContext/) does not expose `pam_setcred` or `pam_open_session`). The session phase never executes, so nothing on DMS's side ever unlocks the keyring after auth. Whichever clients happen to need credentials next race for the unlock and trip #144.

DEs that rely on PAM session phase don't see this crash because their session managers serialize the unlock through one well-defined call before any app gets a chance to race.

## How other projects handle this

| Project | Approach |
|---|---|
| **GDM** | Runs `pam_open_session()` ([gdm-session-worker.c:2256](https://gitlab.gnome.org/GNOME/gdm/-/blob/main/daemon/gdm-session-worker.c#L2256)), with `session optional pam_gnome_keyring.so auto_start` in [data/pam-arch/gdm-password.pam](https://gitlab.gnome.org/GNOME/gdm/-/blob/main/data/pam-arch/gdm-password.pam) |
| **SDDM / LightDM** | Same PAM session phase approach as GDM |
| **KDE Plasma** | Uses KWallet, which has its own PAM module |
| **hyprlock** | Only calls `pam_authenticate()` ([Pam.cpp:127](https://github.com/hyprwm/hyprlock/blob/main/src/auth/Pam.cpp#L127)). Same gap. NixOS users [report it](https://discourse.nixos.org/t/automatically-unlock-gnome-keyring-with-hyprlock/54166) not working reliably |
| **swaylock** | Doesn't handle keyring unlock at all - documented limitation |
| **[umglurf/gnome-keyring-unlock](https://github.com/umglurf/gnome-keyring-unlock)** | Talks directly to `\$XDG_RUNTIME_DIR/keyring/control`, same protocol `pam_gnome_keyring.so` uses; for fingerprint/FIDO2 login workflows |
| **[hyttmi/howdy-unlock-keyring](https://github.com/hyttmi/howdy-unlock-keyring)** | Workaround: uses `ydotool` to type the password into the prompt window |

DMS is in the same position as hyprlock and swaylock. The difference is that DMS owns the shell, so we can fix it instead of pushing the problem onto users.

## The fix

Do what `pam_gnome_keyring.so` does in its session phase, just from outside PAM: spawn `gnome-keyring-daemon --unlock` and pipe the user's password to its stdin. The daemon reads stdin until EOF (all bytes including newlines are part of the password, per [`read_login_password`](https://gitlab.gnome.org/GNOME/gnome-keyring/-/blob/main/daemon/gkd-main.c)) and uses it to unlock the login keyring.

- **`core/internal/server/keyring/keyring.go`** (new) - `Unlock(password)` runs `gnome-keyring-daemon --unlock` with the password written to stdin via `cmd.Stdin = bytes.NewBufferString(password)`. Uses `exec.LookPath` and returns nil if the binary is not installed, so distros without gnome-keyring are unaffected.
- **`core/internal/server/keyring/handlers.go`** (new) - IPC handler for `keyring.unlock`. Extracts the password from the request params and calls `Unlock`.
- **`core/internal/server/keyring/keyring_test.go`** (new) - Tests the runner indirection and the no-binary fallback. Does not require gnome-keyring-daemon to be installed.
- **`core/internal/server/router.go`** - routes `keyring.*` requests to the new handler.
- **`quickshell/Modules/Lock/Pam.qml`** - in `completeUnlock()`, after PAM auth has succeeded and before emitting `unlockRequested()`, calls `DMSService.sendRequest(\"keyring.unlock\", { password: root.buffer })`.

The password travels from the QML buffer over the existing DMS Unix socket to the Go server, then directly into the spawned `gnome-keyring-daemon --unlock` process via a pipe. It is never written to disk, never appears as a command-line argument, and never crosses any external boundary.

After deploying this on the affected machine, the GOA/Evolution failures stopped immediately and no further `gnome-keyring-daemon` crashes have appeared in the journal.

## Test plan

- [x] `make fmt`, `go mod tidy`, `make test` all clean
- [x] New unit tests in `keyring_test.go` pass
- [x] After lock screen unlock, Evolution and GOA can retrieve credentials immediately, including across suspend/resume cycles
- [x] No new `gnome-keyring-daemon.service: Failed with result 'core-dump'` entries since deploying the patch
- [x] Lock screen unlock still works on a system without gnome-keyring (handler short-circuits in `defaultRun`)
- [x] No regression in other lock screen behavior (Bitwarden, fingerprint, U2F flows untouched, very important for me =D)