### PR TITLE
fix(osd): ensure OSD appears on all monitors after resume

### DIFF
--- a/quickshell/Common/OSDManager.qml
+++ b/quickshell/Common/OSDManager.qml
@@ -9,9 +9,11 @@ Singleton {
 
     property var currentOSDsByScreen: ({})
 
-    Connections {
-        target: Quickshell
-        function onScreensChanged() {
+    Timer {
+        id: screensChangedDelayTimer
+        interval: 3000 // 3 seconds
+        repeat: false
+        onTriggered: {
             const activeNames = {};
             for (let i = 0; i < Quickshell.screens.length; i++)
                 activeNames[Quickshell.screens[i].name] = true;
@@ -20,6 +22,12 @@ Singleton {
                     continue;
                 osdManager.currentOSDsByScreen[screenName] = null;
             }
+        }
+    }
+    Connections {
+        target: Quickshell
+        function onScreensChanged() {
+            screensChangedDelayTimer.restart();
         }
     }
 


### PR DESCRIPTION
Some inexpensive monitors (like the one I have) are slow to power on, which causes them to fail to appear in Quickshell.screens when onScreensChanged is triggered. This fix adds a 3-second delay to update the currentOSDsByScreen to mitigate the problem.