### PR TITLE
feat: consolidate plugin directory management into a single dynamic button

### DIFF
--- a/quickshell/Modules/Settings/PluginsTab.qml
+++ b/quickshell/Modules/Settings/PluginsTab.qml
@@ -250,19 +250,15 @@ FocusScope {
                         }
 
                         DankButton {
-                            text: I18n.tr("Create Dir")
-                            iconName: "create_new_folder"
+                            text: PluginService.pluginDirectoryExists ? I18n.tr("Open Dir") : I18n.tr("Create Dir")
+                            iconName: PluginService.pluginDirectoryExists ? "folder_open" : "create_new_folder"
                             onClicked: {
-                                PluginService.createPluginDirectory();
-                                ToastService.showInfo("Created plugin directory: " + PluginService.pluginDirectory);
-                            }
-                        }
-
-                        DankButton {
-                            text: I18n.tr("Open Dir")
-                            iconName: "folder_open"
-                            onClicked: {
-                                PluginService.openPluginDirectory();
+                                if (PluginService.pluginDirectoryExists) {
+                                    PluginService.openPluginDirectory();
+                                } else {
+                                    PluginService.createPluginDirectory();
+                                    ToastService.showInfo("Created plugin directory: " + PluginService.pluginDirectory);
+                                }
                             }
                         }
                     }

--- a/quickshell/Modules/Settings/PluginsTab.qml
+++ b/quickshell/Modules/Settings/PluginsTab.qml
@@ -257,6 +257,14 @@ FocusScope {
                                 ToastService.showInfo("Created plugin directory: " + PluginService.pluginDirectory);
                             }
                         }
+
+                        DankButton {
+                            text: I18n.tr("Open Dir")
+                            iconName: "folder_open"
+                            onClicked: {
+                                PluginService.openPluginDirectory();
+                            }
+                        }
                     }
                 }
             }

--- a/quickshell/Services/PluginService.qml
+++ b/quickshell/Services/PluginService.qml
@@ -778,6 +778,11 @@ Singleton {
         return true;
     }
 
+    function openPluginDirectory() {
+        Quickshell.execDetached(["xdg-open", pluginDirectory]);
+        return true;
+    }
+
     // Launcher plugin helper functions
     function getLauncherPlugins() {
         const launchers = {};

--- a/quickshell/Services/PluginService.qml
+++ b/quickshell/Services/PluginService.qml
@@ -20,14 +20,9 @@ Singleton {
     property var pluginLauncherComponents: ({})
     property var pluginDesktopComponents: ({})
     property var availablePluginsList: []
-    property string pluginDirectory: {
-        var configDir = StandardPaths.writableLocation(StandardPaths.ConfigLocation);
-        var configDirStr = configDir.toString();
-        if (configDirStr.startsWith("file://")) {
-            configDirStr = configDirStr.substring(7);
-        }
-        return configDirStr + "/DankMaterialShell/plugins";
-    }
+    readonly property string pluginDirectory: Paths.strip(Paths.config) + "/plugins"
+
+    property bool pluginDirectoryExists: false
     property string systemPluginDirectory: "/etc/xdg/quickshell/dms-plugins"
 
     property var knownManifests: ({})
@@ -64,10 +59,23 @@ Singleton {
         onTriggered: root._flushDirtyStates()
     }
 
+    Process {
+        id: directoryCheckProcess
+        command: ["test", "-d", root.pluginDirectory]
+        onExited: (exitCode) => {
+            root.pluginDirectoryExists = (exitCode === 0);
+        }
+    }
+
+    function checkPluginDirectoryExists() {
+        directoryCheckProcess.running = true;
+    }
+
     Component.onCompleted: {
         userWatcher.folder = Paths.toFileUrl(root.pluginDirectory);
         systemWatcher.folder = Paths.toFileUrl(root.systemPluginDirectory);
         Qt.callLater(resyncAll);
+        Qt.callLater(checkPluginDirectoryExists);
     }
 
     FolderListModel {
@@ -758,6 +766,7 @@ Singleton {
         systemWatcher.folder = "";
         systemWatcher.folder = systemUrl;
         resyncDebounce.restart();
+        checkPluginDirectoryExists();
     }
 
     function forceRescanPlugin(pluginId) {
@@ -775,11 +784,12 @@ Singleton {
 
     function createPluginDirectory() {
         Quickshell.execDetached(["mkdir", "-p", pluginDirectory]);
+        Qt.callLater(checkPluginDirectoryExists);
         return true;
     }
 
     function openPluginDirectory() {
-        Quickshell.execDetached(["xdg-open", pluginDirectory]);
+        Qt.openUrlExternally(Paths.toFileUrl(pluginDirectory));
         return true;
     }
 


### PR DESCRIPTION
## What
Consolidated the separate "Create Dir" and "Open Dir" buttons in the Plugins management tab into a single, context-aware button.

## Why
To save UI space and improve user experience. The button now dynamically updates its label, icon, and action based on whether the plugin directory actually exists on the system.

## How
- **PluginService.qml**: Added a `pluginDirectoryExists` reactive property and logic to check for the directory using a system process (`test -d`). Updated path handling to use the `Paths` singleton for better consistency.
- **PluginsTab.qml**: Replaced the static buttons with a single `DankButton` that switches between "Open Dir" and "Create Dir" states.

## Testing
- Verified that the button correctly shows "Create Dir" when the folder is missing.
- Verified that it correctly shows "Open Dir" and opens the file manager when the folder exists.
- Verified that creating the directory immediately updates the button state to "Open Dir".