### PR TITLE
Theme: expose tertiary on the singleton (was undefined in dynamic mode)

### DIFF
--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -450,6 +450,7 @@ Singleton {
                 "primaryText": getMatugenColor("on_primary", "#ffffff"),
                 "primaryContainer": getMatugenColor("primary_container", "#1976d2"),
                 "secondary": getMatugenColor("secondary", "#8ab4f8"),
+                "tertiary": getMatugenColor("tertiary", "#efb8c8"),
                 "surface": getMatugenColor("surface", "#1a1c1e"),
                 "surfaceText": getMatugenColor("on_background", "#e3e8ef"),
                 "surfaceVariant": getMatugenColor("surface_variant", "#44464f"),
@@ -522,6 +523,7 @@ Singleton {
     property color primaryText: currentThemeData.primaryText
     property color primaryContainer: currentThemeData.primaryContainer
     property color secondary: currentThemeData.secondary
+    property color tertiary: currentThemeData.tertiary || currentThemeData.secondary
     property color surface: currentThemeData.surface
     property color surfaceText: currentThemeData.surfaceText
     property color surfaceVariant: currentThemeData.surfaceVariant


### PR DESCRIPTION
## Problem

`Theme.tertiary` is referenced at `LockScreenContent.qml:737` and is part of DMS's intended Material You exposure, but the singleton's dynamic-mode `currentThemeData` object (`Theme.qml:447-468`) doesn't include a `tertiary` key. As a result, any QML reading `Theme.tertiary` while the active theme is `dynamic` (matugen-from-wallpaper) gets `undefined`, which Qt then converts to a default-white when accessed via `.r`/`.g`/`.b`/`.a`.

This is silent — no warning, no error — and produces white pixels where matugen-derived pink (or whatever the wallpaper-derived tertiary actually is) was expected.

### Reproduction

1. `SettingsData.currentThemeName = "dynamic"` and a real wallpaper set in `SessionData.wallpaperPath`.
2. Watch the journal for `Setting desired theme - image mode: dark (dynamic)` — confirms the dynamic branch fires and matugen runs.
3. `cat ~/.config/DankMaterialShell/firefox.css` — confirms matugen wrote a real tertiary hex (e.g. `--md-sys-color-tertiary: #e7b9d6` in dark mode).
4. In any QML reading `Theme.tertiary`, the value is undefined → defaults to white when used.

### Root Cause

`Theme.qml:447-468` (the `dynamic` branch of `currentThemeData`) builds an inline object with `primary`, `primaryText`, `primaryContainer`, `secondary`, `surface`, `surfaceText`, etc. — but **no `tertiary` key**, even though `getMatugenColor("tertiary", ...)` would return a real value.

The singleton then has explicit `property color X: currentThemeData.X` declarations for primary/secondary/surface/etc. but **no `property color tertiary` declaration at all**. The non-dynamic stock-theme path adds tertiary via `addColor("tertiary", ...)` at `Theme.qml:1811`, but that populates a *local colors object passed to matugen as input* — it doesn't add a property to the Theme singleton.

So `Theme.tertiary` is actually undefined in every theme mode, but the symptom is most visible in dynamic mode where the user expects matugen-derived chromaticity.

## Fix

Two-line patch:

1. Add `"tertiary": getMatugenColor("tertiary", "#efb8c8")` to the dynamic-mode `currentThemeData` object. Fallback `#efb8c8` is the M3 baseline tertiary for dark mode, used only if matugen output is missing the key.
2. Add `property color tertiary: currentThemeData.tertiary || currentThemeData.secondary` on the Theme singleton, falling back to secondary if tertiary is absent (covers the stock-theme path where tertiary may not be set on `currentThemeData`).

Other theme paths (custom, stock) populate `currentThemeData` from sources that may or may not include tertiary; the `|| currentThemeData.secondary` fallback handles both.

## Testing

Tested on niri with `currentThemeName = "dynamic"` and a wallpaper that produces a distinct tertiary hue. Before: `Theme.tertiary` evaluated to undefined, downstream consumers rendered white. After: `Theme.tertiary` returns the matugen-generated hex (`#e7b9d6` in dark mode for the test wallpaper), matching what `firefox.css` and other matugen template outputs already received.

No QML test infrastructure exists for Theme — manual verification matches the bar of recent fix PRs (#2324, #2317, etc.).