### PR TITLE
refactor(ClipboardHistory): Sync toggle button between saved and recent tabs

### DIFF
--- a/quickshell/Modals/Clipboard/ClipboardHeader.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHeader.qml
@@ -49,8 +49,8 @@ Item {
             iconSize: Theme.iconSize - 4
             iconColor: header.activeTab === "saved" ? Theme.primary : Theme.surfaceText
             visible: header.pinnedCount > 0
-            tooltipText: I18n.tr("Saved")
-            onClicked: tabChanged("saved")
+            tooltipText: header.activeTab === "saved" ? I18n.tr("Recent") : I18n.tr("Saved")
+            onClicked: tabChanged(header.activeTab === "saved" ? "recents" : "saved")
         }
 
         DankActionButton {

--- a/quickshell/Modals/Clipboard/ClipboardHeader.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHeader.qml
@@ -54,14 +54,6 @@ Item {
         }
 
         DankActionButton {
-            iconName: "history"
-            iconSize: Theme.iconSize - 4
-            iconColor: header.activeTab === "recents" ? Theme.primary : Theme.surfaceText
-            tooltipText: I18n.tr("History")
-            onClicked: tabChanged("recents")
-        }
-
-        DankActionButton {
             iconName: "info"
             iconSize: Theme.iconSize - 4
             iconColor: showKeyboardHints ? Theme.primary : Theme.surfaceText


### PR DESCRIPTION
## Summary
- Change the Saved (pin) button to toggle between saved and recents tabs
- Remove the redundant History button for a cleaner UI
- Update tooltip text dynamically based on current tab state

## Problem
When viewing the clipboard history:
1. The Saved button always switched to saved tab but clicking again didn't return to recents
2. Two separate buttons (Saved + History) were redundant since the Saved button can toggle

## Solution
1. Changed Saved button to toggle between tabs:
```qml
// Before
onClicked: tabChanged("saved")

// After
onClicked: tabChanged(header.activeTab === "saved" ? "recents" : "saved")
```

2. Dynamic tooltip:
```qml
// Before
tooltipText: I18n.tr("Saved")

// After  
tooltipText: header.activeTab === "saved" ? I18n.tr("Recent") : I18n.tr("Saved")
```

3. Removed redundant History button

## Testing
- [x] Click Saved button -> shows pinned entries, tooltip shows "Recent"
- [x] Click Saved button again -> returns to recents tab, tooltip shows "Saved"

<img width="1094" height="994" alt="1778606893882720503" src="https://github.com/user-attachments/assets/616b3be1-1465-493d-affd-cfce3b1c767f" />

<img width="1094" height="994" alt="1778606966605758107" src="https://github.com/user-attachments/assets/79f6cdc8-cb50-4fb0-99d1-86f54289cf0a" />
