### PR TITLE
fix(network): open Wi-Fi password modal upfront for enterprise networks

### DIFF
--- a/quickshell/Modules/ControlCenter/Details/NetworkDetail.qml
+++ b/quickshell/Modules/ControlCenter/Details/NetworkDetail.qml
@@ -644,6 +644,7 @@ Rectangle {
                     wifiContent.menuOpen = true;
                     networkContextMenu.currentSSID = modelData.ssid;
                     networkContextMenu.currentSecured = modelData.secured;
+                    networkContextMenu.currentEnterprise = modelData.enterprise;
                     networkContextMenu.currentConnected = wifiDelegate.isConnected;
                     networkContextMenu.currentSaved = modelData.saved;
                     networkContextMenu.currentSignal = modelData.signal;
@@ -744,7 +745,7 @@ Rectangle {
                         event.accepted = true;
                         return;
                     }
-                    if (modelData.secured && !modelData.saved && DMSService.apiVersion < 7) {
+                    if (modelData.secured && !modelData.saved && (DMSService.apiVersion < 7 || modelData.enterprise)) {
                         PopoutService.showWifiPasswordModal(modelData.ssid);
                     } else {
                         NetworkService.connectToWifi(modelData.ssid);
@@ -762,6 +763,7 @@ Rectangle {
 
         property string currentSSID: ""
         property bool currentSecured: false
+        property bool currentEnterprise: false
         property bool currentConnected: false
         property bool currentSaved: false
         property int currentSignal: 0
@@ -802,7 +804,7 @@ Rectangle {
                     NetworkService.disconnectWifi();
                     return;
                 }
-                if (networkContextMenu.currentSecured && !networkContextMenu.currentSaved && DMSService.apiVersion < 7) {
+                if (networkContextMenu.currentSecured && !networkContextMenu.currentSaved && (DMSService.apiVersion < 7 || networkContextMenu.currentEnterprise)) {
                     PopoutService.showWifiPasswordModal(networkContextMenu.currentSSID);
                     return;
                 }

--- a/quickshell/Modules/Settings/NetworkTab.qml
+++ b/quickshell/Modules/Settings/NetworkTab.qml
@@ -1324,6 +1324,10 @@ Item {
                                                         NetworkService.disconnectWifi();
                                                         return;
                                                     }
+                                                    if (modelData.secured && !modelData.saved && (DMSService.apiVersion < 7 || modelData.enterprise)) {
+                                                        PopoutService.showWifiPasswordModal(modelData.ssid);
+                                                        return;
+                                                    }
                                                     NetworkService.connectToWifi(modelData.ssid);
                                                 }
                                             }


### PR DESCRIPTION
## Summary

- NetworkManager rejects `AddConnection` for `802-1x` without a non-empty identity, so on API v7+ the agent-prompt flow never reaches the SecretAgent for a fresh enterprise connection.
- Fall back to the existing modal-upfront path (already wired to ask for username + password via `requiresEnterprise`) whenever `modelData.enterprise`, mirroring the legacy `DMSService.apiVersion < 7` branch.
- Threads `currentEnterprise` through `NetworkDetail.qml`'s context menu so the menu's Connect action takes the same path, and adds the equivalent branch to `NetworkTab.qml`.

Fixes #2358

## Test plan

- [x] Fresh enterprise (802-1x) network in Control Center list: clicking the row opens the password modal with username + password fields.
- [ ] Same network via the row's context menu "Connect" action: opens the modal (not a silent failed AddConnection).
- [ ] Same network from Settings → Network tab: opens the modal.
- [x] Already-saved enterprise network: connects directly (no modal).
- [ ] Regular (non-enterprise) WPA network on API v7+: still uses the agent-prompt flow (no upfront modal).
- [ ] API v6 (legacy) behavior unchanged: secured + unsaved still prompts upfront.

🤖 Generated with [Claude Code](https://claude.com/claude-code)