### PR TITLE
networkd: classify links by Type instead of name prefix

### DIFF
--- a/core/internal/server/network/backend_networkd.go
+++ b/core/internal/server/network/backend_networkd.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -18,10 +19,41 @@ const (
 )
 
 type linkInfo struct {
-	ifindex int32
-	name    string
-	path    dbus.ObjectPath
-	opState string
+	ifindex  int32
+	name     string
+	path     dbus.ObjectPath
+	opState  string
+	linkType string
+}
+
+func (l *linkInfo) isWired() bool {
+	if l.linkType != "" {
+		return l.linkType == "ether"
+	}
+	if looksVirtual(l.name) || strings.HasPrefix(l.name, "wlan") || strings.HasPrefix(l.name, "wlp") {
+		return false
+	}
+	return true
+}
+
+func (l *linkInfo) isWireless() bool {
+	if l.linkType != "" {
+		return l.linkType == "wlan"
+	}
+	return strings.HasPrefix(l.name, "wlan") || strings.HasPrefix(l.name, "wlp")
+}
+
+func looksVirtual(name string) bool {
+	virtualPrefixes := []string{
+		"lo", "docker", "veth", "virbr", "br-", "vnet", "tun", "tap",
+		"vboxnet", "vmnet", "kube", "cni", "flannel", "cali",
+	}
+	for _, prefix := range virtualPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 type SystemdNetworkdBackend struct {
@@ -95,15 +127,35 @@ func (b *SystemdNetworkdBackend) enumerateLinks() error {
 	defer b.linksMutex.Unlock()
 
 	for _, l := range links {
-		b.links[l.Name] = &linkInfo{
+		info := &linkInfo{
 			ifindex: l.Ifindex,
 			name:    l.Name,
 			path:    l.Path,
 		}
-		log.Debugf("networkd: enumerated link %s (ifindex=%d, path=%s)", l.Name, l.Ifindex, l.Path)
+		info.linkType = b.fetchLinkType(l.Path)
+		b.links[l.Name] = info
+		log.Debugf("networkd: enumerated link %s (ifindex=%d, path=%s, type=%q)", l.Name, l.Ifindex, l.Path, info.linkType)
 	}
 
 	return nil
+}
+
+// fetchLinkType queries networkd's Describe method and extracts the link Type
+// (e.g. "ether", "wlan", "loopback", "none"). Returns empty on failure; callers
+// fall back to name-prefix heuristics in that case.
+func (b *SystemdNetworkdBackend) fetchLinkType(path dbus.ObjectPath) string {
+	linkObj := b.conn.Object(networkdBusName, path)
+	var describeJSON string
+	if err := linkObj.Call(networkdLinkIface+".Describe", 0).Store(&describeJSON); err != nil {
+		return ""
+	}
+	var parsed struct {
+		Type string `json:"Type"`
+	}
+	if err := json.Unmarshal([]byte(describeJSON), &parsed); err != nil {
+		return ""
+	}
+	return parsed.Type
 }
 
 func (b *SystemdNetworkdBackend) updateState() error {
@@ -113,8 +165,8 @@ func (b *SystemdNetworkdBackend) updateState() error {
 	var wiredIface *linkInfo
 	var wifiIface *linkInfo
 
-	for name, link := range b.links {
-		if b.isVirtualInterface(name) {
+	for _, link := range b.links {
+		if !link.isWired() && !link.isWireless() {
 			continue
 		}
 
@@ -126,11 +178,11 @@ func (b *SystemdNetworkdBackend) updateState() error {
 			}
 		}
 
-		if strings.HasPrefix(name, "wlan") || strings.HasPrefix(name, "wlp") {
+		if link.isWireless() {
 			if wifiIface == nil || link.opState == "routable" || link.opState == "carrier" {
 				wifiIface = link
 			}
-		} else if !b.isVirtualInterface(name) {
+		} else if link.isWired() {
 			if wiredIface == nil || link.opState == "routable" || link.opState == "carrier" {
 				wiredIface = link
 			}
@@ -140,7 +192,7 @@ func (b *SystemdNetworkdBackend) updateState() error {
 	var wiredConns []WiredConnection
 	var ethernetDevices []EthernetDevice
 	for name, link := range b.links {
-		if b.isVirtualInterface(name) || strings.HasPrefix(name, "wlan") || strings.HasPrefix(name, "wlp") {
+		if !link.isWired() {
 			continue
 		}
 
@@ -227,19 +279,6 @@ func (b *SystemdNetworkdBackend) updateState() error {
 	}
 
 	return nil
-}
-
-func (b *SystemdNetworkdBackend) isVirtualInterface(name string) bool {
-	virtualPrefixes := []string{
-		"lo", "docker", "veth", "virbr", "br-", "vnet", "tun", "tap",
-		"vboxnet", "vmnet", "kube", "cni", "flannel", "cali",
-	}
-	for _, prefix := range virtualPrefixes {
-		if strings.HasPrefix(name, prefix) {
-			return true
-		}
-	}
-	return false
 }
 
 func (b *SystemdNetworkdBackend) getAddresses(ifname string) []string {

--- a/core/internal/server/network/backend_networkd.go
+++ b/core/internal/server/network/backend_networkd.go
@@ -127,12 +127,16 @@ func (b *SystemdNetworkdBackend) enumerateLinks() error {
 	defer b.linksMutex.Unlock()
 
 	for _, l := range links {
-		info := &linkInfo{
-			ifindex: l.Ifindex,
-			name:    l.Name,
-			path:    l.Path,
+		if existing, ok := b.links[l.Name]; ok && existing.path == l.Path {
+			existing.ifindex = l.Ifindex
+			continue
 		}
-		info.linkType = b.fetchLinkType(l.Path)
+		info := &linkInfo{
+			ifindex:  l.Ifindex,
+			name:     l.Name,
+			path:     l.Path,
+			linkType: b.fetchLinkType(l.Path),
+		}
 		b.links[l.Name] = info
 		log.Debugf("networkd: enumerated link %s (ifindex=%d, path=%s, type=%q)", l.Name, l.Ifindex, l.Path, info.linkType)
 	}
@@ -142,13 +146,22 @@ func (b *SystemdNetworkdBackend) enumerateLinks() error {
 
 // fetchLinkType queries networkd's Describe method and extracts the link Type
 // (e.g. "ether", "wlan", "loopback", "none"). Returns empty on failure; callers
-// fall back to name-prefix heuristics in that case.
+// fall back to name-prefix heuristics in that case. The Type is fixed at link
+// creation by the kernel, so callers cache the result for the lifetime of the
+// linkInfo and only refetch when a link is re-created at a new D-Bus path.
 func (b *SystemdNetworkdBackend) fetchLinkType(path dbus.ObjectPath) string {
 	linkObj := b.conn.Object(networkdBusName, path)
 	var describeJSON string
 	if err := linkObj.Call(networkdLinkIface+".Describe", 0).Store(&describeJSON); err != nil {
 		return ""
 	}
+	return parseDescribeType(describeJSON)
+}
+
+// parseDescribeType extracts the top-level "Type" field from a networkd
+// Describe payload. Returns empty when the JSON is malformed or the field is
+// absent, signalling callers to fall back to name-prefix heuristics.
+func parseDescribeType(describeJSON string) string {
 	var parsed struct {
 		Type string `json:"Type"`
 	}

--- a/core/internal/server/network/backend_networkd_ethernet.go
+++ b/core/internal/server/network/backend_networkd_ethernet.go
@@ -12,7 +12,7 @@ func (b *SystemdNetworkdBackend) GetWiredConnections() ([]WiredConnection, error
 
 	var conns []WiredConnection
 	for name, link := range b.links {
-		if b.isVirtualInterface(name) || strings.HasPrefix(name, "wlan") || strings.HasPrefix(name, "wlp") {
+		if !link.isWired() {
 			continue
 		}
 
@@ -73,8 +73,8 @@ func (b *SystemdNetworkdBackend) GetWiredNetworkDetails(id string) (*WiredNetwor
 func (b *SystemdNetworkdBackend) ConnectEthernet() error {
 	b.linksMutex.RLock()
 	var primaryWired *linkInfo
-	for name, l := range b.links {
-		if strings.HasPrefix(name, "lo") || strings.HasPrefix(name, "wlan") || strings.HasPrefix(name, "wlp") {
+	for _, l := range b.links {
+		if !l.isWired() {
 			continue
 		}
 		primaryWired = l

--- a/core/internal/server/network/backend_networkd_test.go
+++ b/core/internal/server/network/backend_networkd_test.go
@@ -177,6 +177,34 @@ func TestLinkInfo_Classify(t *testing.T) {
 	}
 }
 
+func TestParseDescribeType(t *testing.T) {
+	// parseDescribeType is the seam between networkd's Describe RPC and the
+	// classifier. On any failure path it must return "" so callers fall back
+	// to name-prefix heuristics rather than misclassifying the link.
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ether", `{"Type":"ether","Name":"enp141s0"}`, "ether"},
+		{"wlan", `{"Type":"wlan","Name":"wlan0"}`, "wlan"},
+		{"loopback", `{"Type":"loopback","Name":"lo"}`, "loopback"},
+		{"none with kind", `{"Type":"none","Kind":"tun","Name":"nebula.homelab"}`, "none"},
+		{"empty payload", ``, ""},
+		{"empty object", `{}`, ""},
+		{"missing Type field", `{"Name":"wlan0","Kind":""}`, ""},
+		{"explicit empty Type", `{"Type":"","Name":"wlan0"}`, ""},
+		{"malformed json", `{"Type":"ether"`, ""},
+		{"non-string Type", `{"Type":42}`, ""},
+		{"unrelated payload", `"just a string"`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseDescribeType(tc.in))
+		})
+	}
+}
+
 func TestLooksVirtual(t *testing.T) {
 	virtual := []string{"lo", "docker0", "veth123", "virbr0", "br-abc", "vnet0", "tun0", "tap0", "vboxnet0", "vmnet1", "kube-ipvs0", "cni0", "flannel.1", "cali-abc"}
 	for _, n := range virtual {

--- a/core/internal/server/network/backend_networkd_test.go
+++ b/core/internal/server/network/backend_networkd_test.go
@@ -145,3 +145,45 @@ func TestSystemdNetworkdBackend_DisconnectEthernetDevice(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not supported")
 }
+
+func TestLinkInfo_Classify(t *testing.T) {
+	// When networkd reports a Type via Describe, classification is exact.
+	cases := []struct {
+		name      string
+		ifname    string
+		linkType  string
+		wantWired bool
+		wantWifi  bool
+	}{
+		{"ether type", "dock", "ether", true, false},
+		{"wlan type", "wifi", "wlan", false, true},
+		{"loopback type", "lo", "loopback", false, false},
+		{"none type (tun overlay)", "nebula.homelab", "none", false, false},
+		{"none type (wireguard)", "wg0", "none", false, false},
+		// Fallback path: linkType unavailable, name-prefix heuristic applies.
+		{"fallback enp wired", "enp141s0", "", true, false},
+		{"fallback wlan wireless", "wlan0", "", false, true},
+		{"fallback wlp wireless", "wlp3s0", "", false, true},
+		{"fallback lo skipped", "lo", "", false, false},
+		{"fallback docker skipped", "docker0", "", false, false},
+		{"fallback tun skipped", "tun0", "", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := &linkInfo{name: tc.ifname, linkType: tc.linkType}
+			assert.Equal(t, tc.wantWired, l.isWired(), "isWired")
+			assert.Equal(t, tc.wantWifi, l.isWireless(), "isWireless")
+		})
+	}
+}
+
+func TestLooksVirtual(t *testing.T) {
+	virtual := []string{"lo", "docker0", "veth123", "virbr0", "br-abc", "vnet0", "tun0", "tap0", "vboxnet0", "vmnet1", "kube-ipvs0", "cni0", "flannel.1", "cali-abc"}
+	for _, n := range virtual {
+		assert.True(t, looksVirtual(n), "%s should look virtual", n)
+	}
+	real := []string{"enp141s0", "eno1", "wlan0", "wlp3s0", "wifi", "dock", "nebula.homelab", "wg0"}
+	for _, n := range real {
+		assert.False(t, looksVirtual(n), "%s should not look virtual", n)
+	}
+}


### PR DESCRIPTION
## Summary

The `SystemdNetworkdBackend` decided wifi-vs-ethernet by checking whether the interface name started with `wlan` or `wlp`. Anything else (that wasn't on a small virtual-prefix denylist of `lo`, `docker`, `veth`, `virbr`, `br-`, `vnet`, `tun`, `tap`, `vboxnet`, `vmnet`, `kube`, `cni`, `flannel`, `cali`) was treated as a wired ethernet device.

That misclassified two real cases I hit on a thinkpad running iwd + systemd-networkd:

1. **Nebula tunnels** — the overlay interface (kernel name like `nebula.homelab`, `Type=none`, `Kind=tun`) doesn't match any of the virtual prefixes, so DMS rendered an "Ethernet connected" indicator whenever Nebula was up, even with no physical NIC attached.
2. **Renamed wifi interfaces** — systemd link files that rename `wlan0` to something friendlier (e.g. `wifi`) no longer match `wlan*`/`wlp*`, so the wifi NIC would also flip to ethernet under the old logic.

## What changed

networkd already publishes the real link kind in the JSON returned by the per-link `Describe` method:

| Interface | `Type` | `Kind` |
|---|---|---|
| Real ethernet | `ether` | (n/a) |
| Wifi | `wlan` | (n/a) |
| Loopback | `loopback` | (n/a) |
| Nebula / Wireguard / etc. | `none` | `tun` |

This PR fetches `Type` during `enumerateLinks`, caches it on `linkInfo`, and classifies against that. The old prefix logic is kept as a fallback for the case where `Describe` ever fails to populate `Type`, so behaviour on older systemd is unchanged.

Two helpers on `*linkInfo`:

```go
func (l *linkInfo) isWired() bool {
    if l.linkType != "" {
        return l.linkType == "ether"
    }
    // fallback: name-prefix heuristic
}

func (l *linkInfo) isWireless() bool {
    if l.linkType != "" {
        return l.linkType == "wlan"
    }
    // fallback: name-prefix heuristic
}
```

All five name-prefix classification sites (`updateState`, `GetWiredConnections`, `ConnectEthernet`) are replaced. The unexported `isVirtualInterface` method is pulled up into a package-level `looksVirtual` so the new helpers and their tests can use it without a live backend.

## Tests

Added `TestLinkInfo_Classify` (table-driven, 11 cases) covering both the Type-based path and the name-prefix fallback, and `TestLooksVirtual` for the virtual prefix list. All existing tests still pass. `go vet` is clean for the changed package (the pre-existing warning in `manager_test.go` is unrelated).