### PR TITLE
Fix ddc brightness not applying because process exits before debounce timer runs

### DIFF
--- a/core/cmd/dms/commands_brightness.go
+++ b/core/cmd/dms/commands_brightness.go
@@ -236,6 +236,7 @@ func runBrightnessSet(cmd *cobra.Command, args []string) {
 			defer ddc.Close()
 			time.Sleep(100 * time.Millisecond)
 			if err := ddc.SetBrightnessWithExponent(deviceID, percent, exponential, exponent, nil); err == nil {
+				ddc.WaitPending()
 				fmt.Printf("Set %s to %d%%\n", deviceID, percent)
 				return
 			}

--- a/core/internal/server/brightness/ddc.go
+++ b/core/internal/server/brightness/ddc.go
@@ -218,7 +218,9 @@ func (b *DDCBackend) SetBrightnessWithExponent(id string, value int, exponential
 	if timer, exists := b.debounceTimers[id]; exists {
 		timer.Reset(200 * time.Millisecond)
 	} else {
+		b.debounceWg.Add(1)
 		b.debounceTimers[id] = time.AfterFunc(200*time.Millisecond, func() {
+			defer b.debounceWg.Done()
 			b.debounceMutex.Lock()
 			pending, exists := b.debouncePending[id]
 			if exists {
@@ -492,29 +494,16 @@ func (b *DDCBackend) valueToPercent(value int, max int, exponential bool) int {
 
 func (b *DDCBackend) WaitPending() {
     done := make(chan struct{})
-    b.debounceMutex.Lock()
-    hasPending := len(b.debouncePending) > 0
-    b.debounceMutex.Unlock()
-
-    if !hasPending {
-        return
-    }
-
-    // Poll until all pending sets are flushed
     go func() {
-        for {
-            time.Sleep(10 * time.Millisecond)
-            b.debounceMutex.Lock()
-            pending := len(b.debouncePending)
-            b.debounceMutex.Unlock()
-            if pending == 0 {
-                close(done)
-                return
-            }
-        }
+        b.debounceWg.Wait()
+        close(done)
     }()
 
-    <-done
+	select {
+	case <- done:
+	case <- time.After(5 * time.Second):
+			log.Debug("WaitPending timed out waiting for DDC writes")
+	}
 }
 
 func (b *DDCBackend) Close() {

--- a/core/internal/server/brightness/ddc.go
+++ b/core/internal/server/brightness/ddc.go
@@ -490,5 +490,32 @@ func (b *DDCBackend) valueToPercent(value int, max int, exponential bool) int {
 	return percent
 }
 
+func (b *DDCBackend) WaitPending() {
+    done := make(chan struct{})
+    b.debounceMutex.Lock()
+    hasPending := len(b.debouncePending) > 0
+    b.debounceMutex.Unlock()
+
+    if !hasPending {
+        return
+    }
+
+    // Poll until all pending sets are flushed
+    go func() {
+        for {
+            time.Sleep(10 * time.Millisecond)
+            b.debounceMutex.Lock()
+            pending := len(b.debouncePending)
+            b.debounceMutex.Unlock()
+            if pending == 0 {
+                close(done)
+                return
+            }
+        }
+    }()
+
+    <-done
+}
+
 func (b *DDCBackend) Close() {
 }

--- a/core/internal/server/brightness/ddc.go
+++ b/core/internal/server/brightness/ddc.go
@@ -493,16 +493,16 @@ func (b *DDCBackend) valueToPercent(value int, max int, exponential bool) int {
 }
 
 func (b *DDCBackend) WaitPending() {
-    done := make(chan struct{})
-    go func() {
-        b.debounceWg.Wait()
-        close(done)
-    }()
+	done := make(chan struct{})
+	go func() {
+		b.debounceWg.Wait()
+		close(done)
+	}()
 
 	select {
-	case <- done:
-	case <- time.After(5 * time.Second):
-			log.Debug("WaitPending timed out waiting for DDC writes")
+	case <-done:
+	case <-time.After(5 * time.Second):
+		log.Debug("WaitPending timed out waiting for DDC writes")
 	}
 }
 

--- a/core/internal/server/brightness/types.go
+++ b/core/internal/server/brightness/types.go
@@ -84,6 +84,7 @@ type DDCBackend struct {
 	debounceMutex   sync.Mutex
 	debounceTimers  map[string]*time.Timer
 	debouncePending map[string]ddcPendingSet
+	debounceWg sync.WaitGroup
 }
 
 type ddcPendingSet struct {

--- a/core/internal/server/brightness/types.go
+++ b/core/internal/server/brightness/types.go
@@ -84,7 +84,7 @@ type DDCBackend struct {
 	debounceMutex   sync.Mutex
 	debounceTimers  map[string]*time.Timer
 	debouncePending map[string]ddcPendingSet
-	debounceWg sync.WaitGroup
+	debounceWg      sync.WaitGroup
 }
 
 type ddcPendingSet struct {


### PR DESCRIPTION
The debounce timer waits 200ms before applying the brightness. But on cli process exits after `SetBrightnessWithExponent` returns, leading to i2c write never happening.

When i wrote a simple debug log to see what is the problem i saw that
❯ DMS_LOG_LEVEL=debug ./bin/dms brightness set ddc:i2c-3 50 --ddc
...
 DEBUG  go: !!! Attempting to set brightness VIA SYSFS for device: ddc:i2c-3
 DEBUG  go: sysfs.SetBrightness failed: <nil>
 DEBUG  go: initialized I2C-3 with brightness 100/100
 DEBUG  go: found DDC device on i2c-3
...
 DEBUG  go: !!! Attempting to set brightness VIA DDC for device: ddc:i2c-3
Set ddc:i2c-3 to 50%

But after running this it didn't do any change to brightness

❯ DMS_LOG_LEVEL=debug ./bin/dms brightness get ddc:i2c-3 --ddc
...
 DEBUG  go: initialized I2C-3 with brightness 100/100
 DEBUG  go: found DDC device on i2c-3
...
ddc:i2c-3: 100% (100/100)
 

Creating a WaitPending function in core/internal/server/brightness/ddc.go to use before process return fixed it when i use from cli. The issue doesn't persist if i just use brightness slider.
