### PR TITLE
feat(desktop): expose screen var to desktop plugins

### DIFF
--- a/quickshell/Modules/Plugins/DesktopPluginWrapper.qml
+++ b/quickshell/Modules/Plugins/DesktopPluginWrapper.qml
@@ -407,6 +407,8 @@ Item {
                     item.widgetWidth = Qt.binding(() => contentLoader.width);
                 if (item.widgetHeight !== undefined)
                     item.widgetHeight = Qt.binding(() => contentLoader.height);
+                if (item.screen !== undefined)
+                    item.screen = Qt.binding(() => root.screen);
             }
         }
 


### PR DESCRIPTION
# Feature
Exposes screen information to desktop widgets. This helps widgets in multi-monitor setups.

# Example
I am able to easily split widget behaviors based on what monitor i'm in. In this case, i've built-in dragging in the plugin and benefits from knowing which screen's widget to drag. 

https://github.com/user-attachments/assets/a3683c20-cf8a-490e-a9ac-881baf4d287b

# To Use
```qml
DesktopPluginComponent {
    property var screen: null // injected by the wrapper
}
```