### PR TITLE
feat: add Display Profiles builtin control center widget

### DIFF
--- a/quickshell/Modules/ControlCenter/BuiltinPlugins/DisplayProfilesWidget.qml
+++ b/quickshell/Modules/ControlCenter/BuiltinPlugins/DisplayProfilesWidget.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import qs.Common
+import qs.Services
 import qs.Widgets
 import qs.Modules.Plugins
 import qs.Modules.Settings.DisplayConfig
@@ -7,28 +8,47 @@ import qs.Modules.Settings.DisplayConfig
 PluginComponent {
     id: root
 
+    readonly property var allProfiles: DisplayConfigState.validatedProfiles || ({})
     readonly property var profiles: {
-        const p = DisplayConfigState.validatedProfiles;
         const result = [];
-        for (const id in p) {
-            if (p[id].name)
-                result.push({ id: id, name: p[id].name });
+        for (const id in allProfiles) {
+            if (allProfiles[id].name)
+                result.push({ id: id, name: allProfiles[id].name });
         }
         return result;
     }
-
+    readonly property bool autoMode: SettingsData.displayProfileAutoSelect
     readonly property string activeProfileId: SettingsData.getActiveDisplayProfile(CompositorService.compositor)
-    readonly property string activeProfileName: profiles.find(p => p.id === activeProfileId)?.name ?? ""
+    readonly property var activeProfile: allProfiles[activeProfileId] || null
+    readonly property string activeProfileName: activeProfile?.name ?? ""
+    readonly property string displayProfileLabel: {
+        if (autoMode)
+            return I18n.tr("Auto");
+        if (activeProfileName.length > 0)
+            return activeProfileName;
+        if (profiles.length === 0)
+            return I18n.tr("No profiles");
+        return I18n.tr("None active");
+    }
 
     ccWidgetIcon: "monitor"
     ccWidgetPrimaryText: I18n.tr("Display")
-    ccWidgetSecondaryText: activeProfileName || (profiles.length === 0 ? I18n.tr("No profiles") : I18n.tr("None active"))
-    ccWidgetIsActive: activeProfileName.length > 0
+    ccWidgetSecondaryText: displayProfileLabel
+    ccWidgetIsActive: autoMode || activeProfileId.length > 0
 
-    onPillClicked: cycleNext()
+    onCcWidgetToggled: cycleNext()
+
+    function setAutoMode(enabled) {
+        SettingsData.displayProfileAutoSelect = enabled;
+        if (!enabled)
+            SettingsData.setActiveDisplayProfile(CompositorService.compositor, "");
+        SettingsData.saveSettings();
+        if (enabled)
+            DisplayConfigState.applyAutoConfig();
+    }
 
     function cycleNext() {
-        if (profiles.length < 2)
+        if (autoMode || profiles.length < 2)
             return;
         const idx = profiles.findIndex(p => p.id === activeProfileId);
         const next = profiles[(idx + 1) % profiles.length];
@@ -36,27 +56,156 @@ PluginComponent {
     }
 
     ccDetailContent: Component {
-        Column {
-            width: parent.width
-            spacing: Theme.spacingS
+        Rectangle {
+            id: detailRoot
+            implicitHeight: detailColumn.implicitHeight + Theme.spacingM * 2
+            radius: Theme.cornerRadius
+            color: Theme.nestedSurface
+            border.color: Theme.outlineMedium
+            border.width: Theme.layerOutlineWidth
 
-            StyledText {
-                visible: root.profiles.length === 0
-                width: parent.width
-                text: I18n.tr("No display profiles found. Create them in Settings → Displays.")
-                font.pixelSize: Theme.fontSizeSmall
-                color: Theme.surfaceVariantText
-                wrapMode: Text.WordWrap
-            }
+            Column {
+                id: detailColumn
+                anchors.fill: parent
+                anchors.margins: Theme.spacingM
+                spacing: Theme.spacingS
 
-            DankButtonGroup {
-                visible: root.profiles.length > 0
-                width: parent.width
-                model: root.profiles.map(p => p.name)
-                currentIndex: root.profiles.findIndex(p => p.id === root.activeProfileId)
-                onSelectionChanged: (index, selected) => {
-                    if (selected)
-                        DisplayConfigState.activateProfile(root.profiles[index].id);
+                Item {
+                    width: parent.width
+                    height: 32
+
+                    StyledText {
+                        text: I18n.tr("Display Profiles")
+                        font.pixelSize: Theme.fontSizeLarge
+                        color: Theme.surfaceText
+                        font.weight: Font.Medium
+                        anchors.left: parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    Row {
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Theme.spacingS
+
+                        Rectangle {
+                            id: autoButton
+                            width: autoLabel.implicitWidth + Theme.spacingL * 2
+                            height: 28
+                            radius: 14
+                            color: root.autoMode ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.16) : (autoMouseArea.containsMouse ? Theme.surfaceLight : "transparent")
+                            border.color: root.autoMode ? Theme.primary : Theme.outlineMedium
+                            border.width: root.autoMode ? 1 : Theme.layerOutlineWidth
+
+                            StyledText {
+                                id: autoLabel
+                                anchors.centerIn: parent
+                                text: I18n.tr("Auto")
+                                color: root.autoMode ? Theme.primary : Theme.surfaceVariantText
+                                font.pixelSize: Theme.fontSizeSmall
+                                font.weight: Font.Medium
+                            }
+
+                            MouseArea {
+                                id: autoMouseArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.setAutoMode(!root.autoMode)
+                            }
+                        }
+
+                        DankActionButton {
+                            id: settingsButton
+                            anchors.verticalCenter: parent.verticalCenter
+                            iconName: "settings"
+                            buttonSize: 28
+                            iconSize: 16
+                            iconColor: Theme.surfaceVariantText
+                            onClicked: {
+                                PopoutService.closeControlCenter();
+                                PopoutService.openSettingsWithTab("displays");
+                            }
+                        }
+                    }
+                }
+
+                StyledText {
+                    visible: root.autoMode
+                    width: parent.width
+                    text: I18n.tr("Auto mode is on. Manual profile selection is disabled.")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceVariantText
+                    wrapMode: Text.WordWrap
+                }
+
+                StyledText {
+                    visible: root.profiles.length === 0
+                    width: parent.width
+                    text: I18n.tr("No display profiles found. Create them in Settings > Displays.")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceVariantText
+                    wrapMode: Text.WordWrap
+                }
+
+                Column {
+                    visible: root.profiles.length > 0
+                    width: parent.width
+                    spacing: Theme.spacingXS
+                    opacity: root.autoMode ? 0.55 : 1.0
+
+                    Repeater {
+                        model: root.profiles
+
+                        delegate: Rectangle {
+                            required property var modelData
+
+                            readonly property bool isActive: modelData.id === root.activeProfileId && !root.autoMode
+
+                            width: detailColumn.width
+                            height: 44
+                            radius: Theme.cornerRadius
+                            color: {
+                                if (isActive)
+                                    return Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12);
+                                if (profileMouseArea.containsMouse)
+                                    return Theme.surfaceLight;
+                                return Theme.floatingSurface;
+                            }
+                            border.color: isActive ? Theme.primary : Theme.outlineMedium
+                            border.width: isActive ? 1 : Theme.layerOutlineWidth
+
+                            StyledText {
+                                anchors.left: parent.left
+                                anchors.leftMargin: Theme.spacingM
+                                anchors.verticalCenter: parent.verticalCenter
+                                text: modelData.name
+                                color: Theme.surfaceText
+                                font.pixelSize: Theme.fontSizeMedium
+                                font.weight: isActive ? Font.Medium : Font.Normal
+                            }
+
+                            StyledText {
+                                anchors.right: parent.right
+                                anchors.rightMargin: Theme.spacingM
+                                anchors.verticalCenter: parent.verticalCenter
+                                visible: isActive
+                                text: I18n.tr("Active")
+                                color: Theme.primary
+                                font.pixelSize: Theme.fontSizeSmall
+                                font.weight: Font.Medium
+                            }
+
+                            MouseArea {
+                                id: profileMouseArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                enabled: !root.autoMode
+                                cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                                onClicked: DisplayConfigState.activateProfile(modelData.id)
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -72,7 +221,7 @@ PluginComponent {
                 anchors.verticalCenter: parent.verticalCenter
             }
             StyledText {
-                text: root.activeProfileName || I18n.tr("Display")
+                text: root.displayProfileLabel
                 color: Theme.surfaceText
                 font.pixelSize: Theme.fontSizeSmall
                 anchors.verticalCenter: parent.verticalCenter
@@ -90,7 +239,7 @@ PluginComponent {
                 anchors.horizontalCenter: parent.horizontalCenter
             }
             StyledText {
-                text: root.activeProfileName || "—"
+                text: root.displayProfileLabel
                 color: Theme.surfaceText
                 font.pixelSize: Theme.fontSizeSmall
                 anchors.horizontalCenter: parent.horizontalCenter

--- a/quickshell/Modules/ControlCenter/BuiltinPlugins/DisplayProfilesWidget.qml
+++ b/quickshell/Modules/ControlCenter/BuiltinPlugins/DisplayProfilesWidget.qml
@@ -1,0 +1,100 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+import qs.Modules.Plugins
+import qs.Modules.Settings.DisplayConfig
+
+PluginComponent {
+    id: root
+
+    readonly property var profiles: {
+        const p = DisplayConfigState.validatedProfiles;
+        const result = [];
+        for (const id in p) {
+            if (p[id].name)
+                result.push({ id: id, name: p[id].name });
+        }
+        return result;
+    }
+
+    readonly property string activeProfileId: SettingsData.getActiveDisplayProfile(CompositorService.compositor)
+    readonly property string activeProfileName: profiles.find(p => p.id === activeProfileId)?.name ?? ""
+
+    ccWidgetIcon: "monitor"
+    ccWidgetPrimaryText: I18n.tr("Display")
+    ccWidgetSecondaryText: activeProfileName || (profiles.length === 0 ? I18n.tr("No profiles") : I18n.tr("None active"))
+    ccWidgetIsActive: activeProfileName.length > 0
+
+    onPillClicked: cycleNext()
+
+    function cycleNext() {
+        if (profiles.length < 2)
+            return;
+        const idx = profiles.findIndex(p => p.id === activeProfileId);
+        const next = profiles[(idx + 1) % profiles.length];
+        DisplayConfigState.activateProfile(next.id);
+    }
+
+    ccDetailContent: Component {
+        Column {
+            width: parent.width
+            spacing: Theme.spacingS
+
+            StyledText {
+                visible: root.profiles.length === 0
+                width: parent.width
+                text: I18n.tr("No display profiles found. Create them in Settings → Displays.")
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.surfaceVariantText
+                wrapMode: Text.WordWrap
+            }
+
+            DankButtonGroup {
+                visible: root.profiles.length > 0
+                width: parent.width
+                model: root.profiles.map(p => p.name)
+                currentIndex: root.profiles.findIndex(p => p.id === root.activeProfileId)
+                onSelectionChanged: (index, selected) => {
+                    if (selected)
+                        DisplayConfigState.activateProfile(root.profiles[index].id);
+                }
+            }
+        }
+    }
+
+    horizontalBarPill: Component {
+        Row {
+            spacing: Theme.spacingXS
+            DankIcon {
+                name: "monitor"
+                color: Theme.primary
+                size: root.iconSize
+                anchors.verticalCenter: parent.verticalCenter
+            }
+            StyledText {
+                text: root.activeProfileName || I18n.tr("Display")
+                color: Theme.surfaceText
+                font.pixelSize: Theme.fontSizeSmall
+                anchors.verticalCenter: parent.verticalCenter
+            }
+        }
+    }
+
+    verticalBarPill: Component {
+        Column {
+            spacing: 2
+            DankIcon {
+                name: "monitor"
+                color: Theme.primary
+                size: root.iconSize
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+            StyledText {
+                text: root.activeProfileName || "—"
+                color: Theme.surfaceText
+                font.pixelSize: Theme.fontSizeSmall
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+        }
+    }
+}

--- a/quickshell/Modules/ControlCenter/Components/DetailHost.qml
+++ b/quickshell/Modules/ControlCenter/Components/DetailHost.qml
@@ -135,6 +135,12 @@ Item {
                 }
                 builtinInstance = widgetModel.tailscaleBuiltinInstance;
             }
+            if (builtinId === "builtin_display_profiles") {
+                if (widgetModel?.displayProfilesLoader) {
+                    widgetModel.displayProfilesLoader.active = true;
+                }
+                builtinInstance = widgetModel.displayProfilesBuiltinInstance;
+            }
 
             if (!builtinInstance || !builtinInstance.ccDetailContent) {
                 return;

--- a/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
+++ b/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
@@ -924,6 +924,12 @@ Column {
                     }
                     builtinInstance = Qt.binding(() => root.model?.tailscaleBuiltinInstance);
                 }
+                if (id === "builtin_display_profiles") {
+                    if (root.model?.displayProfilesLoader) {
+                        root.model.displayProfilesLoader.active = true;
+                    }
+                    builtinInstance = Qt.binding(() => root.model?.displayProfilesBuiltinInstance);
+                }
             }
 
             sourceComponent: {

--- a/quickshell/Modules/ControlCenter/Models/WidgetModel.qml
+++ b/quickshell/Modules/ControlCenter/Models/WidgetModel.qml
@@ -11,6 +11,7 @@ QtObject {
     property var vpnBuiltinInstance: null
     property var cupsBuiltinInstance: null
     property var tailscaleBuiltinInstance: null
+    property var displayProfilesBuiltinInstance: null
 
     property var vpnLoader: Loader {
         active: false
@@ -88,6 +89,34 @@ QtObject {
                 if (!hasTailscaleWidget && tailscaleLoader.active) {
                     root.log.debug("No Tailscale widget in control center, deactivating loader");
                     tailscaleLoader.active = false;
+                }
+            }
+        }
+    }
+
+    property var displayProfilesLoader: Loader {
+        active: false
+        sourceComponent: Component {
+            DisplayProfilesWidget {}
+        }
+
+        onItemChanged: {
+            root.displayProfilesBuiltinInstance = item;
+        }
+
+        onActiveChanged: {
+            if (!active)
+                root.displayProfilesBuiltinInstance = null;
+        }
+
+        Connections {
+            target: SettingsData
+            function onControlCenterWidgetsChanged() {
+                const widgets = SettingsData.controlCenterWidgets || [];
+                const hasWidget = widgets.some(w => w.id === "builtin_display_profiles");
+                if (!hasWidget && displayProfilesLoader.active) {
+                    root.log.debug("No Display Profiles widget in control center, deactivating loader");
+                    displayProfilesLoader.active = false;
                 }
             }
         }
@@ -241,6 +270,15 @@ QtObject {
             "type": "builtin_plugin",
             "enabled": TailscaleService.available,
             "warning": !TailscaleService.available ? I18n.tr("Tailscale not available", "Warning when Tailscale service is not running") : undefined,
+            "isBuiltinPlugin": true
+        },
+        {
+            "id": "builtin_display_profiles",
+            "text": I18n.tr("Display Profiles"),
+            "description": I18n.tr("Switch between display configurations"),
+            "icon": "monitor",
+            "type": "builtin_plugin",
+            "enabled": true,
             "isBuiltinPlugin": true
         }
     ]


### PR DESCRIPTION
Adds a new built-in widget that lets users switch between configured display profiles directly from the Control Center, without opening Settings.

## Changes
- New `DisplayProfilesWidget.qml` builtin using `DisplayConfigState` and `SettingsData` singletons — no shell subprocess needed
- Detail panel shows all profiles as a button group for direct selection
- Clicking the pill in the bar cycles to the next profile
- Follows the existing loader/instance pattern of VPN, CUPS, and Tailscale widgets

## Usage
Add the **Display Profiles** widget in Settings → Control Center.