### PR TITLE
bar: fix fullscreen-detection race during cross-monitor focus moves

### DIFF
--- a/quickshell/Services/CompositorService.qml
+++ b/quickshell/Services/CompositorService.qml
@@ -417,7 +417,7 @@ Singleton {
 
         if (isNiri) {
             const active = ToplevelManager.activeToplevel;
-            if (active?.fullscreen && active?.activated && NiriService.currentOutput === screenName)
+            if (active?.fullscreen && active?.activated && _toplevelOnScreen(active, screenName))
                 return true;
 
             const filtered = filterCurrentWorkspace(sortedToplevels, screenName);


### PR DESCRIPTION
## Problem

`CompositorService.hasFullscreenToplevelOnScreen` fires a false positive during cross-monitor focus changes when one monitor has a fullscreen toplevel, causing the bar/dock on the *destination* monitor to flicker (hide for one frame, then reappear). This is the "dbar would resurface upon the other monitor refocus shift" symptom Purian23 mentioned in the discussion on #2349.

### Reproduction

1. Two monitors. Bar configured for monitor B only.
2. A toplevel on monitor A is fullscreen + activated (e.g. Alt+F'd terminal).
3. Switch focus to a non-fullscreen toplevel on monitor B.
4. Monitor B's bar hides for one frame, then re-shows.

## Root Cause

The fast-path in the `isNiri` branch:

```qml
const active = ToplevelManager.activeToplevel;
if (active?.fullscreen && active?.activated && NiriService.currentOutput === screenName)
    return true;
```

uses `NiriService.currentOutput === screenName` as a proxy for *"the active toplevel is on screenName"*. Those are two independent state channels:

- `NiriService.currentOutput` is driven by niri's `WorkspaceActivated` IPC event.
- `ToplevelManager.activeToplevel` is driven by the wlr-foreign-toplevel-management protocol.

They don't update atomically. During a focus move from A's fullscreen toplevel to B's non-fullscreen toplevel, `currentOutput` flips to B *before* `activeToplevel` updates away from A's still-fullscreen-and-activated window. For one tick, B's bar evaluates `active.fullscreen && active.activated && currentOutput === B` → `true`, hides itself, then unhides on the next tick when `activeToplevel` finally updates.

## Fix

Replace the proxy with `_toplevelOnScreen(active, screenName)` — the same helper this function already uses 25 lines below in the X11 fallback path (line 445). The check now inspects the toplevel's actual outputs instead of trusting a separate state signal, so the race can't fire.

The per-workspace loop below was already correct: it would catch any real fullscreen+activated toplevel on the bar's workspace regardless of focused output. The fast-path was redundant when the assertion held and wrong when it didn't — this just makes its assertion match the loop's.

## Testing

Tested on niri with two monitors, bar on the right monitor (`HDMI-A-1`), Alt+F'd kitty filling the left monitor (`DP-3`). Before the patch, focusing any window on the right monitor caused a one-frame bar flicker. After the patch, the bar is stable across focus changes. No QML test harness exists to add a regression test against.

## Compatibility

Independent of and compatible with #2349. The `fullscreenDetection` toggle still gates the entire function via `_updateHasFullscreenToplevel`; this fix only corrects the per-screen logic when detection is enabled.