### PR TITLE
flake: use quickshell from nixpkgs-unstable pkgs

### DIFF
--- a/distro/nix/greeter.nix
+++ b/distro/nix/greeter.nix
@@ -3,6 +3,7 @@
   config,
   pkgs,
   dmsPkgs,
+  options,
   ...
 }:
 let
@@ -24,7 +25,7 @@ let
       lib.makeBinPath [
         cfg.quickshell.package
         compositorPackage
-        pkgs.glib  # provides gdbus, used by the fprintd hardware probe in GreeterContent.qml
+        pkgs.glib # provides gdbus, used by the fprintd hardware probe in GreeterContent.qml
       ]
     }
     ${
@@ -117,8 +118,24 @@ in
       '';
     };
     quickshell = {
-      package = lib.mkPackageOption dmsPkgs "quickshell" {
-        extraDescription = "The quickshell package to use (defaults to be built from source, in the commit 26531f due to unreleased features used by DMS).";
+      package = lib.mkOption {
+        default =
+          if (lib.hasAttrByPath [ "programs" "dank-material-shell" "quickshell" "package" ] options) then
+            config.programs.dank-material-shell.quickshell.package
+          else
+            pkgs.quickshell;
+
+        defaultText = ''
+          if (lib.hasAttrByPath [ "programs" "dank-material-shell" "quickshell" "package" ] options) then
+            config.programs.dank-material-shell.quickshell.package
+          else
+            pkgs.quickshell;
+        '';
+
+        description = ''
+          The quickshell package to use (we recommend at least 0.3.0, currently available in nixos-unstable).
+          Defaults to the same set in `programs.dank-material-shell.quickshell.package`, if using the NixOS module.";
+        '';
       };
     };
     logs.save = lib.mkEnableOption "saving logs from DMS greeter to file";

--- a/distro/nix/options.nix
+++ b/distro/nix/options.nix
@@ -80,8 +80,8 @@ in
     };
 
     quickshell = {
-      package = lib.mkPackageOption dmsPkgs "quickshell" {
-        extraDescription = "The quickshell package to use (defaults to be built from source, due to unreleased features used by DMS).";
+      package = lib.mkPackageOption pkgs "quickshell" {
+        extraDescription = "(we recommend at least 0.3.0, currently available in nixos-unstable)";
       };
     };
 

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {
@@ -32,32 +32,10 @@
         "type": "github"
       }
     },
-    "quickshell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776854048,
-        "narHash": "sha256-lLbV66V3RMNp1l8/UelmR4YzoJ5ONtgvEtiUMJATH/o=",
-        "ref": "refs/heads/master",
-        "rev": "783c953987dc56ff0601abe6845ed96f1d00495a",
-        "revCount": 806,
-        "type": "git",
-        "url": "https://git.outfoxxed.me/quickshell/quickshell"
-      },
-      "original": {
-        "rev": "783c953987dc56ff0601abe6845ed96f1d00495a",
-        "type": "git",
-        "url": "https://git.outfoxxed.me/quickshell/quickshell"
-      }
-    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs",
-        "quickshell": "quickshell"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    quickshell = {
-      url = "git+https://git.outfoxxed.me/quickshell/quickshell?rev=783c953987dc56ff0601abe6845ed96f1d00495a";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     flake-compat = {
       url = "github:NixOS/flake-compat";
       flake = false;
@@ -17,7 +13,6 @@
     {
       self,
       nixpkgs,
-      quickshell,
       ...
     }:
     let
@@ -180,15 +175,14 @@
 
       buildDmsPkgs = pkgs: {
         dms-shell = mkDmsShell pkgs;
-        quickshell = quickshell.packages.${pkgs.stdenv.hostPlatform.system}.default;
       };
     in
     {
       packages = forEachSystem (
         system: pkgs: {
           dms-shell = mkDmsShell pkgs;
-          quickshell = quickshell.packages.${system}.default;
           default = self.packages.${system}.dms-shell;
+          quickshell = builtins.warn "dank-material-shell: the package Quickshell is not included in the DMS flake anymore. We recommend you to use the one from nixos-unstable branch of Nixpkgs or the upstream flake." pkgs.quickshell;
         }
       );
 
@@ -213,9 +207,10 @@
       devShells = forEachSystem (
         system: pkgs:
         let
-          devQmlPkgs = [
-            quickshell.packages.${system}.default
-            pkgs.kdePackages.qtdeclarative
+          devQmlPkgs = with pkgs;
+          [
+            quickshell
+            kdePackages.qtdeclarative
           ]
           ++ (qmlPkgs pkgs);
         in


### PR DESCRIPTION
Since Quickshell 0.3.0 is now in nixpkgs unstable, this PR updates quickshell to version `0.3.0` in nixpkgs-unstable. Stable users are advised to use the package from unstable or from the flake directly instead, now we don't have to bundle it here anymore. 

Also updated the greeter module to, if possible, use the package from the NixOS module.

Closes #2352 