### PR TITLE
Fix: close notification center after clicking action buttons

### DIFF
--- a/quickshell/Modules/Notifications/Center/NotificationCard.qml
+++ b/quickshell/Modules/Notifications/Center/NotificationCard.qml
@@ -727,8 +727,10 @@ Rectangle {
                                                     onEntered: parent.isHovered = true
                                                     onExited: parent.isHovered = false
                                                     onClicked: {
-                                                        if (modelData && modelData.invoke)
+                                                        if (modelData && modelData.invoke) {
                                                             modelData.invoke();
+                                                            PopoutService.closeNotificationCenter();
+                                                        }
                                                     }
                                                 }
                                             }
@@ -866,6 +868,7 @@ Rectangle {
                     onClicked: {
                         if (modelData && modelData.invoke) {
                             modelData.invoke();
+                            PopoutService.closeNotificationCenter();
                         }
                     }
                 }

--- a/quickshell/Modules/Notifications/Center/NotificationCenterPopout.qml
+++ b/quickshell/Modules/Notifications/Center/NotificationCenterPopout.qml
@@ -137,6 +137,8 @@ DankPopout {
     onDprChanged: updateStablePopupHeight()
 
     onShouldBeVisibleChanged: {
+        notificationHistoryVisible = shouldBeVisible;
+
         if (shouldBeVisible) {
             NotificationService.onOverlayOpen();
             updateStablePopupHeight();

--- a/quickshell/Services/PopoutService.qml
+++ b/quickshell/Services/PopoutService.qml
@@ -93,7 +93,12 @@ Singleton {
     }
 
     function closeNotificationCenter() {
-        notificationCenterPopout?.close();
+        if (notificationCenterPopout) {
+            if (notificationCenterPopout.notificationHistoryVisible !== undefined)
+                notificationCenterPopout.notificationHistoryVisible = false;
+            else
+                notificationCenterPopout.close();
+        }
     }
 
     function unloadNotificationCenter() {

--- a/quickshell/Services/PopoutService.qml
+++ b/quickshell/Services/PopoutService.qml
@@ -93,12 +93,7 @@ Singleton {
     }
 
     function closeNotificationCenter() {
-        if (notificationCenterPopout) {
-            if (notificationCenterPopout.notificationHistoryVisible !== undefined)
-                notificationCenterPopout.notificationHistoryVisible = false;
-            else
-                notificationCenterPopout.close();
-        }
+        notificationCenterPopout?.close();
     }
 
     function unloadNotificationCenter() {


### PR DESCRIPTION
Closes #2178

Close the notification center when clicking notification action buttons, matching the existing behavior of the popup toast, keyboard navigation (`NotificationKeyboardController`), and control center widgets. This lets the relevant app receive focus after the action is invoked, rather than being blocked by the layer-shell surface.

Also sync `notificationHistoryVisible` from `onShouldBeVisibleChanged` so that programmatic `close()` calls (like from `PopoutService.closeNotificationCenter()`) keep the property consistent. Without this, the bell toggle requires two presses to reopen after a programmatic close.

### Before

https://github.com/user-attachments/assets/63ecffec-30de-40c7-85f4-56e6d8f65325

### After

https://github.com/user-attachments/assets/0f2d5a88-3bed-4f94-925f-d567672736c1