### PR TITLE
fix(DankTextField): set TextInput 'fontFamily'

### DIFF
--- a/quickshell/Widgets/DankTextField.qml
+++ b/quickshell/Widgets/DankTextField.qml
@@ -116,6 +116,7 @@ StyledRect {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: root.bottomPadding
         font.pixelSize: Theme.fontSizeMedium
+        font.family: Theme.fontFamily
         color: Theme.surfaceText
         selectionColor: Theme.primaryContainer
         selectedTextColor: Theme.primary


### PR DESCRIPTION
Absolutely minor fix that allows input fields using the `DankTextField` widget to properly inherit their font family from `Theme`.

Without this, such fields[^1] seem to fallback directly on the default font (Inter), unless (in my tests) `QT_QPA_PLATFORM` is set to `qt5ct` or `qt6ct` and a font is set there.

Since it feels a bit counter-intuitive, I guess this is not the intended behavior (apologize in advance if it is).

### Screenshots

#### Before
<img width="609" height="97" alt="LauncherScreenshot_Before" src="https://github.com/user-attachments/assets/ecc212bb-925d-454e-93b4-c59f9114424c" title="Before patch (font=Inter)" />

#### After
<img width="609" height="97" alt="LauncherScreenshot_After" src="https://github.com/user-attachments/assets/dd6e467a-8e0e-4df9-ae14-860c7fd35d37" title="After path (font=Agave Nerd Font)" />

[^1]: i.e. the launcher and settings search fields, custom command fields in various settings tabs, etc.