### PR TITLE
matugen: fix emacs template constant line number size

### DIFF
--- a/quickshell/matugen/templates/dank-emacs.el
+++ b/quickshell/matugen/templates/dank-emacs.el
@@ -243,8 +243,8 @@
    `(which-key-special-key-face ((t (:foreground ,dank-yellow :weight bold))))
 
    ;; Line numbers
-   `(line-number ((t (:foreground ,dank-gray :inherit fixed-pitch))))
-   `(line-number-current-line ((t (:foreground ,dank-cyan :weight bold :inherit fixed-pitch))))
+   `(line-number ((t (:foreground ,dank-gray :inherit default))))
+   `(line-number-current-line ((t (:foreground ,dank-cyan :weight bold :inherit default))))
 
    ;; Parenthesis matching
    `(sp-show-pair-match-face ((t (:background ,primary-container :foreground ,dank-cyan-bright))))


### PR DESCRIPTION
Made it so line numbers don't stay a constant size when changing buffer text scale.

See this thread:
<https://emacs.stackexchange.com/questions/74507/constant-font-size-in-display-line-numbers-mode-when-zooming-in-and-out>

Before:

<img width="1096" height="614" alt="image" src="https://github.com/user-attachments/assets/379227c3-c578-482a-98e9-ff89b72edd07" />

After:

<img width="1096" height="614" alt="image" src="https://github.com/user-attachments/assets/b4d84bea-2d7e-4d1a-89ab-1d422c0bc37f" />
