### PR TITLE
feat(Clipboard-Bar-Hist): Add search/filter to saved clipboard entries & animation states

### DIFF
--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -970,6 +970,7 @@ Singleton {
 
     readonly property int shorterDuration: (typeof SettingsData !== "undefined" && SettingsData.animationSpeed === SettingsData.AnimationSpeed.Custom) ? SettingsData.customAnimationDuration : currentDurations.shorter
     readonly property int shortDuration: (typeof SettingsData !== "undefined" && SettingsData.animationSpeed === SettingsData.AnimationSpeed.Custom) ? SettingsData.customAnimationDuration : currentDurations.short
+    readonly property bool snapListModelChanges: shortDuration <= 0
     readonly property int mediumDuration: (typeof SettingsData !== "undefined" && SettingsData.animationSpeed === SettingsData.AnimationSpeed.Custom) ? SettingsData.customAnimationDuration : currentDurations.medium
     readonly property int longDuration: (typeof SettingsData !== "undefined" && SettingsData.animationSpeed === SettingsData.AnimationSpeed.Custom) ? SettingsData.customAnimationDuration : currentDurations.long
     readonly property int extraLongDuration: (typeof SettingsData !== "undefined" && SettingsData.animationSpeed === SettingsData.AnimationSpeed.Custom) ? SettingsData.customAnimationDuration : currentDurations.extraLong

--- a/quickshell/Modals/Clipboard/ClipboardContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContent.qml
@@ -109,11 +109,6 @@ Item {
             pressDelay: 0
             flickableDirection: Flickable.VerticalFlick
 
-            add: null
-            remove: null
-            displaced: null
-            move: null
-
             function ensureVisible(index) {
                 if (index < 0 || index >= count) {
                     return;
@@ -172,11 +167,6 @@ Item {
             boundsMovement: Flickable.FollowBoundsBehavior
             pressDelay: 0
             flickableDirection: Flickable.VerticalFlick
-
-            add: null
-            remove: null
-            displaced: null
-            move: null
 
             function ensureVisible(index) {
                 if (index < 0 || index >= count) {

--- a/quickshell/Modals/Clipboard/ClipboardContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContent.qml
@@ -108,6 +108,11 @@ Item {
             pressDelay: 0
             flickableDirection: Flickable.VerticalFlick
 
+            add: null
+            remove: null
+            displaced: null
+            move: null
+
             function ensureVisible(index) {
                 if (index < 0 || index >= count) {
                     return;

--- a/quickshell/Modals/Clipboard/ClipboardContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContent.qml
@@ -26,7 +26,8 @@ Item {
         ClipboardHeader {
             id: header
             width: parent.width
-            totalCount: modal.totalCount
+            recentsCount: modal.unpinnedEntries.length
+            savedCount: modal.pinnedEntries.length
             showKeyboardHints: modal.showKeyboardHints
             activeTab: modal.activeTab
             pinnedCount: modal.pinnedCount
@@ -171,6 +172,11 @@ Item {
             boundsMovement: Flickable.FollowBoundsBehavior
             pressDelay: 0
             flickableDirection: Flickable.VerticalFlick
+
+            add: null
+            remove: null
+            displaced: null
+            move: null
 
             function ensureVisible(index) {
                 if (index < 0 || index >= count) {

--- a/quickshell/Modals/Clipboard/ClipboardContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContent.qml
@@ -109,6 +109,20 @@ Item {
             pressDelay: 0
             flickableDirection: Flickable.VerticalFlick
 
+            states: [
+                State {
+                    name: "snap"
+                    when: Theme.snapListModelChanges
+                    PropertyChanges {
+                        target: clipboardListView
+                        add: null
+                        remove: null
+                        displaced: null
+                        move: null
+                    }
+                }
+            ]
+
             function ensureVisible(index) {
                 if (index < 0 || index >= count) {
                     return;
@@ -167,6 +181,20 @@ Item {
             boundsMovement: Flickable.FollowBoundsBehavior
             pressDelay: 0
             flickableDirection: Flickable.VerticalFlick
+
+            states: [
+                State {
+                    name: "snap"
+                    when: Theme.snapListModelChanges
+                    PropertyChanges {
+                        target: savedListView
+                        add: null
+                        remove: null
+                        displaced: null
+                        move: null
+                    }
+                }
+            ]
 
             function ensureVisible(index) {
                 if (index < 0 || index >= count) {

--- a/quickshell/Modals/Clipboard/ClipboardHeader.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHeader.qml
@@ -6,7 +6,8 @@ import qs.Modals.Clipboard
 Item {
     id: header
 
-    property int totalCount: 0
+    property int recentsCount: 0
+    property int savedCount: 0
     property bool showKeyboardHints: false
     property string activeTab: "recents"
     property int pinnedCount: 0
@@ -31,7 +32,7 @@ Item {
         }
 
         StyledText {
-            text: I18n.tr("Clipboard History") + ` (${totalCount})`
+            text: (header.activeTab === "saved" ? I18n.tr("Clipboard Saved") : I18n.tr("Clipboard History")) + ` (${header.activeTab === "saved" ? header.savedCount : header.recentsCount})`
             font.pixelSize: Theme.fontSizeLarge
             color: Theme.surfaceText
             font.weight: Font.Medium

--- a/quickshell/Modals/Clipboard/ClipboardHeader.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHeader.qml
@@ -49,6 +49,7 @@ Item {
             iconName: "push_pin"
             iconSize: Theme.iconSize - 4
             iconColor: header.activeTab === "saved" ? Theme.primary : Theme.surfaceText
+            backgroundColor: header.activeTab === "saved" ? Theme.primarySelected : "transparent"
             visible: header.pinnedCount > 0
             tooltipText: header.activeTab === "saved" ? I18n.tr("Recent") : I18n.tr("Saved")
             onClicked: tabChanged(header.activeTab === "saved" ? "recents" : "saved")

--- a/quickshell/Modules/ProcessList/ProcessesView.qml
+++ b/quickshell/Modules/ProcessList/ProcessesView.qml
@@ -301,10 +301,19 @@ Item {
             clip: true
             spacing: 2
 
-            add: null
-            remove: null
-            displaced: null
-            move: null
+            states: [
+                State {
+                    name: "snap"
+                    when: Theme.snapListModelChanges
+                    PropertyChanges {
+                        target: processListView
+                        add: null
+                        remove: null
+                        displaced: null
+                        move: null
+                    }
+                }
+            ]
 
             model: ScriptModel {
                 values: root.cachedProcesses

--- a/quickshell/Services/ClipboardService.qml
+++ b/quickshell/Services/ClipboardService.qml
@@ -68,15 +68,17 @@ Singleton {
 
         clipboardEntries = filtered;
         unpinnedEntries = filtered.filter(e => !e.pinned);
+        pinnedEntries = filtered.filter(e => e.pinned);
         totalCount = clipboardEntries.length;
 
-        if (unpinnedEntries.length === 0) {
+        const activeCount = Math.max(unpinnedEntries.length, pinnedEntries.length);
+        if (activeCount === 0) {
             keyboardNavigationActive = false;
             selectedIndex = 0;
             return;
         }
-        if (selectedIndex >= unpinnedEntries.length) {
-            selectedIndex = unpinnedEntries.length - 1;
+        if (selectedIndex >= activeCount) {
+            selectedIndex = activeCount - 1;
         }
     }
 


### PR DESCRIPTION
DankBar: Enable searching in saved clipboard entries and changes the popup title between "Clipboard History" and "Clipboard Saved" when toggling the Saved/Recent button.

Also fixes search/filter issues for DankBar's Clipboard History similar to https://github.com/AvengeMedia/DankMaterialShell/pull/2315