### PR TITLE
Revert "Fix ddc brightness not applying because process exits before debounce timer runs"

### DIFF
--- a/core/cmd/dms/commands_brightness.go
+++ b/core/cmd/dms/commands_brightness.go
@@ -236,7 +236,6 @@ func runBrightnessSet(cmd *cobra.Command, args []string) {
 			defer ddc.Close()
 			time.Sleep(100 * time.Millisecond)
 			if err := ddc.SetBrightnessWithExponent(deviceID, percent, exponential, exponent, nil); err == nil {
-				ddc.WaitPending()
 				fmt.Printf("Set %s to %d%%\n", deviceID, percent)
 				return
 			}

--- a/core/internal/server/brightness/ddc.go
+++ b/core/internal/server/brightness/ddc.go
@@ -218,9 +218,7 @@ func (b *DDCBackend) SetBrightnessWithExponent(id string, value int, exponential
 	if timer, exists := b.debounceTimers[id]; exists {
 		timer.Reset(200 * time.Millisecond)
 	} else {
-		b.debounceWg.Add(1)
 		b.debounceTimers[id] = time.AfterFunc(200*time.Millisecond, func() {
-			defer b.debounceWg.Done()
 			b.debounceMutex.Lock()
 			pending, exists := b.debouncePending[id]
 			if exists {
@@ -490,20 +488,6 @@ func (b *DDCBackend) valueToPercent(value int, max int, exponential bool) int {
 	}
 
 	return percent
-}
-
-func (b *DDCBackend) WaitPending() {
-	done := make(chan struct{})
-	go func() {
-		b.debounceWg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		log.Debug("WaitPending timed out waiting for DDC writes")
-	}
 }
 
 func (b *DDCBackend) Close() {

--- a/core/internal/server/brightness/types.go
+++ b/core/internal/server/brightness/types.go
@@ -84,7 +84,6 @@ type DDCBackend struct {
 	debounceMutex   sync.Mutex
 	debounceTimers  map[string]*time.Timer
 	debouncePending map[string]ddcPendingSet
-	debounceWg      sync.WaitGroup
 }
 
 type ddcPendingSet struct {


### PR DESCRIPTION
Reverts AvengeMedia/DankMaterialShell#2217

This has caused an issue of Brightness Slider not working after some time. Since counter goes negative if slider is moved rapidly (or after some time)

 It requires restart of dms shell until it works

`panic: sync: negative WaitGroup counter

goroutine 838 [running]:
sync.(*WaitGroup).Add(0x2239b54367d0, 0xffffffffffffffff)
	/usr/lib/go/src/sync/waitgroup.go:118 +0x23a
sync.(*WaitGroup).Done(...)
	/usr/lib/go/src/sync/waitgroup.go:156
github.com/AvengeMedia/DankMaterialShell/core/internal/server/brightness.(*DDCBackend).SetBrightnessWithExponent.func1()
	/home/davut/dms/core/internal/server/brightness/ddc.go:243 +0x209
created by time.goFunc
	/usr/lib/go/src/time/sleep.go:215 +0x2d
  WARN quickshell.io.socket: Socket error for Socket(0x7ffa8ddf1d80) QLocalSocket::PeerClosedError
  WARN quickshell.io.socket: Socket error for Socket(0x7ffa8ddf1b00) QLocalSocket::PeerClosedError
  INFO qml: ExtWorkspaceService: ext-workspace available but compositor has native support
  WARN quickshell.io.socket: Socket error for Socket(0x7ffa8ddf1d80) QLocalSocket::ConnectionRefusedError
  WARN quickshell.io.socket: Socket error for Socket(0x7ffa8ddf1b00) QLocalSocket::ConnectionRefusedError
  WARN: QIODevice::write (QLocalSocket): device not open`

