### PR TITLE
lock: respect notification privacy mode

### DIFF
--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -378,6 +378,7 @@ Item {
             id: lockNotificationPanel
 
             readonly property int notificationMode: SettingsData.lockScreenNotificationMode
+            readonly property bool notificationPrivacyMode: SettingsData.notificationPopupPrivacyMode
             readonly property var notifications: NotificationService.groupedNotifications
             readonly property int totalCount: {
                 let count = 0;
@@ -650,7 +651,7 @@ Item {
                                             elide: Text.ElideRight
                                             maximumLineCount: 2
                                             wrapMode: Text.WordWrap
-                                            visible: text.length > 0
+                                            visible: !lockNotificationPanel.notificationPrivacyMode && (text.length > 0)
                                         }
                                     }
                                 }


### PR DESCRIPTION
Lock screen showed notification description irrespective of the privacy mode which isn't expected because lock screen is meant to keep your desktop private. Maybe a separate setting can be added to toggle privacy only for lock screen