### PR TITLE
i18n: add Japanese (ja) translations

### DIFF
--- a/quickshell/translations/poexports/ja.json
+++ b/quickshell/translations/poexports/ja.json
@@ -1,300 +1,300 @@
 {
   "%1 Animation Speed": {
-    "%1 Animation Speed": ""
+    "%1 Animation Speed": "%1 アニメーション速度"
   },
   "%1 Sessions": {
-    "%1 Sessions": ""
+    "%1 Sessions": "%1 件のセッション"
   },
   "%1 active session": {
-    "%1 active session": ""
+    "%1 active session": "%1 件のアクティブなセッション"
   },
   "%1 active sessions": {
-    "%1 active sessions": ""
+    "%1 active sessions": "%1 件のアクティブなセッション"
   },
   "%1 adapter, none connected": {
-    "%1 adapter, none connected": ""
+    "%1 adapter, none connected": "アダプター %1 個、接続なし"
   },
   "%1 adapters, none connected": {
-    "%1 adapters, none connected": ""
+    "%1 adapters, none connected": "アダプター %1 個、接続なし"
   },
   "%1 character": {
-    "%1 character": ""
+    "%1 character": "%1 文字"
   },
   "%1 characters": {
     "%1 characters": "%1 文字"
   },
   "%1 connected": {
-    "%1 connected": ""
+    "%1 connected": "%1 件接続済み"
   },
   "%1 custom animation duration": {
-    "%1 custom animation duration": ""
+    "%1 custom animation duration": "%1 カスタムアニメーション時間"
   },
   "%1 disconnected": {
-    "%1 disconnected": ""
+    "%1 disconnected": "%1 件切断済み"
   },
   "%1 disconnected (hidden)": {
-    "%1 disconnected (hidden)": ""
+    "%1 disconnected (hidden)": "%1 件切断済み（非表示）"
   },
   "%1 display": {
-    "%1 display": ""
+    "%1 display": "%1 ディスプレイ"
   },
   "%1 displays": {
-    "%1 displays": ""
+    "%1 displays": "%1 ディスプレイ"
   },
   "%1 exists but is not included in config. Custom keybinds will not work until this is fixed.": {
-    "%1 exists but is not included in config. Custom keybinds will not work until this is fixed.": ""
+    "%1 exists but is not included in config. Custom keybinds will not work until this is fixed.": "%1 は存在しますが、設定に含まれていません。これが修正されるまでカスタムキーバインドは動作しません。"
   },
   "%1 exists but is not included. Window rules won't apply.": {
-    "%1 exists but is not included. Window rules won't apply.": ""
+    "%1 exists but is not included. Window rules won't apply.": "%1 は存在しますが、含まれていません。ウィンドウルールは適用されません。"
   },
   "%1 filtered": {
-    "%1 filtered": ""
+    "%1 filtered": "フィルター済み %1 件"
   },
   "%1 is now included in config": {
-    "%1 is now included in config": ""
+    "%1 is now included in config": "%1 は設定に含まれるようになりました"
   },
   "%1 issue found": {
-    "%1 issue found": ""
+    "%1 issue found": "問題 %1 件を検出"
   },
   "%1 issues found": {
-    "%1 issues found": ""
+    "%1 issues found": "問題 %1 件を検出"
   },
   "%1 notifications": {
-    "%1 notifications": ""
+    "%1 notifications": "通知 %1 件"
   },
   "%1 update": {
-    "%1 update": ""
+    "%1 update": "更新 %1 件"
   },
   "%1 updates": {
-    "%1 updates": ""
+    "%1 updates": "更新 %1 件"
   },
   "%1 variants": {
-    "%1 variants": ""
+    "%1 variants": "%1 バリアント"
   },
   "%1 wallpaper  •  %2 / %3": {
-    "%1 wallpaper  •  %2 / %3": ""
+    "%1 wallpaper  •  %2 / %3": "壁紙 %1 枚  •  %2 / %3"
   },
   "%1 wallpapers  •  %2 / %3": {
-    "%1 wallpapers  •  %2 / %3": ""
+    "%1 wallpapers  •  %2 / %3": "壁紙 %1 枚  •  %2 / %3"
   },
   "%1 widgets": {
     "%1 widgets": "%1 ウィジェット"
   },
   "%1 window": {
-    "%1 window": ""
+    "%1 window": "ウィンドウ %1 個"
   },
   "%1 windows": {
-    "%1 windows": ""
+    "%1 windows": "ウィンドウ %1 個"
   },
   "%1m ago": {
-    "%1m ago": ""
+    "%1m ago": "%1分前"
   },
   "'Alternative' lets the key unlock on its own. 'Second factor' requires password or fingerprint first, then the key.": {
-    "'Alternative' lets the key unlock on its own. 'Second factor' requires password or fingerprint first, then the key.": ""
+    "'Alternative' lets the key unlock on its own. 'Second factor' requires password or fingerprint first, then the key.": "「Alternative」はキーだけでロックを解除できます。「Second factor」は最初にパスワードまたは指紋認証が必要で、その後にキーが必要です。"
   },
   "(Default)": {
-    "(Default)": ""
+    "(Default)": "（デフォルト）"
   },
   "(Unnamed)": {
     "(Unnamed)": "（名前なし）"
   },
   "+ %1 more": {
-    "+ %1 more": ""
+    "+ %1 more": "さらに %1 件"
   },
   "/path/to/videos": {
-    "/path/to/videos": ""
+    "/path/to/videos": "/path/to/videos"
   },
   "0 = square corners": {
-    "0 = square corners": ""
+    "0 = square corners": "0 = 角丸なし"
   },
   "1 day": {
-    "1 day": ""
+    "1 day": "1日"
   },
   "1 device connected": {
-    "1 device connected": ""
+    "1 device connected": "1台接続済み"
   },
   "1 event": {
     "1 event": "1件のイベント"
   },
   "1 hour": {
-    "1 hour": ""
+    "1 hour": "1時間"
   },
   "1 hour 30 minutes": {
-    "1 hour 30 minutes": ""
+    "1 hour 30 minutes": "1時間30分"
   },
   "1 minute": {
-    "1 minute": ""
+    "1 minute": "1分"
   },
   "1 notification": {
-    "1 notification": ""
+    "1 notification": "1件の通知"
   },
   "1 second": {
-    "1 second": ""
+    "1 second": "1秒"
   },
   "10 minutes": {
-    "10 minutes": ""
+    "10 minutes": "10分"
   },
   "10 seconds": {
-    "10 seconds": ""
+    "10 seconds": "10秒"
   },
   "10-bit Color": {
-    "10-bit Color": ""
+    "10-bit Color": "10ビットカラー"
   },
   "12 hours": {
-    "12 hours": ""
+    "12 hours": "12時間"
   },
   "14 days": {
-    "14 days": ""
+    "14 days": "14日"
   },
   "15 minutes": {
-    "15 minutes": ""
+    "15 minutes": "15分"
   },
   "15 seconds": {
-    "15 seconds": ""
+    "15 seconds": "15秒"
   },
   "180°": {
-    "180°": ""
+    "180°": "180°"
   },
   "2 hours": {
-    "2 hours": ""
+    "2 hours": "2時間"
   },
   "2 minutes": {
-    "2 minutes": ""
+    "2 minutes": "2分"
   },
   "2 seconds": {
-    "2 seconds": ""
+    "2 seconds": "2秒"
   },
   "20 minutes": {
-    "20 minutes": ""
+    "20 minutes": "20分"
   },
   "20 seconds": {
-    "20 seconds": ""
+    "20 seconds": "20秒"
   },
   "24-Hour Format": {
     "24-Hour Format": "24時間形式"
   },
   "24-hour clock": {
-    "24-hour clock": ""
+    "24-hour clock": "24時間時計"
   },
   "24-hour format": {
     "24-hour format": "24時間形式"
   },
   "25 seconds": {
-    "25 seconds": ""
+    "25 seconds": "25秒"
   },
   "250 ms": {
-    "250 ms": ""
+    "250 ms": "250ミリ秒"
   },
   "270°": {
-    "270°": ""
+    "270°": "270°"
   },
   "3 days": {
-    "3 days": ""
+    "3 days": "3日"
   },
   "3 hours": {
-    "3 hours": ""
+    "3 hours": "3時間"
   },
   "3 minutes": {
-    "3 minutes": ""
+    "3 minutes": "3分"
   },
   "3 seconds": {
-    "3 seconds": ""
+    "3 seconds": "3秒"
   },
   "30 days": {
-    "30 days": ""
+    "30 days": "30日"
   },
   "30 minutes": {
-    "30 minutes": ""
+    "30 minutes": "30分"
   },
   "30 seconds": {
-    "30 seconds": ""
+    "30 seconds": "30秒"
   },
   "35 seconds": {
-    "35 seconds": ""
+    "35 seconds": "35秒"
   },
   "3rd party": {
     "3rd party": "サードパーティ"
   },
   "4 hours": {
-    "4 hours": ""
+    "4 hours": "4時間"
   },
   "4 seconds": {
-    "4 seconds": ""
+    "4 seconds": "4秒"
   },
   "40 seconds": {
-    "40 seconds": ""
+    "40 seconds": "40秒"
   },
   "45 seconds": {
-    "45 seconds": ""
+    "45 seconds": "45秒"
   },
   "5 minutes": {
-    "5 minutes": ""
+    "5 minutes": "5分"
   },
   "5 seconds": {
-    "5 seconds": ""
+    "5 seconds": "5秒"
   },
   "50 seconds": {
-    "50 seconds": ""
+    "50 seconds": "50秒"
   },
   "500 ms": {
-    "500 ms": ""
+    "500 ms": "500ミリ秒"
   },
   "55 seconds": {
-    "55 seconds": ""
+    "55 seconds": "55秒"
   },
   "6 hours": {
-    "6 hours": ""
+    "6 hours": "6時間"
   },
   "7 days": {
-    "7 days": ""
+    "7 days": "7日"
   },
   "750 ms": {
-    "750 ms": ""
+    "750 ms": "750ミリ秒"
   },
   "8 hours": {
-    "8 hours": ""
+    "8 hours": "8時間"
   },
   "8 seconds": {
-    "8 seconds": ""
+    "8 seconds": "8秒"
   },
   "90 days": {
-    "90 days": ""
+    "90 days": "90日"
   },
   "90°": {
-    "90°": ""
+    "90°": "90°"
   },
   "<a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/LICENSE\" style=\"text-decoration:none; color:%1;\">MIT License</a>": {
-    "<a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/LICENSE\" style=\"text-decoration:none; color:%1;\">MIT License</a>": ""
+    "<a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/LICENSE\" style=\"text-decoration:none; color:%1;\">MIT License</a>": "<a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/LICENSE\" style=\"text-decoration:none; color:%1;\">MITライセンス</a>"
   },
   "A file with this name already exists. Do you want to overwrite it?": {
     "A file with this name already exists. Do you want to overwrite it?": "この名前のファイルは既に存在します。上書きしてもよろしいですか?"
   },
   "A modern desktop shell for Wayland compositors": {
-    "A modern desktop shell for Wayland compositors": ""
+    "A modern desktop shell for Wayland compositors": "Wayland コンポジター向けのモダンなデスクトップシェル"
   },
   "AC Power": {
-    "AC Power": ""
+    "AC Power": "AC電源"
   },
   "API": {
-    "API": ""
+    "API": "API"
   },
   "Aborted": {
-    "Aborted": ""
+    "Aborted": "中止"
   },
   "About": {
-    "About": "詳細"
+    "About": "バージョン情報"
   },
   "Accent Color": {
-    "Accent Color": ""
+    "Accent Color": "アクセントカラー"
   },
   "Accept": {
-    "Accept": ""
+    "Accept": "承諾"
   },
   "Accept Jobs": {
-    "Accept Jobs": ""
+    "Accept Jobs": "ジョブを受け付ける"
   },
   "Accepting": {
-    "Accepting": ""
+    "Accepting": "受け付け中"
   },
   "Access clipboard history": {
     "Access clipboard history": "クリップボードの履歴へのアクセス"
@@ -306,133 +306,133 @@
     "Access to system controls and settings": "システム制御へのアクセスおよび設定"
   },
   "Action": {
-    "Action": ""
+    "Action": "アクション"
   },
   "Action failed or terminal was closed.": {
-    "Action failed or terminal was closed.": ""
+    "Action failed or terminal was closed.": "アクションに失敗したか、端末が閉じられました。"
   },
   "Actions": {
     "Actions": "アクション"
   },
   "Activate": {
-    "Activate": ""
+    "Activate": "有効化"
   },
   "Activate Greeter": {
-    "Activate Greeter": ""
+    "Activate Greeter": "Greeter を有効にする"
   },
   "Activate the DMS greeter? A terminal will open for sudo authentication. Run Sync after activation to apply your settings.": {
-    "Activate the DMS greeter? A terminal will open for sudo authentication. Run Sync after activation to apply your settings.": ""
+    "Activate the DMS greeter? A terminal will open for sudo authentication. Run Sync after activation to apply your settings.": "DMS greeter を有効にしますか? sudo 認証用の端末が開きます。有効化後に設定を適用するには Sync を実行してください。"
   },
   "Activation": {
-    "Activation": ""
+    "Activation": "有効化"
   },
   "Active": {
-    "Active": ""
+    "Active": "アクティブ"
   },
   "Active Color": {
-    "Active Color": ""
+    "Active Color": "アクティブカラー"
   },
   "Active Lock Screen Monitor": {
-    "Active Lock Screen Monitor": ""
+    "Active Lock Screen Monitor": "アクティブなロック画面モニター"
   },
   "Active tile background and icon color": {
-    "Active tile background and icon color": ""
+    "Active tile background and icon color": "アクティブタイルの背景色とアイコン色"
   },
   "Active: %1": {
-    "Active: %1": ""
+    "Active: %1": "アクティブ: %1"
   },
   "Active: %1 +%2": {
-    "Active: %1 +%2": ""
+    "Active: %1 +%2": "アクティブ: %1 +%2"
   },
   "Active: None": {
-    "Active: None": ""
+    "Active: None": "アクティブ: なし"
   },
   "Adapters": {
-    "Adapters": ""
+    "Adapters": "アダプター"
   },
   "Adaptive Media Width": {
-    "Adaptive Media Width": ""
+    "Adaptive Media Width": "メディア幅の自動調整"
   },
   "Add": {
     "Add": "追加"
   },
   "Add Bar": {
-    "Add Bar": "バーを作る"
+    "Add Bar": "バーを追加"
   },
   "Add Desktop Widget": {
-    "Add Desktop Widget": ""
+    "Add Desktop Widget": "デスクトップウィジェットを追加"
   },
   "Add Printer": {
-    "Add Printer": ""
+    "Add Printer": "プリンターを追加"
   },
   "Add Title": {
-    "Add Title": ""
+    "Add Title": "タイトルを追加"
   },
   "Add Widget": {
     "Add Widget": "ウィジェットを追加"
   },
   "Add Widget to %1 Section": {
-    "Add Widget to %1 Section": ""
+    "Add Widget to %1 Section": "%1 セクションにウィジェットを追加"
   },
   "Add a border around the dock": {
-    "Add a border around the dock": ""
+    "Add a border around the dock": "ドックの周囲に境界線を追加"
   },
   "Add a custom prefix to all application launches. This can be used for things like 'uwsm-app', 'systemd-run', or other command wrappers.": {
-    "Add a custom prefix to all application launches. This can be used for things like 'uwsm-app', 'systemd-run', or other command wrappers.": ""
+    "Add a custom prefix to all application launches. This can be used for things like 'uwsm-app', 'systemd-run', or other command wrappers.": "すべてのアプリ起動にカスタム接頭辞を追加します。これは 'uwsm-app'、'systemd-run'、その他のコマンドラッパーなどに使用できます。"
   },
   "Add and configure widgets that appear on your desktop": {
-    "Add and configure widgets that appear on your desktop": ""
+    "Add and configure widgets that appear on your desktop": "デスクトップに表示されるウィジェットを追加および設定"
   },
   "Add by Address": {
-    "Add by Address": ""
+    "Add by Address": "アドレスで追加"
   },
   "Adjust the number of columns in grid view mode.": {
     "Adjust the number of columns in grid view mode.": "グリッド表示モードでの列数を調整します。"
   },
   "Adjust volume per scroll indent": {
-    "Adjust volume per scroll indent": ""
+    "Adjust volume per scroll indent": "スクロール1段ごとの音量調整"
   },
   "Adjusts contrast of generated colors (-100 = minimum, 0 = standard, 100 = maximum)": {
-    "Adjusts contrast of generated colors (-100 = minimum, 0 = standard, 100 = maximum)": ""
+    "Adjusts contrast of generated colors (-100 = minimum, 0 = standard, 100 = maximum)": "生成される色のコントラストを調整します（-100 = 最小、0 = 標準、100 = 最大）"
   },
   "Advanced": {
-    "Advanced": ""
+    "Advanced": "詳細設定"
   },
   "Afternoon": {
-    "Afternoon": ""
+    "Afternoon": "午後"
   },
   "All": {
     "All": "全て"
   },
   "All Monitors": {
-    "All Monitors": ""
+    "All Monitors": "すべてのモニター"
   },
   "All checks passed": {
-    "All checks passed": ""
+    "All checks passed": "すべてのチェックに成功しました"
   },
   "All day": {
-    "All day": "毎日"
+    "All day": "終日"
   },
   "All displays": {
     "All displays": "すべてのディスプレイ"
   },
   "Allow clicks to pass through the widget": {
-    "Allow clicks to pass through the widget": ""
+    "Allow clicks to pass through the widget": "クリックをウィジェットに透過させる"
   },
   "Alt+←/Backspace: Back • F1/I: File Info • F10: Help • Esc: Close": {
     "Alt+←/Backspace: Back • F1/I: File Info • F10: Help • Esc: Close": "Alt+←/Backspace: 戻る • F1/I: ファイル情報 • F10: ヘルプ • Esc: 閉じる"
   },
   "Alternative (OR)": {
-    "Alternative (OR)": ""
+    "Alternative (OR)": "代替方式（OR）"
   },
   "Always Active": {
-    "Always Active": ""
+    "Always Active": "常にアクティブ"
   },
   "Always Show Percentage": {
-    "Always Show Percentage": ""
+    "Always Show Percentage": "常に割合を表示"
   },
   "Always hide the dock and reveal it when hovering near the dock area": {
-    "Always hide the dock and reveal it when hovering near the dock area": ""
+    "Always hide the dock and reveal it when hovering near the dock area": "常にドックを隠し、ドック領域の近くにホバーしたときに表示します"
   },
   "Always on icons": {
     "Always on icons": "常時表示アイコン"
@@ -441,55 +441,55 @@
     "Always show a minimum of 3 workspaces, even if fewer are available": "使用可能なワークスペースが少ない場合でも、常に最低 3 つを表示"
   },
   "Always show the dock when niri's overview is open": {
-    "Always show the dock when niri's overview is open": ""
+    "Always show the dock when niri's overview is open": "niri の概要が開いているときは常にドックを表示"
   },
   "Always show when there's only one connected display": {
-    "Always show when there's only one connected display": ""
+    "Always show when there's only one connected display": "接続されたディスプレイが1つだけのときは常に表示"
   },
   "Amount": {
-    "Amount": ""
+    "Amount": "量"
   },
   "Analog": {
-    "Analog": ""
+    "Analog": "アナログ"
   },
   "Analog, digital, or stacked clock display": {
-    "Analog, digital, or stacked clock display": ""
+    "Analog, digital, or stacked clock display": "アナログ、デジタル、またはスタック表示の時計"
   },
   "Analyzing configuration...": {
-    "Analyzing configuration...": ""
+    "Analyzing configuration...": "設定を解析中..."
   },
   "Animation Duration": {
-    "Animation Duration": ""
+    "Animation Duration": "アニメーション時間"
   },
   "Animation Speed": {
     "Animation Speed": "アニメーション速度"
   },
   "Anonymous Identity": {
-    "Anonymous Identity": ""
+    "Anonymous Identity": "匿名 ID"
   },
   "Anonymous Identity (optional)": {
     "Anonymous Identity (optional)": "匿名 ID (オプション)"
   },
   "App Customizations": {
-    "App Customizations": ""
+    "App Customizations": "アプリのカスタマイズ"
   },
   "App ID Substitutions": {
-    "App ID Substitutions": ""
+    "App ID Substitutions": "App ID 置換"
   },
   "App ID regex (e.g. ^firefox$)": {
-    "App ID regex (e.g. ^firefox$)": ""
+    "App ID regex (e.g. ^firefox$)": "App ID の正規表現（例: ^firefox$）"
   },
   "App Launcher": {
     "App Launcher": "アプリランチャー"
   },
   "App Names": {
-    "App Names": ""
+    "App Names": "アプリ名"
   },
   "App Theming": {
-    "App Theming": ""
+    "App Theming": "アプリテーマ"
   },
   "Appearance": {
-    "Appearance": ""
+    "Appearance": "外観"
   },
   "Application Dock": {
     "Application Dock": "アプリドック"
@@ -498,7 +498,7 @@
     "Applications": "アプリ"
   },
   "Apply Changes": {
-    "Apply Changes": ""
+    "Apply Changes": "変更を適用"
   },
   "Apply GTK Colors": {
     "Apply GTK Colors": "GTKカラーを適用"
@@ -510,16 +510,16 @@
     "Apply warm color temperature to reduce eye strain. Use automation settings below to control when it activates.": "目の疲れを軽減するために、暖色系の色温度を適用します。以下の自動化設定で、いつアクティブにするか制御できます。"
   },
   "Applying authentication changes…": {
-    "Applying authentication changes…": ""
+    "Applying authentication changes…": "認証の変更を適用中…"
   },
   "Apps": {
-    "Apps": ""
+    "Apps": "アプリ"
   },
   "Apps Dock": {
-    "Apps Dock": ""
+    "Apps Dock": "アプリドック"
   },
   "Apps Dock Settings": {
-    "Apps Dock Settings": ""
+    "Apps Dock Settings": "アプリドック設定"
   },
   "Apps Icon": {
     "Apps Icon": "アプリアイコン"
@@ -528,25 +528,25 @@
     "Apps are ordered by usage frequency, then last used, then alphabetically.": "アプリは使用頻度、最終使用日、アルファベット順の優先順位で並べられています。"
   },
   "Apps with custom display name, icon, or launch options. Right-click an app and select 'Edit App' to customize.": {
-    "Apps with custom display name, icon, or launch options. Right-click an app and select 'Edit App' to customize.": ""
+    "Apps with custom display name, icon, or launch options. Right-click an app and select 'Edit App' to customize.": "表示名、アイコン、または起動オプションをカスタマイズしたアプリ。アプリを右クリックして「Edit App」を選択するとカスタマイズできます。"
   },
   "Apps with notification popups muted. Unmute or delete to remove.": {
-    "Apps with notification popups muted. Unmute or delete to remove.": ""
+    "Apps with notification popups muted. Unmute or delete to remove.": "通知ポップアップがミュートされているアプリ。ミュート解除するか削除すると除外されます。"
   },
   "Architecture": {
-    "Architecture": ""
+    "Architecture": "アーキテクチャ"
   },
   "Are you sure you want to kill session \"%1\"?": {
-    "Are you sure you want to kill session \"%1\"?": ""
+    "Are you sure you want to kill session \"%1\"?": "セッション \"%1\" を終了してもよろしいですか?"
   },
   "Arrange displays and configure resolution, refresh rate, and VRR": {
-    "Arrange displays and configure resolution, refresh rate, and VRR": ""
+    "Arrange displays and configure resolution, refresh rate, and VRR": "ディスプレイを配置し、解像度、リフレッシュレート、VRR を設定"
   },
   "Attach": {
-    "Attach": ""
+    "Attach": "添付"
   },
   "Audio": {
-    "Audio": ""
+    "Audio": "オーディオ"
   },
   "Audio Codec": {
     "Audio Codec": "オーディオコーデック"
@@ -558,58 +558,58 @@
     "Audio Devices": "オーディオデバイス"
   },
   "Audio Input": {
-    "Audio Input": ""
+    "Audio Input": "オーディオ入力"
   },
   "Audio Output": {
-    "Audio Output": ""
+    "Audio Output": "オーディオ出力"
   },
   "Audio Output Devices (": {
     "Audio Output Devices (": "オーディオ出力デバイス（"
   },
   "Audio Output Switch": {
-    "Audio Output Switch": ""
+    "Audio Output Switch": "オーディオ出力切り替え"
   },
   "Audio Visualizer": {
-    "Audio Visualizer": ""
+    "Audio Visualizer": "オーディオビジュアライザー"
   },
   "Audio system restarted": {
-    "Audio system restarted": ""
+    "Audio system restarted": "オーディオシステムが再起動されました"
   },
   "Audio volume control": {
-    "Audio volume control": ""
+    "Audio volume control": "オーディオ音量コントロール"
   },
   "Auth": {
-    "Auth": ""
+    "Auth": "認証"
   },
   "Auth Type": {
-    "Auth Type": ""
+    "Auth Type": "認証タイプ"
   },
   "Authenticate": {
     "Authenticate": "認証"
   },
   "Authenticating...": {
-    "Authenticating...": ""
+    "Authenticating...": "認証中..."
   },
   "Authentication": {
-    "Authentication": ""
+    "Authentication": "認証"
   },
   "Authentication Required": {
     "Authentication Required": "認証が必要です"
   },
   "Authentication changes applied.": {
-    "Authentication changes applied.": ""
+    "Authentication changes applied.": "認証の変更を適用しました。"
   },
   "Authentication changes apply automatically.": {
-    "Authentication changes apply automatically.": ""
+    "Authentication changes apply automatically.": "認証の変更は自動的に適用されます。"
   },
   "Authentication changes apply automatically. Fingerprint-only login may not unlock Keyring.": {
-    "Authentication changes apply automatically. Fingerprint-only login may not unlock Keyring.": ""
+    "Authentication changes apply automatically. Fingerprint-only login may not unlock Keyring.": "認証の変更は自動的に適用されます。指紋のみのログインでは Keyring のロックが解除されない場合があります。"
   },
   "Authentication changes need sudo. Opening terminal so you can use password or fingerprint.": {
-    "Authentication changes need sudo. Opening terminal so you can use password or fingerprint.": ""
+    "Authentication changes need sudo. Opening terminal so you can use password or fingerprint.": "認証の変更には sudo が必要です。パスワードまたは指紋を使用できるよう端末を開きます。"
   },
   "Authentication error - try again": {
-    "Authentication error - try again": ""
+    "Authentication error - try again": "認証エラー - もう一度試してください"
   },
   "Authentication failed, please try again": {
     "Authentication failed, please try again": "認証が失敗しました、もう一度試してください"
@@ -624,13 +624,13 @@
     "Authorize service for ": "サービスを許可 "
   },
   "Auto": {
-    "Auto": ""
+    "Auto": "自動"
   },
   "Auto (Bar-aware)": {
-    "Auto (Bar-aware)": ""
+    "Auto (Bar-aware)": "自動（バー対応）"
   },
   "Auto (Wide)": {
-    "Auto (Wide)": ""
+    "Auto (Wide)": "自動（ワイド）"
   },
   "Auto Location": {
     "Auto Location": "自動位置検出"
@@ -639,16 +639,16 @@
     "Auto Popup Gaps": "自動ポップアップギャップ"
   },
   "Auto-Clear After": {
-    "Auto-Clear After": ""
+    "Auto-Clear After": "自動消去まで"
   },
   "Auto-Hide Timeout": {
-    "Auto-Hide Timeout": ""
+    "Auto-Hide Timeout": "自動非表示までの時間"
   },
   "Auto-close Niri overview when launching apps.": {
-    "Auto-close Niri overview when launching apps.": ""
+    "Auto-close Niri overview when launching apps.": "アプリ起動時に Niri の概要を自動的に閉じます。"
   },
   "Auto-delete notifications older than this": {
-    "Auto-delete notifications older than this": ""
+    "Auto-delete notifications older than this": "これより古い通知を自動削除"
   },
   "Auto-hide": {
     "Auto-hide": "自動的に非表示"
@@ -660,7 +660,7 @@
     "Auto-saving...": "自動保存中..."
   },
   "Autoconnect": {
-    "Autoconnect": ""
+    "Autoconnect": "自動接続"
   },
   "Autoconnect disabled": {
     "Autoconnect disabled": "自動接続が無効"
@@ -669,10 +669,10 @@
     "Autoconnect enabled": "自動接続が有効"
   },
   "Autofill last remembered query when opened": {
-    "Autofill last remembered query when opened": ""
+    "Autofill last remembered query when opened": "開いたときに最後に記憶したクエリを自動入力"
   },
   "Automatic Color Mode": {
-    "Automatic Color Mode": ""
+    "Automatic Color Mode": "自動カラーモード"
   },
   "Automatic Control": {
     "Automatic Control": "自動制御"
@@ -684,7 +684,7 @@
     "Automatically cycle through wallpapers in the same folder": "同じフォルダ内の壁紙を自動的に切り替える"
   },
   "Automatically delete entries older than this": {
-    "Automatically delete entries older than this": ""
+    "Automatically delete entries older than this": "これより古い項目を自動削除"
   },
   "Automatically detect location based on IP address": {
     "Automatically detect location based on IP address": "IPアドレスに基づいて位置を自動的に検出"
@@ -696,13 +696,13 @@
     "Automatically lock after": "自動的にロック"
   },
   "Automatically lock the screen when DMS starts": {
-    "Automatically lock the screen when DMS starts": ""
+    "Automatically lock the screen when DMS starts": "DMS 起動時に自動的に画面をロック"
   },
   "Automatically lock the screen when the system prepares to suspend": {
     "Automatically lock the screen when the system prepares to suspend": "システムが一時停止の準備中に自動的に画面をロック"
   },
   "Automation": {
-    "Automation": ""
+    "Automation": "自動化"
   },
   "Available": {
     "Available": "利用可能"
@@ -711,52 +711,52 @@
     "Available Layouts": "利用可能なレイアウト"
   },
   "Available Networks": {
-    "Available Networks": ""
+    "Available Networks": "利用可能なネットワーク"
   },
   "Available Plugins": {
     "Available Plugins": "利用可能なプラグイン"
   },
   "Available Screens (%1)": {
-    "Available Screens (%1)": ""
+    "Available Screens (%1)": "利用可能な画面（%1）"
   },
   "Available in Detailed and Forecast view modes": {
-    "Available in Detailed and Forecast view modes": ""
+    "Available in Detailed and Forecast view modes": "詳細表示と予報表示で利用可能"
   },
   "Available.": {
-    "Available.": ""
+    "Available.": "利用可能。"
   },
   "BSSID": {
-    "BSSID": ""
+    "BSSID": "BSSID"
   },
   "Back": {
     "Back": "戻る"
   },
   "Backend": {
-    "Backend": ""
+    "Backend": "バックエンド"
   },
   "Background": {
-    "Background": ""
+    "Background": "背景"
   },
   "Background Blur": {
-    "Background Blur": ""
+    "Background Blur": "背景のぼかし"
   },
   "Background Opacity": {
-    "Background Opacity": ""
+    "Background Opacity": "背景の透明度"
   },
   "Background authentication sync failed. Trying terminal mode.": {
-    "Background authentication sync failed. Trying terminal mode.": ""
+    "Background authentication sync failed. Trying terminal mode.": "バックグラウンド認証の同期に失敗しました。端末モードを試します。"
   },
   "Background image": {
-    "Background image": ""
+    "Background image": "背景画像"
   },
   "Backlight device": {
-    "Backlight device": ""
+    "Backlight device": "バックライトデバイス"
   },
   "Balance power and performance": {
-    "Balance power and performance": ""
+    "Balance power and performance": "電力とパフォーマンスのバランス"
   },
   "Balanced": {
-    "Balanced": ""
+    "Balanced": "バランス"
   },
   "Balanced palette with focused accents (default).": {
     "Balanced palette with focused accents (default).": "アクセントに焦点を絞ったバランスの取れたパレット(デフォルト)。"
@@ -765,91 +765,91 @@
     "Bar Configurations": "バーの設定"
   },
   "Bar Shadows": {
-    "Bar Shadows": ""
+    "Bar Shadows": "バーの影"
   },
   "Bar Transparency": {
     "Bar Transparency": "バーの透明度"
   },
   "Base color for shadows (opacity is applied automatically)": {
-    "Base color for shadows (opacity is applied automatically)": ""
+    "Base color for shadows (opacity is applied automatically)": "影の基本色（透明度は自動的に適用されます）"
   },
   "Base duration for animations (drag to use Custom)": {
-    "Base duration for animations (drag to use Custom)": ""
+    "Base duration for animations (drag to use Custom)": "アニメーションの基本時間（ドラッグでカスタムを使用）"
   },
   "Battery": {
     "Battery": "バッテリー"
   },
   "Battery %1": {
-    "Battery %1": ""
+    "Battery %1": "バッテリー %1"
   },
   "Battery Charge Limit": {
-    "Battery Charge Limit": ""
+    "Battery Charge Limit": "バッテリー充電上限"
   },
   "Battery and power management": {
-    "Battery and power management": ""
+    "Battery and power management": "バッテリーと電源管理"
   },
   "Battery level and power management": {
     "Battery level and power management": "バッテリーレベルおよび電源管理"
   },
   "Behavior": {
-    "Behavior": ""
+    "Behavior": "動作"
   },
   "Bind lock screen to dbus signals from loginctl. Disable if using an external lock screen": {
     "Bind lock screen to dbus signals from loginctl. Disable if using an external lock screen": "ロック画面をloginctlからのdbus信号にバインド。外部ロック画面を使用している場合は無効に"
   },
   "Binds Include Missing": {
-    "Binds Include Missing": ""
+    "Binds Include Missing": "Binds Include が不足"
   },
   "Binds include added": {
-    "Binds include added": ""
+    "Binds include added": "Binds include を追加しました"
   },
   "Bit Depth": {
-    "Bit Depth": ""
+    "Bit Depth": "ビット深度"
   },
   "Block Out": {
-    "Block Out": ""
+    "Block Out": "ブロックアウト"
   },
   "Block Out From": {
-    "Block Out From": ""
+    "Block Out From": "次からブロックアウト"
   },
   "Block notifications": {
-    "Block notifications": ""
+    "Block notifications": "通知をブロック"
   },
   "Blocked": {
-    "Blocked": ""
+    "Blocked": "ブロック済み"
   },
   "Blue light filter": {
-    "Blue light filter": ""
+    "Blue light filter": "ブルーライトフィルター"
   },
   "Bluetooth": {
-    "Bluetooth": ""
+    "Bluetooth": "Bluetooth"
   },
   "Bluetooth Settings": {
     "Bluetooth Settings": "Bluetooth設定"
   },
   "Bluetooth not available": {
-    "Bluetooth not available": ""
+    "Bluetooth not available": "Bluetooth は利用できません"
   },
   "Blur Border Color": {
-    "Blur Border Color": ""
+    "Blur Border Color": "ぼかし境界線の色"
   },
   "Blur Border Opacity": {
-    "Blur Border Opacity": ""
+    "Blur Border Opacity": "ぼかし境界線の透明度"
   },
   "Blur Wallpaper Layer": {
-    "Blur Wallpaper Layer": ""
+    "Blur Wallpaper Layer": "ぼかし壁紙レイヤー"
   },
   "Blur on Overview": {
     "Blur on Overview": "概要でぼかす"
   },
   "Blur the background behind bars, popouts, modals, and notifications. Requires compositor support and configuration.": {
-    "Blur the background behind bars, popouts, modals, and notifications. Requires compositor support and configuration.": ""
+    "Blur the background behind bars, popouts, modals, and notifications. Requires compositor support and configuration.": "バー、ポップアウト、モーダル、通知の背後の背景をぼかします。コンポジターのサポートと設定が必要です。"
   },
   "Blur wallpaper when niri overview is open": {
     "Blur wallpaper when niri overview is open": "Niri概要が開いているときに壁紙をぼかす"
   },
   "Body": {
-    "Body": ""
+    "Body": "本文"
   },
   "Border": {
     "Border": "ボーダー"
@@ -861,28 +861,28 @@
     "Border Opacity": "ボーダーの透明度"
   },
   "Border Size": {
-    "Border Size": ""
+    "Border Size": "ボーダーサイズ"
   },
   "Border Thickness": {
     "Border Thickness": "ボーダーの太さ"
   },
   "Border color around blurred surfaces": {
-    "Border color around blurred surfaces": ""
+    "Border color around blurred surfaces": "ぼかしたサーフェスの周囲のボーダー色"
   },
   "Border with BG": {
-    "Border with BG": ""
+    "Border with BG": "背景付きボーダー"
   },
   "Bottom": {
     "Bottom": "ボトム"
   },
   "Bottom Center": {
-    "Bottom Center": ""
+    "Bottom Center": "下中央"
   },
   "Bottom Left": {
-    "Bottom Left": ""
+    "Bottom Left": "左下"
   },
   "Bottom Right": {
-    "Bottom Right": ""
+    "Bottom Right": "右下"
   },
   "Bottom Section": {
     "Bottom Section": "ボトムセクション"
@@ -894,37 +894,37 @@
     "Brightness": "明るさ"
   },
   "Brightness Slider": {
-    "Brightness Slider": ""
+    "Brightness Slider": "明るさスライダー"
   },
   "Brightness Value": {
-    "Brightness Value": ""
+    "Brightness Value": "明るさの値"
   },
   "Brightness control not available": {
-    "Brightness control not available": ""
+    "Brightness control not available": "明るさの制御は利用できません"
   },
   "Browse": {
     "Browse": "ブラウズ"
   },
   "Browse Files": {
-    "Browse Files": ""
+    "Browse Files": "ファイルをブラウズ"
   },
   "Browse Plugins": {
-    "Browse Plugins": "ブラウズプラグイン"
+    "Browse Plugins": "プラグインを閲覧"
   },
   "Browse Themes": {
-    "Browse Themes": ""
+    "Browse Themes": "テーマをブラウズ"
   },
   "Browse or search plugins": {
-    "Browse or search plugins": ""
+    "Browse or search plugins": "プラグインを閲覧または検索"
   },
   "Button Color": {
-    "Button Color": ""
+    "Button Color": "ボタンカラー"
   },
   "CPU": {
     "CPU": "CPU"
   },
   "CPU Graph": {
-    "CPU Graph": ""
+    "CPU Graph": "CPUグラフ"
   },
   "CPU Temperature": {
     "CPU Temperature": "CPU温度"
@@ -939,7 +939,7 @@
     "CPU usage indicator": "CPU使用率インジケーター"
   },
   "CPU, memory, network, and disk monitoring": {
-    "CPU, memory, network, and disk monitoring": ""
+    "CPU, memory, network, and disk monitoring": "CPU、メモリ、ネットワーク、ディスクの監視"
   },
   "CUPS Insecure Filter Warning": {
     "CUPS Insecure Filter Warning": "CUPS の安全でないフィルターの警告"
@@ -948,10 +948,10 @@
     "CUPS Missing Filter Warning": "CUPS の欠落フィルターの警告"
   },
   "CUPS Print Server": {
-    "CUPS Print Server": ""
+    "CUPS Print Server": "CUPS プリントサーバー"
   },
   "CUPS not available": {
-    "CUPS not available": ""
+    "CUPS not available": "CUPS は利用できません"
   },
   "Camera": {
     "Camera": "カメラ"
@@ -960,109 +960,109 @@
     "Cancel": "キャンセル"
   },
   "Cancel all jobs for \"%1\"?": {
-    "Cancel all jobs for \"%1\"?": ""
+    "Cancel all jobs for \"%1\"?": "\"%1\" のすべてのジョブを取り消しますか?"
   },
   "Canceled": {
-    "Canceled": ""
+    "Canceled": "取り消し済み"
   },
   "Cannot pair": {
-    "Cannot pair": ""
+    "Cannot pair": "ペアリングできません"
   },
   "Capabilities": {
-    "Capabilities": ""
+    "Capabilities": "機能"
   },
   "Capacity": {
     "Capacity": "容量"
   },
   "Caps Lock": {
-    "Caps Lock": ""
+    "Caps Lock": "Caps Lock"
   },
   "Caps Lock Indicator": {
     "Caps Lock Indicator": "Caps Lock インジケーター"
   },
   "Caps Lock is on": {
-    "Caps Lock is on": ""
+    "Caps Lock is on": "Caps Lock がオンです"
   },
   "Center Section": {
     "Center Section": "センターセクション"
   },
   "Center Single Column": {
-    "Center Single Column": ""
+    "Center Single Column": "中央の単一列"
   },
   "Center Tiling": {
     "Center Tiling": "中央タイルリング"
   },
   "Certificate Password": {
-    "Certificate Password": ""
+    "Certificate Password": "証明書パスワード"
   },
   "Change Song": {
-    "Change Song": ""
+    "Change Song": "曲を変更"
   },
   "Change Volume": {
-    "Change Volume": ""
+    "Change Volume": "音量を変更"
   },
   "Change bar appearance": {
     "Change bar appearance": "バーの見た目を変更"
   },
   "Change the locale used by the DMS interface.": {
-    "Change the locale used by the DMS interface.": ""
+    "Change the locale used by the DMS interface.": "DMS インターフェースで使用するロケールを変更します。"
   },
   "Change the locale used for date and time formatting, independent of the interface language.": {
-    "Change the locale used for date and time formatting, independent of the interface language.": ""
+    "Change the locale used for date and time formatting, independent of the interface language.": "日時の書式設定に使用するロケールを、インターフェース言語とは独立して変更します。"
   },
   "Channel": {
-    "Channel": ""
+    "Channel": "チャンネル"
   },
   "Charging": {
-    "Charging": ""
+    "Charging": "充電中"
   },
   "Check for system updates": {
     "Check for system updates": "システムアップデートを検査"
   },
   "Check sync status on demand. Sync copies your theme, settings, and wallpaper configuration to the login screen. Authentication changes apply automatically.": {
-    "Check sync status on demand. Sync copies your theme, settings, and wallpaper configuration to the login screen. Authentication changes apply automatically.": ""
+    "Check sync status on demand. Sync copies your theme, settings, and wallpaper configuration to the login screen. Authentication changes apply automatically.": "必要に応じて同期状態を確認します。Sync はテーマ、設定、壁紙設定をログイン画面にコピーします。認証の変更は自動的に適用されます。"
   },
   "Checking for updates...": {
-    "Checking for updates...": ""
+    "Checking for updates...": "更新を確認中..."
   },
   "Checking whether sudo authentication is needed…": {
-    "Checking whether sudo authentication is needed…": ""
+    "Checking whether sudo authentication is needed…": "sudo 認証が必要か確認中…"
   },
   "Checking...": {
-    "Checking...": ""
+    "Checking...": "確認中..."
   },
   "Checking…": {
-    "Checking…": ""
+    "Checking…": "確認中…"
   },
   "Choose Color": {
     "Choose Color": "色を選んでください"
   },
   "Choose Dark Mode Color": {
-    "Choose Dark Mode Color": ""
+    "Choose Dark Mode Color": "ダークモードの色を選ぶ"
   },
   "Choose Dock Launcher Logo Color": {
-    "Choose Dock Launcher Logo Color": ""
+    "Choose Dock Launcher Logo Color": "ドックランチャーロゴの色を選ぶ"
   },
   "Choose Launcher Logo Color": {
     "Choose Launcher Logo Color": "ランチャーロゴの色を選ぶ"
   },
   "Choose Light Mode Color": {
-    "Choose Light Mode Color": ""
+    "Choose Light Mode Color": "ライトモードの色を選ぶ"
   },
   "Choose Wallpaper Color": {
-    "Choose Wallpaper Color": ""
+    "Choose Wallpaper Color": "壁紙の色を選ぶ"
   },
   "Choose a color": {
-    "Choose a color": ""
+    "Choose a color": "色を選ぶ"
   },
   "Choose colors from palette": {
-    "Choose colors from palette": ""
+    "Choose colors from palette": "パレットから色を選ぶ"
   },
   "Choose how the weather widget is displayed": {
-    "Choose how the weather widget is displayed": ""
+    "Choose how the weather widget is displayed": "天気ウィジェットの表示方法を選ぶ"
   },
   "Choose how this bar resolves shadow direction": {
-    "Choose how this bar resolves shadow direction": ""
+    "Choose how this bar resolves shadow direction": "このバーが影の方向を決定する方法を選ぶ"
   },
   "Choose icon": {
     "Choose icon": "アイコンを選ぶ"
@@ -1083,22 +1083,22 @@
     "Choose where on-screen displays appear on screen": "OSDの表示する場所を選んでください"
   },
   "Choose which displays show this widget": {
-    "Choose which displays show this widget": ""
+    "Choose which displays show this widget": "このウィジェットを表示するディスプレイを選ぶ"
   },
   "Choose which monitor shows the lock screen interface. Other monitors will display a solid color for OLED burn-in protection.": {
-    "Choose which monitor shows the lock screen interface. Other monitors will display a solid color for OLED burn-in protection.": ""
+    "Choose which monitor shows the lock screen interface. Other monitors will display a solid color for OLED burn-in protection.": "ロック画面インターフェースを表示するモニターを選びます。ほかのモニターには OLED 焼き付き防止のため単色を表示します。"
   },
   "Chroma Style": {
-    "Chroma Style": ""
+    "Chroma Style": "彩度スタイル"
   },
   "Cipher": {
-    "Cipher": ""
+    "Cipher": "暗号方式"
   },
   "Circle": {
-    "Circle": ""
+    "Circle": "円"
   },
   "Class regex (e.g. ^firefox$)": {
-    "Class regex (e.g. ^firefox$)": ""
+    "Class regex (e.g. ^firefox$)": "Class の正規表現（例: ^firefox$）"
   },
   "Clear": {
     "Clear": "クリア"
@@ -1107,58 +1107,58 @@
     "Clear All": "すべてクリア"
   },
   "Clear All Jobs": {
-    "Clear All Jobs": ""
+    "Clear All Jobs": "すべてのジョブをクリア"
   },
   "Clear History?": {
-    "Clear History?": ""
+    "Clear History?": "履歴をクリアしますか?"
   },
   "Clear Sky": {
-    "Clear Sky": ""
+    "Clear Sky": "快晴"
   },
   "Clear all history when server starts": {
-    "Clear all history when server starts": ""
+    "Clear all history when server starts": "サーバー起動時にすべての履歴をクリア"
   },
   "Clear at Startup": {
-    "Clear at Startup": ""
+    "Clear at Startup": "起動時にクリア"
   },
   "Click 'Setup' to create %1 and add include to config.": {
-    "Click 'Setup' to create %1 and add include to config.": ""
+    "Click 'Setup' to create %1 and add include to config.": "「Setup」をクリックして %1 を作成し、config に include を追加します。"
   },
   "Click 'Setup' to create %1 and add include to your compositor config.": {
-    "Click 'Setup' to create %1 and add include to your compositor config.": ""
+    "Click 'Setup' to create %1 and add include to your compositor config.": "「Setup」をクリックして %1 を作成し、コンポジター設定に include を追加します。"
   },
   "Click 'Setup' to create cursor config and add include to your compositor config.": {
-    "Click 'Setup' to create cursor config and add include to your compositor config.": ""
+    "Click 'Setup' to create cursor config and add include to your compositor config.": "「Setup」をクリックしてカーソル設定を作成し、コンポジター設定に include を追加します。"
   },
   "Click 'Setup' to create the outputs config and add include to your compositor config.": {
-    "Click 'Setup' to create the outputs config and add include to your compositor config.": ""
+    "Click 'Setup' to create the outputs config and add include to your compositor config.": "「Setup」をクリックして outputs 設定を作成し、コンポジター設定に include を追加します。"
   },
   "Click Import to add a .ovpn or .conf": {
-    "Click Import to add a .ovpn or .conf": ""
+    "Click Import to add a .ovpn or .conf": "Import をクリックして .ovpn または .conf を追加"
   },
   "Click Refresh to check status.": {
-    "Click Refresh to check status.": ""
+    "Click Refresh to check status.": "Refresh をクリックして状態を確認します。"
   },
   "Click Through": {
-    "Click Through": ""
+    "Click Through": "クリックを透過"
   },
   "Click any shortcut to edit. Changes save to %1": {
-    "Click any shortcut to edit. Changes save to %1": ""
+    "Click any shortcut to edit. Changes save to %1": "任意のショートカットをクリックして編集します。変更は %1 に保存されます"
   },
   "Click to capture": {
-    "Click to capture": ""
+    "Click to capture": "クリックしてキャプチャ"
   },
   "Click to select a custom theme JSON file": {
-    "Click to select a custom theme JSON file": ""
+    "Click to select a custom theme JSON file": "クリックしてカスタムテーマの JSON ファイルを選択"
   },
   "Clip": {
-    "Clip": ""
+    "Clip": "切り抜き"
   },
   "Clip to Geometry": {
-    "Clip to Geometry": ""
+    "Clip to Geometry": "ジオメトリに合わせて切り抜き"
   },
   "Clipboard": {
-    "Clipboard": ""
+    "Clipboard": "クリップボード"
   },
   "Clipboard History": {
     "Clipboard History": "クリップボード履歴"
@@ -1167,43 +1167,40 @@
     "Clipboard Manager": "クリップボード管理"
   },
   "Clipboard sent": {
-    "Clipboard sent": ""
-  },
-  "Clipboard service not available": {
-    "Clipboard service not available": ""
+    "Clipboard sent": "クリップボードを送信しました"
   },
   "Clipboard works but nothing saved to disk": {
-    "Clipboard works but nothing saved to disk": ""
+    "Clipboard works but nothing saved to disk": "クリップボードは動作しますが、ディスクには何も保存されません"
   },
   "Clock": {
     "Clock": "時計"
   },
   "Clock Style": {
-    "Clock Style": ""
+    "Clock Style": "時計スタイル"
   },
   "Close": {
     "Close": "閉じる"
   },
   "Close All Windows": {
-    "Close All Windows": ""
+    "Close All Windows": "すべてのウィンドウを閉じる"
   },
   "Close Overview on Launch": {
     "Close Overview on Launch": "起動中のときに概要を閉じる"
   },
   "Close Window": {
-    "Close Window": ""
+    "Close Window": "ウィンドウを閉じる"
   },
   "Color": {
-    "Color": ""
+    "Color": "色"
   },
   "Color Gamut": {
-    "Color Gamut": ""
+    "Color Gamut": "色域"
   },
   "Color Management": {
-    "Color Management": ""
+    "Color Management": "カラーマネジメント"
   },
   "Color Mode": {
-    "Color Mode": ""
+    "Color Mode": "カラーモード"
   },
   "Color Override": {
     "Color Override": "色のオーバーライド"
@@ -1212,13 +1209,13 @@
     "Color Picker": "カラーピッカー"
   },
   "Color Temperature": {
-    "Color Temperature": ""
+    "Color Temperature": "色温度"
   },
   "Color displayed on monitors without the lock screen": {
-    "Color displayed on monitors without the lock screen": ""
+    "Color displayed on monitors without the lock screen": "ロック画面を表示しないモニターに表示する色"
   },
   "Color for primary action buttons": {
-    "Color for primary action buttons": ""
+    "Color for primary action buttons": "主要アクションボタンの色"
   },
   "Color temperature for day time": {
     "Color temperature for day time": "昼間の色温度"
@@ -1227,103 +1224,103 @@
     "Color temperature for night mode": "ナイトモードの色温度"
   },
   "Color theme for syntax highlighting.": {
-    "Color theme for syntax highlighting.": ""
+    "Color theme for syntax highlighting.": "シンタックスハイライト用のカラーテーマ。"
   },
   "Color theme for syntax highlighting. %1 themes available.": {
-    "Color theme for syntax highlighting. %1 themes available.": ""
+    "Color theme for syntax highlighting. %1 themes available.": "シンタックスハイライト用のカラーテーマ。%1 個のテーマが利用可能です。"
   },
   "Color theme from DMS registry": {
-    "Color theme from DMS registry": ""
+    "Color theme from DMS registry": "DMS レジストリのカラーテーマ"
   },
   "Colorful": {
-    "Colorful": ""
+    "Colorful": "カラフル"
   },
   "Colorful mix of bright contrasting accents.": {
     "Colorful mix of bright contrasting accents.": "明るいコントラストのアクセントのカラフルなミックス。"
   },
   "Colorize Active": {
-    "Colorize Active": ""
+    "Colorize Active": "アクティブ項目を色付け"
   },
   "Colors from wallpaper": {
-    "Colors from wallpaper": ""
+    "Colors from wallpaper": "壁紙から取得した色"
   },
   "Column": {
-    "Column": ""
+    "Column": "列"
   },
   "Column Display": {
-    "Column Display": ""
+    "Column Display": "列表示"
   },
   "Column Width": {
-    "Column Width": ""
+    "Column Width": "列幅"
   },
   "Comma-separated list of session names to hide. Wrap in slashes for regex (e.g., /^_.*/).": {
-    "Comma-separated list of session names to hide. Wrap in slashes for regex (e.g., /^_.*/).": ""
+    "Comma-separated list of session names to hide. Wrap in slashes for regex (e.g., /^_.*/).": "非表示にするセッション名のカンマ区切りリストです。正規表現を使う場合はスラッシュで囲みます（例: /^_.*/）。"
   },
   "Command": {
-    "Command": ""
+    "Command": "コマンド"
   },
   "Commands": {
-    "Commands": ""
+    "Commands": "コマンド"
   },
   "Communication": {
     "Communication": "コミュニケーション"
   },
   "Community themes": {
-    "Community themes": ""
+    "Community themes": "コミュニティテーマ"
   },
   "Compact": {
-    "Compact": ""
+    "Compact": "コンパクト"
   },
   "Compact Mode": {
     "Compact Mode": "コンパクトモード"
   },
   "Completed": {
-    "Completed": ""
+    "Completed": "完了"
   },
   "Compositor": {
     "Compositor": "コンポジター"
   },
   "Compositor Settings": {
-    "Compositor Settings": ""
+    "Compositor Settings": "コンポジター設定"
   },
   "Compositor not supported": {
-    "Compositor not supported": ""
+    "Compositor not supported": "コンポジターはサポートされていません"
   },
   "Config Format": {
-    "Config Format": ""
+    "Config Format": "設定形式"
   },
   "Config action: %1": {
-    "Config action: %1": ""
+    "Config action: %1": "設定アクション: %1"
   },
   "Config validation failed": {
-    "Config validation failed": ""
+    "Config validation failed": "設定の検証に失敗しました"
   },
   "Configuration": {
-    "Configuration": ""
+    "Configuration": "設定"
   },
   "Configuration activated": {
     "Configuration activated": "設定が適用されました"
   },
   "Configuration will be preserved when this display reconnects": {
-    "Configuration will be preserved when this display reconnects": ""
+    "Configuration will be preserved when this display reconnects": "このディスプレイが再接続されたときに設定が保持されます"
   },
   "Configure": {
-    "Configure": ""
+    "Configure": "設定"
   },
   "Configure Keybinds": {
-    "Configure Keybinds": ""
+    "Configure Keybinds": "キーバインドを設定"
   },
   "Configure a new printer": {
-    "Configure a new printer": ""
+    "Configure a new printer": "新しいプリンターを設定"
   },
   "Configure icons for named workspaces. Icons take priority over numbers when both are enabled.": {
     "Configure icons for named workspaces. Icons take priority over numbers when both are enabled.": "名前付きワークスペースのアイコンを設定します。両方が有効になっている場合、アイコンが数字よりも優先されます。"
   },
   "Configure match criteria and actions": {
-    "Configure match criteria and actions": ""
+    "Configure match criteria and actions": "一致条件とアクションを設定"
   },
-  "Configure which displays show \"%1": {
-    "Configure which displays show \"%1\"": ""
+  "Configure which displays show \"%1\"": {
+    "Configure which displays show \"%1\"": "\"%1\" を表示するディスプレイを設定"
   },
   "Configure which displays show shell components": {
     "Configure which displays show shell components": "シェルコンポーネントを表示するディスプレイを配置"
@@ -1332,7 +1329,7 @@
     "Confirm": "確認"
   },
   "Confirm Delete": {
-    "Confirm Delete": ""
+    "Confirm Delete": "削除を確認"
   },
   "Confirm Display Changes": {
     "Confirm Display Changes": "表示変更を確認"
@@ -1341,13 +1338,13 @@
     "Confirm passkey for ": "パスキーを確認 "
   },
   "Conflicts with: %1": {
-    "Conflicts with: %1": ""
+    "Conflicts with: %1": "競合先: %1"
   },
   "Connect": {
     "Connect": "接続"
   },
   "Connect to Hidden Network": {
-    "Connect to Hidden Network": ""
+    "Connect to Hidden Network": "非表示のネットワークに接続"
   },
   "Connect to VPN": {
     "Connect to VPN": "VPNに接続"
@@ -1356,10 +1353,10 @@
     "Connect to Wi-Fi": "Wi-Fiに接続"
   },
   "Connected": {
-    "Connected": ""
+    "Connected": "接続済み"
   },
   "Connected Device": {
-    "Connected Device": ""
+    "Connected Device": "接続済みデバイス"
   },
   "Connected Displays": {
     "Connected Displays": "接続されたディスプレイ"
@@ -1368,22 +1365,22 @@
     "Connecting to Device": "デバイスに接続中"
   },
   "Connecting to clipboard service…": {
-    "Connecting to clipboard service…": ""
+    "Connecting to clipboard service…": "クリップボードサービスに接続中…"
   },
   "Connecting...": {
-    "Connecting...": ""
+    "Connecting...": "接続中..."
   },
   "Connection failed": {
-    "Connection failed": ""
+    "Connection failed": "接続に失敗しました"
   },
   "Contains": {
-    "Contains": ""
+    "Contains": "含む"
   },
   "Content": {
-    "Content": ""
+    "Content": "内容"
   },
   "Content copied": {
-    "Content copied": ""
+    "Content copied": "内容をコピーしました"
   },
   "Contrast": {
     "Contrast": "コントラスト"
@@ -1392,49 +1389,49 @@
     "Control Center": "コントロールセンター"
   },
   "Control Center Tile Color": {
-    "Control Center Tile Color": ""
+    "Control Center Tile Color": "コントロールセンタータイルの色"
   },
   "Control animation duration for notification popups and history": {
-    "Control animation duration for notification popups and history": ""
+    "Control animation duration for notification popups and history": "通知ポップアップと履歴のアニメーション時間を調整"
   },
   "Control currently playing media": {
     "Control currently playing media": "現在再生中のメディアを制御"
   },
   "Control what notification information is shown on the lock screen": {
-    "Control what notification information is shown on the lock screen": ""
+    "Control what notification information is shown on the lock screen": "ロック画面に表示する通知情報を制御"
   },
   "Control which plugins appear in 'All' mode without requiring a trigger prefix. Drag to reorder.": {
-    "Control which plugins appear in 'All' mode without requiring a trigger prefix. Drag to reorder.": ""
+    "Control which plugins appear in 'All' mode without requiring a trigger prefix. Drag to reorder.": "トリガー接頭辞なしで「All」モードに表示するプラグインを制御します。ドラッグして並べ替えできます。"
   },
   "Control workspaces and columns by scrolling on the bar": {
-    "Control workspaces and columns by scrolling on the bar": ""
+    "Control workspaces and columns by scrolling on the bar": "バー上のスクロールでワークスペースと列を操作"
   },
   "Controls opacity of all popouts, modals, and their content layers": {
-    "Controls opacity of all popouts, modals, and their content layers": ""
+    "Controls opacity of all popouts, modals, and their content layers": "すべてのポップアウト、モーダル、およびそのコンテンツレイヤーの透明度を制御"
   },
   "Controls shadow cast direction for elevation layers": {
-    "Controls shadow cast direction for elevation layers": ""
+    "Controls shadow cast direction for elevation layers": "エレベーションレイヤーの影の方向を制御"
   },
   "Controls the base blur radius and offset of shadows": {
-    "Controls the base blur radius and offset of shadows": ""
+    "Controls the base blur radius and offset of shadows": "影の基本ぼかし半径とオフセットを制御"
   },
   "Controls the transparency of the shadow": {
-    "Controls the transparency of the shadow": ""
+    "Controls the transparency of the shadow": "影の透明度を制御"
   },
   "Convenience options for the login screen. Sync to apply.": {
-    "Convenience options for the login screen. Sync to apply.": ""
+    "Convenience options for the login screen. Sync to apply.": "ログイン画面用の便利なオプションです。適用するには Sync を実行してください。"
   },
   "Cooldown": {
-    "Cooldown": ""
+    "Cooldown": "クールダウン"
   },
   "Copied GIF": {
-    "Copied GIF": ""
+    "Copied GIF": "GIF をコピーしました"
   },
   "Copied MP4": {
-    "Copied MP4": ""
+    "Copied MP4": "MP4 をコピーしました"
   },
   "Copied WebP": {
-    "Copied WebP": ""
+    "Copied WebP": "WebP をコピーしました"
   },
   "Copied to clipboard": {
     "Copied to clipboard": "クリップボードにコピーしました"
@@ -1443,100 +1440,100 @@
     "Copied!": "コピーしました！"
   },
   "Copy": {
-    "Copy": ""
+    "Copy": "コピー"
   },
   "Copy Content": {
-    "Copy Content": ""
+    "Copy Content": "内容をコピー"
   },
   "Copy Full Command": {
-    "Copy Full Command": ""
+    "Copy Full Command": "完全なコマンドをコピー"
   },
   "Copy HTML": {
-    "Copy HTML": ""
+    "Copy HTML": "HTML をコピー"
   },
   "Copy Name": {
-    "Copy Name": ""
+    "Copy Name": "名前をコピー"
   },
   "Copy PID": {
     "Copy PID": "PIDをコピー"
   },
   "Copy Text": {
-    "Copy Text": ""
+    "Copy Text": "テキストをコピー"
   },
   "Copy path": {
-    "Copy path": ""
+    "Copy path": "パスをコピー"
   },
   "Corner Radius": {
-    "Corner Radius": ""
+    "Corner Radius": "角丸半径"
   },
   "Corner Radius Override": {
     "Corner Radius Override": "コーナー半径オーバーライド"
   },
   "Corners & Background": {
-    "Corners & Background": ""
+    "Corners & Background": "角と背景"
   },
   "Count Only": {
-    "Count Only": ""
+    "Count Only": "件数のみ"
   },
   "Cover Open": {
     "Cover Open": "カバーオープン"
   },
   "Create": {
-    "Create": ""
+    "Create": "作成"
   },
   "Create Dir": {
     "Create Dir": "ディレクトリを作成"
   },
   "Create Printer": {
-    "Create Printer": ""
+    "Create Printer": "プリンターを作成"
   },
   "Create Window Rule": {
-    "Create Window Rule": ""
+    "Create Window Rule": "ウィンドウルールを作成"
   },
   "Create a new %1 session (n)": {
-    "Create a new %1 session (n)": ""
+    "Create a new %1 session (n)": "新しい %1 セッションを作成（n）"
   },
   "Create rule for:": {
-    "Create rule for:": ""
+    "Create rule for:": "次のルールを作成:"
   },
   "Create rules to mute, ignore, hide from history, or override notification priority. Default only overrides priority; notifications still show normally.": {
-    "Create rules to mute, ignore, hide from history, or override notification priority. Default only overrides priority; notifications still show normally.": ""
+    "Create rules to mute, ignore, hide from history, or override notification priority. Default only overrides priority; notifications still show normally.": "ミュート、無視、履歴から隠す、または通知優先度を上書きするルールを作成します。デフォルトでは優先度のみを上書きし、通知自体は通常どおり表示されます。"
   },
   "Creating...": {
-    "Creating...": ""
+    "Creating...": "作成中..."
   },
   "Critical Priority": {
     "Critical Priority": "最優先事項"
   },
   "Current": {
-    "Current": ""
+    "Current": "現在"
   },
   "Current Items": {
     "Current Items": "現在のアイテム"
   },
   "Current Locale": {
-    "Current Locale": ""
+    "Current Locale": "現在のロケール"
   },
   "Current Monitor": {
-    "Current Monitor": ""
+    "Current Monitor": "現在のモニター"
   },
   "Current Period": {
-    "Current Period": ""
+    "Current Period": "現在の期間"
   },
   "Current Status": {
-    "Current Status": ""
+    "Current Status": "現在の状態"
   },
   "Current Temp": {
-    "Current Temp": ""
+    "Current Temp": "現在の気温"
   },
   "Current Theme: %1": {
-    "Current Theme: %1": ""
+    "Current Theme: %1": "現在のテーマ: %1"
   },
   "Current Weather": {
     "Current Weather": "現在の天気"
   },
   "Current Workspace": {
-    "Current Workspace": ""
+    "Current Workspace": "現在のワークスペース"
   },
   "Current time and date display": {
     "Current time and date display": "現在の日時を表示"
@@ -1545,73 +1542,73 @@
     "Current weather conditions and temperature": "現在の天気状況と気温"
   },
   "Current: %1": {
-    "Current: %1": ""
+    "Current: %1": "現在: %1"
   },
   "Cursor Config Not Configured": {
-    "Cursor Config Not Configured": ""
+    "Cursor Config Not Configured": "カーソル設定が構成されていません"
   },
   "Cursor Include Missing": {
-    "Cursor Include Missing": ""
+    "Cursor Include Missing": "カーソル include が不足"
   },
   "Cursor Size": {
-    "Cursor Size": ""
+    "Cursor Size": "カーソルサイズ"
   },
   "Cursor Theme": {
-    "Cursor Theme": ""
+    "Cursor Theme": "カーソルテーマ"
   },
   "Custom": {
     "Custom": "カスタム"
   },
   "Custom Color": {
-    "Custom Color": ""
+    "Custom Color": "カスタムカラー"
   },
   "Custom Duration": {
-    "Custom Duration": ""
+    "Custom Duration": "カスタム時間"
   },
   "Custom Hibernate Command": {
-    "Custom Hibernate Command": ""
+    "Custom Hibernate Command": "カスタム休止コマンド"
   },
   "Custom Location": {
     "Custom Location": "カスタムロケーション"
   },
   "Custom Lock Command": {
-    "Custom Lock Command": ""
+    "Custom Lock Command": "カスタムロックコマンド"
   },
   "Custom Logout Command": {
-    "Custom Logout Command": ""
+    "Custom Logout Command": "カスタムログアウトコマンド"
   },
   "Custom Name": {
-    "Custom Name": ""
+    "Custom Name": "カスタム名"
   },
   "Custom Power Actions": {
     "Custom Power Actions": "カスタム電源アクション"
   },
   "Custom Power Off Command": {
-    "Custom Power Off Command": ""
+    "Custom Power Off Command": "カスタム電源オフコマンド"
   },
   "Custom Reboot Command": {
-    "Custom Reboot Command": ""
+    "Custom Reboot Command": "カスタム再起動コマンド"
   },
   "Custom Shadow Color": {
-    "Custom Shadow Color": ""
+    "Custom Shadow Color": "カスタム影色"
   },
   "Custom Shadow Override": {
-    "Custom Shadow Override": ""
+    "Custom Shadow Override": "カスタム影オーバーライド"
   },
   "Custom Suspend Command": {
-    "Custom Suspend Command": ""
+    "Custom Suspend Command": "カスタムサスペンドコマンド"
   },
   "Custom Transparency": {
     "Custom Transparency": "カスタム透明度"
   },
   "Custom power profile": {
-    "Custom power profile": ""
+    "Custom power profile": "カスタム電源プロファイル"
   },
   "Custom theme loaded from JSON file": {
-    "Custom theme loaded from JSON file": ""
+    "Custom theme loaded from JSON file": "JSON ファイルからカスタムテーマを読み込みました"
   },
   "Custom...": {
-    "Custom...": ""
+    "Custom...": "カスタム..."
   },
   "Custom: ": {
     "Custom: ": "カスタム： "
@@ -1623,7 +1620,7 @@
     "Customize which actions appear in the power menu": "電源メニューに表示されるアクションをカスタマイズ"
   },
   "DDC/CI monitor": {
-    "DDC/CI monitor": ""
+    "DDC/CI monitor": "DDC/CI モニター"
   },
   "DEMO MODE - Click anywhere to exit": {
     "DEMO MODE - Click anywhere to exit": "デモモード -任意の場所をクリックして 終了"
@@ -1632,19 +1629,19 @@
     "DMS Plugin Manager Unavailable": "DMS プラグイン マネージャーが利用できません"
   },
   "DMS Shortcuts": {
-    "DMS Shortcuts": ""
+    "DMS Shortcuts": "DMS ショートカット"
   },
   "DMS greeter needs: greetd, dms-greeter. Fingerprint: fprintd, pam_fprintd. Security keys: pam_u2f. Add your user to the greeter group. Authentication changes apply automatically and may open a terminal when sudo authentication is required.": {
-    "DMS greeter needs: greetd, dms-greeter. Fingerprint: fprintd, pam_fprintd. Security keys: pam_u2f. Add your user to the greeter group. Authentication changes apply automatically and may open a terminal when sudo authentication is required.": ""
+    "DMS greeter needs: greetd, dms-greeter. Fingerprint: fprintd, pam_fprintd. Security keys: pam_u2f. Add your user to the greeter group. Authentication changes apply automatically and may open a terminal when sudo authentication is required.": "DMS greeter には greetd と dms-greeter が必要です。指紋認証には fprintd と pam_fprintd、セキュリティキーには pam_u2f が必要です。ユーザーを greeter グループに追加してください。認証の変更は自動的に適用され、sudo 認証が必要な場合は端末が開くことがあります。"
   },
   "DMS out of date": {
     "DMS out of date": "DMSに更新があります"
   },
   "DMS service is not connected. Clipboard settings are unavailable.": {
-    "DMS service is not connected. Clipboard settings are unavailable.": ""
+    "DMS service is not connected. Clipboard settings are unavailable.": "DMS サービスに接続されていません。クリップボード設定は利用できません。"
   },
   "DMS shell actions (launcher, clipboard, etc.)": {
-    "DMS shell actions (launcher, clipboard, etc.)": ""
+    "DMS shell actions (launcher, clipboard, etc.)": "DMS シェルアクション（ランチャー、クリップボードなど）"
   },
   "DMS_SOCKET not available": {
     "DMS_SOCKET not available": "DMS_SOCKETが利用できません"
@@ -1653,7 +1650,7 @@
     "DWL service not available": "DWLサービスが利用できません"
   },
   "Daily": {
-    "Daily": ""
+    "Daily": "毎日"
   },
   "Daily at:": {
     "Daily at:": "毎日："
@@ -1665,22 +1662,22 @@
     "Dank Bar": "Dank Bar"
   },
   "DankBar": {
-    "DankBar": ""
+    "DankBar": "DankBar"
   },
   "DankMaterialShell is ready to use": {
-    "DankMaterialShell is ready to use": ""
+    "DankMaterialShell is ready to use": "DankMaterialShell は使用可能です"
   },
   "DankShell & System Icons (requires restart)": {
-    "DankShell & System Icons (requires restart)": ""
+    "DankShell & System Icons (requires restart)": "DankShell とシステムアイコン（再起動が必要）"
   },
   "Dark Mode": {
     "Dark Mode": "ダークモード"
   },
   "Dark mode base": {
-    "Dark mode base": ""
+    "Dark mode base": "ダークモードベース"
   },
   "Dark mode harmony": {
-    "Dark mode harmony": ""
+    "Dark mode harmony": "ダークモードハーモニー"
   },
   "Darken Modal Background": {
     "Darken Modal Background": "モーダル背景を暗くする"
@@ -1689,31 +1686,31 @@
     "Date Format": "日付形式"
   },
   "Date format": {
-    "Date format": ""
+    "Date format": "日付形式"
   },
   "Date format on greeter": {
-    "Date format on greeter": ""
+    "Date format on greeter": "greeter の日付形式"
   },
   "Dawn (Astronomical Twilight)": {
-    "Dawn (Astronomical Twilight)": ""
+    "Dawn (Astronomical Twilight)": "夜明け（天文薄明）"
   },
   "Dawn (Civil Twilight)": {
-    "Dawn (Civil Twilight)": ""
+    "Dawn (Civil Twilight)": "夜明け（市民薄明）"
   },
   "Dawn (Nautical Twilight)": {
-    "Dawn (Nautical Twilight)": ""
+    "Dawn (Nautical Twilight)": "夜明け（航海薄明）"
   },
   "Day Date": {
-    "Day Date": ""
+    "Day Date": "曜日 日付"
   },
   "Day Month Date": {
-    "Day Month Date": ""
+    "Day Month Date": "曜日 月 日付"
   },
   "Day Temperature": {
     "Day Temperature": "昼間の温度"
   },
   "Daytime": {
-    "Daytime": ""
+    "Daytime": "昼間"
   },
   "Deck": {
     "Deck": "デッキ"
@@ -1722,10 +1719,10 @@
     "Default": "デフォルト"
   },
   "Default (Black)": {
-    "Default (Black)": ""
+    "Default (Black)": "デフォルト（黒）"
   },
   "Default Width (%)": {
-    "Default Width (%)": ""
+    "Default Width (%)": "デフォルト幅（%）"
   },
   "Default selected action": {
     "Default selected action": "デフォルトで選択されるアクション"
@@ -1734,67 +1731,67 @@
     "Defaults": "デフォルト"
   },
   "Define rules for window behavior. Saves to %1": {
-    "Define rules for window behavior. Saves to %1": ""
+    "Define rules for window behavior. Saves to %1": "ウィンドウ動作のルールを定義します。%1 に保存されます"
   },
   "Del: Clear • Shift+Del: Clear All • 1-9: Actions • F10: Help • Esc: Close": {
     "Del: Clear • Shift+Del: Clear All • 1-9: Actions • F10: Help • Esc: Close": "Del: クリア • Shift+Del: すべてクリア • 1-9: アクション • F10: ヘルプ • Esc: 閉じる"
   },
   "Delete": {
-    "Delete": ""
+    "Delete": "削除"
   },
   "Delete \"%1\"?": {
-    "Delete \"%1\"?": ""
+    "Delete \"%1\"?": "\"%1\" を削除しますか?"
   },
   "Delete Class": {
-    "Delete Class": ""
+    "Delete Class": "Class を削除"
   },
   "Delete Printer": {
-    "Delete Printer": ""
+    "Delete Printer": "プリンターを削除"
   },
   "Delete Saved Item?": {
-    "Delete Saved Item?": ""
+    "Delete Saved Item?": "保存済みアイテムを削除しますか?"
   },
   "Delete VPN": {
-    "Delete VPN": ""
+    "Delete VPN": "VPN を削除"
   },
   "Delete class \"%1\"?": {
-    "Delete class \"%1\"?": ""
+    "Delete class \"%1\"?": "class \"%1\" を削除しますか?"
   },
   "Delete profile \"%1\"?": {
-    "Delete profile \"%1\"?": ""
+    "Delete profile \"%1\"?": "プロファイル \"%1\" を削除しますか?"
   },
   "Dependencies & documentation": {
-    "Dependencies & documentation": ""
+    "Dependencies & documentation": "依存関係とドキュメント"
   },
   "Derives colors that closely match the underlying image.": {
     "Derives colors that closely match the underlying image.": "下にある画像に密接に一致する色を導き出します。"
   },
   "Description": {
-    "Description": ""
+    "Description": "説明"
   },
   "Desktop": {
-    "Desktop": ""
+    "Desktop": "デスクトップ"
   },
   "Desktop Clock": {
-    "Desktop Clock": ""
+    "Desktop Clock": "デスクトップ時計"
   },
   "Desktop Entry": {
-    "Desktop Entry": ""
+    "Desktop Entry": "デスクトップエントリ"
   },
   "Desktop Widget": {
-    "Desktop Widget": ""
+    "Desktop Widget": "デスクトップウィジェット"
   },
   "Desktop Widgets": {
-    "Desktop Widgets": ""
+    "Desktop Widgets": "デスクトップウィジェット"
   },
   "Desktop background images": {
     "Desktop background images": "デスクトップの背景画像"
   },
   "Detailed": {
-    "Detailed": ""
+    "Detailed": "詳細"
   },
-  "Details for \"%1": {
-    "Details for \"%1\"": ""
+  "Details for \"%1\"": {
+    "Details for \"%1\"": "\"%1\" の詳細"
   },
   "Development": {
     "Development": "開発"
@@ -1803,100 +1800,100 @@
     "Device": "デバイス"
   },
   "Device connections": {
-    "Device connections": ""
+    "Device connections": "デバイス接続"
   },
   "Device names updated": {
-    "Device names updated": ""
+    "Device names updated": "デバイス名を更新しました"
   },
   "Device paired": {
     "Device paired": "デバイスがペアリングされました"
   },
   "Device unpaired": {
-    "Device unpaired": ""
+    "Device unpaired": "デバイスのペアリングを解除しました"
   },
   "Digital": {
-    "Digital": ""
+    "Digital": "デジタル"
   },
   "Direction Source": {
-    "Direction Source": ""
+    "Direction Source": "方向ソース"
   },
   "Disable Autoconnect": {
     "Disable Autoconnect": "自動接続を無効"
   },
   "Disable Built-in Wallpapers": {
-    "Disable Built-in Wallpapers": ""
+    "Disable Built-in Wallpapers": "内蔵壁紙を無効化"
   },
   "Disable History Persistence": {
-    "Disable History Persistence": ""
+    "Disable History Persistence": "履歴の永続化を無効化"
   },
   "Disable Output": {
-    "Disable Output": ""
+    "Disable Output": "出力を無効化"
   },
   "Disabled": {
     "Disabled": "無効化されました"
   },
   "Disabling WiFi...": {
-    "Disabling WiFi...": ""
+    "Disabling WiFi...": "WiFi を無効化中..."
   },
   "Disc": {
-    "Disc": ""
+    "Disc": "ディスク"
   },
   "Discard": {
-    "Discard": ""
+    "Discard": "破棄"
   },
   "Discharging": {
-    "Discharging": ""
+    "Discharging": "放電中"
   },
   "Disconnect": {
     "Disconnect": "切断"
   },
   "Disconnected": {
-    "Disconnected": ""
+    "Disconnected": "切断済み"
   },
   "Disconnected from WiFi": {
     "Disconnected from WiFi": "WiFiから切断されました"
   },
   "Discover Devices": {
-    "Discover Devices": ""
+    "Discover Devices": "デバイスを検出"
   },
   "Disk": {
     "Disk": "ディスク"
   },
   "Disk I/O": {
-    "Disk I/O": ""
+    "Disk I/O": "ディスク I/O"
   },
   "Disk Usage": {
     "Disk Usage": "ディスク使用率"
   },
   "Disk Usage Display": {
-    "Disk Usage Display": ""
+    "Disk Usage Display": "ディスク使用率表示"
   },
   "Disks": {
-    "Disks": ""
+    "Disks": "ディスク"
   },
   "Dismiss": {
     "Dismiss": "解除"
   },
   "Display": {
-    "Display": ""
+    "Display": "表示"
   },
   "Display Assignment": {
     "Display Assignment": "表示割り当て"
   },
   "Display Control": {
-    "Display Control": ""
+    "Display Control": "表示コントロール"
   },
   "Display Name Format": {
     "Display Name Format": "名称形式を表示"
   },
   "Display Profiles": {
-    "Display Profiles": ""
+    "Display Profiles": "表示プロファイル"
   },
   "Display Settings": {
-    "Display Settings": ""
+    "Display Settings": "表示設定"
   },
   "Display a dock with pinned and running applications": {
-    "Display a dock with pinned and running applications": ""
+    "Display a dock with pinned and running applications": "固定済みおよび実行中のアプリを表示するドックを表示"
   },
   "Display all priorities over fullscreen apps": {
     "Display all priorities over fullscreen apps": "フルスクリーンアプリよりもすべての優先度を表示する"
@@ -1908,43 +1905,43 @@
     "Display application icons in workspace indicators": "ワークスペース インジケーターにアプリのアイコンを表示"
   },
   "Display brightness control": {
-    "Display brightness control": ""
+    "Display brightness control": "明るさコントロールを表示"
   },
   "Display configuration is not available. WLR output management protocol not supported.": {
-    "Display configuration is not available. WLR output management protocol not supported.": ""
+    "Display configuration is not available. WLR output management protocol not supported.": "表示設定は利用できません。WLR 出力管理プロトコルはサポートされていません。"
   },
   "Display currently focused application title": {
     "Display currently focused application title": "現在フォーカスされているアプリケーションのタイトルを表示"
   },
   "Display hourly weather predictions": {
-    "Display hourly weather predictions": ""
+    "Display hourly weather predictions": "時間ごとの天気予報を表示"
   },
   "Display only workspaces that contain windows": {
-    "Display only workspaces that contain windows": ""
+    "Display only workspaces that contain windows": "ウィンドウを含むワークスペースのみ表示"
   },
   "Display power menu actions in a grid instead of a list": {
     "Display power menu actions in a grid instead of a list": "電源メニューのアクションをリストではなくグリッドに表示"
   },
   "Display seconds in the clock": {
-    "Display seconds in the clock": ""
+    "Display seconds in the clock": "時計に秒を表示"
   },
   "Display the power system menu": {
-    "Display the power system menu": ""
+    "Display the power system menu": "電源システムメニューを表示"
   },
   "Display volume and brightness percentage values in OSD popups": {
-    "Display volume and brightness percentage values in OSD popups": ""
+    "Display volume and brightness percentage values in OSD popups": "OSD ポップアップに音量と明るさのパーセンテージ値を表示"
   },
   "Displays": {
     "Displays": "表示"
   },
   "Displays count when overflow is active": {
-    "Displays count when overflow is active": ""
+    "Displays count when overflow is active": "オーバーフローが有効なとき件数を表示"
   },
   "Displays the active keyboard layout and allows switching": {
     "Displays the active keyboard layout and allows switching": "アクティブなキーボードレイアウトを表示、切り替えを可能に"
   },
   "Distribution": {
-    "Distribution": ""
+    "Distribution": "ディストリビューション"
   },
   "Diverse palette spanning the full spectrum.": {
     "Diverse palette spanning the full spectrum.": "全スペクトルにまたがる多様なパレット。"
@@ -1956,91 +1953,91 @@
     "Dock": "ドック"
   },
   "Dock & Launcher": {
-    "Dock & Launcher": ""
+    "Dock & Launcher": "ドックとランチャー"
   },
   "Dock Transparency": {
     "Dock Transparency": "ドックの透明度"
   },
   "Dock Visibility": {
-    "Dock Visibility": ""
+    "Dock Visibility": "ドックの表示"
   },
   "Docs": {
-    "Docs": ""
+    "Docs": "ドキュメント"
   },
   "Documents": {
-    "Documents": ""
+    "Documents": "ドキュメント"
   },
   "Domain (optional)": {
     "Domain (optional)": "ドメイン (オプション)"
   },
   "Don't Change": {
-    "Don't Change": ""
+    "Don't Change": "変更しない"
   },
   "Don't Save": {
-    "Don't Save": ""
+    "Don't Save": "保存しない"
   },
   "Door Open": {
     "Door Open": "ドアオープン"
   },
   "Downloads": {
-    "Downloads": ""
+    "Downloads": "ダウンロード"
   },
   "Drag to Reorder": {
-    "Drag to Reorder": ""
+    "Drag to Reorder": "ドラッグして並べ替え"
   },
   "Drag widgets to reorder within sections. Use the eye icon to hide/show widgets (maintains spacing), or X to remove them completely.": {
     "Drag widgets to reorder within sections. Use the eye icon to hide/show widgets (maintains spacing), or X to remove them completely.": "ウィジェットをドラッグしてセクション内で順序を変更できます。目のアイコンでウィジェットを表示/非表示に（スペースは維持）、Xで完全に削除できます。"
   },
   "Drag workspace indicators to reorder them": {
-    "Drag workspace indicators to reorder them": ""
+    "Drag workspace indicators to reorder them": "ワークスペースインジケーターをドラッグして並べ替え"
   },
   "Driver": {
-    "Driver": ""
+    "Driver": "ドライバー"
   },
   "Drizzle": {
-    "Drizzle": ""
+    "Drizzle": "霧雨"
   },
   "Duplicate": {
-    "Duplicate": ""
+    "Duplicate": "複製"
   },
   "Duplicate Wallpaper with Blur": {
     "Duplicate Wallpaper with Blur": "ぼかしで壁紙を複製"
   },
   "Duration": {
-    "Duration": ""
+    "Duration": "時間"
   },
   "Dusk (Astronomical Twilight)": {
-    "Dusk (Astronomical Twilight)": ""
+    "Dusk (Astronomical Twilight)": "夕暮れ（天文薄明）"
   },
   "Dusk (Civil Twighlight)": {
-    "Dusk (Civil Twighlight)": ""
+    "Dusk (Civil Twighlight)": "夕暮れ（市民薄明）"
   },
   "Dusk (Nautical Twilight)": {
-    "Dusk (Nautical Twilight)": ""
+    "Dusk (Nautical Twilight)": "夕暮れ（航海薄明）"
   },
   "Dynamic": {
-    "Dynamic": ""
+    "Dynamic": "動的"
   },
   "Dynamic Properties": {
-    "Dynamic Properties": ""
+    "Dynamic Properties": "動的プロパティ"
   },
   "Dynamic Theming": {
-    "Dynamic Theming": ""
+    "Dynamic Theming": "動的テーマ"
   },
   "Dynamic colors from wallpaper": {
-    "Dynamic colors from wallpaper": ""
+    "Dynamic colors from wallpaper": "壁紙から動的に取得した色"
   },
   "Dynamic colors, presets": {
-    "Dynamic colors, presets": ""
+    "Dynamic colors, presets": "動的カラー、プリセット"
   },
   "Edge Spacing": {
-    "Edge Spacing": ""
+    "Edge Spacing": "端の余白"
   },
   "Edit App": {
-    "Edit App": ""
+    "Edit App": "アプリを編集"
   },
   "Edit Window Rule": {
-    "Edit Window Rule": ""
+    "Edit Window Rule": "ウィンドウルールを編集"
   },
   "Education": {
     "Education": "教育"
@@ -2049,7 +2046,7 @@
     "Empty": "空白"
   },
   "Enable 10-bit color depth for wider color gamut and HDR support": {
-    "Enable 10-bit color depth for wider color gamut and HDR support": ""
+    "Enable 10-bit color depth for wider color gamut and HDR support": "より広い色域と HDR サポートのために 10 ビット色深度を有効にします"
   },
   "Enable Autoconnect": {
     "Enable Autoconnect": "自動接続を有効"
@@ -2058,22 +2055,22 @@
     "Enable Bar": "バーを起用"
   },
   "Enable Do Not Disturb": {
-    "Enable Do Not Disturb": ""
+    "Enable Do Not Disturb": "サイレントモードを有効にする"
   },
   "Enable History": {
-    "Enable History": ""
+    "Enable History": "履歴を有効にする"
   },
   "Enable Overview Overlay": {
-    "Enable Overview Overlay": ""
+    "Enable Overview Overlay": "概要オーバーレイを有効にする"
   },
   "Enable Ripple Effects": {
-    "Enable Ripple Effects": ""
+    "Enable Ripple Effects": "波紋エフェクトを有効にする"
   },
   "Enable System Sounds": {
     "Enable System Sounds": "システムサウンドを有効に"
   },
   "Enable Video Screensaver": {
-    "Enable Video Screensaver": ""
+    "Enable Video Screensaver": "動画スクリーンセーバーを有効にする"
   },
   "Enable Weather": {
     "Enable Weather": "天気を有効にする"
@@ -2082,73 +2079,73 @@
     "Enable WiFi": "WiFiを有効にする"
   },
   "Enable a custom override below to set per-bar shadow intensity, opacity, and color.": {
-    "Enable a custom override below to set per-bar shadow intensity, opacity, and color.": ""
+    "Enable a custom override below to set per-bar shadow intensity, opacity, and color.": "以下のカスタムオーバーライドを有効にして、バーごとの影の強さ、透明度、色を設定します。"
   },
   "Enable compositor-targetable blur layer (namespace: dms:blurwallpaper). Requires manual niri configuration.": {
     "Enable compositor-targetable blur layer (namespace: dms:blurwallpaper). Requires manual niri configuration.": "コンポジターをターゲットに設定できるぼかしレイヤー(名前空間：dms:blurwallpaper)を有効にします。Niri を手動で設定する必要があります。"
   },
   "Enable fingerprint at login": {
-    "Enable fingerprint at login": ""
+    "Enable fingerprint at login": "ログイン時に指紋認証を有効にする"
   },
   "Enable fingerprint authentication": {
     "Enable fingerprint authentication": "指紋認証を有効に"
   },
   "Enable fingerprint or security key for DMS Greeter. Authentication changes apply automatically.": {
-    "Enable fingerprint or security key for DMS Greeter. Authentication changes apply automatically.": ""
+    "Enable fingerprint or security key for DMS Greeter. Authentication changes apply automatically.": "DMS Greeter で指紋認証またはセキュリティキーを有効にします。認証の変更は自動的に適用されます。"
   },
   "Enable loginctl lock integration": {
     "Enable loginctl lock integration": "ログインロックの統合を有効に"
   },
   "Enable security key at login": {
-    "Enable security key at login": ""
+    "Enable security key at login": "ログイン時にセキュリティキーを有効にする"
   },
   "Enable security key authentication": {
-    "Enable security key authentication": ""
+    "Enable security key authentication": "セキュリティキー認証を有効にする"
   },
   "Enabled": {
     "Enabled": "有効化されました"
   },
   "Enabled, but fingerprint availability could not be confirmed.": {
-    "Enabled, but fingerprint availability could not be confirmed.": ""
+    "Enabled, but fingerprint availability could not be confirmed.": "有効ですが、指紋認証の利用可否を確認できませんでした。"
   },
   "Enabled, but no fingerprint reader was detected.": {
-    "Enabled, but no fingerprint reader was detected.": ""
+    "Enabled, but no fingerprint reader was detected.": "有効ですが、指紋リーダーが検出されませんでした。"
   },
   "Enabled, but no prints are enrolled yet. Authentication changes apply automatically once you enroll fingerprints.": {
-    "Enabled, but no prints are enrolled yet. Authentication changes apply automatically once you enroll fingerprints.": ""
+    "Enabled, but no prints are enrolled yet. Authentication changes apply automatically once you enroll fingerprints.": "有効ですが、まだ指紋が登録されていません。指紋を登録すると認証の変更は自動的に適用されます。"
   },
   "Enabled, but no prints are enrolled yet. Enroll fingerprints and run Sync.": {
-    "Enabled, but no prints are enrolled yet. Enroll fingerprints and run Sync.": ""
+    "Enabled, but no prints are enrolled yet. Enroll fingerprints and run Sync.": "有効ですが、まだ指紋が登録されていません。指紋を登録して Sync を実行してください。"
   },
   "Enabled, but no registered security key was found yet. Authentication changes apply automatically once your key is registered or your U2F config is updated.": {
-    "Enabled, but no registered security key was found yet. Authentication changes apply automatically once your key is registered or your U2F config is updated.": ""
+    "Enabled, but no registered security key was found yet. Authentication changes apply automatically once your key is registered or your U2F config is updated.": "有効ですが、まだ登録済みのセキュリティキーが見つかっていません。キーを登録するか U2F 設定を更新すると、認証の変更は自動的に適用されます。"
   },
   "Enabled, but no registered security key was found yet. Register a key and run Sync.": {
-    "Enabled, but no registered security key was found yet. Register a key and run Sync.": ""
+    "Enabled, but no registered security key was found yet. Register a key and run Sync.": "有効ですが、まだ登録済みのセキュリティキーが見つかっていません。キーを登録して Sync を実行してください。"
   },
   "Enabled, but security-key availability could not be confirmed.": {
-    "Enabled, but security-key availability could not be confirmed.": ""
+    "Enabled, but security-key availability could not be confirmed.": "有効ですが、セキュリティキーの利用可否を確認できませんでした。"
   },
   "Enabled. PAM already provides fingerprint auth.": {
-    "Enabled. PAM already provides fingerprint auth.": ""
+    "Enabled. PAM already provides fingerprint auth.": "有効です。PAM はすでに指紋認証を提供しています。"
   },
   "Enabled. PAM already provides security-key auth.": {
-    "Enabled. PAM already provides security-key auth.": ""
+    "Enabled. PAM already provides security-key auth.": "有効です。PAM はすでにセキュリティキー認証を提供しています。"
   },
   "Enabled. PAM provides fingerprint auth, but no prints are enrolled yet.": {
-    "Enabled. PAM provides fingerprint auth, but no prints are enrolled yet.": ""
+    "Enabled. PAM provides fingerprint auth, but no prints are enrolled yet.": "有効です。PAM は指紋認証を提供していますが、まだ指紋が登録されていません。"
   },
   "Enabling WiFi...": {
-    "Enabling WiFi...": ""
+    "Enabling WiFi...": "WiFi を有効化中..."
   },
   "End": {
     "End": "終わり"
   },
   "Enlarge on Hover": {
-    "Enlarge on Hover": ""
+    "Enlarge on Hover": "ホバー時に拡大"
   },
   "Enlargement %": {
-    "Enlargement %": ""
+    "Enlargement %": "拡大量 (%)"
   },
   "Enter 6-digit passkey": {
     "Enter 6-digit passkey": "6桁のパスキーを入力してください"
@@ -2160,16 +2157,16 @@
     "Enter PIN for ": "PINを入力してください "
   },
   "Enter URL or text to share": {
-    "Enter URL or text to share": ""
+    "Enter URL or text to share": "共有する URL またはテキストを入力"
   },
-  "Enter a new name for session \"%1": {
-    "Enter a new name for session \"%1\"": ""
+  "Enter a new name for session \"%1\"": {
+    "Enter a new name for session \"%1\"": "セッション \"%1\" の新しい名前を入力"
   },
   "Enter a new name for this workspace": {
-    "Enter a new name for this workspace": ""
+    "Enter a new name for this workspace": "このワークスペースの新しい名前を入力"
   },
   "Enter command or script path": {
-    "Enter command or script path": ""
+    "Enter command or script path": "コマンドまたはスクリプトのパスを入力"
   },
   "Enter credentials for ": {
     "Enter credentials for ": "資格情報を入力"
@@ -2181,16 +2178,16 @@
     "Enter custom top bar format (e.g., ddd MMM d)": "カスタムトップバー形式を入力してください (e.g., ddd MMM d)"
   },
   "Enter device name...": {
-    "Enter device name...": ""
+    "Enter device name...": "デバイス名を入力..."
   },
   "Enter filename...": {
     "Enter filename...": "ファイル名を入力してください..."
   },
   "Enter launch prefix (e.g., 'uwsm-app')": {
-    "Enter launch prefix (e.g., 'uwsm-app')": ""
+    "Enter launch prefix (e.g., 'uwsm-app')": "起動接頭辞を入力（例: 'uwsm-app'）"
   },
   "Enter network name and password": {
-    "Enter network name and password": ""
+    "Enter network name and password": "ネットワーク名とパスワードを入力"
   },
   "Enter passkey for ": {
     "Enter passkey for ": "パスキーを入力してください "
@@ -2202,88 +2199,88 @@
     "Enter this passkey on ": "ここでパスキーを入力してください "
   },
   "Enter to Paste": {
-    "Enter to Paste": ""
+    "Enter to Paste": "Enter で貼り付け"
   },
   "Enterprise": {
-    "Enterprise": ""
+    "Enterprise": "エンタープライズ"
   },
   "Entry pinned": {
-    "Entry pinned": ""
+    "Entry pinned": "項目を固定しました"
   },
   "Entry unpinned": {
-    "Entry unpinned": ""
+    "Entry unpinned": "項目の固定を解除しました"
   },
   "Environment Variables": {
-    "Environment Variables": ""
+    "Environment Variables": "環境変数"
   },
   "Error": {
     "Error": "エラー"
   },
   "Errors": {
-    "Errors": ""
+    "Errors": "エラー"
   },
   "Ethernet": {
-    "Ethernet": ""
+    "Ethernet": "Ethernet"
   },
   "Exact": {
-    "Exact": ""
+    "Exact": "完全一致"
   },
   "Exclusive Zone Offset": {
     "Exclusive Zone Offset": "排他ゾーンオフセット"
   },
   "Experimental Feature": {
-    "Experimental Feature": ""
+    "Experimental Feature": "実験的機能"
   },
   "Explore": {
-    "Explore": ""
+    "Explore": "探索"
   },
   "Exponential": {
-    "Exponential": ""
+    "Exponential": "指数"
   },
   "Expressive": {
-    "Expressive": ""
+    "Expressive": "表現豊か"
   },
   "Extend battery life": {
-    "Extend battery life": ""
+    "Extend battery life": "バッテリー寿命を延ばす"
   },
   "Extensible architecture": {
-    "Extensible architecture": ""
+    "Extensible architecture": "拡張可能なアーキテクチャ"
   },
   "External Wallpaper Management": {
-    "External Wallpaper Management": ""
+    "External Wallpaper Management": "外部壁紙管理"
   },
   "Extra Arguments": {
-    "Extra Arguments": ""
+    "Extra Arguments": "追加引数"
   },
   "F1/I: Toggle • F10: Help": {
     "F1/I: Toggle • F10: Help": "F1/I: 切り替え • F10: ヘルプ"
   },
   "Fade": {
-    "Fade": ""
+    "Fade": "フェード"
   },
   "Fade to lock screen": {
-    "Fade to lock screen": ""
+    "Fade to lock screen": "ロック画面へフェード"
   },
   "Fade to monitor off": {
-    "Fade to monitor off": ""
+    "Fade to monitor off": "モニターオフへフェード"
   },
   "Failed to accept pairing": {
-    "Failed to accept pairing": ""
+    "Failed to accept pairing": "ペアリングの承認に失敗しました"
   },
   "Failed to activate configuration": {
     "Failed to activate configuration": "設定が適用できませんでした"
   },
   "Failed to activate profile - file not found": {
-    "Failed to activate profile - file not found": ""
+    "Failed to activate profile - file not found": "プロファイルの有効化に失敗しました - ファイルが見つかりません"
   },
   "Failed to add binds include": {
-    "Failed to add binds include": ""
+    "Failed to add binds include": "binds include の追加に失敗しました"
   },
   "Failed to add printer to class": {
-    "Failed to add printer to class": ""
+    "Failed to add printer to class": "クラスへのプリンター追加に失敗しました"
   },
   "Failed to browse device": {
-    "Failed to browse device": ""
+    "Failed to browse device": "デバイスの参照に失敗しました"
   },
   "Failed to cancel all jobs": {
     "Failed to cancel all jobs": "すべてのジョブの取り消しに失敗しました"
@@ -2292,40 +2289,40 @@
     "Failed to cancel selected job": "選ばれたジョブの取り消しに失敗しました"
   },
   "Failed to check for updates:\n%1": {
-    "Failed to check for updates:\n%1": ""
+    "Failed to check for updates:\n%1": "更新の確認に失敗しました:\n%1"
   },
   "Failed to check pin limit": {
-    "Failed to check pin limit": ""
+    "Failed to check pin limit": "固定数上限の確認に失敗しました"
   },
   "Failed to connect VPN": {
     "Failed to connect VPN": "VPNへの接続が失敗しました"
   },
   "Failed to connect to %1": {
-    "Failed to connect to %1": ""
+    "Failed to connect to %1": "%1 への接続に失敗しました"
   },
   "Failed to copy entry": {
-    "Failed to copy entry": ""
+    "Failed to copy entry": "項目のコピーに失敗しました"
   },
   "Failed to create printer": {
-    "Failed to create printer": ""
+    "Failed to create printer": "プリンターの作成に失敗しました"
   },
   "Failed to create profiles directory": {
-    "Failed to create profiles directory": ""
+    "Failed to create profiles directory": "profiles ディレクトリの作成に失敗しました"
   },
   "Failed to delete VPN": {
-    "Failed to delete VPN": ""
+    "Failed to delete VPN": "VPN の削除に失敗しました"
   },
   "Failed to delete class": {
-    "Failed to delete class": ""
+    "Failed to delete class": "class の削除に失敗しました"
   },
   "Failed to delete printer": {
-    "Failed to delete printer": ""
+    "Failed to delete printer": "プリンターの削除に失敗しました"
   },
   "Failed to disable job acceptance": {
-    "Failed to disable job acceptance": ""
+    "Failed to disable job acceptance": "ジョブ受け付けの無効化に失敗しました"
   },
   "Failed to disable night mode": {
-    "Failed to disable night mode": ""
+    "Failed to disable night mode": "ナイトモードの無効化に失敗しました"
   },
   "Failed to disconnect VPN": {
     "Failed to disconnect VPN": "VPNへの切断が失敗しました"
@@ -2337,169 +2334,169 @@
     "Failed to disconnect WiFi": "WiFiの切断ができませんでした"
   },
   "Failed to enable IP location": {
-    "Failed to enable IP location": ""
+    "Failed to enable IP location": "IP 位置情報の有効化に失敗しました"
   },
   "Failed to enable WiFi": {
     "Failed to enable WiFi": "WiFiを有効化にできませんでした"
   },
   "Failed to enable job acceptance": {
-    "Failed to enable job acceptance": ""
+    "Failed to enable job acceptance": "ジョブ受け付けの有効化に失敗しました"
   },
   "Failed to enable night mode": {
-    "Failed to enable night mode": ""
+    "Failed to enable night mode": "ナイトモードの有効化に失敗しました"
   },
   "Failed to hold job": {
-    "Failed to hold job": ""
+    "Failed to hold job": "ジョブの保留に失敗しました"
   },
   "Failed to import VPN": {
-    "Failed to import VPN": ""
+    "Failed to import VPN": "VPN のインポートに失敗しました"
   },
   "Failed to launch SMS app": {
-    "Failed to launch SMS app": ""
+    "Failed to launch SMS app": "SMS アプリの起動に失敗しました"
   },
   "Failed to load VPN config": {
-    "Failed to load VPN config": ""
+    "Failed to load VPN config": "VPN 設定の読み込みに失敗しました"
   },
   "Failed to load clipboard configuration.": {
-    "Failed to load clipboard configuration.": ""
+    "Failed to load clipboard configuration.": "クリップボード設定の読み込みに失敗しました。"
   },
   "Failed to move job": {
-    "Failed to move job": ""
+    "Failed to move job": "ジョブの移動に失敗しました"
   },
   "Failed to parse plugin_settings.json": {
-    "Failed to parse plugin_settings.json": ""
+    "Failed to parse plugin_settings.json": "plugin_settings.json の解析に失敗しました"
   },
   "Failed to parse session.json": {
-    "Failed to parse session.json": ""
+    "Failed to parse session.json": "session.json の解析に失敗しました"
   },
   "Failed to parse settings.json": {
-    "Failed to parse settings.json": ""
+    "Failed to parse settings.json": "settings.json の解析に失敗しました"
   },
   "Failed to pause printer": {
     "Failed to pause printer": "プリンターの一時中断に失敗しました"
   },
   "Failed to pin entry": {
-    "Failed to pin entry": ""
+    "Failed to pin entry": "項目の固定に失敗しました"
   },
   "Failed to print test page": {
-    "Failed to print test page": ""
+    "Failed to print test page": "テストページの印刷に失敗しました"
   },
   "Failed to reject pairing": {
-    "Failed to reject pairing": ""
+    "Failed to reject pairing": "ペアリングの拒否に失敗しました"
   },
   "Failed to remove device": {
     "Failed to remove device": "デバイスの削除に失敗しました"
   },
   "Failed to remove keybind": {
-    "Failed to remove keybind": ""
+    "Failed to remove keybind": "キーバインドの削除に失敗しました"
   },
   "Failed to remove printer from class": {
-    "Failed to remove printer from class": ""
+    "Failed to remove printer from class": "クラスからのプリンター削除に失敗しました"
   },
   "Failed to restart audio system": {
-    "Failed to restart audio system": ""
+    "Failed to restart audio system": "オーディオシステムの再起動に失敗しました"
   },
   "Failed to restart job": {
-    "Failed to restart job": ""
+    "Failed to restart job": "ジョブの再起動に失敗しました"
   },
   "Failed to resume printer": {
     "Failed to resume printer": "プリンタの再開に失敗しました"
   },
   "Failed to ring device": {
-    "Failed to ring device": ""
+    "Failed to ring device": "デバイスの呼び出しに失敗しました"
   },
   "Failed to run 'dms greeter status'. Ensure DMS is installed and dms is in PATH.": {
-    "Failed to run 'dms greeter status'. Ensure DMS is installed and dms is in PATH.": ""
+    "Failed to run 'dms greeter status'. Ensure DMS is installed and dms is in PATH.": "'dms greeter status' の実行に失敗しました。DMS がインストールされ、dms が PATH にあることを確認してください。"
   },
   "Failed to save audio config": {
-    "Failed to save audio config": ""
+    "Failed to save audio config": "オーディオ設定の保存に失敗しました"
   },
   "Failed to save clipboard setting": {
-    "Failed to save clipboard setting": ""
+    "Failed to save clipboard setting": "クリップボード設定の保存に失敗しました"
   },
   "Failed to save keybind": {
-    "Failed to save keybind": ""
+    "Failed to save keybind": "キーバインドの保存に失敗しました"
   },
   "Failed to save profile file": {
-    "Failed to save profile file": ""
+    "Failed to save profile file": "プロファイルファイルの保存に失敗しました"
   },
   "Failed to send clipboard": {
-    "Failed to send clipboard": ""
+    "Failed to send clipboard": "クリップボードの送信に失敗しました"
   },
   "Failed to send file": {
-    "Failed to send file": ""
+    "Failed to send file": "ファイルの送信に失敗しました"
   },
   "Failed to send ping": {
-    "Failed to send ping": ""
+    "Failed to send ping": "Ping の送信に失敗しました"
   },
   "Failed to set brightness": {
-    "Failed to set brightness": ""
+    "Failed to set brightness": "明るさの設定に失敗しました"
   },
   "Failed to set night mode location": {
-    "Failed to set night mode location": ""
+    "Failed to set night mode location": "ナイトモードの位置設定に失敗しました"
   },
   "Failed to set night mode schedule": {
-    "Failed to set night mode schedule": ""
+    "Failed to set night mode schedule": "ナイトモードのスケジュール設定に失敗しました"
   },
   "Failed to set night mode temperature": {
-    "Failed to set night mode temperature": ""
+    "Failed to set night mode temperature": "ナイトモードの色温度設定に失敗しました"
   },
   "Failed to set power profile": {
-    "Failed to set power profile": ""
+    "Failed to set power profile": "電源プロファイルの設定に失敗しました"
   },
   "Failed to set profile image": {
     "Failed to set profile image": "プロフィール画像の設定に失敗しました"
   },
   "Failed to set profile image: %1": {
-    "Failed to set profile image: %1": ""
+    "Failed to set profile image: %1": "プロフィール画像の設定に失敗しました: %1"
   },
   "Failed to share": {
-    "Failed to share": ""
+    "Failed to share": "共有に失敗しました"
   },
   "Failed to start connection to %1": {
-    "Failed to start connection to %1": ""
+    "Failed to start connection to %1": "%1 への接続開始に失敗しました"
   },
   "Failed to unpin entry": {
-    "Failed to unpin entry": ""
+    "Failed to unpin entry": "項目の固定解除に失敗しました"
   },
   "Failed to update VPN": {
-    "Failed to update VPN": ""
+    "Failed to update VPN": "VPN の更新に失敗しました"
   },
   "Failed to update autoconnect": {
     "Failed to update autoconnect": "自動接続の更新が失敗しました"
   },
   "Failed to update description": {
-    "Failed to update description": ""
+    "Failed to update description": "説明の更新に失敗しました"
   },
   "Failed to update location": {
-    "Failed to update location": ""
+    "Failed to update location": "位置情報の更新に失敗しました"
   },
   "Failed to update sharing": {
-    "Failed to update sharing": ""
+    "Failed to update sharing": "共有設定の更新に失敗しました"
   },
   "Failed to write temp file for validation": {
-    "Failed to write temp file for validation": ""
+    "Failed to write temp file for validation": "検証用の一時ファイル書き込みに失敗しました"
   },
   "Features": {
-    "Features": ""
+    "Features": "機能"
   },
   "Feels": {
-    "Feels": ""
+    "Feels": "体感"
   },
   "Feels Like": {
-    "Feels Like": "どうやら"
+    "Feels Like": "体感温度"
   },
   "Feels Like %1°": {
-    "Feels Like %1°": ""
+    "Feels Like %1°": "体感温度 %1°"
   },
   "Fidelity": {
-    "Fidelity": ""
+    "Fidelity": "忠実度"
   },
   "Field": {
-    "Field": ""
+    "Field": "項目"
   },
   "File": {
-    "File": ""
+    "File": "ファイル"
   },
   "File Already Exists": {
     "File Already Exists": "ファイルが既に存在します"
@@ -2508,19 +2505,19 @@
     "File Information": "ファイル情報"
   },
   "File received from": {
-    "File received from": ""
+    "File received from": "ファイルの受信元"
   },
   "File search requires dsearch\nInstall from github.com/AvengeMedia/danksearch": {
-    "File search requires dsearch\nInstall from github.com/AvengeMedia/danksearch": ""
+    "File search requires dsearch\nInstall from github.com/AvengeMedia/danksearch": "ファイル検索には dsearch が必要です\ngithub.com/AvengeMedia/danksearch からインストールしてください"
   },
   "Files": {
-    "Files": ""
+    "Files": "ファイル"
   },
   "Filesystem usage monitoring": {
-    "Filesystem usage monitoring": ""
+    "Filesystem usage monitoring": "ファイルシステム使用量の監視"
   },
   "Fill": {
-    "Fill": ""
+    "Fill": "埋める"
   },
   "Find in Text": {
     "Find in Text": "テキスト内検索"
@@ -2529,100 +2526,100 @@
     "Find in note...": "メモで検索..."
   },
   "Fingerprint availability could not be confirmed.": {
-    "Fingerprint availability could not be confirmed.": ""
+    "Fingerprint availability could not be confirmed.": "指紋認証の利用可否を確認できませんでした。"
   },
   "Fingerprint error": {
-    "Fingerprint error": ""
+    "Fingerprint error": "指紋認証エラー"
   },
   "Fingerprint error: %1": {
-    "Fingerprint error: %1": ""
+    "Fingerprint error: %1": "指紋認証エラー: %1"
   },
   "Fingerprint not recognized (%1/%2). Please try again or use password.": {
-    "Fingerprint not recognized (%1/%2). Please try again or use password.": ""
+    "Fingerprint not recognized (%1/%2). Please try again or use password.": "指紋を認識できませんでした（%1/%2）。もう一度試すか、パスワードを使用してください。"
   },
   "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and enroll later.": {
-    "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and enroll later.": ""
+    "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and enroll later.": "指紋リーダーが検出されましたが、まだ指紋が登録されていません。今すぐ有効にして、後で登録できます。"
   },
   "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and run Sync later.": {
-    "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and run Sync later.": ""
+    "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and run Sync later.": "指紋リーダーが検出されましたが、まだ指紋が登録されていません。今すぐ有効にして、後で Sync を実行できます。"
   },
   "Finish": {
-    "Finish": ""
+    "Finish": "完了"
   },
   "First Day of Week": {
-    "First Day of Week": ""
+    "First Day of Week": "週の最初の曜日"
   },
   "First Time Setup": {
-    "First Time Setup": ""
+    "First Time Setup": "初回設定"
   },
   "Fit": {
-    "Fit": ""
+    "Fit": "フィット"
   },
   "Fix Now": {
-    "Fix Now": ""
+    "Fix Now": "今すぐ修正"
   },
   "Fixing...": {
-    "Fixing...": ""
+    "Fixing...": "修正中..."
   },
   "Flags": {
-    "Flags": ""
+    "Flags": "フラグ"
   },
   "Flipped": {
-    "Flipped": ""
+    "Flipped": "反転"
   },
   "Flipped 180°": {
-    "Flipped 180°": ""
+    "Flipped 180°": "180° 反転"
   },
   "Flipped 270°": {
-    "Flipped 270°": ""
+    "Flipped 270°": "270° 反転"
   },
   "Flipped 90°": {
-    "Flipped 90°": ""
+    "Flipped 90°": "90° 反転"
   },
   "Float": {
-    "Float": ""
+    "Float": "フロート"
   },
   "Focus": {
-    "Focus": ""
+    "Focus": "フォーカス"
   },
   "Focus at Startup": {
-    "Focus at Startup": ""
+    "Focus at Startup": "起動時にフォーカス"
   },
   "Focused Border": {
-    "Focused Border": ""
+    "Focused Border": "フォーカス時のボーダー"
   },
   "Focused Color": {
-    "Focused Color": ""
+    "Focused Color": "フォーカス時の色"
   },
   "Focused Monitor Only": {
-    "Focused Monitor Only": ""
+    "Focused Monitor Only": "フォーカス中のモニターのみ"
   },
   "Focused Window": {
     "Focused Window": "フォーカスされたウィンドウ"
   },
   "Focused monitor only": {
-    "Focused monitor only": ""
+    "Focused monitor only": "フォーカス中のモニターのみ"
   },
   "Fog": {
-    "Fog": ""
+    "Fog": "霧"
   },
   "Folder": {
-    "Folder": ""
+    "Folder": "フォルダー"
   },
   "Folders": {
-    "Folders": ""
+    "Folders": "フォルダー"
   },
   "Follow DMS background color": {
-    "Follow DMS background color": ""
+    "Follow DMS background color": "DMS の背景色に従う"
   },
   "Follow Monitor Focus": {
-    "Follow Monitor Focus": ""
+    "Follow Monitor Focus": "モニターフォーカスに従う"
   },
   "Follow focus": {
-    "Follow focus": ""
+    "Follow focus": "フォーカスに従う"
   },
   "Font": {
-    "Font": ""
+    "Font": "フォント"
   },
   "Font Family": {
     "Font Family": "フォントファミリー"
@@ -2637,37 +2634,37 @@
     "Font Weight": "フォントの太さ"
   },
   "Font used on the login screen": {
-    "Font used on the login screen": ""
+    "Font used on the login screen": "ログイン画面で使用するフォント"
   },
   "Force HDR": {
-    "Force HDR": ""
+    "Force HDR": "HDR を強制"
   },
   "Force Kill (SIGKILL)": {
-    "Force Kill (SIGKILL)": ""
+    "Force Kill (SIGKILL)": "強制終了（SIGKILL）"
   },
   "Force Wide Color": {
-    "Force Wide Color": ""
+    "Force Wide Color": "ワイドカラーを強制"
   },
   "Force terminal applications to always use dark color schemes": {
     "Force terminal applications to always use dark color schemes": "端末アプリで常に暗い配色を強制使用"
   },
   "Forecast": {
-    "Forecast": ""
+    "Forecast": "予報"
   },
   "Forecast Days": {
-    "Forecast Days": ""
+    "Forecast Days": "予報日数"
   },
   "Forecast Not Available": {
-    "Forecast Not Available": ""
+    "Forecast Not Available": "予報は利用できません"
   },
   "Forever": {
-    "Forever": ""
+    "Forever": "常時"
   },
   "Forget": {
-    "Forget": ""
+    "Forget": "削除"
   },
   "Forget \"%1\"?": {
-    "Forget \"%1\"?": ""
+    "Forget \"%1\"?": "\"%1\" を削除しますか?"
   },
   "Forget Device": {
     "Forget Device": "デバイスを忘れる"
@@ -2676,70 +2673,70 @@
     "Forget Network": "ネットワークを忘れる"
   },
   "Forgot network %1": {
-    "Forgot network %1": ""
+    "Forgot network %1": "ネットワーク %1 を削除しました"
   },
   "Format Legend": {
     "Format Legend": "フォーマット凡例"
   },
   "Found %1 package to update:": {
-    "Found %1 package to update:": ""
+    "Found %1 package to update:": "更新可能なパッケージが %1 個見つかりました:"
   },
   "Found %1 packages to update:": {
-    "Found %1 packages to update:": ""
+    "Found %1 packages to update:": "更新可能なパッケージが %1 個見つかりました:"
   },
   "Free VRAM/memory when the launcher is closed. May cause a slight delay when reopening.": {
-    "Free VRAM/memory when the launcher is closed. May cause a slight delay when reopening.": ""
+    "Free VRAM/memory when the launcher is closed. May cause a slight delay when reopening.": "ランチャーを閉じたときに VRAM/メモリを解放します。再度開く際にわずかな遅延が発生する場合があります。"
   },
   "Freezing Drizzle": {
-    "Freezing Drizzle": ""
+    "Freezing Drizzle": "着氷性の霧雨"
   },
   "Frequency": {
-    "Frequency": ""
+    "Frequency": "頻度"
   },
   "Fruit Salad": {
-    "Fruit Salad": ""
+    "Fruit Salad": "フルーツサラダ"
   },
   "Full Command:": {
-    "Full Command:": ""
+    "Full Command:": "完全なコマンド:"
   },
   "Full Content": {
-    "Full Content": ""
+    "Full Content": "全文"
   },
   "Full Day & Month": {
-    "Full Day & Month": ""
+    "Full Day & Month": "曜日と月を完全表示"
   },
   "Full with Year": {
-    "Full with Year": ""
+    "Full with Year": "年を含めて完全表示"
   },
   "Fullscreen": {
-    "Fullscreen": ""
+    "Fullscreen": "フルスクリーン"
   },
   "Fullscreen Only": {
-    "Fullscreen Only": ""
+    "Fullscreen Only": "フルスクリーン時のみ"
   },
   "Fully Charged": {
-    "Fully Charged": ""
+    "Fully Charged": "フル充電"
   },
   "Fun": {
     "Fun": "娯楽"
   },
   "G: grid • Z/X: size": {
-    "G: grid • Z/X: size": ""
+    "G: grid • Z/X: size": "G: グリッド • Z/X: サイズ"
   },
   "GPU": {
     "GPU": "GPU"
   },
   "GPU Monitoring": {
-    "GPU Monitoring": ""
+    "GPU Monitoring": "GPU監視"
   },
   "GPU Temperature": {
     "GPU Temperature": "GPU温度"
   },
   "GPU temperature display": {
-    "GPU temperature display": ""
+    "GPU temperature display": "GPU温度表示"
   },
   "GTK, Qt, IDEs, more": {
-    "GTK, Qt, IDEs, more": ""
+    "GTK, Qt, IDEs, more": "GTK、Qt、IDE など"
   },
   "Games": {
     "Games": "ゲーム"
@@ -2751,22 +2748,22 @@
     "Gamma control not available. Requires DMS API v6+.": "ガンマ制御は使用できません。DMS API v6+ が必要です。"
   },
   "Generate baseline GTK3/4 or QT5/QT6 (requires qt6ct-kde) configurations to follow DMS colors. Only needed once.<br /><br />It is recommended to configure <a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/README.md#Theming\" style=\"text-decoration:none; color:%1;\">adw-gtk3</a> prior to applying GTK themes.": {
-    "Generate baseline GTK3/4 or QT5/QT6 (requires qt6ct-kde) configurations to follow DMS colors. Only needed once.<br /><br />It is recommended to configure <a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/README.md#Theming\" style=\"text-decoration:none; color:%1;\">adw-gtk3</a> prior to applying GTK themes.": ""
+    "Generate baseline GTK3/4 or QT5/QT6 (requires qt6ct-kde) configurations to follow DMS colors. Only needed once.<br /><br />It is recommended to configure <a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/README.md#Theming\" style=\"text-decoration:none; color:%1;\">adw-gtk3</a> prior to applying GTK themes.": "DMS の色に合わせたベースライン GTK3/4 または QT5/QT6（qt6ct-kde が必要）設定を生成します。必要なのは一度だけです。<br /><br />GTK テーマを適用する前に <a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/README.md#Theming\" style=\"text-decoration:none; color:%1;\">adw-gtk3</a> を設定することを推奨します。"
   },
   "Generic": {
-    "Generic": ""
+    "Generic": "汎用"
   },
   "Get Started": {
-    "Get Started": ""
+    "Get Started": "はじめる"
   },
   "GitHub": {
-    "GitHub": ""
+    "GitHub": "GitHub"
   },
   "Globally scale all animation durations": {
-    "Globally scale all animation durations": ""
+    "Globally scale all animation durations": "すべてのアニメーション時間を全体的にスケール"
   },
   "Golden Hour": {
-    "Golden Hour": ""
+    "Golden Hour": "ゴールデンアワー"
   },
   "Good": {
     "Good": "良い"
@@ -2778,40 +2775,40 @@
     "Goth Corners": "ゴスコーナーズ"
   },
   "Gradually fade the screen before locking with a configurable grace period": {
-    "Gradually fade the screen before locking with a configurable grace period": ""
+    "Gradually fade the screen before locking with a configurable grace period": "設定可能な猶予時間のあと、ロック前に画面を徐々にフェードさせます"
   },
   "Gradually fade the screen before turning off monitors with a configurable grace period": {
-    "Gradually fade the screen before turning off monitors with a configurable grace period": ""
+    "Gradually fade the screen before turning off monitors with a configurable grace period": "設定可能な猶予時間のあと、モニターをオフにする前に画面を徐々にフェードさせます"
   },
   "Graph Time Range": {
-    "Graph Time Range": ""
+    "Graph Time Range": "グラフの時間範囲"
   },
   "Graphics": {
     "Graphics": "グラフィック"
   },
   "Greeter": {
-    "Greeter": ""
+    "Greeter": "Greeter"
   },
   "Greeter Appearance": {
-    "Greeter Appearance": ""
+    "Greeter Appearance": "Greeter の外観"
   },
   "Greeter Behavior": {
-    "Greeter Behavior": ""
+    "Greeter Behavior": "Greeter の動作"
   },
   "Greeter Status": {
-    "Greeter Status": ""
+    "Greeter Status": "Greeter の状態"
   },
   "Greeter activated. greetd is now enabled.": {
-    "Greeter activated. greetd is now enabled.": ""
+    "Greeter activated. greetd is now enabled.": "Greeter を有効化しました。greetd は現在有効です。"
   },
   "Greeter font": {
-    "Greeter font": ""
+    "Greeter font": "Greeter フォント"
   },
   "Greeter only — does not affect main clock": {
-    "Greeter only — does not affect main clock": ""
+    "Greeter only — does not affect main clock": "Greeter のみ — メイン時計には影響しません"
   },
   "Greeter only — format for the date on the login screen": {
-    "Greeter only — format for the date on the login screen": ""
+    "Greeter only — format for the date on the login screen": "Greeter のみ — ログイン画面の日付形式"
   },
   "Grid": {
     "Grid": "グリッド"
@@ -2820,16 +2817,16 @@
     "Grid Columns": "グリッド列"
   },
   "Grid: OFF": {
-    "Grid: OFF": ""
+    "Grid: OFF": "グリッド: OFF"
   },
   "Grid: ON": {
-    "Grid: ON": ""
+    "Grid: ON": "グリッド: ON"
   },
   "Group": {
-    "Group": ""
+    "Group": "グループ"
   },
   "Group Workspace Apps": {
-    "Group Workspace Apps": ""
+    "Group Workspace Apps": "ワークスペースのアプリをグループ化"
   },
   "Group by App": {
     "Group by App": "アプリ別にグループ化"
@@ -2838,49 +2835,49 @@
     "Group multiple windows of the same app together with a window count indicator": "同じアプリの複数のウィンドウをウィンドウ数インジケーターでグループ化します"
   },
   "Group removed": {
-    "Group removed": ""
+    "Group removed": "グループを削除しました"
   },
   "Group repeated application icons in unfocused workspaces": {
-    "Group repeated application icons in unfocused workspaces": ""
+    "Group repeated application icons in unfocused workspaces": "フォーカスされていないワークスペースで重複するアプリアイコンをグループ化"
   },
   "Groups": {
-    "Groups": ""
+    "Groups": "グループ"
   },
   "HDR (EDID)": {
-    "HDR (EDID)": ""
+    "HDR (EDID)": "HDR（EDID）"
   },
   "HDR Tone Mapping": {
-    "HDR Tone Mapping": ""
+    "HDR Tone Mapping": "HDR トーンマッピング"
   },
   "HDR mode is experimental. Verify your monitor supports HDR before enabling.": {
-    "HDR mode is experimental. Verify your monitor supports HDR before enabling.": ""
+    "HDR mode is experimental. Verify your monitor supports HDR before enabling.": "HDR モードは実験的機能です。有効にする前に、モニターが HDR をサポートしていることを確認してください。"
   },
   "HSV": {
     "HSV": "色相/彩度/輝度"
   },
   "HTML copied to clipboard": {
-    "HTML copied to clipboard": ""
+    "HTML copied to clipboard": "HTML をクリップボードにコピーしました"
   },
   "Health": {
     "Health": "健康"
   },
   "Heavy Rain": {
-    "Heavy Rain": ""
+    "Heavy Rain": "大雨"
   },
   "Heavy Snow": {
-    "Heavy Snow": ""
+    "Heavy Snow": "大雪"
   },
   "Heavy Snow Showers": {
-    "Heavy Snow Showers": ""
+    "Heavy Snow Showers": "激しいにわか雪"
   },
   "Height": {
-    "Height": ""
+    "Height": "高さ"
   },
   "Held": {
-    "Held": ""
+    "Held": "保留中"
   },
   "Help": {
-    "Help": ""
+    "Help": "ヘルプ"
   },
   "Hex": {
     "Hex": "16進数"
@@ -2889,172 +2886,172 @@
     "Hibernate": "休止状態"
   },
   "Hidden": {
-    "Hidden": ""
+    "Hidden": "非表示"
   },
   "Hidden (%1)": {
-    "Hidden (%1)": ""
+    "Hidden (%1)": "非表示（%1）"
   },
   "Hidden Apps": {
-    "Hidden Apps": ""
+    "Hidden Apps": "非表示のアプリ"
   },
   "Hidden Network": {
-    "Hidden Network": ""
+    "Hidden Network": "非表示のネットワーク"
   },
   "Hidden apps won't appear in the launcher. Right-click an app and select 'Hide App' to hide it.": {
-    "Hidden apps won't appear in the launcher. Right-click an app and select 'Hide App' to hide it.": ""
+    "Hidden apps won't appear in the launcher. Right-click an app and select 'Hide App' to hide it.": "非表示のアプリはランチャーに表示されません。アプリを右クリックして「Hide App」を選択すると非表示にできます。"
   },
   "Hide": {
-    "Hide": ""
+    "Hide": "非表示"
   },
   "Hide 3rd Party": {
-    "Hide 3rd Party": ""
+    "Hide 3rd Party": "サードパーティを非表示"
   },
   "Hide App": {
-    "Hide App": ""
+    "Hide App": "アプリを非表示"
   },
   "Hide Delay": {
-    "Hide Delay": ""
+    "Hide Delay": "非表示までの遅延"
   },
   "Hide Indicators": {
-    "Hide Indicators": ""
+    "Hide Indicators": "インジケーターを非表示"
   },
   "Hide Updater Widget": {
-    "Hide Updater Widget": ""
+    "Hide Updater Widget": "アップデーターウィジェットを非表示"
   },
   "Hide When Typing": {
-    "Hide When Typing": ""
+    "Hide When Typing": "入力中は非表示"
   },
   "Hide When Windows Open": {
-    "Hide When Windows Open": ""
+    "Hide When Windows Open": "ウィンドウが開いているときは非表示"
   },
   "Hide cursor after inactivity (0 = disabled)": {
-    "Hide cursor after inactivity (0 = disabled)": ""
+    "Hide cursor after inactivity (0 = disabled)": "一定時間操作がないとカーソルを非表示にする（0 = 無効）"
   },
   "Hide cursor when pressing keyboard keys": {
-    "Hide cursor when pressing keyboard keys": ""
+    "Hide cursor when pressing keyboard keys": "キーボード入力時にカーソルを非表示"
   },
   "Hide cursor when using touch input": {
-    "Hide cursor when using touch input": ""
+    "Hide cursor when using touch input": "タッチ入力時にカーソルを非表示"
   },
   "Hide device": {
-    "Hide device": ""
+    "Hide device": "デバイスを非表示"
   },
   "Hide notification content until expanded": {
-    "Hide notification content until expanded": ""
+    "Hide notification content until expanded": "展開するまで通知内容を非表示"
   },
   "Hide notification content until expanded; popups show collapsed by default": {
-    "Hide notification content until expanded; popups show collapsed by default": ""
+    "Hide notification content until expanded; popups show collapsed by default": "展開するまで通知内容を非表示にします。ポップアップはデフォルトで折りたたんで表示されます"
   },
   "Hide on Touch": {
-    "Hide on Touch": ""
+    "Hide on Touch": "タッチ時に非表示"
   },
   "High-fidelity palette that preserves source hues.": {
     "High-fidelity palette that preserves source hues.": "ソースの色相を保持する忠実度の高いパレット。"
   },
   "Highlight Active Workspace App": {
-    "Highlight Active Workspace App": ""
+    "Highlight Active Workspace App": "アクティブなワークスペースアプリを強調表示"
   },
   "Highlight the currently focused app inside workspace indicators": {
-    "Highlight the currently focused app inside workspace indicators": ""
+    "Highlight the currently focused app inside workspace indicators": "ワークスペースインジケーター内で現在フォーカス中のアプリを強調表示"
   },
   "History": {
-    "History": ""
+    "History": "履歴"
   },
   "History Retention": {
-    "History Retention": ""
+    "History Retention": "履歴保持"
   },
   "History Settings": {
-    "History Settings": ""
+    "History Settings": "履歴設定"
   },
   "History cleared. %1 pinned entries kept.": {
-    "History cleared. %1 pinned entries kept.": ""
+    "History cleared. %1 pinned entries kept.": "履歴をクリアしました。固定済みエントリ %1 件は保持されました。"
   },
   "Hold Duration": {
-    "Hold Duration": ""
+    "Hold Duration": "長押し時間"
   },
   "Hold longer to confirm": {
-    "Hold longer to confirm": ""
+    "Hold longer to confirm": "確認するにはさらに長く押してください"
   },
   "Hold to Confirm Power Actions": {
-    "Hold to Confirm Power Actions": ""
+    "Hold to Confirm Power Actions": "長押しで電源アクションを確認"
   },
   "Hold to confirm (%1 ms)": {
-    "Hold to confirm (%1 ms)": ""
+    "Hold to confirm (%1 ms)": "長押しで確認（%1 ms）"
   },
   "Hold to confirm (%1s)": {
-    "Hold to confirm (%1s)": ""
+    "Hold to confirm (%1s)": "長押しで確認（%1秒）"
   },
   "Home": {
-    "Home": ""
+    "Home": "ホーム"
   },
   "Host": {
-    "Host": ""
+    "Host": "ホスト"
   },
   "Hostname": {
-    "Hostname": ""
+    "Hostname": "ホスト名"
   },
   "Hot Corners": {
-    "Hot Corners": ""
+    "Hot Corners": "ホットコーナー"
   },
   "Hotkey overlay title (optional)": {
-    "Hotkey overlay title (optional)": ""
+    "Hotkey overlay title (optional)": "ホットキーオーバーレイのタイトル（オプション）"
   },
   "Hour": {
     "Hour": "時間"
   },
   "Hourly": {
-    "Hourly": ""
+    "Hourly": "1時間ごと"
   },
   "Hourly Forecast Count": {
-    "Hourly Forecast Count": ""
+    "Hourly Forecast Count": "時間別予報件数"
   },
   "How often to change wallpaper": {
     "How often to change wallpaper": "壁紙を切り替える間隔"
   },
   "How the background image is scaled": {
-    "How the background image is scaled": ""
+    "How the background image is scaled": "背景画像の拡大縮小方法"
   },
   "Humidity": {
     "Humidity": "湿度"
   },
   "Hyprland Discord Server": {
-    "Hyprland Discord Server": ""
+    "Hyprland Discord Server": "Hyprland Discord サーバー"
   },
   "Hyprland Layout Overrides": {
-    "Hyprland Layout Overrides": ""
+    "Hyprland Layout Overrides": "Hyprland レイアウト上書き"
   },
   "Hyprland Options": {
-    "Hyprland Options": ""
+    "Hyprland Options": "Hyprland オプション"
   },
   "Hyprland Website": {
-    "Hyprland Website": ""
+    "Hyprland Website": "Hyprland ウェブサイト"
   },
   "I Understand": {
     "I Understand": "わかりました"
   },
   "IP": {
-    "IP": ""
+    "IP": "IP"
   },
   "IP Address:": {
-    "IP Address:": ""
+    "IP Address:": "IP アドレス:"
   },
   "IP address or hostname": {
-    "IP address or hostname": ""
+    "IP address or hostname": "IP アドレスまたはホスト名"
   },
   "ISO Date": {
-    "ISO Date": ""
+    "ISO Date": "ISO 日付"
   },
   "Icon": {
-    "Icon": ""
+    "Icon": "アイコン"
   },
   "Icon Scale": {
-    "Icon Scale": ""
+    "Icon Scale": "アイコンスケール"
   },
   "Icon Size": {
     "Icon Size": "アイコンサイズ"
   },
   "Icon Size %": {
-    "Icon Size %": ""
+    "Icon Size %": "アイコンサイズ %"
   },
   "Icon Theme": {
     "Icon Theme": "アイコンテーマ"
@@ -3072,52 +3069,52 @@
     "Idle monitoring not supported - requires newer Quickshell version": "アイドル監視はサポートされていません - 新しい Quickshell バージョンが必要です"
   },
   "If the field is hidden, it will appear as soon as a key is pressed.": {
-    "If the field is hidden, it will appear as soon as a key is pressed.": ""
+    "If the field is hidden, it will appear as soon as a key is pressed.": "フィールドが非表示の場合、キーが押されるとすぐに表示されます。"
   },
   "Ignore Completely": {
-    "Ignore Completely": ""
+    "Ignore Completely": "完全に無視"
   },
   "Image": {
     "Image": "画像"
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": ""
+    "Image copied to clipboard": "画像をクリップボードにコピーしました"
   },
   "Import": {
-    "Import": ""
+    "Import": "インポート"
   },
   "Import VPN": {
-    "Import VPN": ""
+    "Import VPN": "VPN をインポート"
   },
   "Inactive Monitor Color": {
-    "Inactive Monitor Color": ""
+    "Inactive Monitor Color": "非アクティブモニターの色"
   },
   "Include Files in All Tab": {
-    "Include Files in All Tab": ""
+    "Include Files in All Tab": "All タブにファイルを含める"
   },
   "Include Folders in All Tab": {
-    "Include Folders in All Tab": ""
+    "Include Folders in All Tab": "All タブにフォルダーを含める"
   },
   "Include Transitions": {
     "Include Transitions": "トランジションを含める"
   },
   "Include desktop actions (shortcuts) in search results.": {
-    "Include desktop actions (shortcuts) in search results.": ""
+    "Include desktop actions (shortcuts) in search results.": "検索結果にデスクトップアクション（ショートカット）を含めます。"
   },
   "Incompatible Plugins Loaded": {
-    "Incompatible Plugins Loaded": ""
+    "Incompatible Plugins Loaded": "互換性のないプラグインが読み込まれています"
   },
   "Incorrect password": {
     "Incorrect password": "パスワードが間違っています"
   },
   "Incorrect password - attempt %1 of %2 (lockout may follow)": {
-    "Incorrect password - attempt %1 of %2 (lockout may follow)": ""
+    "Incorrect password - attempt %1 of %2 (lockout may follow)": "パスワードが間違っています - %2 回中 %1 回目の試行です（ロックアウトされる可能性があります）"
   },
   "Incorrect password - next failures may trigger account lockout": {
-    "Incorrect password - next failures may trigger account lockout": ""
+    "Incorrect password - next failures may trigger account lockout": "パスワードが間違っています - 次の失敗でアカウントがロックされる可能性があります"
   },
   "Incorrect password - try again": {
-    "Incorrect password - try again": ""
+    "Incorrect password - try again": "パスワードが間違っています - もう一度試してください"
   },
   "Indicator Style": {
     "Indicator Style": "インジケータースタイル"
@@ -3129,82 +3126,82 @@
     "Individual bar configuration": "バーの個別設定"
   },
   "Info": {
-    "Info": ""
+    "Info": "情報"
   },
   "Inherit": {
-    "Inherit": ""
+    "Inherit": "継承"
   },
   "Inherit Global (Default)": {
-    "Inherit Global (Default)": ""
+    "Inherit Global (Default)": "グローバルを継承（デフォルト）"
   },
   "Inhibitable": {
-    "Inhibitable": ""
+    "Inhibitable": "抑制可能"
   },
   "Input Devices": {
     "Input Devices": "入力デバイス"
   },
   "Input Volume Slider": {
-    "Input Volume Slider": ""
+    "Input Volume Slider": "入力音量スライダー"
   },
   "Insert your security key...": {
-    "Insert your security key...": ""
+    "Insert your security key...": "セキュリティキーを挿入してください..."
   },
   "Install": {
-    "Install": ""
+    "Install": "インストール"
   },
   "Install Greeter": {
-    "Install Greeter": ""
+    "Install Greeter": "Greeter をインストール"
   },
   "Install Plugin": {
-    "Install Plugin": ""
+    "Install Plugin": "プラグインをインストール"
   },
   "Install Theme": {
-    "Install Theme": ""
+    "Install Theme": "テーマをインストール"
   },
   "Install color themes from the DMS theme registry": {
-    "Install color themes from the DMS theme registry": ""
+    "Install color themes from the DMS theme registry": "DMS テーマレジストリからカラーテーマをインストール"
   },
   "Install complete. Greeter has been installed.": {
-    "Install complete. Greeter has been installed.": ""
+    "Install complete. Greeter has been installed.": "インストールが完了しました。Greeter がインストールされました。"
   },
   "Install failed: %1": {
-    "Install failed: %1": ""
+    "Install failed: %1": "インストールに失敗しました: %1"
   },
   "Install matugen package for dynamic theming": {
-    "Install matugen package for dynamic theming": ""
+    "Install matugen package for dynamic theming": "動的テーマ用に matugen パッケージをインストール"
   },
   "Install plugin '%1' from the DMS registry?": {
-    "Install plugin '%1' from the DMS registry?": ""
+    "Install plugin '%1' from the DMS registry?": "DMS レジストリからプラグイン '%1' をインストールしますか?"
   },
   "Install plugins from the DMS plugin registry": {
     "Install plugins from the DMS plugin registry": "DMSプラグインレジストリからプラグインをインストールする"
   },
   "Install the DMS greeter? A terminal will open for sudo authentication.": {
-    "Install the DMS greeter? A terminal will open for sudo authentication.": ""
+    "Install the DMS greeter? A terminal will open for sudo authentication.": "DMS Greeter をインストールしますか? sudo 認証用の端末が開きます。"
   },
   "Install theme '%1' from the DMS registry?": {
-    "Install theme '%1' from the DMS registry?": ""
+    "Install theme '%1' from the DMS registry?": "DMS レジストリからテーマ '%1' をインストールしますか?"
   },
   "Installation and PAM setup: see the ": {
-    "Installation and PAM setup: see the ": ""
+    "Installation and PAM setup: see the ": "インストールと PAM 設定については次を参照してください: "
   },
   "Installed": {
-    "Installed": ""
+    "Installed": "インストール済み"
   },
   "Installed: %1": {
-    "Installed: %1": ""
+    "Installed: %1": "インストール済み: %1"
   },
   "Installing: %1": {
-    "Installing: %1": ""
+    "Installing: %1": "インストール中: %1"
   },
   "Intelligent Auto-hide": {
-    "Intelligent Auto-hide": ""
+    "Intelligent Auto-hide": "インテリジェント自動非表示"
   },
   "Intensity": {
-    "Intensity": ""
+    "Intensity": "強度"
   },
   "Interface:": {
-    "Interface:": ""
+    "Interface:": "インターフェース:"
   },
   "Interlock Open": {
     "Interlock Open": "インターロックオープン"
@@ -3216,16 +3213,16 @@
     "Interval": "間隔"
   },
   "Invalid configuration": {
-    "Invalid configuration": ""
+    "Invalid configuration": "無効な設定"
   },
   "Invert on mode change": {
     "Invert on mode change": "モード変更時に反転"
   },
   "Iris Bloom": {
-    "Iris Bloom": ""
+    "Iris Bloom": "Iris Bloom"
   },
   "Isolate Displays": {
-    "Isolate Displays": ""
+    "Isolate Displays": "表示を分離"
   },
   "Jobs": {
     "Jobs": "ジョブ"
@@ -3243,82 +3240,82 @@
     "Keeping Awake": "活動状態を維持"
   },
   "Kernel": {
-    "Kernel": ""
+    "Kernel": "カーネル"
   },
   "Key": {
-    "Key": ""
+    "Key": "キー"
   },
   "Keybind Sources": {
-    "Keybind Sources": ""
+    "Keybind Sources": "キーバインドソース"
   },
   "Keybinds": {
-    "Keybinds": ""
+    "Keybinds": "キーバインド"
   },
   "Keybinds Search Settings": {
-    "Keybinds Search Settings": ""
+    "Keybinds Search Settings": "キーバインド検索設定"
   },
   "Keybinds shown alongside regular search results": {
-    "Keybinds shown alongside regular search results": ""
+    "Keybinds shown alongside regular search results": "通常の検索結果と一緒にキーバインドを表示"
   },
   "Keyboard Layout Name": {
     "Keyboard Layout Name": "キーボードレイアウト名"
   },
   "Keyboard Shortcuts": {
-    "Keyboard Shortcuts": ""
+    "Keyboard Shortcuts": "キーボードショートカット"
   },
   "Keys": {
-    "Keys": ""
+    "Keys": "キー"
   },
   "Kill": {
-    "Kill": ""
+    "Kill": "終了"
   },
   "Kill Process": {
     "Kill Process": "プロセスを強制終了"
   },
   "Kill Session": {
-    "Kill Session": ""
+    "Kill Session": "セッションを終了"
   },
   "Ko-fi": {
-    "Ko-fi": ""
+    "Ko-fi": "Ko-fi"
   },
   "LED device": {
-    "LED device": ""
+    "LED device": "LED デバイス"
   },
   "LabWC IRC Channel": {
-    "LabWC IRC Channel": ""
+    "LabWC IRC Channel": "LabWC IRC チャンネル"
   },
   "LabWC Website": {
-    "LabWC Website": ""
+    "LabWC Website": "LabWC ウェブサイト"
   },
   "Large": {
-    "Large": ""
+    "Large": "大"
   },
   "Largest": {
-    "Largest": ""
+    "Largest": "最大"
   },
   "Last hour": {
-    "Last hour": ""
+    "Last hour": "過去1時間"
   },
   "Last launched %1": {
     "Last launched %1": "最終起動日 %1"
   },
   "Last launched %1 day ago": {
-    "Last launched %1 day ago": ""
+    "Last launched %1 day ago": "%1 日前に最終起動"
   },
   "Last launched %1 days ago": {
-    "Last launched %1 days ago": ""
+    "Last launched %1 days ago": "%1 日前に最終起動"
   },
   "Last launched %1 hour ago": {
-    "Last launched %1 hour ago": ""
+    "Last launched %1 hour ago": "%1 時間前に最終起動"
   },
   "Last launched %1 hours ago": {
-    "Last launched %1 hours ago": ""
+    "Last launched %1 hours ago": "%1 時間前に最終起動"
   },
   "Last launched %1 minute ago": {
-    "Last launched %1 minute ago": ""
+    "Last launched %1 minute ago": "%1 分前に最終起動"
   },
   "Last launched %1 minutes ago": {
-    "Last launched %1 minutes ago": ""
+    "Last launched %1 minutes ago": "%1 分前に最終起動"
   },
   "Last launched just now": {
     "Last launched just now": "ただいま起動しました"
@@ -3336,13 +3333,13 @@
     "Launch on dGPU": "dGPUで起動"
   },
   "Launch on dGPU by default": {
-    "Launch on dGPU by default": ""
+    "Launch on dGPU by default": "デフォルトで dGPU で起動"
   },
   "Launcher": {
     "Launcher": "ランチャー"
   },
   "Launcher Button": {
-    "Launcher Button": ""
+    "Launcher Button": "ランチャーボタン"
   },
   "Launcher Button Logo": {
     "Launcher Button Logo": "ランチャーのボタンロゴ"
@@ -3351,85 +3348,85 @@
     "Layout": "レイアウト"
   },
   "Layout Overrides": {
-    "Layout Overrides": ""
+    "Layout Overrides": "レイアウト上書き"
   },
   "Layout and module positions on the greeter are synced from your shell (e.g. bar config). Run Sync to apply.": {
-    "Layout and module positions on the greeter are synced from your shell (e.g. bar config). Run Sync to apply.": ""
+    "Layout and module positions on the greeter are synced from your shell (e.g. bar config). Run Sync to apply.": "Greeter のレイアウトとモジュール位置はシェル（例: バー設定）から同期されます。適用するには Sync を実行してください。"
   },
   "Left": {
     "Left": "左"
   },
   "Left Center": {
-    "Left Center": ""
+    "Left Center": "左中央"
   },
   "Left Section": {
     "Left Section": "左セクション"
   },
   "Light Direction": {
-    "Light Direction": ""
+    "Light Direction": "光の方向"
   },
   "Light Mode": {
     "Light Mode": "ライトモード"
   },
   "Light Rain": {
-    "Light Rain": ""
+    "Light Rain": "小雨"
   },
   "Light Snow": {
-    "Light Snow": ""
+    "Light Snow": "小雪"
   },
   "Light Snow Showers": {
-    "Light Snow Showers": ""
+    "Light Snow Showers": "弱いにわか雪"
   },
   "Light mode base": {
-    "Light mode base": ""
+    "Light mode base": "ライトモードベース"
   },
   "Light mode harmony": {
-    "Light mode harmony": ""
+    "Light mode harmony": "ライトモードハーモニー"
   },
   "Line": {
-    "Line": ""
+    "Line": "行"
   },
   "Line: %1": {
-    "Line: %1": ""
+    "Line: %1": "行: %1"
   },
   "Linear": {
-    "Linear": ""
+    "Linear": "線形"
   },
   "Lines: %1": {
     "Lines: %1": "行数: %1"
   },
   "List": {
-    "List": ""
+    "List": "リスト"
   },
   "Lively palette with saturated accents.": {
     "Lively palette with saturated accents.": "彩度の高いアクセントを備えた生き生きとしたパレット。"
   },
   "Load Average": {
-    "Load Average": ""
+    "Load Average": "負荷平均"
   },
   "Loading codecs...": {
-    "Loading codecs...": ""
+    "Loading codecs...": "コーデックを読み込み中..."
   },
   "Loading keybinds...": {
-    "Loading keybinds...": ""
+    "Loading keybinds...": "キーバインドを読み込み中..."
   },
   "Loading trending...": {
-    "Loading trending...": ""
+    "Loading trending...": "トレンドを読み込み中..."
   },
   "Loading...": {
-    "Loading...": ""
+    "Loading...": "読み込み中..."
   },
   "Local": {
-    "Local": ""
+    "Local": "ローカル"
   },
   "Locale": {
-    "Locale": ""
+    "Locale": "ロケール"
   },
   "Locale Settings": {
-    "Locale Settings": ""
+    "Locale Settings": "ロケール設定"
   },
   "Location": {
-    "Location": ""
+    "Location": "位置"
   },
   "Location Search": {
     "Location Search": "ロケーション検索"
@@ -3441,52 +3438,52 @@
     "Lock Screen": "ロック画面"
   },
   "Lock Screen Display": {
-    "Lock Screen Display": ""
+    "Lock Screen Display": "ロック画面表示"
   },
   "Lock Screen Format": {
     "Lock Screen Format": "ロック画面のフォーマット"
   },
   "Lock Screen behaviour": {
-    "Lock Screen behaviour": ""
+    "Lock Screen behaviour": "ロック画面の動作"
   },
   "Lock Screen layout": {
-    "Lock Screen layout": ""
+    "Lock Screen layout": "ロック画面レイアウト"
   },
   "Lock at startup": {
-    "Lock at startup": ""
+    "Lock at startup": "起動時にロック"
   },
   "Lock before suspend": {
     "Lock before suspend": "一時停止前にロック"
   },
   "Lock fade grace period": {
-    "Lock fade grace period": ""
+    "Lock fade grace period": "ロックフェードの猶予時間"
   },
   "Lock screen authentication changes apply automatically and may open a terminal when sudo authentication is required.": {
-    "Lock screen authentication changes apply automatically and may open a terminal when sudo authentication is required.": ""
+    "Lock screen authentication changes apply automatically and may open a terminal when sudo authentication is required.": "ロック画面の認証変更は自動的に適用され、sudo 認証が必要な場合は端末が開くことがあります。"
   },
   "Locked": {
-    "Locked": ""
+    "Locked": "ロック済み"
   },
   "Log Out": {
     "Log Out": "ログアウト"
   },
   "Logging in...": {
-    "Logging in...": ""
+    "Logging in...": "ログイン中..."
   },
   "Login": {
-    "Login": ""
+    "Login": "ログイン"
   },
   "Login Authentication": {
-    "Login Authentication": ""
+    "Login Authentication": "ログイン認証"
   },
   "Long": {
-    "Long": ""
+    "Long": "長い"
   },
   "Long Text": {
     "Long Text": "長文"
   },
   "Long press": {
-    "Long press": ""
+    "Long press": "長押し"
   },
   "Longitude": {
     "Longitude": "経度"
@@ -3495,13 +3492,13 @@
     "Low Priority": "低優先度"
   },
   "MAC": {
-    "MAC": ""
+    "MAC": "MAC"
   },
   "MTU": {
-    "MTU": ""
+    "MTU": "MTU"
   },
   "Make sure KDE Connect or Valent is running on your other devices": {
-    "Make sure KDE Connect or Valent is running on your other devices": ""
+    "Make sure KDE Connect or Valent is running on your other devices": "他のデバイスで KDE Connect または Valent が実行されていることを確認してください"
   },
   "Manage and configure plugins for extending DMS functionality": {
     "Manage and configure plugins for extending DMS functionality": "DMS 機能を拡張するためのプラグインを管理および構成"
@@ -3510,19 +3507,19 @@
     "Manage up to 4 independent bar configurations. Each bar has its own position, widgets, styling, and display assignment.": "最大4つの独立したバー構成を管理できます。各バーには独自の位置、ウィジェット、スタイリング、表示割り当てがあります。"
   },
   "Management": {
-    "Management": ""
+    "Management": "管理"
   },
   "MangoWC Layout Overrides": {
-    "MangoWC Layout Overrides": ""
+    "MangoWC Layout Overrides": "MangoWC レイアウト上書き"
   },
   "Manual": {
-    "Manual": ""
+    "Manual": "手動"
   },
   "Manual Coordinates": {
     "Manual Coordinates": "手動座標"
   },
   "Manual Direction": {
-    "Manual Direction": ""
+    "Manual Direction": "手動方向"
   },
   "Manual Gap Size": {
     "Manual Gap Size": "手動ギャップサイズ"
@@ -3531,7 +3528,7 @@
     "Manual Show/Hide": "手動で表示/非表示"
   },
   "Map window class names to icon names for proper icon display": {
-    "Map window class names to icon names for proper icon display": ""
+    "Map window class names to icon names for proper icon display": "適切にアイコンを表示するため、ウィンドウ class 名をアイコン名にマッピングします"
   },
   "Margin": {
     "Margin": "マージン"
@@ -3549,28 +3546,28 @@
     "Marker Waste Full": "マーカー廃棄物がいっぱい"
   },
   "Match Criteria": {
-    "Match Criteria": ""
+    "Match Criteria": "一致条件"
   },
   "Matches profile: %1": {
-    "Matches profile: %1": ""
+    "Matches profile: %1": "一致するプロファイル: %1"
   },
   "Material Colors": {
     "Material Colors": "Material Colors"
   },
   "Material Design inspired color themes": {
-    "Material Design inspired color themes": ""
+    "Material Design inspired color themes": "Material Design 風のカラーテーマ"
   },
   "Material colors generated from wallpaper": {
-    "Material colors generated from wallpaper": ""
+    "Material colors generated from wallpaper": "壁紙から生成された Material カラー"
   },
   "Material inspired shadows and elevation on modals, popouts, and dialogs": {
-    "Material inspired shadows and elevation on modals, popouts, and dialogs": ""
+    "Material inspired shadows and elevation on modals, popouts, and dialogs": "モーダル、ポップアウト、ダイアログに Material 風の影とエレベーションを適用"
   },
   "Matugen Contrast": {
-    "Matugen Contrast": ""
+    "Matugen Contrast": "Matugen コントラスト"
   },
   "Matugen Missing": {
-    "Matugen Missing": ""
+    "Matugen Missing": "Matugen が見つかりません"
   },
   "Matugen Palette": {
     "Matugen Palette": "Matugen Palette"
@@ -3579,76 +3576,76 @@
     "Matugen Target Monitor": "Matugenターゲットモニター"
   },
   "Matugen Templates": {
-    "Matugen Templates": ""
+    "Matugen Templates": "Matugen テンプレート"
   },
   "Max Edges": {
-    "Max Edges": ""
+    "Max Edges": "最大端"
   },
   "Max H": {
-    "Max H": ""
+    "Max H": "最大高さ"
   },
   "Max Pinned Apps": {
-    "Max Pinned Apps": ""
+    "Max Pinned Apps": "最大固定アプリ数"
   },
   "Max Pinned Apps (0 = Unlimited)": {
-    "Max Pinned Apps (0 = Unlimited)": ""
+    "Max Pinned Apps (0 = Unlimited)": "最大固定アプリ数（0 = 無制限）"
   },
   "Max Running Apps": {
-    "Max Running Apps": ""
+    "Max Running Apps": "最大実行中アプリ数"
   },
   "Max Running Apps (0 = Unlimited)": {
-    "Max Running Apps (0 = Unlimited)": ""
+    "Max Running Apps (0 = Unlimited)": "最大実行中アプリ数（0 = 無制限）"
   },
   "Max Volume": {
-    "Max Volume": ""
+    "Max Volume": "最大音量"
   },
   "Max W": {
-    "Max W": ""
+    "Max W": "最大幅"
   },
   "Max apps to show": {
     "Max apps to show": "表示するアプリの最大数"
   },
   "Max to Edges": {
-    "Max to Edges": ""
+    "Max to Edges": "端まで最大化"
   },
   "Maximize": {
-    "Maximize": ""
+    "Maximize": "最大化"
   },
   "Maximize Detection": {
-    "Maximize Detection": ""
+    "Maximize Detection": "最大化検出"
   },
   "Maximize Widget Icons": {
-    "Maximize Widget Icons": ""
+    "Maximize Widget Icons": "ウィジェットアイコンを最大化"
   },
   "Maximize Widget Text": {
-    "Maximize Widget Text": ""
+    "Maximize Widget Text": "ウィジェットテキストを最大化"
   },
   "Maximum Entry Size": {
-    "Maximum Entry Size": ""
+    "Maximum Entry Size": "エントリの最大サイズ"
   },
   "Maximum History": {
-    "Maximum History": ""
+    "Maximum History": "最大履歴数"
   },
   "Maximum Pinned Entries": {
-    "Maximum Pinned Entries": ""
+    "Maximum Pinned Entries": "最大固定エントリ数"
   },
   "Maximum fingerprint attempts reached. Please use password.": {
-    "Maximum fingerprint attempts reached. Please use password.": ""
+    "Maximum fingerprint attempts reached. Please use password.": "指紋認証の試行回数が上限に達しました。パスワードを使用してください。"
   },
   "Maximum number of clipboard entries to keep": {
-    "Maximum number of clipboard entries to keep": ""
+    "Maximum number of clipboard entries to keep": "保持するクリップボードエントリの最大数"
   },
   "Maximum number of entries that can be saved": {
-    "Maximum number of entries that can be saved": ""
+    "Maximum number of entries that can be saved": "保存できるエントリの最大数"
   },
   "Maximum number of notifications to keep": {
-    "Maximum number of notifications to keep": ""
+    "Maximum number of notifications to keep": "保持する通知の最大数"
   },
   "Maximum pinned entries reached": {
-    "Maximum pinned entries reached": ""
+    "Maximum pinned entries reached": "固定エントリ数が上限に達しました"
   },
   "Maximum size per clipboard entry": {
-    "Maximum size per clipboard entry": ""
+    "Maximum size per clipboard entry": "クリップボードエントリごとの最大サイズ"
   },
   "Media": {
     "Media": "メディア"
@@ -3669,31 +3666,31 @@
     "Media Needed": "メディアが必要"
   },
   "Media Playback": {
-    "Media Playback": ""
+    "Media Playback": "メディア再生"
   },
   "Media Player": {
-    "Media Player": ""
+    "Media Player": "メディアプレーヤー"
   },
   "Media Player Settings": {
     "Media Player Settings": "メディアプレーヤーの設定"
   },
   "Media Players": {
-    "Media Players": ""
+    "Media Players": "メディアプレーヤー"
   },
   "Media Players (": {
     "Media Players (": "メディアプレーヤー（"
   },
   "Media Volume": {
-    "Media Volume": ""
+    "Media Volume": "メディア音量"
   },
   "Medium": {
-    "Medium": ""
+    "Medium": "中"
   },
   "Memory": {
     "Memory": "メモリ"
   },
   "Memory Graph": {
-    "Memory Graph": ""
+    "Memory Graph": "メモリグラフ"
   },
   "Memory Usage": {
     "Memory Usage": "メモリ使用率"
@@ -3702,40 +3699,40 @@
     "Memory usage indicator": "メモリ使用率インジケーター"
   },
   "Merge indexed file results into the All tab (requires dsearch).": {
-    "Merge indexed file results into the All tab (requires dsearch).": ""
+    "Merge indexed file results into the All tab (requires dsearch).": "インデックス化されたファイル結果を All タブに統合します（dsearch が必要）。"
   },
   "Merge indexed folder results into the All tab (requires dsearch).": {
-    "Merge indexed folder results into the All tab (requires dsearch).": ""
+    "Merge indexed folder results into the All tab (requires dsearch).": "インデックス化されたフォルダー結果を All タブに統合します（dsearch が必要）。"
   },
   "Message": {
-    "Message": ""
+    "Message": "メッセージ"
   },
   "Message Content": {
-    "Message Content": ""
+    "Message Content": "メッセージ内容"
   },
   "Microphone": {
     "Microphone": "マイク"
   },
   "Microphone Mute": {
-    "Microphone Mute": ""
+    "Microphone Mute": "マイクミュート"
   },
   "Microphone Volume": {
-    "Microphone Volume": ""
+    "Microphone Volume": "マイク音量"
   },
   "Microphone settings": {
-    "Microphone settings": ""
+    "Microphone settings": "マイク設定"
   },
   "Microphone volume control": {
-    "Microphone volume control": ""
+    "Microphone volume control": "マイク音量コントロール"
   },
   "Middle Section": {
     "Middle Section": "中間区間"
   },
   "Min H": {
-    "Min H": ""
+    "Min H": "最小高さ"
   },
   "Min W": {
-    "Min W": ""
+    "Min W": "最小幅"
   },
   "Minimal palette built around a single hue.": {
     "Minimal palette built around a single hue.": "単一の色相を中心に構築された最小限のパレット。"
@@ -3744,22 +3741,22 @@
     "Minute": "分"
   },
   "Mirror Display": {
-    "Mirror Display": ""
+    "Mirror Display": "ディスプレイをミラーリング"
   },
   "Missing Environment Variables": {
-    "Missing Environment Variables": ""
+    "Missing Environment Variables": "不足している環境変数"
   },
   "Modal Background": {
-    "Modal Background": ""
+    "Modal Background": "モーダル背景"
   },
   "Modal Shadows": {
-    "Modal Shadows": ""
+    "Modal Shadows": "モーダルの影"
   },
   "Modals": {
-    "Modals": ""
+    "Modals": "モーダル"
   },
   "Mode": {
-    "Mode": ""
+    "Mode": "モード"
   },
   "Mode:": {
     "Mode:": "モード："
@@ -3768,25 +3765,25 @@
     "Model": "モデル"
   },
   "Modified": {
-    "Modified": ""
+    "Modified": "変更済み"
   },
   "Modular widget bar": {
-    "Modular widget bar": ""
+    "Modular widget bar": "モジュール式ウィジェットバー"
   },
   "Monitor": {
-    "Monitor": ""
+    "Monitor": "モニター"
   },
   "Monitor Configuration": {
-    "Monitor Configuration": ""
+    "Monitor Configuration": "モニター設定"
   },
   "Monitor fade grace period": {
-    "Monitor fade grace period": ""
+    "Monitor fade grace period": "モニターフェードの猶予時間"
   },
   "Monitor whose wallpaper drives dynamic theming colors": {
     "Monitor whose wallpaper drives dynamic theming colors": "ダイナミックテーマの色を駆動する壁紙をモニター"
   },
   "Monochrome": {
-    "Monochrome": ""
+    "Monochrome": "モノクロ"
   },
   "Monocle": {
     "Monocle": "モノクル"
@@ -3795,55 +3792,55 @@
     "Monospace Font": "等幅フォント"
   },
   "Month Date": {
-    "Month Date": ""
+    "Month Date": "月 日付"
   },
   "Morning": {
-    "Morning": ""
+    "Morning": "朝"
   },
   "Mount Points": {
-    "Mount Points": ""
+    "Mount Points": "マウントポイント"
   },
   "Mouse pointer appearance": {
-    "Mouse pointer appearance": ""
+    "Mouse pointer appearance": "マウスポインターの外観"
   },
   "Mouse pointer size in pixels": {
-    "Mouse pointer size in pixels": ""
+    "Mouse pointer size in pixels": "マウスポインターのサイズ（ピクセル）"
   },
   "Move": {
-    "Move": ""
+    "Move": "移動"
   },
   "Move Widget": {
-    "Move Widget": ""
+    "Move Widget": "ウィジェットを移動"
   },
   "Moving to Paused": {
     "Moving to Paused": "一時停止への移行"
   },
   "Multi-Monitor": {
-    "Multi-Monitor": ""
+    "Multi-Monitor": "マルチモニター"
   },
   "Multiplexer": {
-    "Multiplexer": ""
+    "Multiplexer": "マルチプレクサ"
   },
   "Multiplexer Type": {
-    "Multiplexer Type": ""
+    "Multiplexer Type": "マルチプレクサの種類"
   },
   "Multiplexers": {
-    "Multiplexers": ""
+    "Multiplexers": "マルチプレクサ"
   },
   "Music": {
-    "Music": ""
+    "Music": "音楽"
   },
   "Mute Popups": {
-    "Mute Popups": ""
+    "Mute Popups": "ポップアップをミュート"
   },
   "Mute popups for %1": {
-    "Mute popups for %1": ""
+    "Mute popups for %1": "%1 のポップアップをミュート"
   },
   "Muted": {
-    "Muted": ""
+    "Muted": "ミュート済み"
   },
   "Muted Apps": {
-    "Muted Apps": ""
+    "Muted Apps": "ミュートしたアプリ"
   },
   "Muted palette with subdued, calming tones.": {
     "Muted palette with subdued, calming tones.": "落ち着いた色調のパレット。"
@@ -3858,7 +3855,7 @@
     "Named Workspace Icons": "名前付きワークスペースアイコン"
   },
   "Navigate": {
-    "Navigate": ""
+    "Navigate": "移動"
   },
   "Navigation": {
     "Navigation": "ナビゲーション"
@@ -3867,7 +3864,7 @@
     "Network": "ネットワーク"
   },
   "Network Graph": {
-    "Network Graph": ""
+    "Network Graph": "ネットワークグラフ"
   },
   "Network Info": {
     "Network Info": "ネットワーク情報"
@@ -3876,58 +3873,58 @@
     "Network Information": "ネットワーク情報"
   },
   "Network Name (SSID)": {
-    "Network Name (SSID)": ""
+    "Network Name (SSID)": "ネットワーク名（SSID）"
   },
   "Network Speed Monitor": {
     "Network Speed Monitor": "ネットワーク速度モニター"
   },
   "Network Status": {
-    "Network Status": ""
+    "Network Status": "ネットワーク状態"
   },
   "Network download and upload speed display": {
     "Network download and upload speed display": "ネットワークのダウンロードおよびアップロード速度を表示"
   },
   "Neutral": {
-    "Neutral": ""
+    "Neutral": "中立"
   },
   "Never": {
-    "Never": ""
+    "Never": "なし"
   },
   "Never used": {
-    "Never used": ""
+    "Never used": "未使用"
   },
   "New": {
     "New": "新しい"
   },
   "New Key": {
-    "New Key": ""
+    "New Key": "新しいキー"
   },
   "New Keybind": {
-    "New Keybind": ""
+    "New Keybind": "新しいキーバインド"
   },
   "New Notification": {
     "New Notification": "新しい通知"
   },
   "New Session": {
-    "New Session": ""
+    "New Session": "新しいセッション"
   },
   "New Window Rule": {
-    "New Window Rule": ""
+    "New Window Rule": "新しいウィンドウルール"
   },
   "New York, NY": {
     "New York, NY": "New York, NY"
   },
   "New group name...": {
-    "New group name...": ""
+    "New group name...": "新しいグループ名..."
   },
   "Next": {
-    "Next": ""
+    "Next": "次へ"
   },
   "Next Transition": {
-    "Next Transition": ""
+    "Next Transition": "次の切り替え"
   },
   "Night": {
-    "Night": ""
+    "Night": "夜"
   },
   "Night Mode": {
     "Night Mode": "ナイトモード"
@@ -3936,205 +3933,205 @@
     "Night Temperature": "夜間の温度"
   },
   "Night mode & gamma": {
-    "Night mode & gamma": ""
+    "Night mode & gamma": "ナイトモードとガンマ"
   },
   "Niri Integration": {
-    "Niri Integration": ""
+    "Niri Integration": "Niri 統合"
   },
   "Niri Layout Overrides": {
-    "Niri Layout Overrides": ""
+    "Niri Layout Overrides": "Niri レイアウト上書き"
   },
   "Niri compositor actions (focus, move, etc.)": {
-    "Niri compositor actions (focus, move, etc.)": ""
+    "Niri compositor actions (focus, move, etc.)": "Niri コンポジターアクション（フォーカス、移動など）"
   },
   "No": {
-    "No": ""
+    "No": "いいえ"
   },
   "No Active Players": {
     "No Active Players": "アクティブプレイヤーなし"
   },
   "No Anim": {
-    "No Anim": ""
+    "No Anim": "アニメーションなし"
   },
   "No Background": {
     "No Background": "背景なし"
   },
   "No Battery": {
-    "No Battery": ""
+    "No Battery": "バッテリーなし"
   },
   "No Bluetooth adapter found": {
     "No Bluetooth adapter found": "Bluetoothアダプタが見つかりませんでした"
   },
   "No Blur": {
-    "No Blur": ""
+    "No Blur": "ぼかしなし"
   },
   "No Border": {
-    "No Border": ""
+    "No Border": "ボーダーなし"
   },
   "No DMS shortcuts configured": {
-    "No DMS shortcuts configured": ""
+    "No DMS shortcuts configured": "DMS ショートカットが設定されていません"
   },
   "No Dim": {
-    "No Dim": ""
+    "No Dim": "暗転なし"
   },
   "No Focus": {
-    "No Focus": ""
+    "No Focus": "フォーカスなし"
   },
   "No GPU detected": {
-    "No GPU detected": ""
+    "No GPU detected": "GPU が検出されません"
   },
   "No GPUs detected": {
-    "No GPUs detected": ""
+    "No GPUs detected": "GPU が検出されません"
   },
   "No History": {
-    "No History": ""
+    "No History": "履歴なし"
   },
   "No Media": {
     "No Media": "メディアなし"
   },
   "No Round": {
-    "No Round": ""
+    "No Round": "角丸なし"
   },
   "No Rounding": {
-    "No Rounding": ""
+    "No Rounding": "角丸なし"
   },
   "No Shadow": {
-    "No Shadow": ""
+    "No Shadow": "影なし"
   },
   "No VPN profiles": {
-    "No VPN profiles": ""
+    "No VPN profiles": "VPN プロファイルなし"
   },
   "No Weather": {
-    "No Weather": ""
+    "No Weather": "天気なし"
   },
   "No Weather Data": {
-    "No Weather Data": ""
+    "No Weather Data": "天気データなし"
   },
   "No Weather Data Available": {
     "No Weather Data Available": "気象データはありません"
   },
   "No action": {
-    "No action": ""
+    "No action": "アクションなし"
   },
   "No active %1 sessions": {
-    "No active %1 sessions": ""
+    "No active %1 sessions": "アクティブな %1 セッションはありません"
   },
   "No adapter": {
-    "No adapter": ""
+    "No adapter": "アダプターなし"
   },
   "No adapters": {
-    "No adapters": ""
+    "No adapters": "アダプターなし"
   },
   "No app customizations.": {
-    "No app customizations.": ""
+    "No app customizations.": "アプリのカスタマイズはありません。"
   },
   "No apps found": {
-    "No apps found": ""
+    "No apps found": "アプリが見つかりませんでした"
   },
   "No apps have been launched yet.": {
-    "No apps have been launched yet.": ""
+    "No apps have been launched yet.": "まだアプリは起動されていません。"
   },
   "No apps muted. Right-click a notification and choose \"Mute popups\" to add one here.": {
-    "No apps muted. Right-click a notification and choose \"Mute popups\" to add one here.": ""
+    "No apps muted. Right-click a notification and choose \"Mute popups\" to add one here.": "ミュートされたアプリはありません。通知を右クリックして「Mute popups」を選択すると、ここに追加できます。"
   },
   "No battery": {
-    "No battery": ""
+    "No battery": "バッテリーなし"
   },
   "No brightness devices available": {
-    "No brightness devices available": ""
+    "No brightness devices available": "利用可能な明るさデバイスがありません"
   },
   "No changes": {
-    "No changes": ""
+    "No changes": "変更なし"
   },
   "No checks passed": {
-    "No checks passed": ""
+    "No checks passed": "通過したチェックはありません"
   },
   "No custom theme file": {
-    "No custom theme file": ""
+    "No custom theme file": "カスタムテーマファイルなし"
   },
   "No devices": {
-    "No devices": ""
+    "No devices": "デバイスなし"
   },
   "No devices connected": {
-    "No devices connected": ""
+    "No devices connected": "接続されたデバイスはありません"
   },
   "No devices found": {
-    "No devices found": ""
+    "No devices found": "デバイスが見つかりませんでした"
   },
   "No disk data": {
-    "No disk data": ""
+    "No disk data": "ディスクデータなし"
   },
   "No disk data available": {
-    "No disk data available": ""
+    "No disk data available": "利用可能なディスクデータはありません"
   },
   "No drivers found": {
-    "No drivers found": ""
+    "No drivers found": "ドライバーが見つかりませんでした"
   },
   "No errors": {
-    "No errors": ""
+    "No errors": "エラーなし"
   },
   "No features enabled": {
-    "No features enabled": ""
+    "No features enabled": "有効な機能はありません"
   },
   "No files found": {
     "No files found": "ファイルが見つかりませんでした"
   },
   "No fingerprint reader detected.": {
-    "No fingerprint reader detected.": ""
+    "No fingerprint reader detected.": "指紋リーダーが検出されませんでした。"
   },
   "No folders found": {
-    "No folders found": ""
+    "No folders found": "フォルダーが見つかりませんでした"
   },
   "No hidden apps.": {
-    "No hidden apps.": ""
+    "No hidden apps.": "非表示のアプリはありません。"
   },
   "No info items": {
-    "No info items": ""
+    "No info items": "情報項目はありません"
   },
   "No information available": {
-    "No information available": ""
+    "No information available": "利用可能な情報はありません"
   },
   "No input device": {
-    "No input device": ""
+    "No input device": "入力デバイスなし"
   },
   "No input devices found": {
-    "No input devices found": ""
+    "No input devices found": "入力デバイスが見つかりませんでした"
   },
   "No items added yet": {
     "No items added yet": "まだアイテムが追加されていません"
   },
   "No keybinds found": {
-    "No keybinds found": ""
+    "No keybinds found": "キーバインドが見つかりませんでした"
   },
   "No launcher plugins installed.": {
-    "No launcher plugins installed.": ""
+    "No launcher plugins installed.": "ランチャープラグインはインストールされていません。"
   },
   "No match criteria": {
-    "No match criteria": ""
+    "No match criteria": "一致条件なし"
   },
   "No matches": {
     "No matches": "一致するものはありません"
   },
   "No matching processes": {
-    "No matching processes": ""
+    "No matching processes": "一致するプロセスはありません"
   },
   "No monitors": {
-    "No monitors": ""
+    "No monitors": "モニターなし"
   },
   "No mount points found": {
-    "No mount points found": ""
+    "No mount points found": "マウントポイントが見つかりませんでした"
   },
   "No output device": {
-    "No output device": ""
+    "No output device": "出力デバイスなし"
   },
   "No output devices found": {
-    "No output devices found": ""
+    "No output devices found": "出力デバイスが見つかりませんでした"
   },
   "No package manager found. Please install 'paru' or 'yay' on Arch-based systems to check for updates.": {
-    "No package manager found. Please install 'paru' or 'yay' on Arch-based systems to check for updates.": ""
+    "No package manager found. Please install 'paru' or 'yay' on Arch-based systems to check for updates.": "パッケージマネージャーが見つかりません。Arch 系システムで更新を確認するには 'paru' または 'yay' をインストールしてください。"
   },
   "No plugin results": {
-    "No plugin results": ""
+    "No plugin results": "プラグイン結果はありません"
   },
   "No plugins found": {
     "No plugins found": "プラグインが見つかりませんでした"
@@ -4146,106 +4143,106 @@
     "No printer found": "プリンターが見つかりませんでした"
   },
   "No printers configured": {
-    "No printers configured": ""
+    "No printers configured": "プリンターは設定されていません"
   },
   "No printers found": {
-    "No printers found": ""
+    "No printers found": "プリンターが見つかりませんでした"
   },
   "No profiles": {
-    "No profiles": ""
+    "No profiles": "プロファイルなし"
   },
   "No recent clipboard entries found": {
-    "No recent clipboard entries found": ""
+    "No recent clipboard entries found": "最近のクリップボードエントリは見つかりませんでした"
   },
   "No results found": {
-    "No results found": ""
+    "No results found": "結果が見つかりませんでした"
   },
   "No saved clipboard entries": {
-    "No saved clipboard entries": ""
+    "No saved clipboard entries": "保存済みのクリップボードエントリはありません"
   },
   "No sessions found": {
-    "No sessions found": ""
+    "No sessions found": "セッションが見つかりませんでした"
   },
   "No status output.": {
-    "No status output.": ""
+    "No status output.": "ステータス出力はありません。"
   },
   "No themes found": {
-    "No themes found": ""
+    "No themes found": "テーマが見つかりませんでした"
   },
   "No themes installed. Browse themes to install from the registry.": {
-    "No themes installed. Browse themes to install from the registry.": ""
+    "No themes installed. Browse themes to install from the registry.": "テーマはインストールされていません。テーマを参照してレジストリからインストールしてください。"
   },
   "No trigger": {
-    "No trigger": ""
+    "No trigger": "トリガーなし"
   },
   "No video found in folder": {
-    "No video found in folder": ""
+    "No video found in folder": "フォルダー内に動画が見つかりませんでした"
   },
   "No wallpaper selected": {
-    "No wallpaper selected": ""
+    "No wallpaper selected": "壁紙が選択されていません"
   },
   "No wallpapers": {
-    "No wallpapers": ""
+    "No wallpapers": "壁紙なし"
   },
   "No wallpapers found\n\nClick the folder icon below to browse": {
-    "No wallpapers found\n\nClick the folder icon below to browse": ""
+    "No wallpapers found\n\nClick the folder icon below to browse": "壁紙が見つかりませんでした\n\n下のフォルダーアイコンをクリックして参照してください"
   },
   "No warnings": {
-    "No warnings": ""
+    "No warnings": "警告なし"
   },
   "No widgets added. Click \"Add Widget\" to get started.": {
-    "No widgets added. Click \"Add Widget\" to get started.": ""
+    "No widgets added. Click \"Add Widget\" to get started.": "ウィジェットは追加されていません。「Add Widget」をクリックして開始してください。"
   },
   "No widgets available": {
-    "No widgets available": ""
+    "No widgets available": "利用可能なウィジェットはありません"
   },
   "No widgets match your search": {
-    "No widgets match your search": ""
+    "No widgets match your search": "検索に一致するウィジェットはありません"
   },
   "No window rules configured": {
-    "No window rules configured": ""
+    "No window rules configured": "ウィンドウルールは設定されていません"
   },
   "None": {
     "None": "ない"
   },
   "Normal": {
-    "Normal": ""
+    "Normal": "通常"
   },
   "Normal Font": {
-    "Normal Font": ""
+    "Normal Font": "通常フォント"
   },
   "Normal Priority": {
     "Normal Priority": "通常の優先度"
   },
   "Not available": {
-    "Not available": ""
+    "Not available": "利用できません"
   },
   "Not available — install fprintd and pam_fprintd, or configure greetd PAM.": {
-    "Not available — install fprintd and pam_fprintd, or configure greetd PAM.": ""
+    "Not available — install fprintd and pam_fprintd, or configure greetd PAM.": "利用できません — fprintd と pam_fprintd をインストールするか、greetd PAM を設定してください。"
   },
   "Not available — install fprintd and pam_fprintd.": {
-    "Not available — install fprintd and pam_fprintd.": ""
+    "Not available — install fprintd and pam_fprintd.": "利用できません — fprintd と pam_fprintd をインストールしてください。"
   },
   "Not available — install or configure pam_u2f, or configure greetd PAM.": {
-    "Not available — install or configure pam_u2f, or configure greetd PAM.": ""
+    "Not available — install or configure pam_u2f, or configure greetd PAM.": "利用できません — pam_u2f をインストールまたは設定するか、greetd PAM を設定してください。"
   },
   "Not available — install or configure pam_u2f.": {
-    "Not available — install or configure pam_u2f.": ""
+    "Not available — install or configure pam_u2f.": "利用できません — pam_u2f をインストールまたは設定してください。"
   },
   "Not connected": {
-    "Not connected": ""
+    "Not connected": "未接続"
   },
   "Not detected": {
-    "Not detected": ""
+    "Not detected": "未検出"
   },
   "Not paired": {
-    "Not paired": ""
+    "Not paired": "未ペアリング"
   },
   "Not set": {
-    "Not set": ""
+    "Not set": "未設定"
   },
   "Note: this only changes the percentage, it does not actually limit charging.": {
-    "Note: this only changes the percentage, it does not actually limit charging.": ""
+    "Note: this only changes the percentage, it does not actually limit charging.": "注: これは割合のみを変更するもので、実際に充電を制限するわけではありません。"
   },
   "Notepad": {
     "Notepad": "メモ帳"
@@ -4257,7 +4254,7 @@
     "Notepad Slideout": "メモ帳スライドアウト"
   },
   "Nothing": {
-    "Nothing": ""
+    "Nothing": "なし"
   },
   "Nothing to see here": {
     "Nothing to see here": "ここには何もありません"
@@ -4266,7 +4263,7 @@
     "Notification Center": "通知センター"
   },
   "Notification Display": {
-    "Notification Display": ""
+    "Notification Display": "通知表示"
   },
   "Notification Overlay": {
     "Notification Overlay": "通知オーバーレイ"
@@ -4275,7 +4272,7 @@
     "Notification Popups": "通知ポップアップ"
   },
   "Notification Rules": {
-    "Notification Rules": ""
+    "Notification Rules": "通知ルール"
   },
   "Notification Settings": {
     "Notification Settings": "通知設定"
@@ -4293,13 +4290,13 @@
     "Numbers": "数字"
   },
   "Numeric (D/M)": {
-    "Numeric (D/M)": ""
+    "Numeric (D/M)": "数値（D/M）"
   },
   "Numeric (M/D)": {
-    "Numeric (M/D)": ""
+    "Numeric (M/D)": "数値（M/D）"
   },
   "OK": {
-    "OK": ""
+    "OK": "OK"
   },
   "OS Logo": {
     "OS Logo": "OSロゴ"
@@ -4308,28 +4305,28 @@
     "OSD Position": "OSD位置"
   },
   "Occupied Color": {
-    "Occupied Color": ""
+    "Occupied Color": "使用中の色"
   },
   "Off": {
-    "Off": ""
+    "Off": "オフ"
   },
   "Office": {
     "Office": "オフィス"
   },
   "Offline": {
-    "Offline": ""
+    "Offline": "オフライン"
   },
   "Offline Report": {
     "Offline Report": "オフライン報告"
   },
   "Older": {
-    "Older": ""
+    "Older": "古い"
   },
   "On": {
-    "On": ""
+    "On": "オン"
   },
   "On-Demand": {
-    "On-Demand": ""
+    "On-Demand": "オンデマンド"
   },
   "On-Screen Displays": {
     "On-Screen Displays": "オンスクリーンディスプレイ"
@@ -4341,10 +4338,10 @@
     "Only adjust gamma based on time or location rules.": "ガンマは、時間または場所のルールに基づいてのみ調整します。"
   },
   "Only affects DMS-managed PAM. If greetd already includes pam_fprintd, fingerprint stays enabled.": {
-    "Only affects DMS-managed PAM. If greetd already includes pam_fprintd, fingerprint stays enabled.": ""
+    "Only affects DMS-managed PAM. If greetd already includes pam_fprintd, fingerprint stays enabled.": "DMS 管理の PAM にのみ影響します。greetd がすでに pam_fprintd を含んでいる場合、指紋認証は有効のままです。"
   },
   "Only show windows from the current monitor on each dock": {
-    "Only show windows from the current monitor on each dock": ""
+    "Only show windows from the current monitor on each dock": "各ドックに現在のモニターのウィンドウのみ表示"
   },
   "Only visible if hibernate is supported by your system": {
     "Only visible if hibernate is supported by your system": "システムでサポートされている場合にのみ、休止状態が表示されます"
@@ -4353,76 +4350,76 @@
     "Opacity": "不透明度"
   },
   "Opaque": {
-    "Opaque": ""
+    "Opaque": "不透明"
   },
   "Open": {
     "Open": "開ける"
   },
   "Open App": {
-    "Open App": ""
+    "Open App": "アプリを開く"
   },
   "Open KDE Connect on your phone": {
-    "Open KDE Connect on your phone": ""
+    "Open KDE Connect on your phone": "スマートフォンで KDE Connect を開く"
   },
   "Open Notepad File": {
     "Open Notepad File": "メモ帳ファイルを開く"
   },
   "Open a new note": {
-    "Open a new note": ""
+    "Open a new note": "新しいメモを開く"
   },
   "Open folder": {
-    "Open folder": ""
+    "Open folder": "フォルダーを開く"
   },
   "Open in Browser": {
-    "Open in Browser": ""
+    "Open in Browser": "ブラウザーで開く"
   },
   "Open in terminal": {
-    "Open in terminal": ""
+    "Open in terminal": "端末で開く"
   },
   "Open search bar to find text": {
     "Open search bar to find text": "検索バーを開いてテキストを検索"
   },
   "Open with...": {
-    "Open with...": ""
+    "Open with...": "別のアプリで開く..."
   },
   "Opening SMS": {
-    "Opening SMS": ""
+    "Opening SMS": "SMS を開いています"
   },
   "Opening SMS app": {
-    "Opening SMS app": ""
+    "Opening SMS app": "SMS アプリを開いています"
   },
   "Opening file browser": {
-    "Opening file browser": ""
+    "Opening file browser": "ファイルブラウザーを開いています"
   },
   "Opening files": {
-    "Opening files": ""
+    "Opening files": "ファイルを開いています"
   },
   "Opening terminal: ": {
-    "Opening terminal: ": ""
+    "Opening terminal: ": "端末を開いています: "
   },
   "Optional description": {
-    "Optional description": ""
+    "Optional description": "任意の説明"
   },
   "Optional location": {
-    "Optional location": ""
+    "Optional location": "任意の場所"
   },
   "Options": {
-    "Options": ""
+    "Options": "オプション"
   },
   "Organize widgets into collapsible groups": {
-    "Organize widgets into collapsible groups": ""
+    "Organize widgets into collapsible groups": "ウィジェットを折りたたみ可能なグループに整理"
   },
   "Original: %1": {
-    "Original: %1": ""
+    "Original: %1": "元: %1"
   },
   "Other": {
     "Other": "他"
   },
   "Outline": {
-    "Outline": ""
+    "Outline": "アウトライン"
   },
   "Output": {
-    "Output": ""
+    "Output": "出力"
   },
   "Output Area Almost Full": {
     "Output Area Almost Full": "アウトプットエリアがほぼ満杯"
@@ -4431,85 +4428,85 @@
     "Output Area Full": "アウトプットエリアがいっぱい"
   },
   "Output Device": {
-    "Output Device": ""
+    "Output Device": "出力デバイス"
   },
   "Output Devices": {
-    "Output Devices": ""
+    "Output Devices": "出力デバイス"
   },
   "Output Tray Missing": {
     "Output Tray Missing": "アウトプットトレイが見つかりませんでした"
   },
   "Outputs Include Missing": {
-    "Outputs Include Missing": ""
+    "Outputs Include Missing": "outputs include が不足"
   },
   "Overcast": {
-    "Overcast": ""
+    "Overcast": "曇り"
   },
   "Overflow": {
-    "Overflow": ""
+    "Overflow": "オーバーフロー"
   },
   "Overridden by config": {
-    "Overridden by config": ""
+    "Overridden by config": "設定で上書きされています"
   },
   "Override": {
-    "Override": ""
+    "Override": "上書き"
   },
   "Override Border Size": {
-    "Override Border Size": ""
+    "Override Border Size": "境界線サイズを上書き"
   },
   "Override Corner Radius": {
-    "Override Corner Radius": ""
+    "Override Corner Radius": "コーナー半径を上書き"
   },
   "Override Gaps": {
-    "Override Gaps": ""
+    "Override Gaps": "ギャップを上書き"
   },
   "Override global layout settings for this output": {
-    "Override global layout settings for this output": ""
+    "Override global layout settings for this output": "この出力用にグローバルレイアウト設定を上書き"
   },
   "Override terminal with a custom command or script": {
-    "Override terminal with a custom command or script": ""
+    "Override terminal with a custom command or script": "カスタムコマンドまたはスクリプトで端末を上書き"
   },
   "Override the global shadow with per-bar settings": {
-    "Override the global shadow with per-bar settings": ""
+    "Override the global shadow with per-bar settings": "バーごとの設定でグローバルな影を上書き"
   },
   "Overrides": {
-    "Overrides": ""
+    "Overrides": "上書き設定"
   },
   "Overview": {
     "Overview": "概要"
   },
   "Overview of your network connections": {
-    "Overview of your network connections": ""
+    "Overview of your network connections": "ネットワーク接続の概要"
   },
   "Overwrite": {
     "Overwrite": "上書き"
   },
   "PAM already provides fingerprint auth. Enable this to show it at login.": {
-    "PAM already provides fingerprint auth. Enable this to show it at login.": ""
+    "PAM already provides fingerprint auth. Enable this to show it at login.": "PAM はすでに指紋認証を提供しています。ログイン時に表示するにはこれを有効にしてください。"
   },
   "PAM already provides security-key auth. Enable this to show it at login.": {
-    "PAM already provides security-key auth. Enable this to show it at login.": ""
+    "PAM already provides security-key auth. Enable this to show it at login.": "PAM はすでにセキュリティキー認証を提供しています。ログイン時に表示するにはこれを有効にしてください。"
   },
   "PAM provides fingerprint auth, but availability could not be confirmed.": {
-    "PAM provides fingerprint auth, but availability could not be confirmed.": ""
+    "PAM provides fingerprint auth, but availability could not be confirmed.": "PAM は指紋認証を提供していますが、利用可否を確認できませんでした。"
   },
   "PAM provides fingerprint auth, but no prints are enrolled yet.": {
-    "PAM provides fingerprint auth, but no prints are enrolled yet.": ""
+    "PAM provides fingerprint auth, but no prints are enrolled yet.": "PAM は指紋認証を提供していますが、まだ指紋が登録されていません。"
   },
   "PAM provides fingerprint auth, but no reader was detected.": {
-    "PAM provides fingerprint auth, but no reader was detected.": ""
+    "PAM provides fingerprint auth, but no reader was detected.": "PAM は指紋認証を提供していますが、リーダーが検出されませんでした。"
   },
   "PIN": {
-    "PIN": ""
+    "PIN": "PIN"
   },
   "Pad": {
-    "Pad": ""
+    "Pad": "Pad"
   },
   "Pad Hours": {
-    "Pad Hours": ""
+    "Pad Hours": "時間をゼロ埋め"
   },
   "Pad hours (02:00 vs 2:00)": {
-    "Pad hours (02:00 vs 2:00)": ""
+    "Pad hours (02:00 vs 2:00)": "時間をゼロ埋めする（02:00 と 2:00）"
   },
   "Padding": {
     "Padding": "パディング"
@@ -4521,28 +4518,28 @@
     "Pair Bluetooth Device": "Bluetoothデバイスのペアリング"
   },
   "Paired": {
-    "Paired": ""
+    "Paired": "ペアリング済み"
   },
   "Pairing": {
-    "Pairing": ""
+    "Pairing": "ペアリング中"
   },
   "Pairing failed": {
     "Pairing failed": "ペアリングが失敗しました"
   },
   "Pairing request from": {
-    "Pairing request from": ""
+    "Pairing request from": "ペアリング要求元"
   },
   "Pairing request sent": {
-    "Pairing request sent": ""
+    "Pairing request sent": "ペアリング要求を送信しました"
   },
   "Pairing requested": {
-    "Pairing requested": ""
+    "Pairing requested": "ペアリングを要求しました"
   },
   "Pairing...": {
-    "Pairing...": ""
+    "Pairing...": "ペアリング中..."
   },
   "Partly Cloudy": {
-    "Partly Cloudy": ""
+    "Partly Cloudy": "晴れ時々曇り"
   },
   "Passkey:": {
     "Passkey:": "パスキー："
@@ -4551,16 +4548,16 @@
     "Password": "パスワード"
   },
   "Password...": {
-    "Password...": ""
+    "Password...": "パスワード..."
   },
   "Paste": {
-    "Paste": ""
+    "Paste": "貼り付け"
   },
   "Path to a video file or folder containing videos": {
-    "Path to a video file or folder containing videos": ""
+    "Path to a video file or folder containing videos": "動画ファイル、または動画を含むフォルダーへのパス"
   },
   "Pattern": {
-    "Pattern": ""
+    "Pattern": "パターン"
   },
   "Pause": {
     "Pause": "一時停止"
@@ -4569,13 +4566,13 @@
     "Paused": "一時停止"
   },
   "Pending": {
-    "Pending": ""
+    "Pending": "保留中"
   },
   "Pending Charge": {
-    "Pending Charge": ""
+    "Pending Charge": "充電待機中"
   },
   "Pending Discharge": {
-    "Pending Discharge": ""
+    "Pending Discharge": "放電待機中"
   },
   "Per-Mode Wallpapers": {
     "Per-Mode Wallpapers": "モードごとの壁紙"
@@ -4584,13 +4581,13 @@
     "Per-Monitor Wallpapers": "モニターごとの壁紙"
   },
   "Per-screen config": {
-    "Per-screen config": ""
+    "Per-screen config": "画面ごとの設定"
   },
   "Percentage": {
     "Percentage": "百分率"
   },
   "Performance": {
-    "Performance": ""
+    "Performance": "パフォーマンス"
   },
   "Permission denied to set profile image.": {
     "Permission denied to set profile image.": "プロフィール画像の設定権限が拒否されました。"
@@ -4599,55 +4596,55 @@
     "Personalization": "パーソナライゼーション"
   },
   "Phone Connect Not Available": {
-    "Phone Connect Not Available": ""
+    "Phone Connect Not Available": "Phone Connect は利用できません"
   },
   "Phone Connect unavailable": {
-    "Phone Connect unavailable": ""
+    "Phone Connect unavailable": "Phone Connect は利用できません"
   },
   "Phone number": {
-    "Phone number": ""
+    "Phone number": "電話番号"
   },
   "Pick a different random video each time from the same folder": {
-    "Pick a different random video each time from the same folder": ""
+    "Pick a different random video each time from the same folder": "同じフォルダーから毎回別のランダムな動画を選びます"
   },
   "Pictures": {
-    "Pictures": ""
+    "Pictures": "画像"
   },
   "Pin": {
-    "Pin": ""
+    "Pin": "ピン留め"
   },
   "Pin to Dock": {
     "Pin to Dock": "ドックにピン留め"
   },
   "Ping": {
-    "Ping": ""
+    "Ping": "Ping"
   },
   "Ping sent": {
-    "Ping sent": ""
+    "Ping sent": "Ping を送信しました"
   },
   "Ping sent to": {
-    "Ping sent to": ""
+    "Ping sent to": "Ping の送信先"
   },
   "Pinned": {
-    "Pinned": ""
+    "Pinned": "固定済み"
   },
   "Pinned and running apps with drag-and-drop": {
-    "Pinned and running apps with drag-and-drop": ""
+    "Pinned and running apps with drag-and-drop": "固定済みおよび実行中のアプリをドラッグ＆ドロップ"
   },
   "Pixelate": {
-    "Pixelate": ""
+    "Pixelate": "ピクセル化"
   },
   "Place plugin directories here. Each plugin should have a plugin.json manifest file.": {
     "Place plugin directories here. Each plugin should have a plugin.json manifest file.": "プラグインディレクトリをここに配置します。各プラグインには plugin.json マニフェストファイルが必要です。"
   },
   "Place plugins in %1": {
-    "Place plugins in %1": ""
+    "Place plugins in %1": "%1 にプラグインを配置"
   },
   "Play a video when the screen locks.": {
-    "Play a video when the screen locks.": ""
+    "Play a video when the screen locks.": "画面がロックされたときに動画を再生します。"
   },
   "Play sound after logging in": {
-    "Play sound after logging in": ""
+    "Play sound after logging in": "ログイン後にサウンドを再生"
   },
   "Play sound when new notification arrives": {
     "Play sound when new notification arrives": "新しい通知が届いたときにサウンドを再生"
@@ -4662,25 +4659,25 @@
     "Play sounds for system events": "システムイベントが発生したときにサウンドを再生"
   },
   "Playback": {
-    "Playback": ""
+    "Playback": "再生"
   },
   "Playback error: ": {
-    "Playback error: ": ""
+    "Playback error: ": "再生エラー: "
   },
   "Please wait...": {
-    "Please wait...": ""
+    "Please wait...": "お待ちください..."
   },
   "Please write a name for your new %1 session": {
-    "Please write a name for your new %1 session": ""
+    "Please write a name for your new %1 session": "新しい %1 セッションの名前を入力してください"
   },
   "Plugged In": {
     "Plugged In": "接続"
   },
   "Plugged in": {
-    "Plugged in": ""
+    "Plugged in": "接続中"
   },
   "Plugin": {
-    "Plugin": ""
+    "Plugin": "プラグイン"
   },
   "Plugin Directory": {
     "Plugin Directory": "プラグインディレクトリ"
@@ -4689,7 +4686,7 @@
     "Plugin Management": "プラグイン管理"
   },
   "Plugin Visibility": {
-    "Plugin Visibility": ""
+    "Plugin Visibility": "プラグインの表示"
   },
   "Plugin is disabled - enable in Plugins settings to use": {
     "Plugin is disabled - enable in Plugins settings to use": "プラグインは無効です - 使用するにはプラグイン設定で有効にしてください"
@@ -4698,55 +4695,55 @@
     "Plugins": "プラグイン"
   },
   "Pointer": {
-    "Pointer": ""
+    "Pointer": "ポインター"
   },
   "Popout Shadows": {
-    "Popout Shadows": ""
+    "Popout Shadows": "ポップアウトの影"
   },
   "Popouts": {
-    "Popouts": ""
+    "Popouts": "ポップアウト"
   },
   "Popouts and Modals follow global Animation Speed (disable to customize independently)": {
-    "Popouts and Modals follow global Animation Speed (disable to customize independently)": ""
+    "Popouts and Modals follow global Animation Speed (disable to customize independently)": "ポップアウトとモーダルはグローバルのアニメーション速度に従います（無効にすると個別にカスタマイズ可能）"
   },
   "Popup Only": {
-    "Popup Only": ""
+    "Popup Only": "ポップアップのみ"
   },
   "Popup Position": {
     "Popup Position": "ポップアップの位置"
   },
   "Popup Shadow": {
-    "Popup Shadow": ""
+    "Popup Shadow": "ポップアップの影"
   },
   "Popup Transparency": {
     "Popup Transparency": "ポップアップの透明度"
   },
   "Popup behavior, position": {
-    "Popup behavior, position": ""
+    "Popup behavior, position": "ポップアップの挙動、位置"
   },
   "Port": {
-    "Port": ""
+    "Port": "ポート"
   },
   "Portal": {
-    "Portal": ""
+    "Portal": "ポータル"
   },
   "Position": {
     "Position": "位置"
   },
   "Position, pinned apps": {
-    "Position, pinned apps": ""
+    "Position, pinned apps": "位置、固定アプリ"
   },
   "Possible Override Conflicts": {
-    "Possible Override Conflicts": ""
+    "Possible Override Conflicts": "上書きの競合の可能性"
   },
   "Power": {
-    "Power": ""
+    "Power": "電源"
   },
   "Power & Security": {
     "Power & Security": "電源とセキュリティ"
   },
   "Power & Sleep": {
-    "Power & Sleep": ""
+    "Power & Sleep": "電源とスリープ"
   },
   "Power Action Confirmation": {
     "Power Action Confirmation": "電源アクションの確認"
@@ -4761,55 +4758,55 @@
     "Power Options": "電源オプション"
   },
   "Power Profile": {
-    "Power Profile": ""
+    "Power Profile": "電源プロファイル"
   },
   "Power Profile Degradation": {
     "Power Profile Degradation": "電源プロファイルの劣化"
   },
   "Power Saver": {
-    "Power Saver": ""
+    "Power Saver": "省電力"
   },
   "Power off monitors on lock": {
-    "Power off monitors on lock": ""
+    "Power off monitors on lock": "ロック時にモニターの電源を切る"
   },
   "Power profile management available": {
-    "Power profile management available": ""
+    "Power profile management available": "電源プロファイル管理が利用可能"
   },
   "Power source": {
-    "Power source": ""
+    "Power source": "電源"
   },
   "Pre-fill the last successful username on the greeter": {
-    "Pre-fill the last successful username on the greeter": ""
+    "Pre-fill the last successful username on the greeter": "Greeter に最後に成功したユーザー名を事前入力"
   },
   "Pre-select the last used session on the greeter": {
-    "Pre-select the last used session on the greeter": ""
+    "Pre-select the last used session on the greeter": "Greeter で最後に使用したセッションを事前選択"
   },
   "Precip": {
-    "Precip": ""
+    "Precip": "降水"
   },
   "Precipitation": {
-    "Precipitation": ""
+    "Precipitation": "降水"
   },
   "Precipitation Chance": {
-    "Precipitation Chance": ""
+    "Precipitation Chance": "降水確率"
   },
   "Preference": {
-    "Preference": ""
+    "Preference": "設定"
   },
   "Preset Widths (%)": {
-    "Preset Widths (%)": ""
+    "Preset Widths (%)": "プリセット幅（%）"
   },
   "Press 'n' or click 'New Session' to create one": {
-    "Press 'n' or click 'New Session' to create one": ""
+    "Press 'n' or click 'New Session' to create one": "'n' を押すか「新しいセッション」をクリックして作成してください"
   },
   "Press Enter and the audio system will restart to apply the change": {
-    "Press Enter and the audio system will restart to apply the change": ""
+    "Press Enter and the audio system will restart to apply the change": "Enter を押すと変更を適用するためにオーディオシステムが再起動します"
   },
   "Press Enter to paste, Shift+Enter to copy": {
-    "Press Enter to paste, Shift+Enter to copy": ""
+    "Press Enter to paste, Shift+Enter to copy": "Enter で貼り付け、Shift+Enter でコピー"
   },
   "Press key...": {
-    "Press key...": ""
+    "Press key...": "キーを押してください..."
   },
   "Pressure": {
     "Pressure": "プレッシャー"
@@ -4818,37 +4815,37 @@
     "Prevent screen timeout": "画面のタイムアウトを防止"
   },
   "Preview": {
-    "Preview": ""
+    "Preview": "プレビュー"
   },
   "Primary": {
     "Primary": "プライマリー"
   },
   "Primary Container": {
-    "Primary Container": ""
+    "Primary Container": "プライマリーコンテナー"
   },
   "Print Server Management": {
-    "Print Server Management": ""
+    "Print Server Management": "プリントサーバー管理"
   },
   "Print Server not available": {
     "Print Server not available": "プリントサーバーが利用できません"
   },
   "Printer": {
-    "Printer": ""
+    "Printer": "プリンター"
   },
   "Printer Classes": {
-    "Printer Classes": ""
+    "Printer Classes": "プリンタークラス"
   },
   "Printer created successfully": {
-    "Printer created successfully": ""
+    "Printer created successfully": "プリンターを作成しました"
   },
   "Printer deleted": {
-    "Printer deleted": ""
+    "Printer deleted": "プリンターを削除しました"
   },
   "Printer name (no spaces)": {
-    "Printer name (no spaces)": ""
+    "Printer name (no spaces)": "プリンター名（スペース不可）"
   },
   "Printer reachable": {
-    "Printer reachable": ""
+    "Printer reachable": "プリンターに接続できます"
   },
   "Printers": {
     "Printers": "プリンター"
@@ -4857,28 +4854,28 @@
     "Printers: ": "プリンター: "
   },
   "Prioritize performance": {
-    "Prioritize performance": ""
+    "Prioritize performance": "パフォーマンスを優先"
   },
   "Priority": {
-    "Priority": ""
+    "Priority": "優先度"
   },
   "Privacy Indicator": {
     "Privacy Indicator": "プライバシーインジケーター"
   },
   "Privacy Mode": {
-    "Privacy Mode": ""
+    "Privacy Mode": "プライバシーモード"
   },
   "Private Key Password": {
-    "Private Key Password": ""
+    "Private Key Password": "秘密鍵のパスワード"
   },
   "Process Count": {
-    "Process Count": ""
+    "Process Count": "プロセス数"
   },
   "Processes": {
-    "Processes": ""
+    "Processes": "プロセス"
   },
   "Processes:": {
-    "Processes:": ""
+    "Processes:": "プロセス:"
   },
   "Processing": {
     "Processing": "進行中"
@@ -4887,37 +4884,37 @@
     "Profile Image Error": "プロフィール画像エラー"
   },
   "Profile activated: %1": {
-    "Profile activated: %1": ""
+    "Profile activated: %1": "プロファイルを有効化しました: %1"
   },
   "Profile deleted": {
-    "Profile deleted": ""
+    "Profile deleted": "プロファイルを削除しました"
   },
   "Profile error": {
-    "Profile error": ""
+    "Profile error": "プロファイルエラー"
   },
   "Profile image is too large. Please use a smaller image.": {
     "Profile image is too large. Please use a smaller image.": "プロフィール画像が大きすぎます。より小さい画像を使用してください。"
   },
   "Profile name": {
-    "Profile name": ""
+    "Profile name": "プロファイル名"
   },
   "Profile not found": {
-    "Profile not found": ""
+    "Profile not found": "プロファイルが見つかりません"
   },
   "Profile saved: %1": {
-    "Profile saved: %1": ""
+    "Profile saved: %1": "プロファイルを保存しました: %1"
   },
   "Protocol": {
-    "Protocol": ""
+    "Protocol": "プロトコル"
   },
   "QtMultimedia is not available": {
-    "QtMultimedia is not available": ""
+    "QtMultimedia is not available": "QtMultimedia は利用できません"
   },
   "QtMultimedia is not available - video screensaver requires qt multimedia services": {
-    "QtMultimedia is not available - video screensaver requires qt multimedia services": ""
+    "QtMultimedia is not available - video screensaver requires qt multimedia services": "QtMultimedia は利用できません - 動画スクリーンセーバーには Qt Multimedia サービスが必要です"
   },
   "Quick Access": {
-    "Quick Access": ""
+    "Quick Access": "クイックアクセス"
   },
   "Quick access to application launcher": {
     "Quick access to application launcher": "アプリケーションランチャーへのクイックアクセス"
@@ -4932,31 +4929,31 @@
     "Quick note-taking slideout panel": "クイックノート作成スライドアウトパネル"
   },
   "Quick system toggles": {
-    "Quick system toggles": ""
+    "Quick system toggles": "クイックシステム切り替え"
   },
   "RGB": {
     "RGB": "RGB"
   },
   "Radius": {
-    "Radius": ""
+    "Radius": "半径"
   },
   "Rain": {
-    "Rain": ""
+    "Rain": "雨"
   },
   "Rain Chance": {
     "Rain Chance": "降水確率"
   },
   "Rainbow": {
-    "Rainbow": ""
+    "Rainbow": "虹"
   },
   "Random": {
-    "Random": ""
+    "Random": "ランダム"
   },
   "Rate": {
-    "Rate": ""
+    "Rate": "レート"
   },
   "Read:": {
-    "Read:": ""
+    "Read:": "読み取り:"
   },
   "Reason": {
     "Reason": "原因"
@@ -4971,118 +4968,118 @@
     "Recently Used Apps": "最近使用したアプリ"
   },
   "Recommended available": {
-    "Recommended available": ""
+    "Recommended available": "推奨が利用可能"
   },
   "Refresh": {
     "Refresh": "リフレッシュ"
   },
   "Refresh Weather": {
-    "Refresh Weather": ""
+    "Refresh Weather": "天気を更新"
   },
   "Regex": {
-    "Regex": ""
+    "Regex": "正規表現"
   },
   "Reject": {
-    "Reject": ""
+    "Reject": "拒否"
   },
   "Reject Jobs": {
-    "Reject Jobs": ""
+    "Reject Jobs": "ジョブを拒否"
   },
   "Release": {
-    "Release": ""
+    "Release": "離す"
   },
   "Reload Plugin": {
     "Reload Plugin": "プラグインをリロード"
   },
   "Remaining": {
-    "Remaining": ""
+    "Remaining": "残り"
   },
   "Remaining / Total": {
-    "Remaining / Total": ""
+    "Remaining / Total": "残り / 合計"
   },
   "Remember Last Query": {
-    "Remember Last Query": ""
+    "Remember Last Query": "前回のクエリを記憶"
   },
   "Remember last session": {
-    "Remember last session": ""
+    "Remember last session": "最後のセッションを記憶"
   },
   "Remember last user": {
-    "Remember last user": ""
+    "Remember last user": "最後のユーザーを記憶"
   },
   "Remove": {
     "Remove": "削除"
   },
   "Remove Widget Padding": {
-    "Remove Widget Padding": ""
+    "Remove Widget Padding": "ウィジェットのパディングを削除"
   },
   "Remove gaps and border when windows are maximized": {
-    "Remove gaps and border when windows are maximized": ""
+    "Remove gaps and border when windows are maximized": "ウィンドウ最大化時にギャップと境界線を削除"
   },
   "Rename": {
-    "Rename": ""
+    "Rename": "名前を変更"
   },
   "Rename Session": {
-    "Rename Session": ""
+    "Rename Session": "セッション名を変更"
   },
   "Rename Workspace": {
-    "Rename Workspace": ""
+    "Rename Workspace": "ワークスペース名を変更"
   },
   "Repeat": {
-    "Repeat": ""
+    "Repeat": "繰り返し"
   },
   "Replacement": {
-    "Replacement": ""
+    "Replacement": "置換"
   },
   "Report": {
     "Report": "報告"
   },
   "Request Pairing": {
-    "Request Pairing": ""
+    "Request Pairing": "ペアリングを要求"
   },
   "Require holding button/key to confirm power off, restart, suspend, hibernate and logout": {
-    "Require holding button/key to confirm power off, restart, suspend, hibernate and logout": ""
+    "Require holding button/key to confirm power off, restart, suspend, hibernate and logout": "電源オフ、再起動、サスペンド、休止、ログアウトの確認にボタン/キーの長押しを要求"
   },
   "Required plugin: ": {
-    "Required plugin: ": ""
+    "Required plugin: ": "必要なプラグイン: "
   },
   "Requires %1": {
-    "Requires %1": ""
+    "Requires %1": "%1 が必要"
   },
   "Requires 'dgop' tool": {
-    "Requires 'dgop' tool": ""
+    "Requires 'dgop' tool": "'dgop' ツールが必要"
   },
   "Requires DMS %1": {
-    "Requires DMS %1": ""
+    "Requires DMS %1": "DMS %1 が必要"
   },
   "Requires DWL compositor": {
     "Requires DWL compositor": "DWLコンポジターが必要"
   },
   "Requires a newer version of Quickshell": {
-    "Requires a newer version of Quickshell": ""
+    "Requires a newer version of Quickshell": "より新しいバージョンの Quickshell が必要"
   },
   "Requires night mode support": {
-    "Requires night mode support": ""
+    "Requires night mode support": "ナイトモード対応が必要"
   },
   "Reset": {
     "Reset": "リセット"
   },
   "Reset Position": {
-    "Reset Position": ""
+    "Reset Position": "位置をリセット"
   },
   "Reset Size": {
-    "Reset Size": ""
+    "Reset Size": "サイズをリセット"
   },
   "Reset to default name": {
-    "Reset to default name": ""
+    "Reset to default name": "既定の名前に戻す"
   },
   "Resize Widget": {
-    "Resize Widget": ""
+    "Resize Widget": "ウィジェットのサイズを変更"
   },
   "Resolution & Refresh": {
-    "Resolution & Refresh": ""
+    "Resolution & Refresh": "解像度とリフレッシュレート"
   },
   "Resolution, position, scale": {
-    "Resolution, position, scale": ""
+    "Resolution, position, scale": "解像度、位置、スケール"
   },
   "Restart DMS": {
     "Restart DMS": "DMSを再起動"
@@ -5091,19 +5088,19 @@
     "Restart the DankMaterialShell": "DankMaterialShellを再起動"
   },
   "Restarting audio system...": {
-    "Restarting audio system...": ""
+    "Restarting audio system...": "オーディオシステムを再起動しています..."
   },
   "Restore Special Workspace Windows": {
-    "Restore Special Workspace Windows": ""
+    "Restore Special Workspace Windows": "特殊ワークスペースのウィンドウを復元"
   },
   "Resume": {
     "Resume": "レジュメ"
   },
   "Reverse Scrolling Direction": {
-    "Reverse Scrolling Direction": ""
+    "Reverse Scrolling Direction": "スクロール方向を反転"
   },
   "Reverse workspace switch direction when scrolling over the bar": {
-    "Reverse workspace switch direction when scrolling over the bar": ""
+    "Reverse workspace switch direction when scrolling over the bar": "バー上でスクロールしたときのワークスペース切り替え方向を反転"
   },
   "Revert": {
     "Revert": "戻す"
@@ -5112,7 +5109,7 @@
     "Right": "右"
   },
   "Right Center": {
-    "Right Center": ""
+    "Right Center": "右中央"
   },
   "Right Section": {
     "Right Section": "右セクション"
@@ -5121,58 +5118,58 @@
     "Right Tiling": "右タイリング"
   },
   "Right-click and drag anywhere on the widget": {
-    "Right-click and drag anywhere on the widget": ""
+    "Right-click and drag anywhere on the widget": "ウィジェット上の任意の場所を右クリックしてドラッグ"
   },
   "Right-click and drag the bottom-right corner": {
-    "Right-click and drag the bottom-right corner": ""
+    "Right-click and drag the bottom-right corner": "右下隅を右クリックしてドラッグ"
   },
   "Right-click bar widget to cycle": {
     "Right-click bar widget to cycle": "バーウィジェットを右クリックして循環"
   },
   "Ring": {
-    "Ring": ""
+    "Ring": "着信"
   },
   "Ringing": {
-    "Ringing": ""
+    "Ringing": "着信中"
   },
   "Ripple Effects": {
-    "Ripple Effects": ""
+    "Ripple Effects": "リップル効果"
   },
   "Root Filesystem": {
-    "Root Filesystem": ""
+    "Root Filesystem": "ルートファイルシステム"
   },
   "Rounded corners for windows": {
-    "Rounded corners for windows": ""
+    "Rounded corners for windows": "ウィンドウの角を丸くする"
   },
   "Rounded corners for windows (border_radius)": {
-    "Rounded corners for windows (border_radius)": ""
+    "Rounded corners for windows (border_radius)": "ウィンドウの角を丸くする（border_radius）"
   },
   "Rounded corners for windows (decoration.rounding)": {
-    "Rounded corners for windows (decoration.rounding)": ""
+    "Rounded corners for windows (decoration.rounding)": "ウィンドウの角を丸くする（decoration.rounding）"
   },
   "Rule": {
-    "Rule": ""
+    "Rule": "ルール"
   },
   "Rule Name": {
-    "Rule Name": ""
+    "Rule Name": "ルール名"
   },
   "Rules (%1)": {
-    "Rules (%1)": ""
+    "Rules (%1)": "ルール（%1）"
   },
   "Run Again": {
-    "Run Again": ""
+    "Run Again": "再実行"
   },
   "Run DMS Templates": {
-    "Run DMS Templates": ""
+    "Run DMS Templates": "DMS テンプレートを実行"
   },
   "Run User Templates": {
     "Run User Templates": "ユーザーのテンプレを実行"
   },
   "Run a program (e.g., firefox, kitty)": {
-    "Run a program (e.g., firefox, kitty)": ""
+    "Run a program (e.g., firefox, kitty)": "プログラムを実行（例: firefox、kitty）"
   },
   "Run a shell command (e.g., notify-send)": {
-    "Run a shell command (e.g., notify-send)": ""
+    "Run a shell command (e.g., notify-send)": "シェルコマンドを実行（例: notify-send）"
   },
   "Running Apps": {
     "Running Apps": "実行中のアプリ"
@@ -5181,16 +5178,16 @@
     "Running Apps Settings": "実行中のアプリの設定"
   },
   "Running greeter sync…": {
-    "Running greeter sync…": ""
+    "Running greeter sync…": "Greeter 同期を実行中…"
   },
   "SDR Brightness": {
-    "SDR Brightness": ""
+    "SDR Brightness": "SDR の明るさ"
   },
   "SDR Saturation": {
-    "SDR Saturation": ""
+    "SDR Saturation": "SDR の彩度"
   },
   "SMS": {
-    "SMS": ""
+    "SMS": "SMS"
   },
   "Save": {
     "Save": "保存"
@@ -5199,22 +5196,22 @@
     "Save Notepad File": "メモ帳ファイルを保存"
   },
   "Save QR Code": {
-    "Save QR Code": ""
+    "Save QR Code": "QR コードを保存"
   },
   "Save and switch between display configurations": {
-    "Save and switch between display configurations": ""
+    "Save and switch between display configurations": "ディスプレイ設定を保存して切り替える"
   },
   "Save critical priority notifications to history": {
-    "Save critical priority notifications to history": ""
+    "Save critical priority notifications to history": "最優先の通知を履歴に保存"
   },
   "Save dismissed notifications to history": {
-    "Save dismissed notifications to history": ""
+    "Save dismissed notifications to history": "閉じた通知を履歴に保存"
   },
   "Save low priority notifications to history": {
-    "Save low priority notifications to history": ""
+    "Save low priority notifications to history": "低優先度の通知を履歴に保存"
   },
   "Save normal priority notifications to history": {
-    "Save normal priority notifications to history": ""
+    "Save normal priority notifications to history": "通常優先度の通知を履歴に保存"
   },
   "Save password": {
     "Save password": "パスワードを保存"
@@ -5223,106 +5220,106 @@
     "Saved": "保存されました"
   },
   "Saved Configurations": {
-    "Saved Configurations": ""
+    "Saved Configurations": "保存済み設定"
   },
   "Saved Note": {
-    "Saved Note": ""
+    "Saved Note": "保存済みメモ"
   },
   "Saved item deleted": {
-    "Saved item deleted": ""
+    "Saved item deleted": "保存済み項目を削除しました"
   },
   "Saving...": {
-    "Saving...": ""
+    "Saving...": "保存しています..."
   },
   "Scale": {
-    "Scale": ""
+    "Scale": "スケール"
   },
   "Scale DankBar font sizes independently": {
     "Scale DankBar font sizes independently": "Dank Barのフォントサイズを個別に調整"
   },
   "Scale DankBar icon sizes independently": {
-    "Scale DankBar icon sizes independently": ""
+    "Scale DankBar icon sizes independently": "DankBar のアイコンサイズを個別に調整"
   },
   "Scale all font sizes throughout the shell": {
-    "Scale all font sizes throughout the shell": ""
+    "Scale all font sizes throughout the shell": "シェル全体のフォントサイズを調整"
   },
   "Scan": {
     "Scan": "スキャン"
   },
   "Scanning": {
-    "Scanning": ""
+    "Scanning": "スキャン中"
   },
   "Scanning...": {
-    "Scanning...": ""
+    "Scanning...": "スキャンしています..."
   },
   "Science": {
     "Science": "科学"
   },
   "Score": {
-    "Score": ""
+    "Score": "スコア"
   },
   "Screen Sharing": {
-    "Screen Sharing": ""
+    "Screen Sharing": "画面共有"
   },
   "Screen sharing": {
     "Screen sharing": "画面共有"
   },
   "Scroll": {
-    "Scroll": ""
+    "Scroll": "スクロール"
   },
   "Scroll Factor": {
-    "Scroll Factor": ""
+    "Scroll Factor": "スクロール係数"
   },
   "Scroll GitHub": {
-    "Scroll GitHub": ""
+    "Scroll GitHub": "GitHub をスクロール"
   },
   "Scroll Wheel": {
-    "Scroll Wheel": ""
+    "Scroll Wheel": "スクロールホイール"
   },
   "Scroll song title": {
-    "Scroll song title": ""
+    "Scroll song title": "曲名をスクロール"
   },
   "Scroll title if it doesn't fit in widget": {
-    "Scroll title if it doesn't fit in widget": ""
+    "Scroll title if it doesn't fit in widget": "ウィジェットに収まらない場合はタイトルをスクロール"
   },
   "Scroll wheel behavior on media widget": {
-    "Scroll wheel behavior on media widget": ""
+    "Scroll wheel behavior on media widget": "メディアウィジェットでのスクロールホイール動作"
   },
   "Scrolling": {
     "Scrolling": "スクロール"
   },
   "Search App Actions": {
-    "Search App Actions": ""
+    "Search App Actions": "アプリのアクションを検索"
   },
   "Search Options": {
-    "Search Options": ""
+    "Search Options": "検索オプション"
   },
   "Search by key combo, description, or action name.\n\nDefault action copies the keybind to clipboard.\nRight-click or press Right Arrow to pin frequently used keybinds - they'll appear at the top when not searching.": {
-    "Search by key combo, description, or action name.\n\nDefault action copies the keybind to clipboard.\nRight-click or press Right Arrow to pin frequently used keybinds - they'll appear at the top when not searching.": ""
+    "Search by key combo, description, or action name.\n\nDefault action copies the keybind to clipboard.\nRight-click or press Right Arrow to pin frequently used keybinds - they'll appear at the top when not searching.": "キーの組み合わせ、説明、またはアクション名で検索します。\n\n既定の操作ではキーバインドをクリップボードにコピーします。\nよく使うキーバインドは右クリックまたは右矢印キーでピン留めできます。検索していないときに上部に表示されます。"
   },
   "Search for a location...": {
     "Search for a location...": "ロケーションを検索..."
   },
   "Search keybinds...": {
-    "Search keybinds...": ""
+    "Search keybinds...": "キーバインドを検索..."
   },
   "Search keyboard shortcuts from your compositor and applications": {
-    "Search keyboard shortcuts from your compositor and applications": ""
+    "Search keyboard shortcuts from your compositor and applications": "コンポジターとアプリケーションのキーボードショートカットを検索"
   },
   "Search plugins...": {
     "Search plugins...": "プラグインを検索..."
   },
   "Search processes...": {
-    "Search processes...": ""
+    "Search processes...": "プロセスを検索..."
   },
   "Search sessions...": {
-    "Search sessions...": ""
+    "Search sessions...": "セッションを検索..."
   },
   "Search themes...": {
-    "Search themes...": ""
+    "Search themes...": "テーマを検索..."
   },
   "Search widgets...": {
-    "Search widgets...": ""
+    "Search widgets...": "ウィジェットを検索..."
   },
   "Search...": {
     "Search...": "検索..."
@@ -5331,46 +5328,46 @@
     "Searching...": "検索中..."
   },
   "Second Factor (AND)": {
-    "Second Factor (AND)": ""
+    "Second Factor (AND)": "第2要素（AND）"
   },
   "Secondary": {
-    "Secondary": ""
+    "Secondary": "セカンダリー"
   },
   "Secured": {
-    "Secured": ""
+    "Secured": "保護済み"
   },
   "Security": {
-    "Security": ""
+    "Security": "セキュリティ"
   },
   "Security & privacy": {
-    "Security & privacy": ""
+    "Security & privacy": "セキュリティとプライバシー"
   },
   "Security key mode": {
-    "Security key mode": ""
+    "Security key mode": "セキュリティキーモード"
   },
   "Security-key availability could not be confirmed.": {
-    "Security-key availability could not be confirmed.": ""
+    "Security-key availability could not be confirmed.": "セキュリティキーの利用可否を確認できませんでした。"
   },
   "Security-key support was detected, but no registered key was found yet. You can enable this now and register one later.": {
-    "Security-key support was detected, but no registered key was found yet. You can enable this now and register one later.": ""
+    "Security-key support was detected, but no registered key was found yet. You can enable this now and register one later.": "セキュリティキー対応は検出されましたが、登録済みのキーはまだ見つかっていません。今すぐ有効にして、後で登録できます。"
   },
   "Select": {
-    "Select": ""
+    "Select": "選択"
   },
   "Select Application": {
-    "Select Application": ""
+    "Select Application": "アプリケーションを選択"
   },
   "Select Bar": {
-    "Select Bar": ""
+    "Select Bar": "バーを選択"
   },
   "Select Custom Theme": {
     "Select Custom Theme": "カスタムテーマを選んでください"
   },
   "Select Dock Launcher Logo": {
-    "Select Dock Launcher Logo": ""
+    "Select Dock Launcher Logo": "Dock ランチャーロゴを選択"
   },
   "Select File to Send": {
-    "Select File to Send": ""
+    "Select File to Send": "送信するファイルを選択"
   },
   "Select Launcher Logo": {
     "Select Launcher Logo": "ランチャーロゴを選ぶ"
@@ -5379,7 +5376,7 @@
     "Select Profile Image": "プロファイル画像を選んでください"
   },
   "Select Video or Folder": {
-    "Select Video or Folder": ""
+    "Select Video or Folder": "動画またはフォルダーを選択"
   },
   "Select Wallpaper": {
     "Select Wallpaper": "壁紙を選んでください"
@@ -5391,34 +5388,34 @@
     "Select a color from the palette or use custom sliders": "パレットから色を選ぶか、カスタムスライダーを使用します"
   },
   "Select a widget to add to your desktop. Each widget is a separate instance with its own settings.": {
-    "Select a widget to add to your desktop. Each widget is a separate instance with its own settings.": ""
+    "Select a widget to add to your desktop. Each widget is a separate instance with its own settings.": "デスクトップに追加するウィジェットを選択してください。各ウィジェットはそれぞれ独自の設定を持つ別インスタンスです。"
   },
   "Select a widget to add. You can add multiple instances of the same widget if needed.": {
-    "Select a widget to add. You can add multiple instances of the same widget if needed.": ""
+    "Select a widget to add. You can add multiple instances of the same widget if needed.": "追加するウィジェットを選択してください。必要に応じて同じウィジェットを複数追加できます。"
   },
   "Select a window...": {
-    "Select a window...": ""
+    "Select a window...": "ウィンドウを選択..."
   },
   "Select an image file...": {
     "Select an image file...": "画像ファイルを選ぶ..."
   },
   "Select at least one provider": {
-    "Select at least one provider": ""
+    "Select at least one provider": "少なくとも1つのプロバイダーを選択"
   },
   "Select device": {
-    "Select device": ""
+    "Select device": "デバイスを選択"
   },
   "Select device...": {
-    "Select device...": ""
+    "Select device...": "デバイスを選択..."
   },
   "Select driver...": {
-    "Select driver...": ""
+    "Select driver...": "ドライバーを選択..."
   },
   "Select font weight for UI text": {
-    "Select font weight for UI text": ""
+    "Select font weight for UI text": "UI テキストのフォントの太さを選択"
   },
   "Select greeter background image": {
-    "Select greeter background image": ""
+    "Select greeter background image": "Greeter の背景画像を選択"
   },
   "Select monitor to configure wallpaper": {
     "Select monitor to configure wallpaper": "壁紙を設定するモニターを選ぶ"
@@ -5427,64 +5424,64 @@
     "Select monospace font for process list and technical displays": "プロセスリストと技術表示用の等幅フォントを選ぶ"
   },
   "Select network": {
-    "Select network": ""
+    "Select network": "ネットワークを選択"
   },
   "Select system sound theme": {
     "Select system sound theme": "システムサウンドテーマを選ぶ"
   },
   "Select the font family for UI text": {
-    "Select the font family for UI text": ""
+    "Select the font family for UI text": "UI テキストのフォントファミリーを選択"
   },
   "Select the palette algorithm used for wallpaper-based colors": {
     "Select the palette algorithm used for wallpaper-based colors": "壁紙ベースの色で、使用するパレットアルゴリズムを選ぶ"
   },
   "Select which keybind providers to include": {
-    "Select which keybind providers to include": ""
+    "Select which keybind providers to include": "含めるキーバインドプロバイダーを選択"
   },
   "Select which transitions to include in randomization": {
     "Select which transitions to include in randomization": "含めたいトランジションをランダム化に選択"
   },
   "Select...": {
-    "Select...": ""
+    "Select...": "選択..."
   },
   "Selected image file not found.": {
     "Selected image file not found.": "選択した画像ファイルが見つかりませんでした。"
   },
   "Send": {
-    "Send": ""
+    "Send": "送信"
   },
   "Send Clipboard": {
-    "Send Clipboard": ""
+    "Send Clipboard": "クリップボードを送信"
   },
   "Send File": {
-    "Send File": ""
+    "Send File": "ファイルを送信"
   },
   "Send SMS": {
-    "Send SMS": ""
+    "Send SMS": "SMS を送信"
   },
   "Sending": {
-    "Sending": ""
+    "Sending": "送信中"
   },
   "Separator": {
     "Separator": "区切り"
   },
   "Server": {
-    "Server": ""
+    "Server": "サーバー"
   },
   "Session Filter": {
-    "Session Filter": ""
+    "Session Filter": "セッションフィルター"
   },
   "Set Custom Device Name": {
-    "Set Custom Device Name": ""
+    "Set Custom Device Name": "カスタムデバイス名を設定"
   },
   "Set custom name": {
-    "Set custom name": ""
+    "Set custom name": "カスタム名を設定"
   },
   "Set custom names for your audio input devices": {
-    "Set custom names for your audio input devices": ""
+    "Set custom names for your audio input devices": "音声入力デバイスにカスタム名を設定"
   },
   "Set custom names for your audio output devices": {
-    "Set custom names for your audio output devices": ""
+    "Set custom names for your audio output devices": "音声出力デバイスにカスタム名を設定"
   },
   "Set different wallpapers for each connected monitor": {
     "Set different wallpapers for each connected monitor": "接続されているモニターごとに異なる壁紙を設定する"
@@ -5493,151 +5490,151 @@
     "Set different wallpapers for light and dark mode": "ライトモードとダークモードで異なる壁紙を設定する"
   },
   "Set key and action to save": {
-    "Set key and action to save": ""
+    "Set key and action to save": "保存するキーとアクションを設定"
   },
   "Set notification rules": {
-    "Set notification rules": ""
+    "Set notification rules": "通知ルールを設定"
   },
   "Settings": {
     "Settings": "設定"
   },
   "Settings are read-only. Changes will not persist.": {
-    "Settings are read-only. Changes will not persist.": ""
+    "Settings are read-only. Changes will not persist.": "設定は読み取り専用です。変更は保持されません。"
   },
   "Setup": {
-    "Setup": ""
+    "Setup": "セットアップ"
   },
   "Shadow Color": {
-    "Shadow Color": ""
+    "Shadow Color": "影の色"
   },
   "Shadow Intensity": {
-    "Shadow Intensity": ""
+    "Shadow Intensity": "影の強さ"
   },
   "Shadow Opacity": {
-    "Shadow Opacity": ""
+    "Shadow Opacity": "影の不透明度"
   },
   "Shadow Override": {
-    "Shadow Override": ""
+    "Shadow Override": "影の上書き"
   },
   "Shadow elevation on bars and panels": {
-    "Shadow elevation on bars and panels": ""
+    "Shadow elevation on bars and panels": "バーとパネルの影の強さ"
   },
   "Shadow elevation on modals and dialogs": {
-    "Shadow elevation on modals and dialogs": ""
+    "Shadow elevation on modals and dialogs": "モーダルとダイアログの影の強さ"
   },
   "Shadow elevation on popouts, OSDs, and dropdowns": {
-    "Shadow elevation on popouts, OSDs, and dropdowns": ""
+    "Shadow elevation on popouts, OSDs, and dropdowns": "ポップアウト、OSD、ドロップダウンの影の強さ"
   },
   "Shadows": {
-    "Shadows": ""
+    "Shadows": "影"
   },
   "Share": {
-    "Share": ""
+    "Share": "共有"
   },
   "Share Gamma Control Settings": {
-    "Share Gamma Control Settings": ""
+    "Share Gamma Control Settings": "ガンマ制御設定を共有"
   },
   "Share Text": {
-    "Share Text": ""
+    "Share Text": "テキストを共有"
   },
   "Share URL": {
-    "Share URL": ""
+    "Share URL": "URL を共有"
   },
   "Shared": {
-    "Shared": ""
+    "Shared": "共有済み"
   },
   "Shell": {
-    "Shell": ""
+    "Shell": "シェル"
   },
   "Shift+Del: Clear All • Esc: Close": {
     "Shift+Del: Clear All • Esc: Close": "Shift+Del: すべてクリア • Esc: 閉じる"
   },
   "Shift+Enter to paste": {
-    "Shift+Enter to paste": ""
+    "Shift+Enter to paste": "Shift+Enter で貼り付け"
   },
   "Shift+Enter: Copy • Shift+Del: Clear All • Esc: Close": {
-    "Shift+Enter: Copy • Shift+Del: Clear All • Esc: Close": ""
+    "Shift+Enter: Copy • Shift+Del: Clear All • Esc: Close": "Shift+Enter: コピー • Shift+Del: すべてクリア • Esc: 閉じる"
   },
   "Shift+Enter: Paste • Shift+Del: Clear All • Esc: Close": {
-    "Shift+Enter: Paste • Shift+Del: Clear All • Esc: Close": ""
+    "Shift+Enter: Paste • Shift+Del: Clear All • Esc: Close": "Shift+Enter: 貼り付け • Shift+Del: すべてクリア • Esc: 閉じる"
   },
   "Short": {
-    "Short": ""
+    "Short": "短い"
   },
   "Shortcut (%1)": {
-    "Shortcut (%1)": ""
+    "Shortcut (%1)": "ショートカット（%1）"
   },
   "Shortcuts": {
-    "Shortcuts": ""
+    "Shortcuts": "ショートカット"
   },
   "Shortcuts (%1)": {
-    "Shortcuts (%1)": ""
+    "Shortcuts (%1)": "ショートカット（%1）"
   },
   "Show": {
-    "Show": ""
+    "Show": "表示"
   },
   "Show 3rd Party": {
-    "Show 3rd Party": ""
+    "Show 3rd Party": "サードパーティを表示"
   },
   "Show All Tags": {
     "Show All Tags": "すべてのタグを表示"
   },
   "Show Badge": {
-    "Show Badge": ""
+    "Show Badge": "バッジを表示"
   },
   "Show CPU": {
-    "Show CPU": ""
+    "Show CPU": "CPU を表示"
   },
   "Show CPU Graph": {
-    "Show CPU Graph": ""
+    "Show CPU Graph": "CPU グラフを表示"
   },
   "Show CPU Temp": {
-    "Show CPU Temp": ""
+    "Show CPU Temp": "CPU 温度を表示"
   },
   "Show Date": {
-    "Show Date": ""
+    "Show Date": "日付を表示"
   },
   "Show Disk": {
-    "Show Disk": ""
+    "Show Disk": "ディスクを表示"
   },
   "Show Dock": {
     "Show Dock": "ドックを表示"
   },
   "Show Feels Like Temperature": {
-    "Show Feels Like Temperature": ""
+    "Show Feels Like Temperature": "体感温度を表示"
   },
   "Show Footer": {
-    "Show Footer": ""
+    "Show Footer": "フッターを表示"
   },
   "Show Forecast": {
-    "Show Forecast": ""
+    "Show Forecast": "予報を表示"
   },
   "Show GPU Temperature": {
-    "Show GPU Temperature": ""
+    "Show GPU Temperature": "GPU 温度を表示"
   },
   "Show Header": {
-    "Show Header": ""
+    "Show Header": "ヘッダーを表示"
   },
   "Show Hibernate": {
     "Show Hibernate": "休止状態を表示"
   },
   "Show Hour Numbers": {
-    "Show Hour Numbers": ""
+    "Show Hour Numbers": "時間の数字を表示"
   },
   "Show Hourly Forecast": {
-    "Show Hourly Forecast": ""
+    "Show Hourly Forecast": "時間ごとの予報を表示"
   },
   "Show Humidity": {
-    "Show Humidity": ""
+    "Show Humidity": "湿度を表示"
   },
   "Show Launcher Button": {
-    "Show Launcher Button": ""
+    "Show Launcher Button": "ランチャーボタンを表示"
   },
   "Show Line Numbers": {
     "Show Line Numbers": "行番号を表示"
   },
   "Show Location": {
-    "Show Location": ""
+    "Show Location": "場所を表示"
   },
   "Show Lock": {
     "Show Lock": "ロックを表示"
@@ -5646,49 +5643,49 @@
     "Show Log Out": "ログアウトを表示"
   },
   "Show Material Design ripple animations on interactive elements": {
-    "Show Material Design ripple animations on interactive elements": ""
+    "Show Material Design ripple animations on interactive elements": "操作可能な要素に Material Design のリップルアニメーションを表示"
   },
   "Show Media Player": {
-    "Show Media Player": ""
+    "Show Media Player": "メディアプレーヤーを表示"
   },
   "Show Memory": {
-    "Show Memory": ""
+    "Show Memory": "メモリーを表示"
   },
   "Show Memory Graph": {
-    "Show Memory Graph": ""
+    "Show Memory Graph": "メモリーグラフを表示"
   },
   "Show Memory in GB": {
-    "Show Memory in GB": ""
+    "Show Memory in GB": "メモリーを GB で表示"
   },
   "Show Network": {
-    "Show Network": ""
+    "Show Network": "ネットワークを表示"
   },
   "Show Network Graph": {
-    "Show Network Graph": ""
+    "Show Network Graph": "ネットワークグラフを表示"
   },
   "Show Occupied Workspaces Only": {
-    "Show Occupied Workspaces Only": ""
+    "Show Occupied Workspaces Only": "使用中のワークスペースのみ表示"
   },
   "Show Overflow Badge Count": {
-    "Show Overflow Badge Count": ""
+    "Show Overflow Badge Count": "オーバーフローバッジ数を表示"
   },
   "Show Password Field": {
-    "Show Password Field": ""
+    "Show Password Field": "パスワード欄を表示"
   },
   "Show Power Actions": {
-    "Show Power Actions": ""
+    "Show Power Actions": "電源アクションを表示"
   },
   "Show Power Off": {
     "Show Power Off": "パワーオフを表示"
   },
   "Show Precipitation Probability": {
-    "Show Precipitation Probability": ""
+    "Show Precipitation Probability": "降水確率を表示"
   },
   "Show Pressure": {
-    "Show Pressure": ""
+    "Show Pressure": "気圧を表示"
   },
   "Show Profile Image": {
-    "Show Profile Image": ""
+    "Show Profile Image": "プロフィール画像を表示"
   },
   "Show Reboot": {
     "Show Reboot": "再起動を表示"
@@ -5697,43 +5694,43 @@
     "Show Restart DMS": "DMS再起動を表示"
   },
   "Show Saved Items": {
-    "Show Saved Items": ""
+    "Show Saved Items": "保存済み項目を表示"
   },
   "Show Seconds": {
-    "Show Seconds": ""
+    "Show Seconds": "秒を表示"
   },
   "Show Sunrise/Sunset": {
-    "Show Sunrise/Sunset": ""
+    "Show Sunrise/Sunset": "日の出/日の入りを表示"
   },
   "Show Suspend": {
     "Show Suspend": "一時停止を表示"
   },
   "Show Swap": {
-    "Show Swap": ""
+    "Show Swap": "スワップを表示"
   },
   "Show System Date": {
-    "Show System Date": ""
+    "Show System Date": "システム日付を表示"
   },
   "Show System Icons": {
-    "Show System Icons": ""
+    "Show System Icons": "システムアイコンを表示"
   },
   "Show System Time": {
-    "Show System Time": ""
+    "Show System Time": "システム時刻を表示"
   },
   "Show Top Processes": {
-    "Show Top Processes": ""
+    "Show Top Processes": "上位プロセスを表示"
   },
   "Show Weather Condition": {
-    "Show Weather Condition": ""
+    "Show Weather Condition": "天気の状態を表示"
   },
   "Show Week Number": {
-    "Show Week Number": ""
+    "Show Week Number": "週番号を表示"
   },
   "Show Welcome": {
-    "Show Welcome": ""
+    "Show Welcome": "ウェルカムを表示"
   },
   "Show Wind Speed": {
-    "Show Wind Speed": ""
+    "Show Wind Speed": "風速を表示"
   },
   "Show Workspace Apps": {
     "Show Workspace Apps": "ワークスペースアプリを表示"
@@ -5742,49 +5739,49 @@
     "Show all 9 tags instead of only occupied tags (DWL only)": "占有タグのみではなく、9 つのタグをすべて表示 (DWL のみ)"
   },
   "Show an outline ring around the focused workspace indicator": {
-    "Show an outline ring around the focused workspace indicator": ""
+    "Show an outline ring around the focused workspace indicator": "フォーカス中のワークスペースインジケーターの周囲にアウトラインリングを表示"
   },
   "Show cava audio visualizer in media widget": {
-    "Show cava audio visualizer in media widget": ""
+    "Show cava audio visualizer in media widget": "メディアウィジェットに cava オーディオビジュアライザーを表示"
   },
   "Show darkened overlay behind modal dialogs": {
     "Show darkened overlay behind modal dialogs": "モーダルダイアログの背後に暗いオーバーレイを表示"
   },
   "Show device": {
-    "Show device": ""
+    "Show device": "デバイスを表示"
   },
   "Show dock when floating windows don't overlap its area": {
-    "Show dock when floating windows don't overlap its area": ""
+    "Show dock when floating windows don't overlap its area": "フローティングウィンドウがドック領域に重ならないときはドックを表示"
   },
   "Show drop shadow on notification popups. Requires M3 Elevation to be enabled in Theme & Colors.": {
-    "Show drop shadow on notification popups. Requires M3 Elevation to be enabled in Theme & Colors.": ""
+    "Show drop shadow on notification popups. Requires M3 Elevation to be enabled in Theme & Colors.": "通知ポップアップにドロップシャドウを表示します。Theme & Colors で M3 Elevation を有効にする必要があります。"
   },
   "Show in GB": {
-    "Show in GB": ""
+    "Show in GB": "GB で表示"
   },
   "Show launcher overlay when typing in Niri overview. Disable to use another launcher.": {
-    "Show launcher overlay when typing in Niri overview. Disable to use another launcher.": ""
+    "Show launcher overlay when typing in Niri overview. Disable to use another launcher.": "Niri の概要で入力時にランチャーオーバーレイを表示します。別のランチャーを使う場合は無効にしてください。"
   },
   "Show mode tabs and keyboard hints at the bottom.": {
-    "Show mode tabs and keyboard hints at the bottom.": ""
+    "Show mode tabs and keyboard hints at the bottom.": "下部にモードタブとキーボードヒントを表示します。"
   },
   "Show notification popups only on the currently focused monitor": {
-    "Show notification popups only on the currently focused monitor": ""
+    "Show notification popups only on the currently focused monitor": "現在フォーカスされているモニターにのみ通知ポップアップを表示"
   },
   "Show notifications only on the currently focused monitor": {
-    "Show notifications only on the currently focused monitor": ""
+    "Show notifications only on the currently focused monitor": "現在フォーカスされているモニターにのみ通知を表示"
   },
   "Show on Last Display": {
     "Show on Last Display": "最後のディスプレイに表示"
   },
   "Show on Overlay": {
-    "Show on Overlay": ""
+    "Show on Overlay": "オーバーレイに表示"
   },
   "Show on Overview": {
     "Show on Overview": "概要に表示"
   },
   "Show on Overview Only": {
-    "Show on Overview Only": ""
+    "Show on Overview Only": "概要のみに表示"
   },
   "Show on all connected displays": {
     "Show on all connected displays": "すべての接続されたディスプレイに表示"
@@ -5799,13 +5796,13 @@
     "Show on-screen display when caps lock state changes": "Caps Lock の状態が変化した時にOSDを表示"
   },
   "Show on-screen display when cycling audio output devices": {
-    "Show on-screen display when cycling audio output devices": ""
+    "Show on-screen display when cycling audio output devices": "音声出力デバイスを切り替えたときに OSD を表示"
   },
   "Show on-screen display when idle inhibitor state changes": {
     "Show on-screen display when idle inhibitor state changes": "アイドルインヒビターの状態が変化した時にOSDを表示"
   },
   "Show on-screen display when media player status changes": {
-    "Show on-screen display when media player status changes": ""
+    "Show on-screen display when media player status changes": "メディアプレーヤーの状態が変化したときに OSD を表示"
   },
   "Show on-screen display when media player volume changes": {
     "Show on-screen display when media player volume changes": "メディアプレーヤーの音量が変化したときにOSDを表示"
@@ -5820,22 +5817,22 @@
     "Show on-screen display when volume changes": "音量が変化したときにOSDを表示"
   },
   "Show seconds": {
-    "Show seconds": ""
+    "Show seconds": "秒を表示"
   },
   "Show weather information in top bar and control center": {
     "Show weather information in top bar and control center": "トップバーとコントロールセンターに天気情報を表示"
   },
   "Show week number in the calendar": {
-    "Show week number in the calendar": ""
+    "Show week number in the calendar": "カレンダーに週番号を表示"
   },
   "Show workspace index numbers in the top bar workspace switcher": {
     "Show workspace index numbers in the top bar workspace switcher": "上部バーのワークスペーススイッチャーにワークスペースインデックス番号を表示"
   },
   "Show workspace name on horizontal bars, and first letter on vertical bars": {
-    "Show workspace name on horizontal bars, and first letter on vertical bars": ""
+    "Show workspace name on horizontal bars, and first letter on vertical bars": "横バーではワークスペース名を、縦バーでは先頭文字を表示"
   },
   "Show workspaces of the currently focused monitor": {
-    "Show workspaces of the currently focused monitor": ""
+    "Show workspaces of the currently focused monitor": "現在フォーカスされているモニターのワークスペースを表示"
   },
   "Shows all running applications with focus indication": {
     "Shows all running applications with focus indication": "実行中のすべてのアプリケーションをフォーカス状態で表示"
@@ -5850,79 +5847,79 @@
     "Shows when microphone, camera, or screen sharing is active": "マイク、カメラ、または画面共有がアクティブなときに表示"
   },
   "Shrink the media widget to fit shorter song titles while still respecting the configured maximum size": {
-    "Shrink the media widget to fit shorter song titles while still respecting the configured maximum size": ""
+    "Shrink the media widget to fit shorter song titles while still respecting the configured maximum size": "設定した最大サイズを保ちながら、短い曲名に合わせてメディアウィジェットを縮小"
   },
   "Shutdown": {
     "Shutdown": "シャットダウン"
   },
   "Signal": {
-    "Signal": ""
+    "Signal": "Signal"
   },
   "Signal:": {
-    "Signal:": ""
+    "Signal:": "Signal:"
   },
   "Size": {
     "Size": "サイズ"
   },
   "Size Constraints": {
-    "Size Constraints": ""
+    "Size Constraints": "サイズ制約"
   },
   "Size Offset": {
     "Size Offset": "サイズオフセット"
   },
   "Sizing": {
-    "Sizing": ""
+    "Sizing": "サイズ設定"
   },
   "Skip": {
-    "Skip": ""
+    "Skip": "スキップ"
   },
   "Skip confirmation": {
-    "Skip confirmation": ""
+    "Skip confirmation": "確認をスキップ"
   },
   "Skip setup": {
-    "Skip setup": ""
+    "Skip setup": "セットアップをスキップ"
   },
   "Small": {
-    "Small": ""
+    "Small": "小"
   },
   "Smartcard Authentication": {
-    "Smartcard Authentication": ""
+    "Smartcard Authentication": "スマートカード認証"
   },
   "Smartcard PIN": {
-    "Smartcard PIN": ""
+    "Smartcard PIN": "スマートカード PIN"
   },
   "Snap": {
-    "Snap": ""
+    "Snap": "スナップ"
   },
   "Snow": {
-    "Snow": ""
+    "Snow": "雪"
   },
   "Some plugins require a newer version of DMS:": {
-    "Some plugins require a newer version of DMS:": ""
+    "Some plugins require a newer version of DMS:": "一部のプラグインにはより新しいバージョンの DMS が必要です:"
   },
   "Sort Alphabetically": {
     "Sort Alphabetically": "アルファベット順に並べ替える"
   },
   "Sort By": {
-    "Sort By": ""
+    "Sort By": "並べ替え方法"
   },
   "Sorting & Layout": {
-    "Sorting & Layout": ""
+    "Sorting & Layout": "並べ替えとレイアウト"
   },
   "Sound Theme": {
     "Sound Theme": "サウンドテーマ"
   },
   "Sounds": {
-    "Sounds": ""
+    "Sounds": "サウンド"
   },
   "Space between windows": {
-    "Space between windows": ""
+    "Space between windows": "ウィンドウ間の間隔"
   },
   "Space between windows (gappih/gappiv/gappoh/gappov)": {
-    "Space between windows (gappih/gappiv/gappoh/gappov)": ""
+    "Space between windows (gappih/gappiv/gappoh/gappov)": "ウィンドウ間の間隔（gappih/gappiv/gappoh/gappov）"
   },
   "Space between windows (gaps_in and gaps_out)": {
-    "Space between windows (gaps_in and gaps_out)": ""
+    "Space between windows (gaps_in and gaps_out)": "ウィンドウ間の間隔（gaps_in と gaps_out）"
   },
   "Spacer": {
     "Spacer": "間隔"
@@ -5931,10 +5928,10 @@
     "Spacing": "間隔"
   },
   "Speaker settings": {
-    "Speaker settings": ""
+    "Speaker settings": "スピーカー設定"
   },
   "Speed": {
-    "Speed": ""
+    "Speed": "速度"
   },
   "Spool Area Full": {
     "Spool Area Full": "スプールエリアがいっぱい"
@@ -5943,25 +5940,25 @@
     "Square Corners": "四角コーナー"
   },
   "Stacked": {
-    "Stacked": ""
+    "Stacked": "スタック"
   },
   "Standard": {
-    "Standard": ""
+    "Standard": "標準"
   },
   "Start": {
     "Start": "始める"
   },
   "Start KDE Connect or Valent": {
-    "Start KDE Connect or Valent": ""
+    "Start KDE Connect or Valent": "KDE Connect または Valent を起動"
   },
   "Start KDE Connect or Valent to use this plugin": {
-    "Start KDE Connect or Valent to use this plugin": ""
+    "Start KDE Connect or Valent to use this plugin": "このプラグインを使うには KDE Connect または Valent を起動してください"
   },
   "Start typing your notes here...": {
     "Start typing your notes here...": "ここでメモを入力しましょう..."
   },
   "State": {
-    "State": ""
+    "State": "状態"
   },
   "Status": {
     "Status": "状態"
@@ -5976,31 +5973,31 @@
     "Stopping": "停止中"
   },
   "Stretch": {
-    "Stretch": ""
+    "Stretch": "引き伸ばし"
   },
   "Stripes": {
-    "Stripes": ""
+    "Stripes": "ストライプ"
   },
   "Summary": {
-    "Summary": ""
+    "Summary": "概要"
   },
   "Sunrise": {
-    "Sunrise": ""
+    "Sunrise": "日の出"
   },
   "Sunset": {
-    "Sunset": ""
+    "Sunset": "日の入り"
   },
   "Suppress notification popups while enabled": {
-    "Suppress notification popups while enabled": ""
+    "Suppress notification popups while enabled": "有効時は通知ポップアップを抑制"
   },
   "Surface": {
     "Surface": "表面"
   },
   "Surface Variant": {
-    "Surface Variant": ""
+    "Surface Variant": "サーフェスバリアント"
   },
   "Suspend": {
-    "Suspend": "一時停止"
+    "Suspend": "スリープ"
   },
   "Suspend behavior": {
     "Suspend behavior": "一時停止の行為"
@@ -6009,40 +6006,40 @@
     "Suspend system after": "後にシステムを一時停止"
   },
   "Suspend then Hibernate": {
-    "Suspend then Hibernate": ""
+    "Suspend then Hibernate": "サスペンド後に休止"
   },
   "Sway Website": {
-    "Sway Website": ""
+    "Sway Website": "Sway のウェブサイト"
   },
   "Switch User": {
     "Switch User": "ユーザーを切り替える"
   },
   "Switch to power profile": {
-    "Switch to power profile": ""
+    "Switch to power profile": "電源プロファイルに切り替え"
   },
   "Sync": {
-    "Sync": ""
+    "Sync": "同期"
   },
   "Sync Mode with Portal": {
     "Sync Mode with Portal": "ポータルとの同期モード"
   },
   "Sync Popouts & Modals": {
-    "Sync Popouts & Modals": ""
+    "Sync Popouts & Modals": "ポップアウトとモーダルを同期"
   },
   "Sync Position Across Screens": {
-    "Sync Position Across Screens": ""
+    "Sync Position Across Screens": "画面間で位置を同期"
   },
   "Sync completed successfully.": {
-    "Sync completed successfully.": ""
+    "Sync completed successfully.": "同期が正常に完了しました。"
   },
   "Sync dark mode with settings portals for system-wide theme hints": {
     "Sync dark mode with settings portals for system-wide theme hints": "ダークモードをシステム全体のテーマヒントの設定ポータルと同期"
   },
   "Sync failed in background mode. Trying terminal mode so you can authenticate interactively.": {
-    "Sync failed in background mode. Trying terminal mode so you can authenticate interactively.": ""
+    "Sync failed in background mode. Trying terminal mode so you can authenticate interactively.": "バックグラウンドモードでの同期に失敗しました。対話的に認証できるよう、端末モードを試します。"
   },
   "Sync needs sudo authentication. Opening terminal so you can use password or fingerprint.": {
-    "Sync needs sudo authentication. Opening terminal so you can use password or fingerprint.": ""
+    "Sync needs sudo authentication. Opening terminal so you can use password or fingerprint.": "同期には sudo 認証が必要です。パスワードまたは指紋を使えるよう端末を開きます。"
   },
   "System": {
     "System": "システム"
@@ -6051,13 +6048,13 @@
     "System App Theming": "システムアプリのテーマ設定"
   },
   "System Check": {
-    "System Check": ""
+    "System Check": "システムチェック"
   },
   "System Default": {
-    "System Default": ""
+    "System Default": "システム既定"
   },
   "System Information": {
-    "System Information": ""
+    "System Information": "システム情報"
   },
   "System Monitor": {
     "System Monitor": "システムモニタ"
@@ -6066,7 +6063,7 @@
     "System Monitor Unavailable": "システムモニターが利用できません"
   },
   "System Sounds": {
-    "System Sounds": ""
+    "System Sounds": "システムサウンド"
   },
   "System Tray": {
     "System Tray": "システムトレイ"
@@ -6084,10 +6081,10 @@
     "System notification area icons": "システム通知エリアアイコン"
   },
   "System sounds are not available. Install %1 for sound support.": {
-    "System sounds are not available. Install %1 for sound support.": ""
+    "System sounds are not available. Install %1 for sound support.": "システムサウンドは利用できません。サウンド対応のために %1 をインストールしてください。"
   },
   "System theme toggle": {
-    "System theme toggle": ""
+    "System theme toggle": "システムテーマ切り替え"
   },
   "System toast notifications": {
     "System toast notifications": "システムトースト通知"
@@ -6096,61 +6093,61 @@
     "System update custom command": "システム更新カスタムコマンド"
   },
   "Tab": {
-    "Tab": ""
+    "Tab": "タブ"
   },
   "Tab/Shift+Tab: Nav • ←→↑↓: Grid Nav • Enter/Space: Select": {
     "Tab/Shift+Tab: Nav • ←→↑↓: Grid Nav • Enter/Space: Select": "Tab/Shift+Tab: ナビゲーション • ←→↑↓: グリッドナビゲーション • Enter/Space: 選択"
   },
   "Terminal": {
-    "Terminal": ""
+    "Terminal": "端末"
   },
   "Terminal custom additional parameters": {
     "Terminal custom additional parameters": "端末のカスタム追加パラメーター"
   },
   "Terminal fallback failed. Install a supported terminal emulator or run 'dms auth sync' manually.": {
-    "Terminal fallback failed. Install a supported terminal emulator or run 'dms auth sync' manually.": ""
+    "Terminal fallback failed. Install a supported terminal emulator or run 'dms auth sync' manually.": "端末フォールバックに失敗しました。対応する端末エミュレーターをインストールするか、'dms auth sync' を手動で実行してください。"
   },
   "Terminal fallback failed. Install one of the supported terminal emulators or run 'dms greeter sync' manually.": {
-    "Terminal fallback failed. Install one of the supported terminal emulators or run 'dms greeter sync' manually.": ""
+    "Terminal fallback failed. Install one of the supported terminal emulators or run 'dms greeter sync' manually.": "端末フォールバックに失敗しました。対応する端末エミュレーターのいずれかをインストールするか、'dms greeter sync' を手動で実行してください。"
   },
   "Terminal fallback opened. Complete authentication setup there; it will close automatically when done.": {
-    "Terminal fallback opened. Complete authentication setup there; it will close automatically when done.": ""
+    "Terminal fallback opened. Complete authentication setup there; it will close automatically when done.": "端末フォールバックを開きました。そこで認証設定を完了してください。完了すると自動的に閉じます。"
   },
   "Terminal fallback opened. Complete sync there; it will close automatically when done.": {
-    "Terminal fallback opened. Complete sync there; it will close automatically when done.": ""
+    "Terminal fallback opened. Complete sync there; it will close automatically when done.": "端末フォールバックを開きました。そこで同期を完了してください。完了すると自動的に閉じます。"
   },
   "Terminal multiplexer backend to use": {
-    "Terminal multiplexer backend to use": ""
+    "Terminal multiplexer backend to use": "使用する端末マルチプレクサーバックエンド"
   },
   "Terminal opened. Complete authentication setup there; it will close automatically when done.": {
-    "Terminal opened. Complete authentication setup there; it will close automatically when done.": ""
+    "Terminal opened. Complete authentication setup there; it will close automatically when done.": "端末を開きました。そこで認証設定を完了してください。完了すると自動的に閉じます。"
   },
   "Terminal opened. Complete sync authentication there; it will close automatically when done.": {
-    "Terminal opened. Complete sync authentication there; it will close automatically when done.": ""
+    "Terminal opened. Complete sync authentication there; it will close automatically when done.": "端末を開きました。そこで同期認証を完了してください。完了すると自動的に閉じます。"
   },
   "Terminals - Always use Dark Theme": {
     "Terminals - Always use Dark Theme": "端末 - 常にダークテーマを使用"
   },
   "Test Connection": {
-    "Test Connection": ""
+    "Test Connection": "接続をテスト"
   },
   "Test Page": {
-    "Test Page": ""
+    "Test Page": "テストページ"
   },
   "Test page sent to printer": {
-    "Test page sent to printer": ""
+    "Test page sent to printer": "テストページをプリンターに送信しました"
   },
   "Testing...": {
-    "Testing...": ""
+    "Testing...": "テスト中..."
   },
   "Text": {
     "Text": "テキスト"
   },
   "Text Color": {
-    "Text Color": ""
+    "Text Color": "テキスト色"
   },
   "The 'dgop' tool is required for system monitoring.\nPlease install dgop to use this feature.": {
-    "The 'dgop' tool is required for system monitoring.\nPlease install dgop to use this feature.": ""
+    "The 'dgop' tool is required for system monitoring.\nPlease install dgop to use this feature.": "システム監視には 'dgop' ツールが必要です。\nこの機能を使うには dgop をインストールしてください。"
   },
   "The DMS_SOCKET environment variable is not set or the socket is unavailable. Automated plugin management requires the DMS_SOCKET.": {
     "The DMS_SOCKET environment variable is not set or the socket is unavailable. Automated plugin management requires the DMS_SOCKET.": "DMS_SOCKET環境変数が設定されていないか、ソケットが利用できません。自動プラグイン管理にはDMS_SOCKETが必要です。"
@@ -6159,7 +6156,7 @@
     "The below settings will modify your GTK and Qt settings. If you wish to preserve your current configurations, please back them up (qt5ct.conf|qt6ct.conf and ~/.config/gtk-3.0|gtk-4.0).": "以下の設定は、GTKとQtの設定を変更します。現在の設定を維持したい場合は、バックアップを作成してください（qt5ct.conf|qt6ct.conf および ~/.config/gtk-3.0|gtk-4.0）。"
   },
   "The custom command used when attaching to sessions (receives the session name as the first argument)": {
-    "The custom command used when attaching to sessions (receives the session name as the first argument)": ""
+    "The custom command used when attaching to sessions (receives the session name as the first argument)": "セッション接続時に使うカスタムコマンド（第1引数としてセッション名を受け取ります）"
   },
   "The job queue of this printer is empty": {
     "The job queue of this printer is empty": "このプリンタのジョブ待ち行列は空です"
@@ -6171,103 +6168,103 @@
     "Theme Color": "テーマカラー"
   },
   "Theme Registry": {
-    "Theme Registry": ""
+    "Theme Registry": "テーマレジストリ"
   },
   "Themes": {
-    "Themes": ""
+    "Themes": "テーマ"
   },
   "Thickness": {
-    "Thickness": ""
+    "Thickness": "太さ"
   },
   "Third-Party Plugin Warning": {
     "Third-Party Plugin Warning": "サードパーティ製プラグインの警告"
   },
   "Third-party plugins are created by the community and are not officially supported by DankMaterialShell.\n\nThese plugins may pose security and privacy risks - install at your own risk.": {
-    "Third-party plugins are created by the community and are not officially supported by DankMaterialShell.\n\nThese plugins may pose security and privacy risks - install at your own risk.": ""
+    "Third-party plugins are created by the community and are not officially supported by DankMaterialShell.\n\nThese plugins may pose security and privacy risks - install at your own risk.": "サードパーティ製プラグインはコミュニティによって作成されており、DankMaterialShell では公式にサポートされていません。\n\nこれらのプラグインにはセキュリティおよびプライバシー上のリスクがある可能性があります。自己責任でインストールしてください。"
   },
   "This bind is overridden by config.kdl": {
-    "This bind is overridden by config.kdl": ""
+    "This bind is overridden by config.kdl": "このバインドは config.kdl によって上書きされています"
   },
   "This may take a few seconds": {
-    "This may take a few seconds": ""
+    "This may take a few seconds": "これには数秒かかる場合があります"
   },
   "This plugin does not have 'settings_write' permission.\n\nAdd \"permissions\": [\"settings_read\", \"settings_write\"] to plugin.json": {
-    "This plugin does not have 'settings_write' permission.\n\nAdd \"permissions\": [\"settings_read\", \"settings_write\"] to plugin.json": ""
+    "This plugin does not have 'settings_write' permission.\n\nAdd \"permissions\": [\"settings_read\", \"settings_write\"] to plugin.json": "このプラグインには 'settings_write' 権限がありません。\n\nplugin.json に \"permissions\": [\"settings_read\", \"settings_write\"] を追加してください"
   },
   "This widget prevents GPU power off states, which can significantly impact battery life on laptops. It is not recommended to use this on laptops with hybrid graphics.": {
     "This widget prevents GPU power off states, which can significantly impact battery life on laptops. It is not recommended to use this on laptops with hybrid graphics.": "このウィジェットはGPUの省電力状態を防ぎ、ノートパソコンのバッテリー寿命に大きな影響を与える可能性があります。ハイブリッドグラフィックス搭載のノートパソコンでの使用は推奨されません。"
   },
   "This will delete all unpinned entries. %1 pinned entries will be kept.": {
-    "This will delete all unpinned entries. %1 pinned entries will be kept.": ""
+    "This will delete all unpinned entries. %1 pinned entries will be kept.": "固定されていない項目をすべて削除します。固定済みの %1 件は保持されます。"
   },
   "This will permanently delete all clipboard history.": {
     "This will permanently delete all clipboard history.": "これはすべてのクリップボード履歴を完全に削除します。"
   },
   "This will permanently remove this saved clipboard item. This action cannot be undone.": {
-    "This will permanently remove this saved clipboard item. This action cannot be undone.": ""
+    "This will permanently remove this saved clipboard item. This action cannot be undone.": "この保存済みクリップボード項目を完全に削除します。この操作は元に戻せません。"
   },
   "Thunderstorm": {
-    "Thunderstorm": ""
+    "Thunderstorm": "雷雨"
   },
   "Thunderstorm with Hail": {
-    "Thunderstorm with Hail": ""
+    "Thunderstorm with Hail": "ひょうを伴う雷雨"
   },
   "Tile": {
-    "Tile": ""
+    "Tile": "タイル"
   },
   "Tile H": {
-    "Tile H": ""
+    "Tile H": "横にタイル"
   },
   "Tile V": {
-    "Tile V": ""
+    "Tile V": "縦にタイル"
   },
   "Tiled": {
-    "Tiled": ""
+    "Tiled": "タイル化"
   },
   "Tiled State": {
-    "Tiled State": ""
+    "Tiled State": "タイル状態"
   },
   "Tiling": {
     "Tiling": "タイリング"
   },
   "Time": {
-    "Time": ""
+    "Time": "時刻"
   },
   "Time & Date Locale": {
-    "Time & Date Locale": ""
+    "Time & Date Locale": "時刻と日付のロケール"
   },
   "Time & Weather": {
     "Time & Weather": "時間および天気"
   },
   "Time Format": {
-    "Time Format": ""
+    "Time Format": "時刻形式"
   },
   "Time format": {
-    "Time format": ""
+    "Time format": "時刻形式"
   },
   "Time remaining: %1": {
-    "Time remaining: %1": ""
+    "Time remaining: %1": "残り時間: %1"
   },
   "Time until full: %1": {
-    "Time until full: %1": ""
+    "Time until full: %1": "満充電まで: %1"
   },
   "Timed Out": {
     "Timed Out": "タイムアウト"
   },
   "Timeout for critical priority notifications": {
-    "Timeout for critical priority notifications": ""
+    "Timeout for critical priority notifications": "最優先通知のタイムアウト"
   },
   "Timeout for low priority notifications": {
-    "Timeout for low priority notifications": ""
+    "Timeout for low priority notifications": "低優先度通知のタイムアウト"
   },
   "Timeout for normal priority notifications": {
-    "Timeout for normal priority notifications": ""
+    "Timeout for normal priority notifications": "通常優先度通知のタイムアウト"
   },
   "Title": {
-    "Title": ""
+    "Title": "タイトル"
   },
   "Title regex (optional)": {
-    "Title regex (optional)": ""
+    "Title regex (optional)": "タイトルの正規表現（任意）"
   },
   "To Full": {
     "To Full": "フルへ"
@@ -6276,7 +6273,7 @@
     "To update, run the following command:": "更新するには以下のコマンドを実行してください："
   },
   "To use this DMS bind, remove or change the keybind in your config.kdl": {
-    "To use this DMS bind, remove or change the keybind in your config.kdl": ""
+    "To use this DMS bind, remove or change the keybind in your config.kdl": "この DMS バインドを使うには、config.kdl 内のキーバインドを削除または変更してください"
   },
   "Toast Messages": {
     "Toast Messages": "トーストメッセージ"
@@ -6288,13 +6285,13 @@
     "Toggle visibility of this bar configuration": "このバー構成の可視性を切り替える"
   },
   "Toggling...": {
-    "Toggling...": ""
+    "Toggling...": "切り替え中..."
   },
   "Tomorrow": {
     "Tomorrow": "明日"
   },
   "Tonal Spot": {
-    "Tonal Spot": ""
+    "Tonal Spot": "Tonal Spot"
   },
   "Toner Empty": {
     "Toner Empty": "トナーが空です"
@@ -6303,184 +6300,184 @@
     "Toner Low": "トナーが低い"
   },
   "Too many attempts - locked out": {
-    "Too many attempts - locked out": ""
+    "Too many attempts - locked out": "試行回数が多すぎます - ロックされました"
   },
   "Too many failed attempts - account may be locked": {
-    "Too many failed attempts - account may be locked": ""
+    "Too many failed attempts - account may be locked": "失敗回数が多すぎます - アカウントがロックされている可能性があります"
   },
   "Tools": {
-    "Tools": ""
+    "Tools": "ツール"
   },
   "Top": {
     "Top": "トップ"
   },
   "Top (Default)": {
-    "Top (Default)": ""
+    "Top (Default)": "上（既定）"
   },
   "Top Bar Format": {
     "Top Bar Format": "トップバー形式"
   },
   "Top Center": {
-    "Top Center": ""
+    "Top Center": "上中央"
   },
   "Top Left": {
-    "Top Left": ""
+    "Top Left": "左上"
   },
   "Top Processes": {
-    "Top Processes": ""
+    "Top Processes": "上位プロセス"
   },
   "Top Right": {
-    "Top Right": ""
+    "Top Right": "右上"
   },
   "Top Section": {
     "Top Section": "トップセクション"
   },
   "Total": {
-    "Total": ""
+    "Total": "合計"
   },
   "Total Jobs": {
-    "Total Jobs": ""
+    "Total Jobs": "ジョブ総数"
   },
   "Touch your security key...": {
-    "Touch your security key...": ""
+    "Touch your security key...": "セキュリティキーに触れてください..."
   },
   "Transform": {
-    "Transform": ""
+    "Transform": "変形"
   },
   "Transition Effect": {
     "Transition Effect": "トランジション効果"
   },
   "Transparency": {
-    "Transparency": ""
+    "Transparency": "透明度"
   },
   "Trending GIFs": {
-    "Trending GIFs": ""
+    "Trending GIFs": "人気の GIF"
   },
   "Trending Stickers": {
-    "Trending Stickers": ""
+    "Trending Stickers": "人気のステッカー"
   },
   "Trigger": {
-    "Trigger": ""
+    "Trigger": "トリガー"
   },
   "Trigger Prefix": {
-    "Trigger Prefix": ""
+    "Trigger Prefix": "トリガープレフィックス"
   },
   "Trigger: %1": {
-    "Trigger: %1": ""
+    "Trigger: %1": "トリガー: %1"
   },
   "Trust": {
-    "Trust": ""
+    "Trust": "信頼"
   },
   "Try a different search": {
-    "Try a different search": ""
+    "Try a different search": "別の検索を試してください"
   },
   "Turn off all displays immediately when the lock screen activates": {
-    "Turn off all displays immediately when the lock screen activates": ""
+    "Turn off all displays immediately when the lock screen activates": "ロック画面が有効になったらすべてのディスプレイをすぐにオフにする"
   },
   "Turn off monitors after": {
     "Turn off monitors after": "後にモニターの電源を切る"
   },
   "Type": {
-    "Type": ""
+    "Type": "種類"
   },
   "Type at least 2 characters": {
-    "Type at least 2 characters": ""
+    "Type at least 2 characters": "少なくとも 2 文字入力してください"
   },
   "Type this prefix to search keybinds": {
-    "Type this prefix to search keybinds": ""
+    "Type this prefix to search keybinds": "キーバインドを検索するにはこの接頭辞を入力"
   },
   "Type to search files": {
-    "Type to search files": ""
+    "Type to search files": "入力してファイルを検索"
   },
   "Typography": {
-    "Typography": ""
+    "Typography": "タイポグラフィ"
   },
   "Typography & Motion": {
-    "Typography & Motion": ""
+    "Typography & Motion": "タイポグラフィとモーション"
   },
   "Unavailable": {
-    "Unavailable": ""
+    "Unavailable": "利用できません"
   },
   "Unfocused Color": {
-    "Unfocused Color": ""
+    "Unfocused Color": "非フォーカス時の色"
   },
   "Ungrouped": {
-    "Ungrouped": ""
+    "Ungrouped": "グループ化なし"
   },
   "Uninstall": {
-    "Uninstall": ""
+    "Uninstall": "アンインストール"
   },
   "Uninstall Greeter": {
-    "Uninstall Greeter": ""
+    "Uninstall Greeter": "Greeter をアンインストール"
   },
   "Uninstall Plugin": {
     "Uninstall Plugin": "プラグインをアンインストール"
   },
   "Uninstall complete. Greeter has been removed.": {
-    "Uninstall complete. Greeter has been removed.": ""
+    "Uninstall complete. Greeter has been removed.": "アンインストールが完了しました。Greeter は削除されました。"
   },
   "Uninstall failed: %1": {
-    "Uninstall failed: %1": ""
+    "Uninstall failed: %1": "アンインストールに失敗しました: %1"
   },
   "Uninstall the DMS greeter? This will remove configuration and restore your previous display manager. A terminal will open for sudo authentication.": {
-    "Uninstall the DMS greeter? This will remove configuration and restore your previous display manager. A terminal will open for sudo authentication.": ""
+    "Uninstall the DMS greeter? This will remove configuration and restore your previous display manager. A terminal will open for sudo authentication.": "DMS Greeter をアンインストールしますか? 設定を削除し、以前のディスプレイマネージャーを復元します。sudo 認証のために端末が開きます。"
   },
   "Uninstalled: %1": {
-    "Uninstalled: %1": ""
+    "Uninstalled: %1": "アンインストールしました: %1"
   },
   "Uninstalling: %1": {
-    "Uninstalling: %1": ""
+    "Uninstalling: %1": "アンインストール中: %1"
   },
   "Unknown": {
-    "Unknown": ""
+    "Unknown": "不明"
   },
   "Unknown App": {
-    "Unknown App": ""
+    "Unknown App": "不明なアプリ"
   },
   "Unknown Artist": {
-    "Unknown Artist": ""
+    "Unknown Artist": "不明なアーティスト"
   },
   "Unknown Config": {
-    "Unknown Config": ""
+    "Unknown Config": "不明な設定"
   },
   "Unknown Device": {
-    "Unknown Device": ""
+    "Unknown Device": "不明なデバイス"
   },
   "Unknown GPU": {
-    "Unknown GPU": ""
+    "Unknown GPU": "不明な GPU"
   },
   "Unknown Monitor": {
-    "Unknown Monitor": ""
+    "Unknown Monitor": "不明なモニター"
   },
   "Unknown Network": {
-    "Unknown Network": ""
+    "Unknown Network": "不明なネットワーク"
   },
   "Unknown Title": {
-    "Unknown Title": ""
+    "Unknown Title": "不明なタイトル"
   },
   "Unknown Track": {
-    "Unknown Track": ""
+    "Unknown Track": "不明なトラック"
   },
   "Unload on Close": {
-    "Unload on Close": ""
+    "Unload on Close": "閉じたときにアンロード"
   },
   "Unmute": {
-    "Unmute": ""
+    "Unmute": "ミュート解除"
   },
   "Unmute popups for %1": {
-    "Unmute popups for %1": ""
+    "Unmute popups for %1": "%1 のポップアップのミュートを解除"
   },
   "Unnamed Rule": {
-    "Unnamed Rule": ""
+    "Unnamed Rule": "無名のルール"
   },
   "Unpair": {
-    "Unpair": ""
+    "Unpair": "ペアリング解除"
   },
   "Unpair failed": {
-    "Unpair failed": ""
+    "Unpair failed": "ペアリング解除に失敗しました"
   },
   "Unpin": {
-    "Unpin": ""
+    "Unpin": "固定解除"
   },
   "Unpin from Dock": {
     "Unpin from Dock": "ドックから固定を解除"
@@ -6498,13 +6495,13 @@
     "Untitled": "無題"
   },
   "Untrust": {
-    "Untrust": ""
+    "Untrust": "信頼を解除"
   },
   "Up to date": {
-    "Up to date": ""
+    "Up to date": "最新です"
   },
   "Update": {
-    "Update": ""
+    "Update": "更新"
   },
   "Update All": {
     "Update All": "すべて更新"
@@ -6513,16 +6510,16 @@
     "Update Plugin": "プラグインを更新"
   },
   "Uptime": {
-    "Uptime": ""
+    "Uptime": "稼働時間"
   },
   "Uptime:": {
-    "Uptime:": ""
+    "Uptime:": "稼働時間:"
   },
   "Urgent Color": {
-    "Urgent Color": ""
+    "Urgent Color": "緊急時の色"
   },
   "Usage Tips": {
-    "Usage Tips": ""
+    "Usage Tips": "使用のヒント"
   },
   "Use 24-hour time format instead of 12-hour AM/PM": {
     "Use 24-hour time format instead of 12-hour AM/PM": "12時間制のAM/PMではなく、24時間表記を使用"
@@ -6543,7 +6540,7 @@
     "Use Imperial units (°F, mph, inHg) instead of Metric (°C, km/h, hPa)": "メートル法(°C、km / h、hPa)の代わりにインペリアル単位(°F、mph、inHg)を使用"
   },
   "Use Inline Expansion": {
-    "Use Inline Expansion": ""
+    "Use Inline Expansion": "インライン展開を使用"
   },
   "Use Monospace Font": {
     "Use Monospace Font": "等幅フォントを使用"
@@ -6552,82 +6549,82 @@
     "Use System Theme": "システムテーマを使用"
   },
   "Use a custom image for the login screen, or leave empty to use your desktop wallpaper.": {
-    "Use a custom image for the login screen, or leave empty to use your desktop wallpaper.": ""
+    "Use a custom image for the login screen, or leave empty to use your desktop wallpaper.": "ログイン画面にカスタム画像を使用します。空のままにするとデスクトップ壁紙を使用します。"
   },
   "Use a fixed shadow direction for this bar": {
-    "Use a fixed shadow direction for this bar": ""
+    "Use a fixed shadow direction for this bar": "このバーに固定の影の方向を使用"
   },
   "Use a security key for lock screen authentication.": {
-    "Use a security key for lock screen authentication.": ""
+    "Use a security key for lock screen authentication.": "ロック画面の認証にセキュリティキーを使用します。"
   },
   "Use an external wallpaper manager like swww, hyprpaper, or swaybg.": {
-    "Use an external wallpaper manager like swww, hyprpaper, or swaybg.": ""
+    "Use an external wallpaper manager like swww, hyprpaper, or swaybg.": "swww、hyprpaper、swaybg などの外部壁紙マネージャーを使用します。"
   },
   "Use animated wave progress bars for media playback": {
     "Use animated wave progress bars for media playback": "アニメーション化されたウェーブの進行状況バーをメディア再生に使用"
   },
   "Use custom border size": {
-    "Use custom border size": ""
+    "Use custom border size": "カスタム境界線サイズを使用"
   },
   "Use custom border/focus-ring width": {
-    "Use custom border/focus-ring width": ""
+    "Use custom border/focus-ring width": "カスタムの境界線/フォーカスリング幅を使用"
   },
   "Use custom command for update your system": {
     "Use custom command for update your system": "カスタムコマンドを使用してシステムを更新"
   },
   "Use custom gaps instead of bar spacing": {
-    "Use custom gaps instead of bar spacing": ""
+    "Use custom gaps instead of bar spacing": "バー間隔の代わりにカスタムギャップを使用"
   },
   "Use custom window radius instead of theme radius": {
-    "Use custom window radius instead of theme radius": ""
+    "Use custom window radius instead of theme radius": "テーマ半径の代わりにカスタムウィンドウ半径を使用"
   },
   "Use custom window rounding instead of theme radius": {
-    "Use custom window rounding instead of theme radius": ""
+    "Use custom window rounding instead of theme radius": "テーマ半径の代わりにカスタムウィンドウ丸みを使用"
   },
   "Use desktop wallpaper": {
-    "Use desktop wallpaper": ""
+    "Use desktop wallpaper": "デスクトップ壁紙を使用"
   },
   "Use fingerprint authentication for the lock screen.": {
-    "Use fingerprint authentication for the lock screen.": ""
+    "Use fingerprint authentication for the lock screen.": "ロック画面に指紋認証を使用します。"
   },
   "Use light theme instead of dark theme": {
     "Use light theme instead of dark theme": "ダークテーマではなく、ライトテーマを使用"
   },
   "Use meters per second instead of km/h for wind speed": {
-    "Use meters per second instead of km/h for wind speed": ""
+    "Use meters per second instead of km/h for wind speed": "風速に km/h ではなく m/s を使用"
   },
   "Use smaller notification cards": {
-    "Use smaller notification cards": ""
+    "Use smaller notification cards": "小さめの通知カードを使用"
   },
   "Use sound theme from system settings": {
     "Use sound theme from system settings": "システム設定からサウンドテーマを使用"
   },
   "Use the same position and size on all displays": {
-    "Use the same position and size on all displays": ""
+    "Use the same position and size on all displays": "すべてのディスプレイで同じ位置とサイズを使用"
   },
   "Use trigger prefix to activate": {
-    "Use trigger prefix to activate": ""
+    "Use trigger prefix to activate": "有効化にはトリガープレフィックスを使う"
   },
   "Used when accent color is set to Custom": {
-    "Used when accent color is set to Custom": ""
+    "Used when accent color is set to Custom": "アクセントカラーが Custom に設定されている場合に使用"
   },
   "User": {
-    "User": ""
+    "User": "ユーザー"
   },
   "Username": {
     "Username": "ユーザー名"
   },
   "Username...": {
-    "Username...": ""
+    "Username...": "ユーザー名..."
   },
   "Uses sunrise/sunset times based on your location.": {
-    "Uses sunrise/sunset times based on your location.": ""
+    "Uses sunrise/sunset times based on your location.": "位置情報に基づく日の出/日の入り時刻を使用します。"
   },
   "Uses sunrise/sunset times to automatically adjust night mode based on your location.": {
     "Uses sunrise/sunset times to automatically adjust night mode based on your location.": "あなたの位置情報に基づいて、日の出と日の入りの時間を使ってナイトモードを自動調整します。"
   },
   "Using shared settings from Gamma Control": {
-    "Using shared settings from Gamma Control": ""
+    "Using shared settings from Gamma Control": "Gamma Control の共有設定を使用中"
   },
   "Utilities": {
     "Utilities": "ユーティリティ"
@@ -6639,43 +6636,43 @@
     "VPN Connections": "VPN接続"
   },
   "VPN Password": {
-    "VPN Password": ""
+    "VPN Password": "VPN パスワード"
   },
   "VPN configuration updated": {
-    "VPN configuration updated": ""
+    "VPN configuration updated": "VPN 設定を更新しました"
   },
   "VPN connections": {
-    "VPN connections": ""
+    "VPN connections": "VPN 接続"
   },
   "VPN deleted": {
-    "VPN deleted": ""
+    "VPN deleted": "VPN を削除しました"
   },
   "VPN imported: %1": {
-    "VPN imported: %1": ""
+    "VPN imported: %1": "VPN をインポートしました: %1"
   },
   "VPN not available": {
-    "VPN not available": ""
+    "VPN not available": "VPN は利用できません"
   },
   "VPN status and quick connect": {
     "VPN status and quick connect": "VPNステータスとクイック接続"
   },
   "VRR": {
-    "VRR": ""
+    "VRR": "VRR"
   },
   "VRR Fullscreen Only": {
-    "VRR Fullscreen Only": ""
+    "VRR Fullscreen Only": "VRR はフルスクリーン時のみ"
   },
   "VRR On-Demand": {
-    "VRR On-Demand": ""
+    "VRR On-Demand": "VRR オンデマンド"
   },
   "Variable Refresh Rate": {
-    "Variable Refresh Rate": ""
+    "Variable Refresh Rate": "可変リフレッシュレート"
   },
   "Verification": {
-    "Verification": ""
+    "Verification": "確認"
   },
   "Version": {
-    "Version": ""
+    "Version": "バージョン"
   },
   "Vertical Deck": {
     "Vertical Deck": "垂直デッキ"
@@ -6690,28 +6687,28 @@
     "Vertical Tiling": "垂直タイリング"
   },
   "Vibrant": {
-    "Vibrant": ""
+    "Vibrant": "Vibrant"
   },
   "Vibrant palette with playful saturation.": {
     "Vibrant palette with playful saturation.": "遊び心のある彩度の鮮やかなパレット。"
   },
   "Video Path": {
-    "Video Path": ""
+    "Video Path": "動画パス"
   },
   "Video Screensaver": {
-    "Video Screensaver": ""
+    "Video Screensaver": "動画スクリーンセーバー"
   },
   "Videos": {
-    "Videos": ""
+    "Videos": "動画"
   },
   "View Mode": {
-    "View Mode": ""
+    "View Mode": "表示モード"
   },
   "Visibility": {
     "Visibility": "可視性"
   },
   "Visual Effects": {
-    "Visual Effects": ""
+    "Visual Effects": "視覚効果"
   },
   "Visual divider between widgets": {
     "Visual divider between widgets": "ウィジェット間の視覚的分離"
@@ -6720,49 +6717,49 @@
     "Visual effect used when wallpaper changes": "壁紙が変更される時に使用されるビジュアルエフェクト"
   },
   "Volume": {
-    "Volume": ""
+    "Volume": "音量"
   },
   "Volume Changed": {
     "Volume Changed": "音量変更"
   },
   "Volume Slider": {
-    "Volume Slider": ""
+    "Volume Slider": "音量スライダー"
   },
   "Volume, brightness, and other system OSDs": {
     "Volume, brightness, and other system OSDs": "音量、明るさ、その他のシステム OSD"
   },
   "WPA/WPA2": {
-    "WPA/WPA2": ""
+    "WPA/WPA2": "WPA/WPA2"
   },
   "Wallpaper": {
     "Wallpaper": "壁紙"
   },
   "Wallpaper Error": {
-    "Wallpaper Error": ""
+    "Wallpaper Error": "壁紙エラー"
   },
   "Wallpaper Monitor": {
     "Wallpaper Monitor": "壁紙モニター"
   },
   "Wallpaper fill mode": {
-    "Wallpaper fill mode": ""
+    "Wallpaper fill mode": "壁紙の塗りつぶしモード"
   },
   "Wallpaper processing failed": {
-    "Wallpaper processing failed": ""
+    "Wallpaper processing failed": "壁紙の処理に失敗しました"
   },
   "Wallpaper processing failed - check wallpaper path": {
-    "Wallpaper processing failed - check wallpaper path": ""
+    "Wallpaper processing failed - check wallpaper path": "壁紙の処理に失敗しました - 壁紙パスを確認してください"
   },
   "Wallpapers": {
     "Wallpapers": "壁紙"
   },
   "Warm color temperature to apply": {
-    "Warm color temperature to apply": ""
+    "Warm color temperature to apply": "適用する暖色の色温度"
   },
   "Warning": {
     "Warning": "警告"
   },
   "Warnings": {
-    "Warnings": ""
+    "Warnings": "警告"
   },
   "Wave Progress Bars": {
     "Wave Progress Bars": "ウェーブプログレスバー"
@@ -6774,40 +6771,40 @@
     "Weather Widget": "天気ウィジェット"
   },
   "Welcome": {
-    "Welcome": ""
+    "Welcome": "ようこそ"
   },
   "Welcome to DankMaterialShell": {
-    "Welcome to DankMaterialShell": ""
+    "Welcome to DankMaterialShell": "DankMaterialShell へようこそ"
   },
   "When clicking a dock window in a Hyprland special workspace, bring that special workspace back before focusing the window": {
-    "When clicking a dock window in a Hyprland special workspace, bring that special workspace back before focusing the window": ""
+    "When clicking a dock window in a Hyprland special workspace, bring that special workspace back before focusing the window": "Hyprland の特殊ワークスペースでドックのウィンドウをクリックしたときは、ウィンドウにフォーカスする前にその特殊ワークスペースを戻します"
   },
   "When enabled, apps are sorted alphabetically. When disabled, apps are sorted by usage frequency.": {
     "When enabled, apps are sorted alphabetically. When disabled, apps are sorted by usage frequency.": "有効にすると、アプリはアルファベット順に並べ替えられます。無効にすると、アプリは使用頻度で並べ替えられます。"
   },
   "When locked": {
-    "When locked": ""
+    "When locked": "ロック時"
   },
   "When updater widget is used, then hide it if no update found": {
-    "When updater widget is used, then hide it if no update found": ""
+    "When updater widget is used, then hide it if no update found": "アップデーターウィジェット使用時、更新がなければ非表示にする"
   },
   "Wi-Fi Password": {
-    "Wi-Fi Password": ""
+    "Wi-Fi Password": "Wi-Fi パスワード"
   },
   "Wi-Fi and Ethernet connection": {
-    "Wi-Fi and Ethernet connection": ""
+    "Wi-Fi and Ethernet connection": "Wi-Fi と Ethernet 接続"
   },
   "Wi-Fi not available": {
-    "Wi-Fi not available": ""
+    "Wi-Fi not available": "Wi-Fi は利用できません"
   },
   "WiFi": {
-    "WiFi": ""
+    "WiFi": "WiFi"
   },
   "WiFi Device": {
-    "WiFi Device": ""
+    "WiFi Device": "WiFi デバイス"
   },
   "WiFi QR code for ": {
-    "WiFi QR code for ": ""
+    "WiFi QR code for ": "WiFi QR コード: "
   },
   "WiFi disabled": {
     "WiFi disabled": "WiFiを無効化にしました"
@@ -6819,10 +6816,10 @@
     "WiFi is off": "Wi-Fiはオフ中"
   },
   "WiFi off": {
-    "WiFi off": ""
+    "WiFi off": "WiFi オフ"
   },
   "Wide (BT2020)": {
-    "Wide (BT2020)": ""
+    "Wide (BT2020)": "Wide (BT2020)"
   },
   "Widget Background Color": {
     "Widget Background Color": "ウィジェットの背景色"
@@ -6831,7 +6828,7 @@
     "Widget Management": "ウィジェット管理"
   },
   "Widget Outline": {
-    "Widget Outline": ""
+    "Widget Outline": "ウィジェットのアウトライン"
   },
   "Widget Style": {
     "Widget Style": "ウィジェットのスタイル"
@@ -6843,79 +6840,79 @@
     "Widget Transparency": "ウィジェットの透明度"
   },
   "Widget added": {
-    "Widget added": ""
+    "Widget added": "ウィジェットを追加しました"
   },
   "Widget removed": {
-    "Widget removed": ""
+    "Widget removed": "ウィジェットを削除しました"
   },
   "Widgets": {
-    "Widgets": ""
+    "Widgets": "ウィジェット"
   },
   "Widgets, layout, style": {
-    "Widgets, layout, style": ""
+    "Widgets, layout, style": "ウィジェット、レイアウト、スタイル"
   },
   "Width": {
-    "Width": ""
+    "Width": "幅"
   },
   "Width of window border (borderpx)": {
-    "Width of window border (borderpx)": ""
+    "Width of window border (borderpx)": "ウィンドウ境界線の幅（borderpx）"
   },
   "Width of window border (general.border_size)": {
-    "Width of window border (general.border_size)": ""
+    "Width of window border (general.border_size)": "ウィンドウ境界線の幅（general.border_size）"
   },
   "Width of window border and focus ring": {
-    "Width of window border and focus ring": ""
+    "Width of window border and focus ring": "ウィンドウ境界線とフォーカスリングの幅"
   },
   "Wind": {
     "Wind": "風"
   },
   "Wind Speed": {
-    "Wind Speed": ""
+    "Wind Speed": "風速"
   },
   "Wind Speed in m/s": {
-    "Wind Speed in m/s": ""
+    "Wind Speed in m/s": "風速（m/s）"
   },
   "Window Corner Radius": {
-    "Window Corner Radius": ""
+    "Window Corner Radius": "ウィンドウの角の半径"
   },
   "Window Gaps": {
-    "Window Gaps": ""
+    "Window Gaps": "ウィンドウのギャップ"
   },
   "Window Gaps (px)": {
-    "Window Gaps (px)": ""
+    "Window Gaps (px)": "ウィンドウのギャップ（px）"
   },
   "Window Height": {
-    "Window Height": ""
+    "Window Height": "ウィンドウの高さ"
   },
   "Window Opening": {
-    "Window Opening": ""
+    "Window Opening": "ウィンドウの開く動作"
   },
   "Window Rounding": {
-    "Window Rounding": ""
+    "Window Rounding": "ウィンドウの丸み"
   },
   "Window Rules": {
-    "Window Rules": ""
+    "Window Rules": "ウィンドウルール"
   },
   "Window Rules Include Missing": {
-    "Window Rules Include Missing": ""
+    "Window Rules Include Missing": "window_rules include が不足"
   },
   "Window Rules Not Configured": {
-    "Window Rules Not Configured": ""
+    "Window Rules Not Configured": "ウィンドウルールは設定されていません"
   },
   "Wipe": {
-    "Wipe": ""
+    "Wipe": "ワイプ"
   },
   "Workspace": {
     "Workspace": "ワークスペース"
   },
   "Workspace Appearance": {
-    "Workspace Appearance": ""
+    "Workspace Appearance": "ワークスペースの外観"
   },
   "Workspace Index Numbers": {
     "Workspace Index Numbers": "ワークスペースのインデックス番号"
   },
   "Workspace Names": {
-    "Workspace Names": ""
+    "Workspace Names": "ワークスペース名"
   },
   "Workspace Padding": {
     "Workspace Padding": "ワークスペースのパディング"
@@ -6927,28 +6924,28 @@
     "Workspace Switcher": "ワークスペーススイッチャー"
   },
   "Workspace name": {
-    "Workspace name": ""
+    "Workspace name": "ワークスペース名"
   },
   "Workspaces": {
-    "Workspaces": ""
+    "Workspaces": "ワークスペース"
   },
   "Workspaces & Widgets": {
-    "Workspaces & Widgets": ""
+    "Workspaces & Widgets": "ワークスペースとウィジェット"
   },
   "Write:": {
-    "Write:": ""
+    "Write:": "書き込み:"
   },
   "X Axis": {
-    "X Axis": ""
+    "X Axis": "X 軸"
   },
   "Y Axis": {
-    "Y Axis": ""
+    "Y Axis": "Y 軸"
   },
   "Yes": {
-    "Yes": ""
+    "Yes": "はい"
   },
   "Yesterday": {
-    "Yesterday": ""
+    "Yesterday": "昨日"
   },
   "You have unsaved changes. Save before closing this tab?": {
     "You have unsaved changes. Save before closing this tab?": "保存されていない変更があります。このタブを閉じる前に保存しますか?"
@@ -6963,166 +6960,166 @@
     "You have unsaved changes. Save before opening a file?": "保存されていない変更があります。ファイルを開く前に保存しますか?"
   },
   "You need to set either:\nQT_QPA_PLATFORMTHEME=gtk3 OR\nQT_QPA_PLATFORMTHEME=qt6ct\nas environment variables, and then restart the shell.\n\nqt6ct requires qt6ct-kde to be installed.": {
-    "You need to set either:\nQT_QPA_PLATFORMTHEME=gtk3 OR\nQT_QPA_PLATFORMTHEME=qt6ct\nas environment variables, and then restart the shell.\n\nqt6ct requires qt6ct-kde to be installed.": ""
+    "You need to set either:\nQT_QPA_PLATFORMTHEME=gtk3 OR\nQT_QPA_PLATFORMTHEME=qt6ct\nas environment variables, and then restart the shell.\n\nqt6ct requires qt6ct-kde to be installed.": "環境変数として以下のいずれかを設定し、その後シェルを再起動する必要があります。\nQT_QPA_PLATFORMTHEME=gtk3 または\nQT_QPA_PLATFORMTHEME=qt6ct\n\nqt6ct には qt6ct-kde のインストールが必要です。"
   },
   "You're All Set!": {
-    "You're All Set!": ""
+    "You're All Set!": "準備完了です!"
   },
   "Your system is up to date!": {
-    "Your system is up to date!": ""
+    "Your system is up to date!": "システムは最新です!"
   },
   "actions": {
-    "actions": ""
+    "actions": "アクション"
   },
   "attached": {
-    "attached": ""
+    "attached": "接続済み"
   },
   "brandon": {
-    "brandon": ""
+    "brandon": "brandon"
   },
   "by %1": {
-    "by %1": ""
+    "by %1": "%1 による"
   },
   "days": {
-    "days": ""
+    "days": "日"
   },
   "detached": {
-    "detached": ""
+    "detached": "切り離し済み"
   },
   "device": {
-    "device": ""
+    "device": "デバイス"
   },
   "devices connected": {
-    "devices connected": ""
+    "devices connected": "接続中のデバイス"
   },
   "dgop not available": {
-    "dgop not available": ""
+    "dgop not available": "dgop は利用できません"
   },
   "dms is a highly customizable, modern desktop shell with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": {
-    "dms is a highly customizable, modern desktop shell with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": ""
+    "dms is a highly customizable, modern desktop shell with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": "dms は、<a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">Material 3 に着想を得た</a>デザインを持つ、高度にカスタマイズ可能なモダンなデスクトップシェルです。<br /><br/>デスクトップシェルを構築するための QT6 フレームワークである <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a> と、静的型付けのコンパイル言語である <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a> で構築されています。"
   },
   "dms/cursor config exists but is not included. Cursor settings won't apply.": {
-    "dms/cursor config exists but is not included. Cursor settings won't apply.": ""
+    "dms/cursor config exists but is not included. Cursor settings won't apply.": "dms/cursor 設定は存在しますが、読み込まれていません。カーソル設定は適用されません。"
   },
   "dms/outputs config exists but is not included in your compositor config. Display changes won't persist.": {
-    "dms/outputs config exists but is not included in your compositor config. Display changes won't persist.": ""
+    "dms/outputs config exists but is not included in your compositor config. Display changes won't persist.": "dms/outputs 設定は存在しますが、コンポジター設定に含まれていません。ディスプレイ変更は保持されません。"
   },
   "e.g., firefox, kitty --title foo": {
-    "e.g., firefox, kitty --title foo": ""
+    "e.g., firefox, kitty --title foo": "例: firefox、kitty --title foo"
   },
   "e.g., focus-workspace 3, resize-column -10": {
-    "e.g., focus-workspace 3, resize-column -10": ""
+    "e.g., focus-workspace 3, resize-column -10": "例: focus-workspace 3、resize-column -10"
   },
   "e.g., notify-send 'Hello' && sleep 1": {
-    "e.g., notify-send 'Hello' && sleep 1": ""
+    "e.g., notify-send 'Hello' && sleep 1": "例: notify-send 'Hello' && sleep 1"
   },
   "e.g., scratch, /^tmp_.*/, build": {
-    "e.g., scratch, /^tmp_.*/, build": ""
+    "e.g., scratch, /^tmp_.*/, build": "例: scratch、/^tmp_.*/、build"
   },
   "events": {
     "events": "イベント"
   },
   "ext": {
-    "ext": ""
+    "ext": "ext"
   },
   "featured": {
-    "featured": ""
+    "featured": "おすすめ"
   },
   "leave empty for default": {
-    "leave empty for default": ""
+    "leave empty for default": "既定値を使うには空のままにしてください"
   },
   "loginctl not available - lock integration requires DMS socket connection": {
     "loginctl not available - lock integration requires DMS socket connection": "loginctlが利用できません- ロック統合のためにDMS socketの接続が必要です。"
   },
   "mangowc Discord Server": {
-    "mangowc Discord Server": ""
+    "mangowc Discord Server": "mangowc Discord サーバー"
   },
   "mangowc GitHub": {
-    "mangowc GitHub": ""
+    "mangowc GitHub": "mangowc GitHub"
   },
   "matugen not found - install matugen package for dynamic theming": {
-    "matugen not found - install matugen package for dynamic theming": ""
+    "matugen not found - install matugen package for dynamic theming": "matugen が見つかりません - 動的テーマ設定には matugen パッケージをインストールしてください"
   },
   "minutes": {
-    "minutes": ""
+    "minutes": "分"
   },
   "ms": {
-    "ms": ""
+    "ms": "ms"
   },
   "nav": {
-    "nav": ""
+    "nav": "ナビゲーション"
   },
   "niri GitHub": {
-    "niri GitHub": ""
+    "niri GitHub": "niri GitHub"
   },
   "niri Matrix Chat": {
-    "niri Matrix Chat": ""
+    "niri Matrix Chat": "niri Matrix チャット"
   },
   "niri shortcuts config": {
-    "niri shortcuts config": ""
+    "niri shortcuts config": "niri ショートカット設定"
   },
   "niri/dms Discord": {
-    "niri/dms Discord": ""
+    "niri/dms Discord": "niri/dms Discord"
   },
   "now": {
-    "now": ""
+    "now": "今"
   },
   "official": {
     "official": "公式"
   },
   "on Hyprland": {
-    "on Hyprland": ""
+    "on Hyprland": "Hyprland 上"
   },
   "on MangoWC": {
-    "on MangoWC": ""
+    "on MangoWC": "MangoWC 上"
   },
   "on Miracle WM": {
-    "on Miracle WM": ""
+    "on Miracle WM": "Miracle WM 上"
   },
   "on Niri": {
-    "on Niri": ""
+    "on Niri": "Niri 上"
   },
   "on Scroll": {
-    "on Scroll": ""
+    "on Scroll": "スクロール時"
   },
   "on Sway": {
-    "on Sway": ""
+    "on Sway": "Sway 上"
   },
   "open": {
-    "open": ""
+    "open": "開く"
   },
   "or run ": {
-    "or run ": ""
+    "or run ": "または実行: "
   },
   "power-profiles-daemon not available": {
-    "power-profiles-daemon not available": ""
+    "power-profiles-daemon not available": "power-profiles-daemon は利用できません"
   },
   "procs": {
-    "procs": ""
+    "procs": "procs"
   },
   "r/niri Subreddit": {
-    "r/niri Subreddit": ""
+    "r/niri Subreddit": "r/niri サブレディット"
   },
   "seconds": {
-    "seconds": ""
+    "seconds": "秒"
   },
   "source": {
-    "source": ""
+    "source": "ソース"
   },
   "this app": {
-    "this app": ""
+    "this app": "このアプリ"
   },
   "up": {
-    "up": ""
+    "up": "上"
   },
   "update dms for NM integration.": {
     "update dms for NM integration.": "NM統合のためにDMSを更新します。"
   },
   "v%1 by %2": {
-    "v%1 by %2": ""
+    "v%1 by %2": "v%1 by %2"
   },
   "wtype not available - install wtype for paste support": {
-    "wtype not available - install wtype for paste support": ""
+    "wtype not available - install wtype for paste support": "wtype は利用できません - 貼り付け対応には wtype をインストールしてください"
   },
   "• Install only from trusted sources": {
     "• Install only from trusted sources": "• 信頼できるソースからのみインストールする"
@@ -7164,12 +7161,12 @@
     "• yyyy - Year (2024)": "• yyyy - 年（2024年）"
   },
   "↑/↓: Nav • Space: Expand • Enter: Action/Expand • E: Text": {
-    "↑/↓: Nav • Space: Expand • Enter: Action/Expand • E: Text": ""
+    "↑/↓: Nav • Space: Expand • Enter: Action/Expand • E: Text": "↑/↓: ナビゲーション • Space: 展開 • Enter: アクション/展開 • E: テキスト"
   },
   "↑/↓: Navigate • Enter/Ctrl+C: Copy • Del: Delete • F10: Help": {
-    "↑/↓: Navigate • Enter/Ctrl+C: Copy • Del: Delete • F10: Help": ""
+    "↑/↓: Navigate • Enter/Ctrl+C: Copy • Del: Delete • F10: Help": "↑/↓: 移動 • Enter/Ctrl+C: コピー • Del: 削除 • F10: ヘルプ"
   },
   "↑/↓: Navigate • Enter: Paste • Del: Delete • F10: Help": {
-    "↑/↓: Navigate • Enter: Paste • Del: Delete • F10: Help": ""
+    "↑/↓: Navigate • Enter: Paste • Del: Delete • F10: Help": "↑/↓: 移動 • Enter: 貼り付け • Del: 削除 • F10: ヘルプ"
   }
 }


### PR DESCRIPTION
## Summary

- Add Japanese translations for DankMaterialShell
- 2343 / 2390 entries translated (98.0%)
- The 47 remaining untranslated entries are intentionally kept in English
  (technical acronyms and proper nouns: `WiFi`, `VPN`, `Bluetooth`, `CPU`,
  `GPU`, `MAC`, `BSSID`, `Dank Bar`, `GitHub`, etc.)

## Translation notes

Several terms were carefully chosen for natural Japanese UX:

| Term | Translation | Note |
|------|-------------|------|
| All day | 終日 | Calendar all-day event (not 毎日 = every day) |
| Suspend | スリープ | Power menu action |
| Do Not Disturb | サイレントモード | Common Japanese equivalent |
| Hibernate | 休止状態 | Standard Japanese term |
| Greeter | Greeter | Kept as-is (product name) |

## Test plan

- [ ] Verify strings appear correctly in the UI under Japanese locale
- [ ] Check that untranslated entries fall back to English gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)