### PR TITLE
feat(desktop): expose accept keyboard focus to desktop widgets

### DIFF
--- a/quickshell/Modules/Plugins/DesktopPluginWrapper.qml
+++ b/quickshell/Modules/Plugins/DesktopPluginWrapper.qml
@@ -211,6 +211,7 @@ Item {
     property real minWidth: contentLoader.item?.minWidth ?? 100
     property real minHeight: contentLoader.item?.minHeight ?? 100
     property bool forceSquare: contentLoader.item?.forceSquare ?? false
+    property bool acceptsKeyboardFocus: contentLoader.item?.acceptsKeyboardFocus ?? false
     property bool isInteracting: dragArea.pressed || resizeArea.pressed
 
     property var _gridSettingsTrigger: SettingsData.desktopWidgetGridSettings
@@ -299,11 +300,14 @@ Item {
         }
         WlrLayershell.exclusionMode: ExclusionMode.Ignore
         WlrLayershell.keyboardFocus: {
-            if (!root.isInteracting)
-                return WlrKeyboardFocus.None;
-            if (CompositorService.useHyprlandFocusGrab)
+            if (root.isInteracting) {
+                if (CompositorService.useHyprlandFocusGrab)
+                    return WlrKeyboardFocus.OnDemand;
+                return WlrKeyboardFocus.Exclusive;
+            }
+            if (root.acceptsKeyboardFocus)
                 return WlrKeyboardFocus.OnDemand;
-            return WlrKeyboardFocus.Exclusive;
+            return WlrKeyboardFocus.None;
         }
 
         HyprlandFocusGrab {


### PR DESCRIPTION
# Feature
Enables keyboard access for desktop widgets. 

# Example 
A Stickies desktop widget I'm writing utilizes this:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0bcca381-5730-41f6-972a-55ecb5a58142" />


# To use
Widgets can opt in by setting:
```qml
  DesktopPluginComponent {                                               
      property bool acceptsKeyboardFocus: true                         
  }
```