### PR TITLE
feat(system-tray): add optional monochrome icons setting

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -211,6 +211,7 @@ Singleton {
     property int selectedGpuIndex: 0
     property var enabledGpuPciIds: []
     property bool showSystemTray: true
+    property bool systemTrayMonochromeIcons: false
     property bool showClock: true
     property bool showNotificationButton: true
     property bool showBattery: true

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -79,6 +79,7 @@ var SPEC = {
     selectedGpuIndex: { def: 0 },
     enabledGpuPciIds: { def: [] },
     showSystemTray: { def: true },
+    systemTrayMonochromeIcons: { def: false },
     showClock: { def: true },
     showNotificationButton: { def: true },
     showBattery: { def: true },

--- a/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
+++ b/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
@@ -366,6 +366,10 @@ BasePill {
                             smooth: true
                             mipmap: true
                             visible: status === Image.Ready
+                            layer.enabled: SettingsData.systemTrayMonochromeIcons
+                            layer.effect: MultiEffect {
+                                saturation: -1
+                            }
                         }
 
                         Text {
@@ -581,6 +585,10 @@ BasePill {
                     smooth: true
                     mipmap: true
                     visible: status === Image.Ready
+                    layer.enabled: SettingsData.systemTrayMonochromeIcons
+                    layer.effect: MultiEffect {
+                        saturation: -1
+                    }
                 }
 
                 Text {
@@ -709,6 +717,10 @@ BasePill {
                     smooth: true
                     mipmap: true
                     visible: status === Image.Ready
+                    layer.enabled: SettingsData.systemTrayMonochromeIcons
+                    layer.effect: MultiEffect {
+                        saturation: -1
+                    }
                 }
 
                 Text {
@@ -1210,6 +1222,10 @@ BasePill {
                             smooth: true
                             mipmap: true
                             visible: status === Image.Ready
+                            layer.enabled: SettingsData.systemTrayMonochromeIcons
+                            layer.effect: MultiEffect {
+                                saturation: -1
+                            }
                         }
 
                         Text {

--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -715,6 +715,15 @@ Item {
             }
 
             SettingsToggleCard {
+                iconName: "filter_b_and_w"
+                title: I18n.tr("Monochrome System Tray Icons")
+                description: I18n.tr("Desaturate all system tray icons for a uniform monochrome look")
+                visible: selectedBarConfig?.enabled
+                checked: SettingsData.systemTrayMonochromeIcons
+                onToggled: checked => SettingsData.set("systemTrayMonochromeIcons", checked)
+            }
+
+            SettingsToggleCard {
                 iconName: "mouse"
                 title: I18n.tr("Scroll Wheel")
                 description: I18n.tr("Control workspaces and columns by scrolling on the bar")


### PR DESCRIPTION
## Summary

Adds an opt-in "Monochrome System Tray Icons" toggle under Settings → Dank Bar → Settings (right after "Maximize Detection"). When enabled, every system tray icon is desaturated via MultiEffect { saturation: -1 }, producing a uniform monochrome bar that matches minimal / one-color themes.

Default is false, so existing users see no change.

## Changes

- quickshell/Common/settings/SettingsSpec.js - add systemTrayMonochromeIcons: { def: false }
- quickshell/Common/SettingsData.qml - add property bool systemTrayMonochromeIcons: false
- quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml - wire layer.enabled + MultiEffect with saturation: -1 on the four IconImage blocks (horizontal bar, vertical bar, overflow menu item, inline expansion icon)
- quickshell/Modules/Settings/DankBarTab.qml - new SettingsToggleCard after "Maximize Detection"

## Test plan

-  [x] Toggle in Settings → Dank Bar appears after "Maximize Detection"
-  [x] Enabling the toggle desaturates all tray icons (Signal, 1Password, Spotify, Element, etc.) to grayscale
-  [x] Disabling restores color
-  [ ] Overflow menu icons also respect the setting

Disabled (default):

<img width="1191" height="1093" alt="20260418_183935" src="https://github.com/user-attachments/assets/e2bcbe79-781d-4a2f-9ff6-32cdaf715435" />

Enabled (toggled):

<img width="1212" height="1106" alt="20260418_183942" src="https://github.com/user-attachments/assets/51722b55-8fd6-47a9-966c-16c3dd268c12" />

Icon: https://fonts.google.com/icons?selected=Material+Symbols+Rounded:filter_b_and_w