### PR TITLE
Fix night mode and OSD recovery after suspend/resume

### DIFF
--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -346,12 +346,11 @@ Singleton {
         function onLoginctlEvent(event) {
             if (!SessionData.themeModeAutoEnabled)
                 return;
-            if (event.event === "unlock" || event.event === "resume") {
-                if (!themeAutoBackendAvailable()) {
-                    root.evaluateThemeMode();
-                    return;
-                }
-                DMSService.sendRequest("theme.auto.trigger", {});
+            if (typeof SettingsData !== "undefined" && SettingsData.loginctlLockIntegration)
+                return;
+            const eventType = String(event?.type || event?.event || "").toLowerCase();
+            if (eventType === "unlock") {
+                root.triggerThemeAutomationRefresh();
             }
         }
 
@@ -412,6 +411,27 @@ Singleton {
                 }
             }
         }
+    }
+
+    Connections {
+        target: SessionService
+        enabled: typeof SessionService !== "undefined" && typeof SessionData !== "undefined" && SessionData.themeModeAutoEnabled
+
+        function onSessionUnlocked() {
+            root.triggerThemeAutomationRefresh();
+        }
+
+        function onSessionResumed() {
+            root.triggerThemeAutomationRefresh();
+        }
+    }
+
+    function triggerThemeAutomationRefresh() {
+        if (!themeAutoBackendAvailable()) {
+            root.evaluateThemeMode();
+            return;
+        }
+        DMSService.sendRequest("theme.auto.trigger", {});
     }
 
     function applyGreeterTheme(themeName) {

--- a/quickshell/DMSShell.qml
+++ b/quickshell/DMSShell.qml
@@ -27,6 +27,15 @@ import qs.Services
 Item {
     id: root
 
+    property bool osdSurfacesLoaded: true
+    property int pendingOsdResumeReloads: 0
+
+    function recreateOsdSurfaces() {
+        OSDManager.currentOSDsByScreen = ({});
+        osdSurfacesLoaded = false;
+        osdSurfaceReloadTimer.restart();
+    }
+
     Instantiator {
         id: daemonPluginInstantiator
         asynchronous: true
@@ -230,6 +239,32 @@ Item {
         onTriggered: {
             AudioService.playLoginSoundIfApplicable();
         }
+    }
+
+    Timer {
+        id: osdResumeRecreateTimer
+        interval: 400
+        repeat: false
+        onTriggered: {
+            root.recreateOsdSurfaces();
+
+            if (root.pendingOsdResumeReloads > 1) {
+                root.pendingOsdResumeReloads--;
+                interval = 1400;
+                restart();
+                return;
+            }
+
+            root.pendingOsdResumeReloads = 0;
+            interval = 400;
+        }
+    }
+
+    Timer {
+        id: osdSurfaceReloadTimer
+        interval: 120
+        repeat: false
+        onTriggered: root.osdSurfacesLoaded = true
     }
 
     Component.onCompleted: {
@@ -749,6 +784,16 @@ Item {
         }
     }
 
+    Connections {
+        target: SessionService
+
+        function onSessionResumed() {
+            root.pendingOsdResumeReloads = 2;
+            osdResumeRecreateTimer.interval = 400;
+            osdResumeRecreateTimer.restart();
+        }
+    }
+
     DankColorPickerModal {
         id: colorPickerModal
 
@@ -923,51 +968,85 @@ Item {
         }
     }
 
-    Variants {
-        model: SettingsData.getFilteredScreens("osd")
+    Loader {
+        id: osdSurfacesLoader
+        active: root.osdSurfacesLoaded
+        asynchronous: false
 
-        delegate: VolumeOSD {
-            modelData: item
-        }
-    }
+        sourceComponent: Component {
+            Item {
+                Variants {
+                    model: SettingsData.getFilteredScreens("osd")
 
-    Variants {
-        model: SettingsData.getFilteredScreens("osd")
+                    delegate: VolumeOSD {
+                        modelData: item
+                    }
+                }
 
-        delegate: MediaVolumeOSD {
-            modelData: item
-        }
-    }
+                Variants {
+                    model: SettingsData.getFilteredScreens("osd")
 
-    Variants {
-        model: SettingsData.getFilteredScreens("osd")
+                    delegate: MediaVolumeOSD {
+                        modelData: item
+                    }
+                }
 
-        delegate: MediaPlaybackOSD {
-            modelData: item
-        }
-    }
+                Variants {
+                    model: SettingsData.getFilteredScreens("osd")
 
-    Variants {
-        model: SettingsData.getFilteredScreens("osd")
+                    delegate: MediaPlaybackOSD {
+                        modelData: item
+                    }
+                }
 
-        delegate: MicMuteOSD {
-            modelData: item
-        }
-    }
+                Variants {
+                    model: SettingsData.getFilteredScreens("osd")
 
-    Variants {
-        model: SettingsData.getFilteredScreens("osd")
+                    delegate: MicMuteOSD {
+                        modelData: item
+                    }
+                }
 
-        delegate: BrightnessOSD {
-            modelData: item
-        }
-    }
+                Variants {
+                    model: SettingsData.getFilteredScreens("osd")
 
-    Variants {
-        model: SettingsData.getFilteredScreens("osd")
+                    delegate: BrightnessOSD {
+                        modelData: item
+                    }
+                }
 
-        delegate: IdleInhibitorOSD {
-            modelData: item
+                Variants {
+                    model: SettingsData.getFilteredScreens("osd")
+
+                    delegate: IdleInhibitorOSD {
+                        modelData: item
+                    }
+                }
+
+                Variants {
+                    model: SettingsData.osdPowerProfileEnabled ? SettingsData.getFilteredScreens("osd") : []
+
+                    delegate: PowerProfileOSD {
+                        modelData: item
+                    }
+                }
+
+                Variants {
+                    model: SettingsData.getFilteredScreens("osd")
+
+                    delegate: CapsLockOSD {
+                        modelData: item
+                    }
+                }
+
+                Variants {
+                    model: SettingsData.getFilteredScreens("osd")
+
+                    delegate: AudioOutputOSD {
+                        modelData: item
+                    }
+                }
+            }
         }
     }
 
@@ -975,30 +1054,6 @@ Item {
         id: powerProfileWatcherLoader
         active: SettingsData.osdPowerProfileEnabled
         source: "Services/PowerProfileWatcher.qml"
-    }
-
-    Variants {
-        model: SettingsData.osdPowerProfileEnabled ? SettingsData.getFilteredScreens("osd") : []
-
-        delegate: PowerProfileOSD {
-            modelData: item
-        }
-    }
-
-    Variants {
-        model: SettingsData.getFilteredScreens("osd")
-
-        delegate: CapsLockOSD {
-            modelData: item
-        }
-    }
-
-    Variants {
-        model: SettingsData.getFilteredScreens("osd")
-
-        delegate: AudioOutputOSD {
-            modelData: item
-        }
     }
 
     LazyLoader {

--- a/quickshell/Services/DisplayService.qml
+++ b/quickshell/Services/DisplayService.qml
@@ -40,6 +40,7 @@ Singleton {
     property bool nightModeEnabled: false
     property bool automationAvailable: false
     property bool gammaControlAvailable: false
+    property int resumeRecoveryAttempt: 0
 
     property var gammaState: ({})
     property int gammaCurrentTemp: gammaState?.currentTemp ?? 0
@@ -672,6 +673,15 @@ Singleton {
         }
     }
 
+    function runResumeRecoveryPass() {
+        checkGammaControlAvailability();
+        rescanDevices();
+
+        if (nightModeEnabled) {
+            evaluateNightMode();
+        }
+    }
+
     function checkGammaControlAvailability() {
         if (!DMSService.isConnected) {
             return;
@@ -727,6 +737,26 @@ Singleton {
                 applyNightModeDirectly();
             }
             nextAction = "";
+        }
+    }
+
+    Timer {
+        id: resumeRecoveryTimer
+        interval: 400
+        repeat: false
+
+        onTriggered: {
+            runResumeRecoveryPass();
+            resumeRecoveryAttempt++;
+
+            if (resumeRecoveryAttempt < 3) {
+                interval = resumeRecoveryAttempt === 1 ? 1400 : 2600;
+                restart();
+                return;
+            }
+
+            resumeRecoveryAttempt = 0;
+            interval = 400;
         }
     }
 
@@ -815,16 +845,20 @@ Singleton {
             updateSingleDevice(device);
         }
 
-        function onLoginctlEvent(event) {
-            if (event.event === "unlock" || event.event === "resume") {
-                suppressOsd = true;
-                osdSuppressTimer.restart();
-                evaluateNightMode();
-            }
-        }
-
         function onGammaStateUpdate(data) {
             root.gammaState = data;
+        }
+    }
+
+    Connections {
+        target: SessionService
+
+        function onSessionResumed() {
+            suppressOsd = true;
+            osdSuppressTimer.restart();
+            resumeRecoveryAttempt = 0;
+            resumeRecoveryTimer.interval = 400;
+            resumeRecoveryTimer.restart();
         }
     }
 

--- a/quickshell/Services/SessionService.qml
+++ b/quickshell/Services/SessionService.qml
@@ -48,6 +48,9 @@ Singleton {
     signal loginctlStateChanged
 
     property bool stateInitialized: false
+    property string prepareForSleepSubscriptionId: ""
+    property bool prepareForSleepSubscriptionPending: false
+    property double lastResumeSignalTimestamp: 0
 
     readonly property string socketPath: Quickshell.env("DMS_SOCKET")
 
@@ -463,10 +466,13 @@ Singleton {
         function onConnectionStateChanged() {
             if (DMSService.isConnected) {
                 checkDMSCapabilities();
+            } else {
+                clearPrepareForSleepSubscriptionState();
             }
         }
 
         function onCapabilitiesReceived() {
+            checkDMSCapabilities();
             syncSleepInhibitor();
         }
     }
@@ -477,6 +483,13 @@ Singleton {
 
         function onCapabilitiesChanged() {
             checkDMSCapabilities();
+        }
+
+        function onDbusSignalReceived(subscriptionId, data) {
+            if (subscriptionId !== prepareForSleepSubscriptionId) {
+                return;
+            }
+            handlePrepareForSleepSignal(data);
         }
     }
 
@@ -538,6 +551,61 @@ Singleton {
         } else {
             loginctlAvailable = false;
             console.log("SessionService: loginctl capability not available in DMS");
+        }
+
+        if (DMSService.capabilities.includes("dbus")) {
+            ensurePrepareForSleepSubscription();
+        } else {
+            clearPrepareForSleepSubscriptionState();
+        }
+    }
+
+    function clearPrepareForSleepSubscriptionState() {
+        prepareForSleepSubscriptionId = "";
+        prepareForSleepSubscriptionPending = false;
+    }
+
+    function ensurePrepareForSleepSubscription() {
+        if (!DMSService.isConnected || !DMSService.capabilities.includes("dbus")) {
+            return;
+        }
+
+        if (prepareForSleepSubscriptionId || prepareForSleepSubscriptionPending) {
+            return;
+        }
+
+        prepareForSleepSubscriptionPending = true;
+        DMSService.dbusSubscribe("system", "org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager", "PrepareForSleep", response => {
+            prepareForSleepSubscriptionPending = false;
+
+            if (response.error) {
+                console.warn("SessionService: Failed to subscribe to PrepareForSleep:", response.error);
+                return;
+            }
+
+            prepareForSleepSubscriptionId = response.result?.subscriptionId || "";
+        });
+    }
+
+    function emitSessionResumedOnce() {
+        const now = Date.now();
+        if ((now - lastResumeSignalTimestamp) < 1000) {
+            return;
+        }
+        lastResumeSignalTimestamp = now;
+        sessionResumed();
+    }
+
+    function handlePrepareForSleepSignal(data) {
+        if (!data?.body || data.body.length === 0) {
+            return;
+        }
+
+        const wasSleeping = preparingForSleep;
+        preparingForSleep = data.body[0] === true;
+
+        if (wasSleeping && !preparingForSleep) {
+            emitSessionResumedOnce();
         }
     }
 
@@ -604,7 +672,7 @@ Singleton {
         }
 
         if (wasSleeping && !preparingForSleep) {
-            sessionResumed();
+            emitSessionResumedOnce();
         }
 
         loginctlStateChanged();


### PR DESCRIPTION
Fixes #424 

## Summary

Fix suspend/resume recovery in Quickshell so that:

- night mode / blue light filtering is restored after resume
- OSDs render correctly again after resume
- theme automation can refresh on unlock/resume

## What changed

### `quickshell/Services/SessionService.qml`
- subscribe to logind `PrepareForSleep` over DBus
- emit a dedicated `sessionResumed` signal when sleep ends
- deduplicate resume emission to avoid duplicate recovery work

### `quickshell/Services/DisplayService.qml`
- listen for `SessionService.sessionResumed`
- re-check gamma availability after resume
- rescan brightness devices after resume
- re-run night mode recovery with delayed retry passes
- suppress OSD briefly during resume recovery

### `quickshell/DMSShell.qml`
- recreate OSD layer-shell surfaces after resume
- reload OSD surfaces through a loader so stale surfaces are torn down cleanly
- retry OSD surface recreation to handle delayed compositor recovery

### `quickshell/Common/Theme.qml`
- refresh theme automation on unlock/resume via `SessionService`
- keep a fallback unlock refresh path when direct loginctl integration is used differently

## Why

After suspend/resume, some session state comes back asynchronously:

- gamma/night mode backends may not be ready immediately
- layer-shell surfaces used by OSD windows may become stale and stop rendering

This change makes resume recovery explicit and retries it with small delays so the shell can recover reliably.

## Manual testing

Tested on CachyOS with Niri

Tested manually by:

1. starting the shell normally
2. enabling blue light / night mode
3. suspending the session
4. resuming the session
5. verifying:
   - blue light filter is restored
   - OSD appears again when changing brightness/volume






## Notes

Made with the help of GPT-5.4 as I am not that proficient with Qt, please review thoroughly.