### PR TITLE
feat: add expandable search bar to plugins settings tab

### DIFF
--- a/quickshell/Modules/Settings/PluginsTab.qml
+++ b/quickshell/Modules/Settings/PluginsTab.qml
@@ -16,6 +16,28 @@ FocusScope {
     property var installedPluginsData: ({})
     property bool isReloading: false
     property alias sharedTooltip: sharedTooltip
+    property bool isSearchExpanded: false
+    property string searchQuery: ""
+    property var filteredPlugins: []
+
+    function updateFilteredPlugins() {
+        var query = searchQuery.toLowerCase();
+        filteredPlugins = PluginService.availablePluginsList.filter(plugin => {
+            if (!query) return true;
+            var name = (plugin.name || "").toLowerCase();
+            var desc = (plugin.description || "").toLowerCase();
+            var author = (plugin.author || "").toLowerCase();
+            return name.includes(query) || desc.includes(query) || author.includes(query);
+        });
+    }
+
+
+    Connections {
+        target: PluginService
+        function onAvailablePluginsListChanged() {
+            pluginsTab.updateFilteredPlugins();
+        }
+    }
 
     focus: true
 
@@ -296,13 +318,72 @@ FocusScope {
                     anchors.margins: Theme.spacingL
                     spacing: Theme.spacingM
 
-                    StyledText {
-                        text: I18n.tr("Available Plugins")
-                        font.pixelSize: Theme.fontSizeLarge
-                        color: Theme.surfaceText
-                        font.weight: Font.Medium
+                    Row {
                         width: parent.width
-                        horizontalAlignment: Text.AlignLeft
+                        spacing: Theme.spacingM
+
+                        StyledText {
+                            text: I18n.tr("Available Plugins")
+                            font.pixelSize: Theme.fontSizeLarge
+                            color: Theme.surfaceText
+                            font.weight: Font.Medium
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+
+                        Item {
+                            width: parent.width - parent.children[0].implicitWidth - searchIconBtn.width - parent.spacing * 2
+                            height: 1
+                        }
+
+                        DankActionButton {
+                            id: searchIconBtn
+                            iconName: "search"
+                            iconSize: 20
+                            iconColor: pluginsTab.isSearchExpanded ? Theme.primary : Theme.surfaceVariantText
+                            anchors.verticalCenter: parent.verticalCenter
+                            onClicked: {
+                                pluginsTab.isSearchExpanded = !pluginsTab.isSearchExpanded;
+                                if (pluginsTab.isSearchExpanded) {
+                                    Qt.callLater(() => pluginSearchField.forceActiveFocus());
+                                } else {
+                                    pluginSearchField.text = "";
+                                    pluginsTab.searchQuery = "";
+                                    pluginsTab.updateFilteredPlugins();
+                                }
+                            }
+                        }
+                    }
+
+                    DankTextField {
+                        id: pluginSearchField
+                        width: parent.width
+                        visible: pluginsTab.isSearchExpanded || height > 0
+                        height: pluginsTab.isSearchExpanded ? 48 : 0
+                        opacity: pluginsTab.isSearchExpanded ? 1 : 0
+                        clip: true
+                        placeholderText: I18n.tr("Search installed plugins...")
+                        leftIconName: "search"
+                        showClearButton: true
+
+                        Behavior on height {
+                            enabled: Theme.currentAnimationSpeed !== SettingsData.AnimationSpeed.None
+                            NumberAnimation {
+                                duration: Theme.shortDuration
+                                easing.type: Theme.standardEasing
+                            }
+                        }
+
+                        Behavior on opacity {
+                            enabled: Theme.currentAnimationSpeed !== SettingsData.AnimationSpeed.None
+                            NumberAnimation {
+                                duration: Theme.shortDuration
+                            }
+                        }
+
+                        onTextEdited: {
+                            pluginsTab.searchQuery = text;
+                            pluginsTab.updateFilteredPlugins();
+                        }
                     }
 
                     Column {
@@ -311,7 +392,7 @@ FocusScope {
 
                         Repeater {
                             id: pluginRepeater
-                            model: PluginService.availablePluginsList
+                            model: pluginsTab.filteredPlugins
 
                             PluginListItem {
                                 pluginData: modelData
@@ -415,6 +496,7 @@ FocusScope {
     }
 
     Component.onCompleted: {
+        updateFilteredPlugins();
         if (DMSService.dmsAvailable && DMSService.apiVersion >= 8)
             DMSService.listInstalled();
         if (PopoutService.pendingPluginInstall)


### PR DESCRIPTION
### **What**:
Introduced an expandable search bar in the "Available Plugins" section of the Settings menu.
- Added a search icon (magnifying glass) to the right of the "Available Plugins" title.
- Implemented real-time filtering of the plugin list based on **Name**, **Description**, and **Author**.
- Added smooth height and opacity transitions for the search field expansion.
- Auto-focuses the search field when expanded.

### **Why**:
As the number of available plugins grows, it becomes difficult for users to find specific plugins in the settings menu. A search bar improves the user experience by allowing quick discovery and management of installed plugins.

### **How tested**:
- Manually tested by running `quickshell -p quickshell/`.
- Verified that the search icon toggles the search bar and resets the filter when collapsed.
- Verified that the search is case-insensitive.
- Verified that the list remains in sync when plugins are added/removed.

<img width="1122" height="560" alt="image" src="https://github.com/user-attachments/assets/1de66124-dc3f-43a4-8656-4444812f5a2c" />
