### PR TITLE
notifications: honor freedesktop suppress-sound hint

### DIFF
--- a/quickshell/Services/NotificationService.qml
+++ b/quickshell/Services/NotificationService.qml
@@ -656,7 +656,11 @@ Singleton {
                 }
             }
 
-            if (SettingsData.soundsEnabled && SettingsData.soundNewNotification) {
+            // Honor the freedesktop "suppress-sound" hint: the sender
+            // plays its own audio for this notification and asks the
+            // server not to double up.
+            const suppressSound = !!(notif.hints && notif.hints["suppress-sound"]);
+            if (SettingsData.soundsEnabled && SettingsData.soundNewNotification && !suppressSound) {
                 if (policy.urgency === NotificationUrgency.Critical) {
                     AudioService.playCriticalNotificationSound();
                 } else {


### PR DESCRIPTION
A notification sender that plays its own audio has no way to tell DMS not to also play the notification sound. The freedesktop Desktop Notifications spec defines the `suppress-sound` hint for exactly this case: a BOOLEAN that "causes the server to suppress playing any sounds, if it has any, associated with the notification," set when the client is going to play its own sound. DMS doesn't read it.

Today the only thing that keeps DMS quiet for such a sender is incidental. The sound call in `NotificationService.qml`'s `onNotification` handler sits after the duplicate-detection early return. A notification that is a duplicate of one whose popup is still on screen (same app, summary, body, urgency, icon) returns before the sound plays; one that isn't reaches the sound. So a client that posts its own audio gets DMS's sound layered on top or not depending on whether a matching popup happens to still be visible -- transient notifications double up, lingering ones don't.

This reads `notif.hints["suppress-sound"]` (Quickshell surfaces notification hints as a `QVariantMap`; there is no typed property for this one) and adds it to the existing sound guard:

```qml
const suppressSound = !!(notif.hints && notif.hints["suppress-sound"]);
if (SettingsData.soundsEnabled && SettingsData.soundNewNotification && !suppressSound) {
```

The guard wraps both the critical and normal `AudioService.play*NotificationSound()` calls, so both paths are covered. The `!!(... && ...)` form treats a missing `hints` map and an absent or falsey hint identically, and accepts a sender that sends the hint as integer `1` rather than a strict boolean. When the hint is absent the condition is unchanged, so existing behavior is preserved.

Scope is limited to the shell's own sound. The notification still shows -- the popup and notification-center paths below this block are untouched. This matches how swaync treats the hint.

## Testing

The repo has no QML test harness, so this was checked by hand: a notification carrying `suppress-sound` shows normally with no DMS sound; the same notification without the hint sounds as before; both urgency levels exercised.
