### PR TITLE
chore(settings): ensure plugin browser install button resizes correctly

### DIFF
--- a/quickshell/Modules/Settings/PluginBrowser.qml
+++ b/quickshell/Modules/Settings/PluginBrowser.qml
@@ -570,7 +570,8 @@ FloatingWindow {
                                         return "available";
                                     }
 
-                                    width: buttonState === "incompatible" ? incompatRow.implicitWidth + Theme.spacingM * 2 : 80
+                                    implicitWidth: Math.max(80, incompatRow.implicitWidth + Theme.spacingM * 2)
+                                    width: implicitWidth
                                     height: 32
                                     radius: Theme.cornerRadius
                                     anchors.verticalCenter: parent.verticalCenter
@@ -638,6 +639,8 @@ FloatingWindow {
                                             }
                                             font.pixelSize: Theme.fontSizeSmall
                                             font.weight: Font.Medium
+                                            elide: Text.ElideNone
+                                            wrapMode: Text.NoWrap
                                             color: {
                                                 switch (installButton.buttonState) {
                                                 case "installed":


### PR DESCRIPTION
## Description
This PR fixes a minor visual bug in the Plugin Browser where the install button's width would not re-evaluate correctly after a plugin was installed, causing the 'Installed' text to overflow the button's boundaries.

### Changes:
- Disabled `elide` and `wrapMode` in the `StyledText` component within the install button to ensure accurate `implicitWidth` reporting.
- Switched the button's `width` property to be bound via `implicitWidth` for better reactivity in QML.

### Visual Comparison
Before
<img width="600" height="650" alt="before" src="https://github.com/user-attachments/assets/51a6f16c-1c14-423c-9cdd-96ebd9939353" />
After
<img width="600" height="650" alt="after" src="https://github.com/user-attachments/assets/4075a44a-f6c5-45d1-ad72-1f391cf4e9b0" />