### PR TITLE
fix(Network): bucket WiFi signal for stable list order

### DIFF
--- a/quickshell/Modules/ControlCenter/Details/NetworkDetail.qml
+++ b/quickshell/Modules/ControlCenter/Details/NetworkDetail.qml
@@ -541,7 +541,11 @@ Rectangle {
                     return -1;
                 if (b.ssid === ssid)
                     return 1;
-                return b.signal - a.signal;
+                const aBucket = Math.floor((a.signal || 0) / 25);
+                const bBucket = Math.floor((b.signal || 0) / 25);
+                if (aBucket !== bBucket)
+                    return bBucket - aBucket;
+                return (a.ssid || "").localeCompare(b.ssid || "");
             });
             return sorted;
         }


### PR DESCRIPTION
## Summary
- When the WiFi list is open and a scan completes, networks reorder because the sort key is raw RSSI (`b.signal - a.signal`), and signal strength jitters between scans. The user goes to click a network and a different one slides under the cursor.
- This bucketizes signal into groups of 25 (matching the typical 4-bar indicator) and uses SSID as a stable tiebreaker. Pinned and the currently connected network still come first. Networks within the same bucket no longer swap places on micro-fluctuations.

Change is in `quickshell/Modules/ControlCenter/Details/NetworkDetail.qml` only — 4 lines added in the `sortedNetworks` comparator.

## Test plan
- [ ] Open Control Center → WiFi while multiple networks are visible
- [ ] Trigger a scan (or wait for auto-scan) and confirm rows do not swap when signal numbers wiggle by a few percent
- [ ] Confirm pinned networks still appear first, then the connected SSID, then by signal bucket
- [ ] Confirm a network that drops a full bucket (e.g. 78 → 60) does move down — only intra-bucket jitter is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)