### PR TITLE
fix(ipc): dash and dankdash commands work without clock widget

### DIFF
--- a/quickshell/DMSShellIPC.qml
+++ b/quickshell/DMSShellIPC.qml
@@ -176,7 +176,7 @@ Item {
         }
 
         function open(tab: string): string {
-            const bar = root.getPreferredBar("clockButtonRef");
+            const bar = root.getPreferredBar("clockButtonRef") || root.getPreferredBar();
             if (!bar)
                 return "DASH_OPEN_FAILED";
 
@@ -209,7 +209,7 @@ Item {
                 return "DASH_TOGGLE_SUCCESS";
             }
 
-            const bar = root.getPreferredBar("clockButtonRef");
+            const bar = root.getPreferredBar("clockButtonRef") || root.getPreferredBar();
             if (bar) {
                 if (!bar.triggerDashTab(resolveTabIndex(tab)))
                     return "DASH_TOGGLE_FAILED";
@@ -582,7 +582,7 @@ Item {
 
     IpcHandler {
         function wallpaper(): string {
-            const bar = root.getPreferredBar("clockButtonRef");
+            const bar = root.getPreferredBar("clockButtonRef") || root.getPreferredBar();
             if (bar) {
                 bar.triggerWallpaperBrowser();
                 return "SUCCESS: Toggled wallpaper browser";


### PR DESCRIPTION
## Summary
- Dash IPC commands (`dash open`, `dash toggle`, `dankdash wallpaper`) fail when the clock widget is removed from the bar
- `getPreferredBar("clockButtonRef")` returns null without a clock, so the IPC never reaches `triggerDashTab`
- Fall back to `getPreferredBar()` (any bar) - `triggerDashTab` already handles missing clock positioning gracefully