### PR TITLE
Labwc service

### DIFF
--- a/quickshell/Services/LabwcService.qml
+++ b/quickshell/Services/LabwcService.qml
@@ -1,0 +1,15 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+
+Singleton {
+    id: root
+
+    // Exit the labwc session. Used by SessionService when the user
+    // triggers logout and no custom logout command is configured.
+    function quit() {
+        Quickshell.execDetached(["labwc", "--exit"]);
+    }
+}

--- a/quickshell/Services/SessionService.qml
+++ b/quickshell/Services/SessionService.qml
@@ -320,6 +320,11 @@ Singleton {
                 return;
             }
 
+            if (CompositorService.isLabwc) {
+                LabwcService.quit();
+                return;
+            }
+
             if (CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle) {
                 try {
                     I3.dispatch("exit");


### PR DESCRIPTION
Add a basic `labwc` service so the user doesn't have to manually set the logout command to exit the session.

I may work on adding support for including config files to labwc so we can add a proper keybindings section too. Right now it would be too hairy as there is only `rc.xml`. 