### PR TITLE
resolved plugins bieng ignored in Nix by adding resolveSymlinks: false

### DIFF
--- a/quickshell/Services/PluginService.qml
+++ b/quickshell/Services/PluginService.qml
@@ -83,6 +83,7 @@ Singleton {
         showDirs: true
         showFiles: false
         showDotAndDotDot: false
+        resolveSymlinks: false
 
         onCountChanged: resyncDebounce.restart()
         onStatusChanged: {
@@ -96,6 +97,7 @@ Singleton {
         showDirs: true
         showFiles: false
         showDotAndDotDot: false
+        resolveSymlinks: false
 
         onCountChanged: resyncDebounce.restart()
         onStatusChanged: {


### PR DESCRIPTION

This pull request makes a minor configuration change to the directory listing behavior in `PluginService.qml`. The change ensures that symbolic links are not automatically resolved when displaying directories.

- Set `resolveSymlinks` to `false` in the directory listing configuration to prevent symlink resolution. [[1]](diffhunk://#diff-168d8bcf2eb6644029295e854792054a4ea9fcc68b320933c3af629e025c0ebfR86) [[2]](diffhunk://#diff-168d8bcf2eb6644029295e854792054a4ea9fcc68b320933c3af629e025c0ebfR100)

Fix #2413 