### PR TITLE
fix(DankBar): Resolve tray freeze and wallpaper loss after DPMS resume

### DIFF
--- a/quickshell/DMSShell.qml
+++ b/quickshell/DMSShell.qml
@@ -63,15 +63,27 @@ Item {
         }
     }
 
+    property bool wallpaperSurfacesLoaded: true
+
     Loader {
         id: blurredWallpaperBackgroundLoader
-        active: SettingsData.blurredWallpaperLayer && CompositorService.isNiri
+        active: root.wallpaperSurfacesLoaded && SettingsData.blurredWallpaperLayer && CompositorService.isNiri
         asynchronous: false
 
         sourceComponent: BlurredWallpaperBackground {}
     }
 
-    WallpaperBackground {}
+    DeferredAction {
+        id: wallpaperSurfaceReloadAction
+        onTriggered: root.wallpaperSurfacesLoaded = true
+    }
+
+    Loader {
+        id: wallpaperBackgroundLoader
+        active: root.wallpaperSurfacesLoaded
+        asynchronous: false
+        sourceComponent: WallpaperBackground {}
+    }
 
     DesktopWidgetLayer {}
 
@@ -168,6 +180,8 @@ Item {
     property bool barSurfacesLoaded: true
 
     function recreateBarSurfaces() {
+        log.info("Recreating bar surfaces, screens:", Quickshell.screens.length,
+                 Quickshell.screens.map(s => s.name).join(","));
         if (barSurfacesLoaded)
             barSurfacesLoaded = false;
         barSurfaceReloadAction.schedule();
@@ -217,7 +231,18 @@ Item {
         }
     }
 
-    Frame {}
+    property bool frameSurfacesLoaded: true
+
+    Loader {
+        active: root.frameSurfacesLoaded
+        asynchronous: false
+        sourceComponent: Frame {}
+    }
+
+    DeferredAction {
+        id: frameSurfaceReloadAction
+        onTriggered: root.frameSurfacesLoaded = true
+    }
 
     Repeater {
         id: dankBarRepeater
@@ -299,6 +324,81 @@ Item {
         interval: 120
         repeat: false
         onTriggered: root.osdSurfacesLoaded = true
+    }
+
+    property bool hadRealScreen: true
+
+    function _hasRealScreen() {
+        for (let i = 0; i < Quickshell.screens.length; i++) {
+            if (Quickshell.screens[i].name.length > 0)
+                return true;
+        }
+        return false;
+    }
+
+    function triggerSurfaceRecovery(source) {
+        log.info("Surface recovery triggered by:", source,
+                 "screens:", Quickshell.screens.length,
+                 Quickshell.screens.map(s => s.name).join(","),
+                 "barLoaded:", root.barSurfacesLoaded,
+                 "frameLoaded:", root.frameSurfacesLoaded,
+                 "dockEnabled:", root.dockEnabled);
+        surfaceResumeRecoveryTimer.pass = 0;
+        surfaceResumeRecoveryTimer.interval = 800;
+        surfaceResumeRecoveryTimer.restart();
+    }
+
+    Connections {
+        target: Quickshell
+        function onScreensChanged() {
+            const hasReal = root._hasRealScreen();
+            log.info("Screens changed:", Quickshell.screens.length,
+                     Quickshell.screens.map(s => "'" + s.name + "'").join(","),
+                     "hasReal:", hasReal, "hadReal:", root.hadRealScreen);
+            if (!root.hadRealScreen && hasReal) {
+                log.info("Real screen reappeared after placeholder state, triggering surface recovery");
+                root.triggerSurfaceRecovery("screen-reconnect");
+            }
+            root.hadRealScreen = hasReal;
+        }
+    }
+
+    Timer {
+        id: surfaceResumeRecoveryTimer
+        interval: 800
+        repeat: false
+        property int pass: 0
+        onTriggered: {
+            pass++;
+            log.info("Surface recovery pass", pass,
+                     "screens:", Quickshell.screens.length,
+                     Quickshell.screens.map(s => s.name).join(","));
+
+            root.recreateBarSurfaces();
+
+            if (root.frameSurfacesLoaded) {
+                root.frameSurfacesLoaded = false;
+                frameSurfaceReloadAction.schedule();
+            }
+
+            if (root.wallpaperSurfacesLoaded) {
+                root.wallpaperSurfacesLoaded = false;
+                wallpaperSurfaceReloadAction.schedule();
+            }
+
+            root.dockEnabled = false;
+            Qt.callLater(() => {
+                root.dockEnabled = true;
+            });
+
+            if (pass < 2) {
+                interval = 2000;
+                restart();
+            } else {
+                pass = 0;
+                interval = 800;
+            }
+        }
     }
 
     Component.onCompleted: {
@@ -868,9 +968,17 @@ Item {
         target: SessionService
 
         function onSessionResumed() {
+            log.info("Session resumed: screens:", Quickshell.screens.length,
+                     Quickshell.screens.map(s => s.name).join(","),
+                     "barLoaded:", root.barSurfacesLoaded,
+                     "frameLoaded:", root.frameSurfacesLoaded,
+                     "dockEnabled:", root.dockEnabled);
+
             root.pendingOsdResumeReloads = 2;
             osdResumeRecreateTimer.interval = 400;
             osdResumeRecreateTimer.restart();
+
+            root.triggerSurfaceRecovery("sessionResumed");
         }
     }
 

--- a/quickshell/Modules/DankBar/DankBarWindow.qml
+++ b/quickshell/Modules/DankBar/DankBarWindow.qml
@@ -726,7 +726,7 @@ PanelWindow {
         item: clickThroughEnabled ? null : inputMask
 
         Region {
-            readonly property var r: barWindow.clickThroughEnabled ? barWindow.sectionRect(barWindow._leftSection, false, barWindow._revealProgress) : {
+            readonly property var r: barWindow.clickThroughEnabled ? barWindow.sectionRect(barWindow._leftSection, false, barWindow._revealProgress + barWindow.width * 0) : {
                 "x": 0,
                 "y": 0,
                 "w": 0,
@@ -739,7 +739,7 @@ PanelWindow {
         }
 
         Region {
-            readonly property var r: barWindow.clickThroughEnabled ? barWindow.sectionRect(barWindow._centerSection, true, barWindow._revealProgress) : {
+            readonly property var r: barWindow.clickThroughEnabled ? barWindow.sectionRect(barWindow._centerSection, true, barWindow._revealProgress + barWindow.width * 0) : {
                 "x": 0,
                 "y": 0,
                 "w": 0,
@@ -752,7 +752,7 @@ PanelWindow {
         }
 
         Region {
-            readonly property var r: barWindow.clickThroughEnabled ? barWindow.sectionRect(barWindow._rightSection, false, barWindow._revealProgress) : {
+            readonly property var r: barWindow.clickThroughEnabled ? barWindow.sectionRect(barWindow._rightSection, false, barWindow._revealProgress + barWindow.width * 0) : {
                 "x": 0,
                 "y": 0,
                 "w": 0,

--- a/quickshell/Services/WlrOutputService.qml
+++ b/quickshell/Services/WlrOutputService.qml
@@ -345,4 +345,13 @@ Singleton {
             return 0;
         }
     }
+
+    Connections {
+        target: SessionService
+
+        function onSessionResumed() {
+            log.info("Session resumed, re-requesting output state, current outputs:", outputs.length);
+            requestState();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Bar tray icons and wallpaper become unresponsive/black after display reconnects from DPMS deep sleep. Only `dms restart` could recover.

Fixes #2354

## Root Cause

**Tray freeze (clickThrough mode):** The PanelWindow mask uses `sectionRect()` → `mapToItem()` to compute input regions. After DPMS resume, the PanelWindow is recreated with `width=0`. When the compositor later sets the actual screen width, `mapToItem()` results change but the QML binding is never re-evaluated because the right section's `implicitWidth` (fixed-size tray icons) doesn't trigger a binding update.

**Wallpaper loss:** Wallpaper PanelWindows are recreated by Variants during screen reconnection before the compositor finishes output initialization. The wallpaper Image renders at 0×0 dimensions → black screen.

## Changes

| File | Change |
|------|--------|
| `DankBarWindow.qml` | Add `barWindow.width` dependency to clickThrough mask bindings so mask recalculates on resize |
| `DMSShell.qml` | Add surface recovery: detect screen reconnect via `hadRealScreen` tracking, 2-pass progressive timer (800ms + 2800ms) that recreates bar/Frame/wallpaper/dock after compositor is ready. Also triggers on `sessionResumed` for suspend scenarios. |
| `WlrOutputService.qml` | Re-request wlr-output-management state on session resume |

## Test Plan

- [x] Normal startup: bar/tray/wallpaper render and interact correctly
- [x] `niri msg action power-off-monitors` → mouse wake: tray icons clickable, wallpaper visible
- [x] Multiple DPMS off/on cycles: consistent recovery
- [x] Workspace switcher (left section) and clock (center section) work before and after recovery
- [x] `dms restart` still works as fallback