### PR TITLE
fix: clean up orphaned idle inhibitor processes on startup

### DIFF
--- a/quickshell/Services/SessionService.qml
+++ b/quickshell/Services/SessionService.qml
@@ -66,6 +66,7 @@ Singleton {
             detectHibernateProcess.running = true;
             detectPrimeRunProcess.running = true;
             detectWtypeProcess.running = true;
+            cleanupOrphanedInhibitors();
             log.info("Native inhibitor available:", nativeInhibitorAvailable);
             if (!SettingsData.loginctlLockIntegration) {
                 log.debug("loginctl lock integration disabled by user");
@@ -458,6 +459,26 @@ Singleton {
                 log.warn("Inhibitor process crashed with exit code:", exitCode);
                 idleInhibited = false;
                 ToastService.showWarning("Idle inhibitor failed");
+            }
+        }
+    }
+
+    // Kill orphaned idle inhibitor processes left behind by previous quickshell sessions.
+    // When quickshell crashes or is force-killed, the child systemd-inhibit process gets
+    // reparented to PID 1 and continues to block idle indefinitely.
+    function cleanupOrphanedInhibitors() {
+        if (nativeInhibitorAvailable) return;
+        orphanCleanupProcess.running = true;
+    }
+
+    Process {
+        id: orphanCleanupProcess
+        running: false
+        command: ["pkill", "-f", "systemd-inhibit --what=idle --who=quickshell.*sleep infinity"]
+
+        onExited: function (exitCode) {
+            if (exitCode === 0) {
+                log.info("Cleaned up orphaned idle inhibitor process(es) from a previous session");
             }
         }
     }


### PR DESCRIPTION
## Problem

When quickshell crashes or is force-killed, the child `systemd-inhibit` process (used as a fallback when native `IdleInhibitor` Wayland protocol is unavailable) gets reparented to PID 1 and continues to block idle **indefinitely**.

This causes `hypridle` (or any idle daemon respecting `systemd-inhibit` locks) to ignore all idle timeout rules, even though the idle inhibitor widget appears inactive after quickshell restarts.

### Reproduction

1. Enable the idle inhibitor widget in the bar (or have it enabled at any point)
2. Force-kill quickshell (`kill -9`) or let it crash
3. Restart quickshell — the widget shows "not inhibited"
4. Run `systemd-inhibit --list` — orphaned process still present:
   ```
   quickshell  1000  ksp  <old-pid>  systemd-inhibit  idle  Keep system awake  block
   ```
5. `hypridle` logs confirm: `Ignoring from onIdled(), inhibit locks: 1`

### Root Cause

`SessionService.qml` spawns `systemd-inhibit --what=idle --who=quickshell --mode=block sleep infinity` as a child process. When quickshell exits abnormally, this process is not cleaned up and persists as an orphan under PID 1.

## Fix

Add a cleanup step during `sessionInitTimer` that kills any orphaned `systemd-inhibit` processes matching the exact command pattern used by DMS. This only runs when native `IdleInhibitor` is unavailable (i.e., the fallback path that spawns the process).

The cleanup is safe because:
- It matches a very specific pattern (`systemd-inhibit --what=idle --who=quickshell.*sleep infinity`)
- It only targets processes spawned by quickshell's own idle inhibitor
- If no orphan exists, `pkill` exits silently with code 1 (no match)
- If the current session's inhibitor is active, it will be re-spawned immediately after cleanup by the existing `running: idleInhibited && !nativeInhibitorAvailable` binding