### PR TITLE
processes: fix list gaps and overlap when searching

### DIFF
--- a/quickshell/Modules/ProcessList/ProcessesView.qml
+++ b/quickshell/Modules/ProcessList/ProcessesView.qml
@@ -301,10 +301,10 @@ Item {
             clip: true
             spacing: 2
 
-            add: root.searchText.length > 0 ? ListViewTransitions.add : null
-            remove: root.searchText.length > 0 ? ListViewTransitions.remove : null
-            displaced: root.searchText.length > 0 ? ListViewTransitions.displaced : null
-            move: root.searchText.length > 0 ? ListViewTransitions.move : null
+            add: null
+            remove: null
+            displaced: null
+            move: null
 
             model: ScriptModel {
                 values: root.cachedProcesses


### PR DESCRIPTION
When searching in the process list the transitions caused some misbehavior like gaps and overlaps. Getting rid of the transitions solves it entirely. If a different fix is wanted feel free to close the PR.
<img width="635" height="377" alt="image" src="https://github.com/user-attachments/assets/db299532-10a2-44e7-9229-1f07f75c49f7" />
<img width="628" height="505" alt="image" src="https://github.com/user-attachments/assets/f4b758f9-7523-4638-a8f4-e3b4bfae337d" />

