### PR TITLE
feat: add default value marker to DankSlider

### DIFF
--- a/quickshell/Modules/Plugins/SliderSetting.qml
+++ b/quickshell/Modules/Plugins/SliderSetting.qml
@@ -69,6 +69,7 @@ Column {
         value: root.value
         minimum: root.minimum
         maximum: root.maximum
+        defaultValue: root.defaultValue
         leftIcon: root.leftIcon
         rightIcon: root.rightIcon
         unit: root.unit

--- a/quickshell/Widgets/DankSlider.qml
+++ b/quickshell/Widgets/DankSlider.qml
@@ -18,6 +18,8 @@ Item {
     property bool centerMinimum: false
     property real valueOverride: -1
     property bool alwaysShowValue: false
+    property int defaultValue: -1
+    property bool showDefaultMarker: false
     readonly property bool containsMouse: sliderMouseArea.containsMouse
 
     property color thumbOutlineColor: Theme.surfaceContainer
@@ -34,6 +36,7 @@ Item {
         if (centerMinimum)
             ratio = Math.max(0, (ratio - 0.5) * 2);
         let rawValue = minimum + ratio * (maximum - minimum);
+
         let newValue = step > 1 ? Math.round(rawValue / step) * step : Math.round(rawValue);
         newValue = Math.max(minimum, Math.min(maximum, newValue));
         if (newValue !== value) {
@@ -84,6 +87,25 @@ Item {
                     return Math.max(0, Math.min(sliderTrack.width, endPoint));
                 }
                 color: slider.enabled ? Theme.primary : Theme.withAlpha(Theme.onSurface, 0.12)
+            }
+
+            StyledRect {
+                id: defaultValueMarker
+                width: 3
+                height: 16
+                radius: 1.5
+                color: Theme.surfaceText
+                opacity: 0.4
+                visible: slider.showDefaultMarker && slider.defaultValue >= slider.minimum && slider.defaultValue <= slider.maximum
+                x: {
+                    const range = slider.maximum - slider.minimum;
+                    const rawRatio = range === 0 ? 0 : (slider.defaultValue - slider.minimum) / range;
+                    const ratio = slider.centerMinimum ? (0.5 + rawRatio * 0.5) : rawRatio;
+                    const travel = sliderTrack.width - sliderHandle.width;
+                    return Math.max(0, Math.min(travel, travel * ratio)) + sliderHandle.width / 2 - width / 2;
+                }
+                anchors.verticalCenter: parent.verticalCenter
+                z: 0
             }
 
             StyledRect {


### PR DESCRIPTION
### What
This PR adds an optional visual marker for default values to the `DankSlider` component.

### Why
Providing a visual indicator for default values helps users see the recommended or initial state of a setting.

### How it works
- **Property**: `defaultValue` (int) sets the value where the marker will appear.
- **Toggle**: `showDefaultMarker` (bool) must be set to `true` to display the marker. It is `false` by default to maintain compatibility.
- **Aesthetics**: The marker is a 3px wide vertical line using `Theme.surfaceText` with 0.4 opacity.

### Visual Proof
<img width="936" height="548" alt="image" src="https://github.com/user-attachments/assets/6e2bc92e-367f-4278-a8e2-76f5d4cc3746" />

### How tested
- Verified positioning logic for both standard and centered sliders.
- Verified visibility toggle.