### PR TITLE
feat: add cycleProfile IPC command and default Mod+P keybind

### DIFF
--- a/core/internal/config/embedded/hypr-binds.conf
+++ b/core/internal/config/embedded/hypr-binds.conf
@@ -158,5 +158,8 @@ bind = , Print, exec, dms screenshot
 bind = CTRL, Print, exec, dms screenshot full
 bind = ALT, Print, exec, dms screenshot window
 
+# === Display Profiles ===
+bind = SUPER, P, exec, dms ipc outputs cycleProfile
+
 # === System Controls ===
 bind = SUPER SHIFT, P, dpms, toggle

--- a/core/internal/config/embedded/niri-binds.kdl
+++ b/core/internal/config/embedded/niri-binds.kdl
@@ -215,6 +215,11 @@ binds {
     Print { screenshot; }
     Ctrl+Print { screenshot-screen; }
     Alt+Print { screenshot-window; }
+    // === Display Profiles ===
+    Mod+P hotkey-overlay-title="Cycle Display Profile" {
+        spawn "dms" "ipc" "outputs" "cycleProfile";
+    }
+
     // === System Controls ===
     Mod+Escape allow-inhibiting=false { toggle-keyboard-shortcuts-inhibit; }
     Mod+Shift+P { power-off-monitors; }

--- a/quickshell/DMSShellIPC.qml
+++ b/quickshell/DMSShellIPC.qml
@@ -1726,6 +1726,22 @@ Item {
             return `PROFILE_SET_SUCCESS: ${profileName}`;
         }
 
+        function cycleProfile(): string {
+            if (SettingsData.displayProfileAutoSelect)
+                return "ERROR: Auto profile selection is enabled. Use toggleAuto first";
+
+            const profiles = DisplayConfigState.validatedProfiles;
+            const ids = Object.keys(profiles).filter(id => profiles[id].name);
+            if (ids.length === 0)
+                return "ERROR: No profiles configured";
+
+            const activeId = SettingsData.getActiveDisplayProfile(CompositorService.compositor);
+            const idx = ids.indexOf(activeId);
+            const nextId = ids[(idx + 1) % ids.length];
+            DisplayConfigState.activateProfile(nextId);
+            return `PROFILE_SET_SUCCESS: ${profiles[nextId].name}`;
+        }
+
         function toggleAuto(): string {
             SettingsData.displayProfileAutoSelect = !SettingsData.displayProfileAutoSelect;
             SettingsData.saveSettings();


### PR DESCRIPTION
Adds `dms ipc outputs cycleProfile` which cycles through configured display profiles in order, wrapping from last back to first. Useful for binding a compositor key shortcut without needing an external script.

## Changes
- `cycleProfile` function added to the `outputs` IPC handler in `DMSShellIPC.qml`
- `Mod+P` bound to `dms ipc outputs cycleProfile` in the default niri and Hyprland keybind configs (`niri-binds.kdl`, `hypr-binds.conf`)

## Usage
```
dms ipc outputs cycleProfile
```
Or use the pre-configured `Mod+P` shortcut on fresh installs.