### PR TITLE
Fix focused app when switching to empty workspace

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/FocusedApp.qml
+++ b/quickshell/Modules/DankBar/Widgets/FocusedApp.qml
@@ -42,11 +42,15 @@ BasePill {
         const active = ToplevelManager.activeToplevel;
 
         if (!active) {
-            // Only clear if our tracked window is no longer alive
             if (activeWindow) {
-                const alive = ToplevelManager.toplevels?.values;
-                if (alive && !Array.from(alive).some(t => t === activeWindow))
-                    activeWindow = null;
+                if (CompositorService.isNiri) {
+                    if (NiriService.currentOutput === (parentScreen?.name ?? ""))
+                        activeWindow = null;
+                } else {
+                    const alive = ToplevelManager.toplevels?.values;
+                    if (alive && !Array.from(alive).some(t => t === activeWindow))
+                        activeWindow = null;
+                }
             }
             return;
         }
@@ -68,7 +72,8 @@ BasePill {
     Connections {
         target: ToplevelManager
         function onActiveToplevelChanged() {
-            root.updateActiveWindow();
+            if (!CompositorService.isNiri)
+                root.updateActiveWindow();
         }
     }
 
@@ -81,6 +86,9 @@ BasePill {
 
     Connections {
         target: CompositorService.isNiri ? NiriService : null
+        function onWindowsChanged() {
+            root.updateActiveWindow();
+        }
         function onCurrentOutputChanged() {
             root.updateActiveWindow();
         }
@@ -117,7 +125,17 @@ BasePill {
     }
     readonly property bool hasWindowsOnCurrentWorkspace: {
         if (CompositorService.isNiri) {
-            return !!activeWindow && !!(activeWindow.title || activeWindow.appId);
+            if (!activeWindow || !(activeWindow.title || activeWindow.appId))
+                return false;
+            if (NiriService.currentOutput !== (parentScreen?.name ?? ""))
+                return true;
+            const focusedWin = NiriService.windows.find(w => w.is_focused);
+            if (!focusedWin)
+                return false;
+            const screenWsIds = new Set(
+                NiriService.allWorkspaces.filter(ws => ws.output === parentScreen.name).map(ws => ws.id)
+            );
+            return screenWsIds.has(focusedWin.workspace_id);
         }
 
         if (CompositorService.isHyprland) {

--- a/quickshell/Modules/DankBar/Widgets/FocusedApp.qml
+++ b/quickshell/Modules/DankBar/Widgets/FocusedApp.qml
@@ -53,8 +53,11 @@ BasePill {
 
         if (!parentScreen || CompositorService.filterCurrentDisplay([active], parentScreen?.name)?.length > 0) {
             activeWindow = active;
+        } else if (activeWindow) {
+            const alive = ToplevelManager.toplevels?.values;
+            if (alive && !Array.from(alive).some(t => t === activeWindow))
+                activeWindow = null;
         }
-        // else: active window is on a different screen so keep the previous value
     }
 
     Component.onCompleted: {
@@ -72,6 +75,13 @@ BasePill {
     Connections {
         target: CompositorService
         function onToplevelsChanged() {
+            root.updateActiveWindow();
+        }
+    }
+
+    Connections {
+        target: CompositorService.isNiri ? NiriService : null
+        function onCurrentOutputChanged() {
             root.updateActiveWindow();
         }
     }
@@ -107,21 +117,7 @@ BasePill {
     }
     readonly property bool hasWindowsOnCurrentWorkspace: {
         if (CompositorService.isNiri) {
-            let currentWorkspaceId = null;
-            for (var i = 0; i < NiriService.allWorkspaces.length; i++) {
-                const ws = NiriService.allWorkspaces[i];
-                if (ws.is_focused) {
-                    currentWorkspaceId = ws.id;
-                    break;
-                }
-            }
-
-            if (!currentWorkspaceId) {
-                return false;
-            }
-
-            const workspaceWindows = NiriService.windows.filter(w => w.workspace_id === currentWorkspaceId);
-            return workspaceWindows.length > 0 && activeWindow && (activeWindow.title || activeWindow.appId);
+            return !!activeWindow && !!(activeWindow.title || activeWindow.appId);
         }
 
         if (CompositorService.isHyprland) {

--- a/quickshell/Services/CompositorService.qml
+++ b/quickshell/Services/CompositorService.qml
@@ -371,8 +371,21 @@ Singleton {
     function filterCurrentDisplay(toplevels, screenName) {
         if (!toplevels || toplevels.length === 0 || !screenName)
             return toplevels;
-        if (useNiriSorting)
+        if (useNiriSorting) {
+            const active = ToplevelManager.activeToplevel;
+            if (active && toplevels.length === 1 && toplevels[0] === active) {
+                if (NiriService.currentOutput !== screenName)
+                    return [];
+                const focusedWin = NiriService.windows.find(nw => nw.is_focused);
+                if (!focusedWin)
+                    return [];
+                const screenWsIds = new Set(
+                    NiriService.allWorkspaces.filter(ws => ws.output === screenName).map(ws => ws.id)
+                );
+                return screenWsIds.has(focusedWin.workspace_id) ? toplevels : [];
+            }
             return NiriService.filterCurrentDisplay(toplevels, screenName);
+        }
         if (isHyprland)
             return filterHyprlandCurrentDisplaySafe(toplevels, screenName);
         return toplevels;


### PR DESCRIPTION
When having multiple screens one with a workspace and a window open, if selecting an empty workspace in another screen, the first screen focused app would behave strangely(either go blank or point to a seperate window)