### PR TITLE
Add inline sliders to Control Center toggle buttons

### DIFF
--- a/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
+++ b/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
@@ -150,13 +150,11 @@ Column {
                                 return builtinPluginWidgetComponent;
                             } else if (id.startsWith("plugin_")) {
                                 return pluginWidgetComponent;
-                            } else if (id === "wifi" || id === "bluetooth" || id === "audioOutput" || id === "audioInput") {
+} else if (id === "wifi" || id === "bluetooth" || id === "audioOutput" || id === "audioInput" || id === "brightnessSlider") {
                                 return compoundPillComponent;
                             } else if (id === "volumeSlider") {
                                 return audioSliderComponent;
                             } else if (id === "brightnessSlider") {
-                                return brightnessSliderComponent;
-                            } else if (id === "inputVolumeSlider") {
                                 return inputAudioSliderComponent;
                             } else if (id === "battery") {
                                 return widgetWidth <= 25 ? smallBatteryComponent : batteryPillComponent;
@@ -235,6 +233,88 @@ Column {
             property var widgetDef: root.model?.getWidgetForId(widgetData.id || "")
             width: parent.width
             height: 60
+
+            hasSlider: {
+                const id = widgetData.id || "";
+                return id === "audioOutput" || id === "audioInput" || id === "brightnessSlider";
+            }
+            sliderValue: {
+                const id = widgetData.id || "";
+                if (id === "audioOutput") {
+                    return Math.round((AudioService.sink?.audio?.volume ?? 0.5) * 100);
+                } else if (id === "audioInput") {
+                    return Math.round((AudioService.source?.audio?.volume ?? 0.5) * 100);
+                } else if (id === "brightnessSlider") {
+                    DisplayService.brightnessVersion;
+                    const targetDeviceName = (() => {
+                        if (!DisplayService.brightnessAvailable || !DisplayService.devices || DisplayService.devices.length === 0) {
+                            return "";
+                        }
+                        const screenName = root.screenName || "";
+                        const pins = SettingsData.brightnessDevicePins || {};
+                        if (screenName && pins[screenName]) {
+                            const found = DisplayService.devices.find(d => d.name === pins[screenName]);
+                            if (found) return found.name;
+                        }
+                        const deviceName = widgetData.deviceName || "";
+                        if (deviceName) {
+                            const found = DisplayService.devices.find(d => d.name === deviceName);
+                            if (found) return found.name;
+                        }
+                        const currentDevice = DisplayService.currentDevice;
+                        if (currentDevice) {
+                            const found = DisplayService.devices.find(d => d.name === currentDevice);
+                            if (found) return found.name;
+                        }
+                        const backlight = DisplayService.devices.find(d => d.class === "backlight");
+                        if (backlight) return backlight.name;
+                        const ddc = DisplayService.devices.find(d => d.class === "ddc");
+                        if (ddc) return ddc.name;
+                        return DisplayService.devices[0]?.name || "";
+                    })();
+                    return targetDeviceName ? DisplayService.getDeviceBrightness(targetDeviceName) : 50;
+                }
+                return 50;
+            }
+            sliderAction: (value) => {
+                const id = widgetData.id || "";
+                if (id === "audioOutput" && AudioService.sink?.audio) {
+                    AudioService.sink.audio.volume = value / 100;
+                } else if (id === "audioInput" && AudioService.source?.audio) {
+                    AudioService.source.audio.volume = value / 100;
+                } else if (id === "brightnessSlider") {
+                    const targetDeviceName = (() => {
+                        if (!DisplayService.brightnessAvailable || !DisplayService.devices || DisplayService.devices.length === 0) {
+                            return "";
+                        }
+                        const screenName = root.screenName || "";
+                        const pins = SettingsData.brightnessDevicePins || {};
+                        if (screenName && pins[screenName]) {
+                            const found = DisplayService.devices.find(d => d.name === pins[screenName]);
+                            if (found) return found.name;
+                        }
+                        const deviceName = widgetData.deviceName || "";
+                        if (deviceName) {
+                            const found = DisplayService.devices.find(d => d.name === deviceName);
+                            if (found) return found.name;
+                        }
+                        const currentDevice = DisplayService.currentDevice;
+                        if (currentDevice) {
+                            const found = DisplayService.devices.find(d => d.name === currentDevice);
+                            if (found) return found.name;
+                        }
+                        const backlight = DisplayService.devices.find(d => d.class === "backlight");
+                        if (backlight) return backlight.name;
+                        const ddc = DisplayService.devices.find(d => d.class === "ddc");
+                        if (ddc) return ddc.name;
+                        return DisplayService.devices[0]?.name || "";
+                    })();
+                    if (targetDeviceName) {
+                        DisplayService.setBrightness(value, targetDeviceName);
+                    }
+                }
+            }
+
             iconName: {
                 switch (widgetData.id || "") {
                 case "wifi":
@@ -284,6 +364,46 @@ Column {
                         let muted = AudioService.source.audio.muted;
                         return muted ? "mic_off" : "mic";
                     }
+                case "brightnessSlider":
+                    {
+                        const targetDeviceName = (() => {
+                            if (!DisplayService.brightnessAvailable || !DisplayService.devices || DisplayService.devices.length === 0) {
+                                return "";
+                            }
+                            const screenName = root.screenName || "";
+                            const pins = SettingsData.brightnessDevicePins || {};
+                            if (screenName && pins[screenName]) {
+                                const found = DisplayService.devices.find(d => d.name === pins[screenName]);
+                                if (found) return found.name;
+                            }
+                            const deviceName = widgetData.deviceName || "";
+                            if (deviceName) {
+                                const found = DisplayService.devices.find(d => d.name === deviceName);
+                                if (found) return found.name;
+                            }
+                            const currentDevice = DisplayService.currentDevice;
+                            if (currentDevice) {
+                                const found = DisplayService.devices.find(d => d.name === currentDevice);
+                                if (found) return found.name;
+                            }
+                            const backlight = DisplayService.devices.find(d => d.class === "backlight");
+                            if (backlight) return backlight.name;
+                            const ddc = DisplayService.devices.find(d => d.class === "ddc");
+                            if (ddc) return ddc.name;
+                            return DisplayService.devices[0]?.name || "";
+                        })();
+                        const device = DisplayService.devices?.find(d => d.name === targetDeviceName);
+                        if (!device) return "brightness_low";
+                        if (device.class === "backlight" || device.class === "ddc") {
+                            const brightness = DisplayService.getDeviceBrightness(targetDeviceName);
+                            if (brightness <= 33) return "brightness_low";
+                            if (brightness <= 66) return "brightness_medium";
+                            return "brightness_high";
+                        } else if (targetDeviceName.includes("kbd")) {
+                            return "keyboard";
+                        }
+                        return "lightbulb";
+                    }
                 default:
                     return widgetDef?.icon || "help";
                 }
@@ -324,6 +444,8 @@ Column {
                     return AudioService.sink?.description || I18n.tr("No output device", "audio status");
                 case "audioInput":
                     return AudioService.source?.description || I18n.tr("No input device", "audio status");
+                case "brightnessSlider":
+                    return "";
                 default:
                     return widgetDef?.text || I18n.tr("Unknown", "widget status");
                 }

--- a/quickshell/Modules/ControlCenter/Widgets/CompoundPill.qml
+++ b/quickshell/Modules/ControlCenter/Widgets/CompoundPill.qml
@@ -16,6 +16,12 @@ Rectangle {
     property bool isActive: false
     property bool showExpandArea: true
 
+    property bool hasSlider: false
+    property real sliderValue: 50
+    property real sliderMin: 0
+    property real sliderMax: 100
+    property var sliderAction: null
+
     signal toggled
     signal expandClicked
     signal wheelEvent(var wheelEvent)
@@ -138,7 +144,9 @@ Rectangle {
             Column {
                 anchors.left: parent.left
                 anchors.right: parent.right
-                anchors.verticalCenter: parent.verticalCenter
+                anchors.top: root.hasSlider && root.primaryText ? parent.top : undefined
+                anchors.topMargin: root.hasSlider && root.primaryText ? 10 : 0
+                anchors.verticalCenter: root.hasSlider && root.primaryText ? undefined : parent.verticalCenter
                 spacing: 2
 
                 StyledText {
@@ -156,11 +164,27 @@ Rectangle {
                     text: root.secondaryText
                     color: _labelSecondary
                     font.pixelSize: Theme.fontSizeSmall
-                    visible: text.length > 0
+                    visible: text.length > 0 && !root.hasSlider
                     elide: Text.ElideRight
                     wrapMode: Text.NoWrap
                     horizontalAlignment: Text.AlignLeft
                 }
+            }
+
+            DankSlider {
+                id: inlineSlider
+                z: 1
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: root.primaryText ? parent.bottom : undefined
+                anchors.bottomMargin: root.primaryText ? 4 : 0
+                anchors.verticalCenter: root.primaryText ? undefined : parent.verticalCenter
+                height: 28
+                visible: root.hasSlider
+                minimum: root.sliderMin
+                maximum: root.sliderMax
+                value: root.sliderValue
+                onSliderValueChanged: (value) => { if (root.sliderAction) root.sliderAction(value) }
             }
 
             MouseArea {


### PR DESCRIPTION
## Summary
Add inline sliders to Control Center toggle buttons for audio output, audio input, and brightness.

## Behavior
- **audioOutput/audioInput**: Slider shows current volume, adjusts on change
- **brightnessSlider**: Uses same device resolution logic as original `BrightnessSliderRow` component
  - Respects screen-to-device pins (`SettingsData.brightnessDevicePins`)
  - Falls back to widget deviceName, then currentDevice, then first available device
  - Icons change dynamically based on brightness level (low/medium/high)
  - No title (primaryText empty) so slider centers like original component

## Implementation
- `CompoundPill`: Added `hasSlider`, `sliderValue`, `sliderMin`, `sliderMax`, `sliderAction` properties
- `DragDropGrid`: Added slider logic for widget types + icon/primaryText cases for brightnessSlider

## Motivation
This approach is **composable** - slider behavior added via properties to existing CompoundPill, no new widget types needed.

## Screenshots
Before:
<img width="985" height="663" alt="ss-20260501-084910" src="https://github.com/user-attachments/assets/c124b294-f8fa-4d8f-8881-47def87d2697" />

After:
<img width="985" height="573" alt="ss-20260501-085820" src="https://github.com/user-attachments/assets/e9384eac-855f-4b71-8c17-9670293d946e" />
