### PR TITLE
flake: expose `mkDmsShell` and `buildDmsPkgs` via lib output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -192,6 +192,8 @@
         }
       );
 
+      lib = { inherit mkDmsShell buildDmsPkgs; };
+
       homeModules.dank-material-shell = mkModuleWithDmsPkgs ./distro/nix/home.nix;
 
       homeModules.default = self.homeModules.dank-material-shell;


### PR DESCRIPTION
> [!NOTE]
> - This is a follow-up to #2244

In the prior PR, I made `mkDmsShell` parametric on pkgs and wired it through the NixOS module via `mkModuleWithDmsPkgs`, but the function itself was never exported. This PR re-exports `mkDmsShell` and `buildDmsPkgs` via lib so downstream flakes that need to layer .overrideAttrs/extraQtPackages on top can reach them without forking.