### PR TITLE
feat: unify media controls dropdown interactions, hover behavior and cycle controls

### DIFF
--- a/quickshell/Modules/DankDash/DankDashPopout.qml
+++ b/quickshell/Modules/DankDash/DankDashPopout.qml
@@ -230,6 +230,13 @@ DankPopout {
                     return;
                 }
 
+                if (root.currentTabIndex === 1 && mediaLoader.item?.handleKeyEvent) {
+                    if (mediaLoader.item.handleKeyEvent(event)) {
+                        event.accepted = true;
+                        return;
+                    }
+                }
+
                 if (root.currentTabIndex === 2 && wallpaperLoader.item?.handleKeyEvent) {
                     if (wallpaperLoader.item.handleKeyEvent(event)) {
                         event.accepted = true;

--- a/quickshell/Modules/DankDash/DankDashPopout.qml
+++ b/quickshell/Modules/DankDash/DankDashPopout.qml
@@ -402,6 +402,7 @@ DankPopout {
                                 }
                                 onHideDropdowns: root.__hideDropdowns()
                                 onDropdownButtonExited: root.__startCloseTimer()
+                                onDropdownButtonEntered: root.__stopCloseTimer()
                             }
                         }
                     }

--- a/quickshell/Modules/DankDash/DankDashPopout.qml
+++ b/quickshell/Modules/DankDash/DankDashPopout.qml
@@ -25,14 +25,14 @@ DankPopout {
     property int __dropdownType: 0
     property point __dropdownAnchor: Qt.point(0, 0)
     property bool __dropdownRightEdge: false
-    property var __dropdownPlayer: null
-    property var __dropdownPlayers: []
+    property var __dropdownPlayer: MprisController.activePlayer
+    property var __dropdownPlayers: MprisController.availablePlayers
 
     function __showVolumeDropdown(pos, rightEdge, player, players) {
         __dropdownAnchor = pos;
         __dropdownRightEdge = rightEdge;
-        __dropdownPlayer = player;
-        __dropdownPlayers = players;
+        __dropdownPlayer = Qt.binding(() => MprisController.activePlayer);
+        __dropdownPlayers = Qt.binding(() => MprisController.availablePlayers);
         __dropdownType = 1;
     }
 
@@ -45,8 +45,8 @@ DankPopout {
     function __showPlayersDropdown(pos, rightEdge, player, players) {
         __dropdownAnchor = pos;
         __dropdownRightEdge = rightEdge;
-        __dropdownPlayer = player;
-        __dropdownPlayers = players;
+        __dropdownPlayer = Qt.binding(() => MprisController.activePlayer);
+        __dropdownPlayers = Qt.binding(() => MprisController.availablePlayers);
         __dropdownType = 3;
     }
 
@@ -69,7 +69,7 @@ DankPopout {
         id: __volumeCloseTimer
         interval: 400
         onTriggered: {
-            if (__dropdownType === 1) {
+            if (__dropdownType !== 0) {
                 __hideDropdowns();
             }
         }
@@ -394,7 +394,7 @@ DankPopout {
                                     root.__showPlayersDropdown(pos, rightEdge, player, players);
                                 }
                                 onHideDropdowns: root.__hideDropdowns()
-                                onVolumeButtonExited: root.__startCloseTimer()
+                                onDropdownButtonExited: root.__startCloseTimer()
                             }
                         }
                     }

--- a/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
+++ b/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
@@ -357,7 +357,13 @@ Item {
                                     }
 
                                     StyledText {
-                                        text: modelData === AudioService.sink ? "Active" : "Available"
+                                        text: {
+                                            if (!modelData?.audio)
+                                                return modelData === AudioService.sink ? I18n.tr("Active") : I18n.tr("Available");
+                                            if (modelData.audio.muted)
+                                                return I18n.tr("Muted", "audio status");
+                                            return Math.round(modelData.audio.volume * 100) + "%";
+                                        }
                                         font.pixelSize: Theme.fontSizeSmall
                                         color: Theme.surfaceVariantText
                                         elide: Text.ElideRight

--- a/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
+++ b/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
@@ -522,14 +522,7 @@ Item {
                                     }
 
                                     StyledText {
-                                        text: {
-                                            if (!modelData)
-                                                return "";
-                                            const artist = modelData.trackArtist || "";
-                                            if (artist.length > 0)
-                                                return artist;
-                                            return modelData === activePlayer ? I18n.tr("Active") : I18n.tr("Available");
-                                        }
+                                        text: modelData?.trackArtist || I18n.tr("Unknown Artist")
                                         font.pixelSize: Theme.fontSizeSmall
                                         color: Theme.surfaceVariantText
                                         elide: Text.ElideRight

--- a/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
+++ b/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
@@ -42,16 +42,16 @@ Item {
     signal panelEntered
     signal panelExited
 
-    property int __volumeHoverCount: 0
+    property int __panelHoverCount: 0
 
-    function volumeAreaEntered() {
-        __volumeHoverCount++;
+    function panelAreaEntered() {
+        __panelHoverCount++;
         panelEntered();
     }
 
-    function volumeAreaExited() {
-        __volumeHoverCount = Math.max(0, __volumeHoverCount - 1);
-        if (__volumeHoverCount === 0)
+    function panelAreaExited() {
+        __panelHoverCount = Math.max(0, __panelHoverCount - 1);
+        if (__panelHoverCount === 0)
             panelExited();
     }
 
@@ -131,8 +131,8 @@ Item {
             anchors.fill: parent
             anchors.margins: -12
             hoverEnabled: true
-            onEntered: volumeAreaEntered()
-            onExited: volumeAreaExited()
+            onEntered: panelAreaEntered()
+            onExited: panelAreaExited()
         }
 
         Item {
@@ -190,8 +190,8 @@ Item {
                     cursorShape: Qt.PointingHandCursor
                     preventStealing: true
 
-                    onEntered: volumeAreaEntered()
-                    onExited: volumeAreaExited()
+                    onEntered: panelAreaEntered()
+                    onExited: panelAreaExited()
                     onPressed: mouse => updateVolume(mouse)
                     onPositionChanged: mouse => {
                         if (pressed)
@@ -267,6 +267,14 @@ Item {
             borderWidth: audioDevicesPanel.border.width
             shadowOpacity: Theme.elevationLevel2 && Theme.elevationLevel2.alpha !== undefined ? Theme.elevationLevel2.alpha : 0.25
             shadowEnabled: Theme.elevationEnabled && !BlurService.enabled
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            anchors.margins: -12
+            hoverEnabled: true
+            onEntered: panelAreaEntered()
+            onExited: panelAreaExited()
         }
 
         Column {
@@ -369,6 +377,8 @@ Item {
                                         root.deviceSelected(modelData);
                                     }
                                 }
+                                onEntered: panelAreaEntered()
+                                onExited: panelAreaExited()
                             }
                         }
                     }
@@ -423,6 +433,14 @@ Item {
             borderWidth: playersPanel.border.width
             shadowOpacity: Theme.elevationLevel2 && Theme.elevationLevel2.alpha !== undefined ? Theme.elevationLevel2.alpha : 0.25
             shadowEnabled: Theme.elevationEnabled && !BlurService.enabled
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            anchors.margins: -12
+            hoverEnabled: true
+            onEntered: panelAreaEntered()
+            onExited: panelAreaExited()
         }
 
         Column {
@@ -526,6 +544,8 @@ Item {
                                         root.playerSelected(modelData);
                                     }
                                 }
+                                onEntered: panelAreaEntered()
+                                onExited: panelAreaExited()
                             }
                         }
                     }

--- a/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
+++ b/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
@@ -520,10 +520,9 @@ Item {
                                             if (!modelData)
                                                 return "";
                                             const artist = modelData.trackArtist || "";
-                                            const isActive = modelData === activePlayer;
                                             if (artist.length > 0)
-                                                return artist + (isActive ? " (Active)" : "");
-                                            return isActive ? "Active" : "Available";
+                                                return artist;
+                                            return modelData === activePlayer ? I18n.tr("Active") : I18n.tr("Available");
                                         }
                                         font.pixelSize: Theme.fontSizeSmall
                                         color: Theme.surfaceVariantText

--- a/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
+++ b/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
@@ -44,6 +44,12 @@ Item {
 
     property int __panelHoverCount: 0
 
+    onDropdownTypeChanged: {
+        if (dropdownType === 0) {
+            __panelHoverCount = 0;
+        }
+    }
+
     function panelAreaEntered() {
         __panelHoverCount++;
         panelEntered();

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -13,7 +13,7 @@ Item {
     LayoutMirroring.childrenInherit: true
 
     property MprisPlayer activePlayer: MprisController.activePlayer
-    property real stableLength: 0
+    readonly property real stableLength: MprisController.activePlayerStableLength
     property var allPlayers: MprisController.availablePlayers
     property var targetScreen: null
     property real popoutX: 0
@@ -76,7 +76,6 @@ Item {
     }
 
     onActivePlayerChanged: {
-        stableLength = (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) ? activePlayer.length : 0;
         if (!activePlayer) {
             isSwitching = false;
             _switchHold = false;
@@ -110,17 +109,11 @@ Item {
     Connections {
         target: activePlayer
         function onTrackTitleChanged() {
-            root.stableLength = (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) ? activePlayer.length : 0;
             _switchHoldTimer.restart();
             maybeFinishSwitch();
         }
         function onTrackArtUrlChanged() {
             TrackArtService.loadArtwork(activePlayer.trackArtUrl);
-        }
-        function onLengthChanged() {
-            if (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) {
-                root.stableLength = activePlayer.length;
-            }
         }
     }
 

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -184,6 +184,20 @@ Item {
         }
     }
 
+    function triggerVolumeDropdown() {
+        if (!volumeAvailable)
+            return;
+        if (volumeExpanded)
+            return;
+        hideDropdowns();
+        volumeExpanded = true;
+        const buttonsOnRight = !isRightEdge;
+        const btnY = volumeButton.y + volumeButton.height / 2;
+        const screenX = buttonsOnRight ? (popoutX + popoutWidth) : popoutX;
+        const screenY = popoutY + contentOffsetY + btnY;
+        showVolumeDropdown(Qt.point(screenX, screenY), targetScreen, buttonsOnRight, activePlayer, allPlayers);
+    }
+
     function handleKeyEvent(event) {
         if (!activePlayer)
             return false;
@@ -215,10 +229,14 @@ Item {
         // 3. Up / Down arrows to adjust volume
         if (event.key === Qt.Key_Up) {
             adjustVolume(5);
+            triggerVolumeDropdown();
+            dropdownButtonExited();
             return true;
         }
         if (event.key === Qt.Key_Down) {
             adjustVolume(-5);
+            triggerVolumeDropdown();
+            dropdownButtonExited();
             return true;
         }
 

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -29,6 +29,7 @@ Item {
     signal showPlayersDropdown(point pos, var screen, bool rightEdge, var player, var players)
     signal hideDropdowns
     signal dropdownButtonExited
+    signal dropdownButtonEntered
 
     property bool volumeExpanded: false
     property bool devicesExpanded: false
@@ -761,6 +762,7 @@ Item {
                 showPlayersDropdown(Qt.point(screenX, screenY), targetScreen, buttonsOnRight, activePlayer, allPlayers);
             }
             onEntered: {
+                dropdownButtonEntered();
                 if (playersExpanded)
                     return;
                 hideDropdowns();
@@ -806,6 +808,7 @@ Item {
             hoverEnabled: true
             cursorShape: Qt.PointingHandCursor
             onEntered: {
+                dropdownButtonEntered();
                 if (volumeExpanded)
                     return;
                 hideDropdowns();
@@ -889,6 +892,7 @@ Item {
                 showAudioDevicesDropdown(Qt.point(screenX, screenY), targetScreen, buttonsOnRight);
             }
             onEntered: {
+                dropdownButtonEntered();
                 if (devicesExpanded)
                     return;
                 hideDropdowns();

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -198,6 +198,27 @@ Item {
         showVolumeDropdown(Qt.point(screenX, screenY), targetScreen, buttonsOnRight, activePlayer, allPlayers);
     }
 
+    function toggleMute() {
+        if (!volumeAvailable)
+            return;
+        SessionData.suppressOSDTemporarily();
+        if (currentVolume > 0) {
+            volumeButton.previousVolume = currentVolume;
+            if (usePlayerVolume) {
+                activePlayer.volume = 0;
+            } else if (AudioService.sink?.audio) {
+                AudioService.sink.audio.volume = 0;
+            }
+        } else {
+            const restoreVolume = volumeButton.previousVolume > 0 ? volumeButton.previousVolume : 0.5;
+            if (usePlayerVolume) {
+                activePlayer.volume = restoreVolume;
+            } else if (AudioService.sink?.audio) {
+                AudioService.sink.audio.volume = restoreVolume;
+            }
+        }
+    }
+
     function handleKeyEvent(event) {
         if (!activePlayer)
             return false;
@@ -246,6 +267,14 @@ Item {
                 activePlayer.togglePlaying();
                 return true;
             }
+        }
+
+        // 5. M key to toggle mute
+        if (event.key === Qt.Key_M) {
+            toggleMute();
+            triggerVolumeDropdown();
+            dropdownButtonExited();
+            return true;
         }
 
         return false;
@@ -794,22 +823,7 @@ Item {
                     dropdownButtonExited();
             }
             onClicked: {
-                SessionData.suppressOSDTemporarily();
-                if (currentVolume > 0) {
-                    volumeButton.previousVolume = currentVolume;
-                    if (usePlayerVolume) {
-                        activePlayer.volume = 0;
-                    } else if (AudioService.sink?.audio) {
-                        AudioService.sink.audio.volume = 0;
-                    }
-                } else {
-                    const restoreVolume = volumeButton.previousVolume > 0 ? volumeButton.previousVolume : 0.5;
-                    if (usePlayerVolume) {
-                        activePlayer.volume = restoreVolume;
-                    } else if (AudioService.sink?.audio) {
-                        AudioService.sink.audio.volume = restoreVolume;
-                    }
-                }
+                toggleMute();
             }
             onWheel: wheelEvent => {
                 SessionData.suppressOSDTemporarily();

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -228,7 +228,7 @@ Item {
             if (activePlayer.canSeek && activePlayer.length > 0) {
                 const ratio = (event.key - Qt.Key_0) * 0.1;
                 const targetPosition = ratio * activePlayer.length;
-                activePlayer.position = Math.min(targetPosition, activePlayer.length * 0.99);
+                activePlayer.position = Math.max(0.1, Math.min(targetPosition, activePlayer.length * 0.99));
                 return true;
             }
         }
@@ -236,13 +236,13 @@ Item {
         // 2. Left / Right arrows to seek backward / forward 5s
         if (event.key === Qt.Key_Left) {
             if (activePlayer.canSeek) {
-                activePlayer.position = Math.max(0, activePlayer.position - 5);
+                activePlayer.position = Math.max(0.1, activePlayer.position - 5);
                 return true;
             }
         }
         if (event.key === Qt.Key_Right) {
             if (activePlayer.canSeek && activePlayer.length > 0) {
-                activePlayer.position = Math.min(activePlayer.length - 1, activePlayer.position + 5);
+                activePlayer.position = Math.max(0.1, Math.min(activePlayer.length - 1, activePlayer.position + 5));
                 return true;
             }
         }

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -13,6 +13,7 @@ Item {
     LayoutMirroring.childrenInherit: true
 
     property MprisPlayer activePlayer: MprisController.activePlayer
+    property real stableLength: 0
     property var allPlayers: MprisController.availablePlayers
     property var targetScreen: null
     property real popoutX: 0
@@ -75,6 +76,7 @@ Item {
     }
 
     onActivePlayerChanged: {
+        stableLength = (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) ? activePlayer.length : 0;
         if (!activePlayer) {
             isSwitching = false;
             _switchHold = false;
@@ -94,11 +96,11 @@ Item {
     }
 
     readonly property real ratio: {
-        if (!activePlayer || !activePlayer.length || activePlayer.length <= 0) {
+        if (!activePlayer || stableLength <= 0) {
             return 0;
         }
-        const pos = (activePlayer.position || 0) % Math.max(1, activePlayer.length);
-        const calculatedRatio = pos / activePlayer.length;
+        const pos = (activePlayer.position || 0) % Math.max(1, stableLength);
+        const calculatedRatio = pos / stableLength;
         return Math.max(0, Math.min(1, calculatedRatio));
     }
 
@@ -108,11 +110,17 @@ Item {
     Connections {
         target: activePlayer
         function onTrackTitleChanged() {
+            root.stableLength = (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) ? activePlayer.length : 0;
             _switchHoldTimer.restart();
             maybeFinishSwitch();
         }
         function onTrackArtUrlChanged() {
             TrackArtService.loadArtwork(activePlayer.trackArtUrl);
+        }
+        function onLengthChanged() {
+            if (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) {
+                root.stableLength = activePlayer.length;
+            }
         }
     }
 
@@ -225,10 +233,10 @@ Item {
 
         // 1. Number keys 0-9 to seek to 0%-90%
         if (event.key >= Qt.Key_0 && event.key <= Qt.Key_9) {
-            if (activePlayer.canSeek && activePlayer.length > 0) {
+            if (activePlayer.canSeek && stableLength > 0) {
                 const ratio = (event.key - Qt.Key_0) * 0.1;
-                const targetPosition = ratio * activePlayer.length;
-                activePlayer.position = Math.max(0.1, Math.min(targetPosition, activePlayer.length * 0.99));
+                const targetPosition = ratio * stableLength;
+                activePlayer.position = Math.max(0.1, Math.min(targetPosition, stableLength * 0.99));
                 return true;
             }
         }
@@ -241,8 +249,8 @@ Item {
             }
         }
         if (event.key === Qt.Key_Right) {
-            if (activePlayer.canSeek && activePlayer.length > 0) {
-                activePlayer.position = Math.max(0.1, Math.min(activePlayer.length - 1, activePlayer.position + 5));
+            if (activePlayer.canSeek && stableLength > 0) {
+                activePlayer.position = Math.max(0.1, Math.min(stableLength - 1, activePlayer.position + 5));
                 return true;
             }
         }
@@ -483,7 +491,7 @@ Item {
                                     if (!activePlayer)
                                         return "0:00";
                                     const rawPos = Math.max(0, activePlayer.position || 0);
-                                    const pos = activePlayer.length ? rawPos % Math.max(1, activePlayer.length) : rawPos;
+                                    const pos = stableLength ? rawPos % Math.max(1, stableLength) : rawPos;
                                     const minutes = Math.floor(pos / 60);
                                     const seconds = Math.floor(pos % 60);
                                     const timeStr = minutes + ":" + (seconds < 10 ? "0" : "") + seconds;
@@ -497,9 +505,9 @@ Item {
                                 anchors.right: parent.right
                                 anchors.verticalCenter: parent.verticalCenter
                                 text: {
-                                    if (!activePlayer || !activePlayer.length)
-                                        return "0:00";
-                                    const dur = Math.max(0, activePlayer.length || 0);
+                                    if (!activePlayer || stableLength <= 0)
+                                        return "--:--";
+                                    const dur = stableLength;
                                     const minutes = Math.floor(dur / 60);
                                     const seconds = Math.floor(dur % 60);
                                     return minutes + ":" + (seconds < 10 ? "0" : "") + seconds;

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -27,7 +27,7 @@ Item {
     signal showAudioDevicesDropdown(point pos, var screen, bool rightEdge)
     signal showPlayersDropdown(point pos, var screen, bool rightEdge, var player, var players)
     signal hideDropdowns
-    signal volumeButtonExited
+    signal dropdownButtonExited
 
     property bool volumeExpanded: false
     property bool devicesExpanded: false
@@ -39,9 +39,7 @@ Item {
         playersExpanded = false;
     }
 
-    DankTooltipV2 {
-        id: sharedTooltip
-    }
+
 
     readonly property bool isRightEdge: {
         if (barPosition === SettingsData.Position.Right)
@@ -647,7 +645,17 @@ Item {
             cursorShape: Qt.PointingHandCursor
             onClicked: {
                 if (playersExpanded) {
-                    hideDropdowns();
+                    if (allPlayers && allPlayers.length > 1) {
+                        let currentIndex = -1;
+                        for (let i = 0; i < allPlayers.length; i++) {
+                            if (allPlayers[i] === activePlayer) {
+                                currentIndex = i;
+                                break;
+                            }
+                        }
+                        const nextIndex = (currentIndex + 1) % allPlayers.length;
+                        MprisController.setActivePlayer(allPlayers[nextIndex]);
+                    }
                     return;
                 }
                 hideDropdowns();
@@ -658,8 +666,21 @@ Item {
                 const screenY = popoutY + contentOffsetY + btnY;
                 showPlayersDropdown(Qt.point(screenX, screenY), targetScreen, buttonsOnRight, activePlayer, allPlayers);
             }
-            onEntered: sharedTooltip.show(I18n.tr("Media Players"), playerSelectorButton, 0, 0, isRightEdge ? "right" : "left")
-            onExited: sharedTooltip.hide()
+            onEntered: {
+                if (playersExpanded)
+                    return;
+                hideDropdowns();
+                playersExpanded = true;
+                const buttonsOnRight = !isRightEdge;
+                const btnY = playerSelectorButton.y + playerSelectorButton.height / 2;
+                const screenX = buttonsOnRight ? (popoutX + popoutWidth) : popoutX;
+                const screenY = popoutY + contentOffsetY + btnY;
+                showPlayersDropdown(Qt.point(screenX, screenY), targetScreen, buttonsOnRight, activePlayer, allPlayers);
+            }
+            onExited: {
+                if (playersExpanded)
+                    dropdownButtonExited();
+            }
         }
     }
 
@@ -703,7 +724,7 @@ Item {
             }
             onExited: {
                 if (volumeExpanded)
-                    volumeButtonExited();
+                    dropdownButtonExited();
             }
             onClicked: {
                 SessionData.suppressOSDTemporarily();
@@ -754,7 +775,7 @@ Item {
 
         DankIcon {
             anchors.centerIn: parent
-            name: devicesExpanded ? "expand_less" : "speaker"
+            name: "speaker"
             size: 18
             color: Theme.surfaceText
         }
@@ -766,7 +787,18 @@ Item {
             cursorShape: Qt.PointingHandCursor
             onClicked: {
                 if (devicesExpanded) {
-                    hideDropdowns();
+                    const sinks = AudioService.getAvailableSinks();
+                    if (sinks && sinks.length > 1) {
+                        let currentIndex = -1;
+                        for (let i = 0; i < sinks.length; i++) {
+                            if (sinks[i]?.name === AudioService.sink?.name) {
+                                currentIndex = i;
+                                break;
+                            }
+                        }
+                        const nextIndex = (currentIndex + 1) % sinks.length;
+                        AudioService.setSink(sinks[nextIndex]);
+                    }
                     return;
                 }
                 hideDropdowns();
@@ -777,8 +809,21 @@ Item {
                 const screenY = popoutY + contentOffsetY + btnY;
                 showAudioDevicesDropdown(Qt.point(screenX, screenY), targetScreen, buttonsOnRight);
             }
-            onEntered: sharedTooltip.show(I18n.tr("Output Device"), audioDevicesButton, 0, 0, isRightEdge ? "right" : "left")
-            onExited: sharedTooltip.hide()
+            onEntered: {
+                if (devicesExpanded)
+                    return;
+                hideDropdowns();
+                devicesExpanded = true;
+                const buttonsOnRight = !isRightEdge;
+                const btnY = audioDevicesButton.y + audioDevicesButton.height / 2;
+                const screenX = buttonsOnRight ? (popoutX + popoutWidth) : popoutX;
+                const screenY = popoutY + contentOffsetY + btnY;
+                showAudioDevicesDropdown(Qt.point(screenX, screenY), targetScreen, buttonsOnRight);
+            }
+            onExited: {
+                if (devicesExpanded)
+                    dropdownButtonExited();
+            }
         }
     }
 }

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -84,7 +84,6 @@ Item {
         isSwitching = true;
         _switchHold = true;
         _switchHoldTimer.restart();
-        TrackArtService.loadArtwork(TrackArtService.getArtworkUrl(activePlayer));
     }
 
     function maybeFinishSwitch() {
@@ -112,12 +111,6 @@ Item {
         function onTrackTitleChanged() {
             _switchHoldTimer.restart();
             maybeFinishSwitch();
-        }
-        function onTrackArtUrlChanged() {
-            TrackArtService.loadArtwork(TrackArtService.getArtworkUrl(activePlayer));
-        }
-        function onMetadataChanged() {
-            TrackArtService.loadArtwork(TrackArtService.getArtworkUrl(activePlayer));
         }
     }
 
@@ -297,14 +290,14 @@ Item {
     Item {
         id: bgContainer
         anchors.fill: parent
-        visible: TrackArtService._bgArtSource !== ""
+        visible: TrackArtService.resolvedArtUrl !== ""
 
         Image {
             id: bgImage
             anchors.centerIn: parent
             width: Math.max(parent.width, parent.height) * 1.1
             height: width
-            source: TrackArtService._bgArtSource
+            source: TrackArtService.resolvedArtUrl
             fillMode: Image.PreserveAspectCrop
             asynchronous: true
             cache: true

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -329,7 +329,7 @@ Item {
                     }
 
                     StyledText {
-                        text: activePlayer?.trackTitle || I18n.tr("Unknown Artist")
+                        text: activePlayer?.trackArtist || I18n.tr("Unknown Artist")
                         font.pixelSize: Theme.fontSizeMedium
                         color: Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.8)
                         width: parent.width

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -212,18 +212,14 @@ Item {
             }
         }
 
-        // 3. Up / Down arrows to play previous / next track
+        // 3. Up / Down arrows to adjust volume
         if (event.key === Qt.Key_Up) {
-            if (activePlayer.canGoPrevious) {
-                activePlayer.previous();
-                return true;
-            }
+            adjustVolume(5);
+            return true;
         }
         if (event.key === Qt.Key_Down) {
-            if (activePlayer.canGoNext) {
-                activePlayer.next();
-                return true;
-            }
+            adjustVolume(-5);
+            return true;
         }
 
         // 4. Spacebar to play/pause

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -84,7 +84,7 @@ Item {
         isSwitching = true;
         _switchHold = true;
         _switchHoldTimer.restart();
-        TrackArtService.loadArtwork(activePlayer.trackArtUrl);
+        TrackArtService.loadArtwork(TrackArtService.getArtworkUrl(activePlayer));
     }
 
     function maybeFinishSwitch() {
@@ -108,12 +108,16 @@ Item {
 
     Connections {
         target: activePlayer
+        ignoreUnknownSignals: true
         function onTrackTitleChanged() {
             _switchHoldTimer.restart();
             maybeFinishSwitch();
         }
         function onTrackArtUrlChanged() {
-            TrackArtService.loadArtwork(activePlayer.trackArtUrl);
+            TrackArtService.loadArtwork(TrackArtService.getArtworkUrl(activePlayer));
+        }
+        function onMetadataChanged() {
+            TrackArtService.loadArtwork(TrackArtService.getArtworkUrl(activePlayer));
         }
     }
 

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -184,6 +184,59 @@ Item {
         }
     }
 
+    function handleKeyEvent(event) {
+        if (!activePlayer)
+            return false;
+
+        // 1. Number keys 0-9 to seek to 0%-90%
+        if (event.key >= Qt.Key_0 && event.key <= Qt.Key_9) {
+            if (activePlayer.canSeek && activePlayer.length > 0) {
+                const ratio = (event.key - Qt.Key_0) * 0.1;
+                const targetPosition = ratio * activePlayer.length;
+                activePlayer.position = Math.min(targetPosition, activePlayer.length * 0.99);
+                return true;
+            }
+        }
+
+        // 2. Left / Right arrows to seek backward / forward 5s
+        if (event.key === Qt.Key_Left) {
+            if (activePlayer.canSeek) {
+                activePlayer.position = Math.max(0, activePlayer.position - 5);
+                return true;
+            }
+        }
+        if (event.key === Qt.Key_Right) {
+            if (activePlayer.canSeek && activePlayer.length > 0) {
+                activePlayer.position = Math.min(activePlayer.length - 1, activePlayer.position + 5);
+                return true;
+            }
+        }
+
+        // 3. Up / Down arrows to play previous / next track
+        if (event.key === Qt.Key_Up) {
+            if (activePlayer.canGoPrevious) {
+                activePlayer.previous();
+                return true;
+            }
+        }
+        if (event.key === Qt.Key_Down) {
+            if (activePlayer.canGoNext) {
+                activePlayer.next();
+                return true;
+            }
+        }
+
+        // 4. Spacebar to play/pause
+        if (event.key === Qt.Key_Space) {
+            if (activePlayer.canTogglePlaying) {
+                activePlayer.togglePlaying();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     property bool isSeeking: false
 
     Timer {

--- a/quickshell/Modules/DankDash/Overview/MediaOverviewCard.qml
+++ b/quickshell/Modules/DankDash/Overview/MediaOverviewCard.qml
@@ -15,10 +15,11 @@ Card {
     property real displayPosition: currentPosition
 
     readonly property real ratio: {
-        if (!activePlayer || !activePlayer.lengthSupported || activePlayer.length <= 0)
+        const len = MprisController.activePlayerStableLength;
+        if (!activePlayer || !activePlayer.lengthSupported || len <= 0)
             return 0;
-        const pos = displayPosition % Math.max(1, activePlayer.length);
-        const calculatedRatio = pos / activePlayer.length;
+        const pos = displayPosition % Math.max(1, len);
+        const calculatedRatio = pos / len;
         return Math.max(0, Math.min(1, calculatedRatio));
     }
 

--- a/quickshell/Modules/DankDash/Overview/MediaOverviewCard.qml
+++ b/quickshell/Modules/DankDash/Overview/MediaOverviewCard.qml
@@ -15,7 +15,7 @@ Card {
     property real displayPosition: currentPosition
 
     readonly property real ratio: {
-        if (!activePlayer || activePlayer.length <= 0)
+        if (!activePlayer || !activePlayer.lengthSupported || activePlayer.length <= 0)
             return 0;
         const pos = displayPosition % Math.max(1, activePlayer.length);
         const calculatedRatio = pos / activePlayer.length;

--- a/quickshell/Modules/OSD/MediaPlaybackOSD.qml
+++ b/quickshell/Modules/OSD/MediaPlaybackOSD.qml
@@ -60,7 +60,7 @@ DankOSD {
 
     Image {
         id: artPreloader
-        source: TrackArtService._bgArtSource
+        source: TrackArtService.resolvedArtUrl
         visible: false
         asynchronous: true
         cache: true
@@ -78,7 +78,7 @@ DankOSD {
         function onLoadingChanged() {
             if (TrackArtService.loading || !root._pendingShow)
                 return;
-            if (!TrackArtService._bgArtSource || artPreloader.status === Image.Ready) {
+            if (!TrackArtService.resolvedArtUrl || artPreloader.status === Image.Ready) {
                 root._pendingShow = false;
                 root.show();
             }
@@ -116,8 +116,7 @@ DankOSD {
             root._displayAlbum = player.trackAlbum || "";
 
             root.updatePlaybackIcon();
-            const resolvedArtUrl = TrackArtService.getArtworkUrl(player);
-            TrackArtService.loadArtwork(resolvedArtUrl);
+            const resolvedArtUrl = TrackArtService.resolvedArtUrl;
 
             if (!resolvedArtUrl || resolvedArtUrl === "") {
                 root.show();
@@ -127,7 +126,7 @@ DankOSD {
                 root._pendingShow = true;
                 return;
             }
-            if (!TrackArtService._bgArtSource || artPreloader.status === Image.Ready) {
+            if (!TrackArtService.resolvedArtUrl || artPreloader.status === Image.Ready) {
                 root.show();
                 return;
             }
@@ -135,10 +134,10 @@ DankOSD {
         }
 
         function onTrackArtUrlChanged() {
-            TrackArtService.loadArtwork(TrackArtService.getArtworkUrl(player));
+            handleUpdate();
         }
         function onMetadataChanged() {
-            TrackArtService.loadArtwork(TrackArtService.getArtworkUrl(player));
+            handleUpdate();
         }
         function onIsPlayingChanged() {
             handleUpdate();
@@ -172,14 +171,14 @@ DankOSD {
             Item {
                 id: bgContainer
                 anchors.fill: parent
-                visible: TrackArtService._bgArtSource !== ""
+                visible: TrackArtService.resolvedArtUrl !== ""
 
                 Image {
                     id: bgImage
                     anchors.centerIn: parent
                     width: Math.max(parent.width, parent.height)
                     height: width
-                    source: TrackArtService._bgArtSource
+                    source: TrackArtService.resolvedArtUrl
                     fillMode: Image.PreserveAspectCrop
                     asynchronous: true
                     cache: true

--- a/quickshell/Modules/OSD/MediaPlaybackOSD.qml
+++ b/quickshell/Modules/OSD/MediaPlaybackOSD.qml
@@ -116,9 +116,10 @@ DankOSD {
             root._displayAlbum = player.trackAlbum || "";
 
             root.updatePlaybackIcon();
-            TrackArtService.loadArtwork(player.trackArtUrl);
+            const resolvedArtUrl = TrackArtService.getArtworkUrl(player);
+            TrackArtService.loadArtwork(resolvedArtUrl);
 
-            if (!player.trackArtUrl || player.trackArtUrl === "") {
+            if (!resolvedArtUrl || resolvedArtUrl === "") {
                 root.show();
                 return;
             }
@@ -134,7 +135,10 @@ DankOSD {
         }
 
         function onTrackArtUrlChanged() {
-            TrackArtService.loadArtwork(player.trackArtUrl);
+            TrackArtService.loadArtwork(TrackArtService.getArtworkUrl(player));
+        }
+        function onMetadataChanged() {
+            TrackArtService.loadArtwork(TrackArtService.getArtworkUrl(player));
         }
         function onIsPlayingChanged() {
             handleUpdate();

--- a/quickshell/Services/MprisController.qml
+++ b/quickshell/Services/MprisController.qml
@@ -81,7 +81,7 @@ Singleton {
         if (!activePlayer)
             return;
         if (activePlayer.position > 8 && activePlayer.canSeek)
-            activePlayer.position = 0;
+            activePlayer.position = 0.1;
         else if (activePlayer.canGoPrevious)
             activePlayer.previous();
     }

--- a/quickshell/Services/MprisController.qml
+++ b/quickshell/Services/MprisController.qml
@@ -11,6 +11,23 @@ Singleton {
 
     readonly property list<MprisPlayer> availablePlayers: Mpris.players.values
     property MprisPlayer activePlayer: null
+    property real activePlayerStableLength: 0
+
+    Connections {
+        target: root.activePlayer
+        function onTrackTitleChanged() {
+            root.activePlayerStableLength = (root.activePlayer && root.activePlayer.lengthSupported && root.activePlayer.length > 1) ? root.activePlayer.length : 0;
+        }
+        function onLengthChanged() {
+            if (root.activePlayer && root.activePlayer.lengthSupported && root.activePlayer.length > 1) {
+                root.activePlayerStableLength = root.activePlayer.length;
+            }
+        }
+    }
+
+    onActivePlayerChanged: {
+        activePlayerStableLength = (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) ? activePlayer.length : 0;
+    }
 
     onAvailablePlayersChanged: _resolveActivePlayer()
     Component.onCompleted: _resolveActivePlayer()

--- a/quickshell/Services/TrackArtService.qml
+++ b/quickshell/Services/TrackArtService.qml
@@ -12,6 +12,37 @@ Singleton {
     property string _lastArtUrl: ""
     property string _bgArtSource: ""
     property bool loading: false
+    property string activePlayerArtUrl: ""
+
+    function getArtworkUrl(player) {
+        if (!player) return "";
+        
+        // 1. If native trackArtUrl is present and valid
+        let artUrl = player.trackArtUrl || "";
+        if (artUrl !== "") {
+            return artUrl;
+        }
+
+        // 2. Fallback to raw metadata mpris:artUrl if present
+        if (player.metadata && player.metadata["mpris:artUrl"]) {
+            artUrl = player.metadata["mpris:artUrl"].toString();
+            if (artUrl !== "") return artUrl;
+        }
+
+        // 3. Fallback for YouTube from xesam:url
+        if (player.metadata && player.metadata["xesam:url"]) {
+            const url = player.metadata["xesam:url"].toString();
+            if (url.includes("youtube.com") || url.includes("youtu.be")) {
+                const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/;
+                const match = url.match(regExp);
+                if (match && match[2].length === 11) {
+                    return "https://img.youtube.com/vi/" + match[2] + "/hqdefault.jpg";
+                }
+            }
+        }
+
+        return "";
+    }
 
     function loadArtwork(url) {
         if (!url || url === "") {
@@ -43,7 +74,19 @@ Singleton {
 
     property MprisPlayer activePlayer: MprisController.activePlayer
 
-    onActivePlayerChanged: {
-        loadArtwork(activePlayer?.trackArtUrl ?? "");
+    onActivePlayerChanged: _updateArtUrl()
+
+    Connections {
+        target: root.activePlayer
+        ignoreUnknownSignals: true
+        function onTrackTitleChanged() { root._updateArtUrl(); }
+        function onTrackArtUrlChanged() { root._updateArtUrl(); }
+        function onMetadataChanged() { root._updateArtUrl(); }
+    }
+
+    function _updateArtUrl() {
+        const url = getArtworkUrl(activePlayer);
+        activePlayerArtUrl = url;
+        loadArtwork(url);
     }
 }

--- a/quickshell/Services/TrackArtService.qml
+++ b/quickshell/Services/TrackArtService.qml
@@ -83,7 +83,7 @@ Singleton {
                     resolvedArtUrl = localFileUrl;
                     loading = false;
                 } else {
-                    Paths.mkdir(Paths.imagecache);
+                    const dlCmd = "mkdir -p \"$(dirname \"$1\")\" && curl -f -s -L -o \"$1\" \"$2\" && mv \"$1\" \"$3\" || { rm -f \"$1\"; exit 1; }";
 
                     // 2. Check if this is a YouTube URL to do high quality 16:9 fallback
                     if (targetUrl.includes("img.youtube.com/vi/")) {
@@ -92,8 +92,7 @@ Singleton {
                         const mqUrl = "https://img.youtube.com/vi/" + videoId + "/mqdefault.jpg";
                         const tmpPath = filePath + ".tmp";
 
-                        const maxresCmd = "curl -f -s -L -o '" + tmpPath + "' '" + maxresUrl + "' && mv '" + tmpPath + "' '" + filePath + "' || { rm -f '" + tmpPath + "'; exit 1; }";
-                        Proc.runCommand(null, ["sh", "-c", maxresCmd], (maxOutput, maxExitCode) => {
+                        Proc.runCommand(null, ["sh", "-c", dlCmd, "sh", tmpPath, maxresUrl, filePath], (maxOutput, maxExitCode) => {
                             if (_lastArtUrl !== targetUrl)
                                 return;
 
@@ -101,8 +100,7 @@ Singleton {
                                 resolvedArtUrl = localFileUrl;
                                 loading = false;
                             } else {
-                                const mqCmd = "curl -f -s -L -o '" + tmpPath + "' '" + mqUrl + "' && mv '" + tmpPath + "' '" + filePath + "' || { rm -f '" + tmpPath + "'; exit 1; }";
-                                Proc.runCommand(null, ["sh", "-c", mqCmd], (mqOutput, mqExitCode) => {
+                                Proc.runCommand(null, ["sh", "-c", dlCmd, "sh", tmpPath, mqUrl, filePath], (mqOutput, mqExitCode) => {
                                     if (_lastArtUrl !== targetUrl)
                                         return;
 
@@ -118,8 +116,7 @@ Singleton {
                     } else {
                         // Standard curl download for other remote URLs (e.g. SoundCloud)
                         const tmpPath = filePath + ".tmp";
-                        const dlCmd = "curl -f -s -L -o '" + tmpPath + "' '" + targetUrl + "' && mv '" + tmpPath + "' '" + filePath + "' || { rm -f '" + tmpPath + "'; exit 1; }";
-                        Proc.runCommand(null, ["sh", "-c", dlCmd], (dlOutput, dlExitCode) => {
+                        Proc.runCommand(null, ["sh", "-c", dlCmd, "sh", tmpPath, targetUrl, filePath], (dlOutput, dlExitCode) => {
                             if (_lastArtUrl !== targetUrl)
                                 return;
 

--- a/quickshell/Services/TrackArtService.qml
+++ b/quickshell/Services/TrackArtService.qml
@@ -10,9 +10,20 @@ Singleton {
     id: root
 
     property string _lastArtUrl: ""
-    property string _bgArtSource: ""
+    property string resolvedArtUrl: ""
+    property alias _bgArtSource: root.resolvedArtUrl
     property bool loading: false
     property string activePlayerArtUrl: ""
+
+    function djb2Hash(str) {
+        if (!str) return "";
+        let hash = 5381;
+        for (let i = 0; i < str.length; i++) {
+            hash = ((hash << 5) + hash) + str.charCodeAt(i);
+            hash = hash & 0x7FFFFFFF;
+        }
+        return hash.toString(16).padStart(8, '0');
+    }
 
     function getArtworkUrl(player) {
         if (!player) return "";
@@ -46,7 +57,7 @@ Singleton {
 
     function loadArtwork(url) {
         if (!url || url === "") {
-            _bgArtSource = "";
+            resolvedArtUrl = "";
             _lastArtUrl = "";
             loading = false;
             return;
@@ -56,8 +67,67 @@ Singleton {
         _lastArtUrl = url;
 
         if (url.startsWith("http://") || url.startsWith("https://")) {
-            _bgArtSource = url;
-            loading = false;
+            loading = true;
+            const targetUrl = url;
+            const hash = djb2Hash(url);
+            const cacheDir = Paths.strip(Paths.imagecache);
+            const filePath = cacheDir + "/remote_" + hash;
+            const localFileUrl = "file://" + filePath;
+
+            // 1. First, check if the file already exists locally
+            Proc.runCommand("trackart_check_" + hash, ["test", "-f", filePath], (output, exitCode) => {
+                if (_lastArtUrl !== targetUrl)
+                    return;
+
+                if (exitCode === 0) {
+                    resolvedArtUrl = localFileUrl;
+                    loading = false;
+                } else {
+                    Paths.mkdir(Paths.imagecache);
+
+                    // 2. Check if this is a YouTube URL to do high quality 16:9 fallback
+                    if (targetUrl.includes("img.youtube.com/vi/")) {
+                        const videoId = targetUrl.split("/vi/")[1].split("/")[0];
+                        const maxresUrl = "https://img.youtube.com/vi/" + videoId + "/maxresdefault.jpg";
+                        const mqUrl = "https://img.youtube.com/vi/" + videoId + "/mqdefault.jpg";
+
+                        Proc.runCommand("trackart_dl_max_" + hash, ["curl", "-f", "-s", "-L", "-o", filePath, maxresUrl], (maxOutput, maxExitCode) => {
+                            if (_lastArtUrl !== targetUrl)
+                                return;
+
+                            if (maxExitCode === 0) {
+                                resolvedArtUrl = localFileUrl;
+                                loading = false;
+                            } else {
+                                Proc.runCommand("trackart_dl_mq_" + hash, ["curl", "-f", "-s", "-L", "-o", filePath, mqUrl], (mqOutput, mqExitCode) => {
+                                    if (_lastArtUrl !== targetUrl)
+                                        return;
+
+                                    if (mqExitCode === 0) {
+                                        resolvedArtUrl = localFileUrl;
+                                    } else {
+                                        resolvedArtUrl = targetUrl; // Ultimate fallback
+                                    }
+                                    loading = false;
+                                }, 50, 15000);
+                            }
+                        }, 50, 15000);
+                    } else {
+                        // Standard curl download for other remote URLs (e.g. SoundCloud)
+                        Proc.runCommand("trackart_dl_" + hash, ["curl", "-f", "-s", "-L", "-o", filePath, targetUrl], (dlOutput, dlExitCode) => {
+                            if (_lastArtUrl !== targetUrl)
+                                return;
+
+                            if (dlExitCode === 0) {
+                                resolvedArtUrl = localFileUrl;
+                            } else {
+                                resolvedArtUrl = targetUrl; // Fallback to raw URL
+                            }
+                            loading = false;
+                        }, 50, 15000);
+                    }
+                }
+            }, 50, 5000);
             return;
         }
 
@@ -67,7 +137,7 @@ Singleton {
         Proc.runCommand("trackart", ["test", "-f", filePath], (output, exitCode) => {
             if (_lastArtUrl !== localUrl)
                 return;
-            _bgArtSource = exitCode === 0 ? localUrl : "";
+            resolvedArtUrl = exitCode === 0 ? localUrl : "";
             loading = false;
         }, 200);
     }

--- a/quickshell/Services/TrackArtService.qml
+++ b/quickshell/Services/TrackArtService.qml
@@ -13,7 +13,6 @@ Singleton {
     property string resolvedArtUrl: ""
     property alias _bgArtSource: root.resolvedArtUrl
     property bool loading: false
-    property string activePlayerArtUrl: ""
 
     function djb2Hash(str) {
         if (!str) return "";
@@ -68,6 +67,7 @@ Singleton {
 
         if (url.startsWith("http://") || url.startsWith("https://")) {
             loading = true;
+            resolvedArtUrl = ""; // Clear stale artwork immediately while loading
             const targetUrl = url;
             const hash = djb2Hash(url);
             const cacheDir = Paths.strip(Paths.imagecache);
@@ -75,7 +75,7 @@ Singleton {
             const localFileUrl = "file://" + filePath;
 
             // 1. First, check if the file already exists locally
-            Proc.runCommand("trackart_check_" + hash, ["test", "-f", filePath], (output, exitCode) => {
+            Proc.runCommand(null, ["test", "-f", filePath], (output, exitCode) => {
                 if (_lastArtUrl !== targetUrl)
                     return;
 
@@ -90,8 +90,10 @@ Singleton {
                         const videoId = targetUrl.split("/vi/")[1].split("/")[0];
                         const maxresUrl = "https://img.youtube.com/vi/" + videoId + "/maxresdefault.jpg";
                         const mqUrl = "https://img.youtube.com/vi/" + videoId + "/mqdefault.jpg";
+                        const tmpPath = filePath + ".tmp";
 
-                        Proc.runCommand("trackart_dl_max_" + hash, ["curl", "-f", "-s", "-L", "-o", filePath, maxresUrl], (maxOutput, maxExitCode) => {
+                        const maxresCmd = "curl -f -s -L -o '" + tmpPath + "' '" + maxresUrl + "' && mv '" + tmpPath + "' '" + filePath + "' || { rm -f '" + tmpPath + "'; exit 1; }";
+                        Proc.runCommand(null, ["sh", "-c", maxresCmd], (maxOutput, maxExitCode) => {
                             if (_lastArtUrl !== targetUrl)
                                 return;
 
@@ -99,7 +101,8 @@ Singleton {
                                 resolvedArtUrl = localFileUrl;
                                 loading = false;
                             } else {
-                                Proc.runCommand("trackart_dl_mq_" + hash, ["curl", "-f", "-s", "-L", "-o", filePath, mqUrl], (mqOutput, mqExitCode) => {
+                                const mqCmd = "curl -f -s -L -o '" + tmpPath + "' '" + mqUrl + "' && mv '" + tmpPath + "' '" + filePath + "' || { rm -f '" + tmpPath + "'; exit 1; }";
+                                Proc.runCommand(null, ["sh", "-c", mqCmd], (mqOutput, mqExitCode) => {
                                     if (_lastArtUrl !== targetUrl)
                                         return;
 
@@ -114,7 +117,9 @@ Singleton {
                         }, 50, 15000);
                     } else {
                         // Standard curl download for other remote URLs (e.g. SoundCloud)
-                        Proc.runCommand("trackart_dl_" + hash, ["curl", "-f", "-s", "-L", "-o", filePath, targetUrl], (dlOutput, dlExitCode) => {
+                        const tmpPath = filePath + ".tmp";
+                        const dlCmd = "curl -f -s -L -o '" + tmpPath + "' '" + targetUrl + "' && mv '" + tmpPath + "' '" + filePath + "' || { rm -f '" + tmpPath + "'; exit 1; }";
+                        Proc.runCommand(null, ["sh", "-c", dlCmd], (dlOutput, dlExitCode) => {
                             if (_lastArtUrl !== targetUrl)
                                 return;
 
@@ -132,9 +137,10 @@ Singleton {
         }
 
         loading = true;
+        resolvedArtUrl = ""; // Clear stale artwork immediately while verifying local file
         const localUrl = url;
         const filePath = url.startsWith("file://") ? url.substring(7) : url;
-        Proc.runCommand("trackart", ["test", "-f", filePath], (output, exitCode) => {
+        Proc.runCommand(null, ["test", "-f", filePath], (output, exitCode) => {
             if (_lastArtUrl !== localUrl)
                 return;
             resolvedArtUrl = exitCode === 0 ? localUrl : "";
@@ -156,7 +162,6 @@ Singleton {
 
     function _updateArtUrl() {
         const url = getArtworkUrl(activePlayer);
-        activePlayerArtUrl = url;
         loadArtwork(url);
     }
 }

--- a/quickshell/Services/TrackArtService.qml
+++ b/quickshell/Services/TrackArtService.qml
@@ -27,7 +27,7 @@ Singleton {
 
     function getArtworkUrl(player) {
         if (!player) return "";
-        
+
         // 1. If native trackArtUrl is present and valid
         let artUrl = player.trackArtUrl || "";
         if (artUrl !== "") {

--- a/quickshell/Widgets/DankAlbumArt.qml
+++ b/quickshell/Widgets/DankAlbumArt.qml
@@ -15,6 +15,10 @@ Item {
     property bool showAnimation: true
     property real animationScale: 1.0
 
+    onActivePlayerChanged: {
+        lastValidArtUrl = "";
+    }
+
     onArtUrlChanged: {
         if (artUrl && albumArt.status !== Image.Error) {
             lastValidArtUrl = artUrl;

--- a/quickshell/Widgets/DankAlbumArt.qml
+++ b/quickshell/Widgets/DankAlbumArt.qml
@@ -8,19 +8,32 @@ Item {
     id: root
 
     property MprisPlayer activePlayer
-    property string artUrl: (activePlayer?.trackArtUrl) || ""
+    property string artUrl: ""
     property string lastValidArtUrl: ""
     property alias albumArtStatus: albumArt.imageStatus
     property real albumSize: Math.min(width, height) * 0.88
     property bool showAnimation: true
     property real animationScale: 1.0
 
+    function _updateArtUrl() {
+        artUrl = TrackArtService.getArtworkUrl(activePlayer);
+    }
+
     onActivePlayerChanged: {
         lastValidArtUrl = "";
+        _updateArtUrl();
+    }
+
+    Connections {
+        target: root.activePlayer
+        ignoreUnknownSignals: true
+        function onTrackTitleChanged() { root._updateArtUrl(); }
+        function onTrackArtUrlChanged() { root._updateArtUrl(); }
+        function onMetadataChanged() { root._updateArtUrl(); }
     }
 
     onArtUrlChanged: {
-        if (artUrl && albumArt.status !== Image.Error) {
+        if (artUrl && albumArtStatus !== Image.Error) {
             lastValidArtUrl = artUrl;
         }
     }

--- a/quickshell/Widgets/DankAlbumArt.qml
+++ b/quickshell/Widgets/DankAlbumArt.qml
@@ -8,28 +8,15 @@ Item {
     id: root
 
     property MprisPlayer activePlayer
-    property string artUrl: ""
+    property string artUrl: TrackArtService.resolvedArtUrl
     property string lastValidArtUrl: ""
     property alias albumArtStatus: albumArt.imageStatus
     property real albumSize: Math.min(width, height) * 0.88
     property bool showAnimation: true
     property real animationScale: 1.0
 
-    function _updateArtUrl() {
-        artUrl = TrackArtService.getArtworkUrl(activePlayer);
-    }
-
     onActivePlayerChanged: {
         lastValidArtUrl = "";
-        _updateArtUrl();
-    }
-
-    Connections {
-        target: root.activePlayer
-        ignoreUnknownSignals: true
-        function onTrackTitleChanged() { root._updateArtUrl(); }
-        function onTrackArtUrlChanged() { root._updateArtUrl(); }
-        function onMetadataChanged() { root._updateArtUrl(); }
     }
 
     onArtUrlChanged: {

--- a/quickshell/Widgets/DankCircularImage.qml
+++ b/quickshell/Widgets/DankCircularImage.qml
@@ -81,6 +81,8 @@ Rectangle {
         mipmap: true
         cache: true
         visible: false
+        sourceSize.width: Math.max(width * 2, 128)
+        sourceSize.height: Math.max(height * 2, 128)
         source: !root.shouldProbe ? root.imageSource : ""
     }
 

--- a/quickshell/Widgets/DankCircularImage.qml
+++ b/quickshell/Widgets/DankCircularImage.qml
@@ -81,8 +81,6 @@ Rectangle {
         mipmap: true
         cache: true
         visible: false
-        sourceSize.width: Math.max(width * 2, 128)
-        sourceSize.height: Math.max(height * 2, 128)
         source: !root.shouldProbe ? root.imageSource : ""
     }
 

--- a/quickshell/Widgets/DankSeekbar.qml
+++ b/quickshell/Widgets/DankSeekbar.qml
@@ -8,23 +8,7 @@ Item {
     id: root
 
     property MprisPlayer activePlayer
-    property real stableLength: 0
-
-    Connections {
-        target: activePlayer
-        function onLengthChanged() {
-            if (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) {
-                root.stableLength = activePlayer.length;
-            }
-        }
-        function onTrackTitleChanged() {
-            root.stableLength = (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) ? activePlayer.length : 0;
-        }
-    }
-
-    onActivePlayerChanged: {
-        stableLength = (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) ? activePlayer.length : 0;
-    }
+    readonly property real stableLength: MprisController.activePlayerStableLength
 
     property real seekPreviewRatio: -1
     readonly property real playerValue: {

--- a/quickshell/Widgets/DankSeekbar.qml
+++ b/quickshell/Widgets/DankSeekbar.qml
@@ -8,12 +8,30 @@ Item {
     id: root
 
     property MprisPlayer activePlayer
+    property real stableLength: 0
+
+    Connections {
+        target: activePlayer
+        function onLengthChanged() {
+            if (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) {
+                root.stableLength = activePlayer.length;
+            }
+        }
+        function onTrackTitleChanged() {
+            root.stableLength = (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) ? activePlayer.length : 0;
+        }
+    }
+
+    onActivePlayerChanged: {
+        stableLength = (activePlayer && activePlayer.lengthSupported && activePlayer.length > 1) ? activePlayer.length : 0;
+    }
+
     property real seekPreviewRatio: -1
     readonly property real playerValue: {
-        if (!activePlayer || activePlayer.length <= 0)
+        if (!activePlayer || stableLength <= 0)
             return 0;
-        const pos = (activePlayer.position || 0) % Math.max(1, activePlayer.length);
-        const calculatedRatio = pos / activePlayer.length;
+        const pos = (activePlayer.position || 0) % Math.max(1, stableLength);
+        const calculatedRatio = pos / stableLength;
         return Math.max(0, Math.min(1, calculatedRatio));
     }
     property real value: seekPreviewRatio >= 0 ? seekPreviewRatio : playerValue
@@ -29,20 +47,20 @@ Item {
     }
 
     function ratioForPosition(position) {
-        if (!activePlayer || activePlayer.length <= 0)
+        if (!activePlayer || stableLength <= 0)
             return 0;
-        return clampRatio(position / activePlayer.length);
+        return clampRatio(position / stableLength);
     }
 
     function positionForRatio(ratio) {
-        if (!activePlayer || activePlayer.length <= 0)
+        if (!activePlayer || stableLength <= 0)
             return 0;
-        const rawPosition = clampRatio(ratio) * activePlayer.length;
-        return Math.min(rawPosition, activePlayer.length * 0.99);
+        const rawPosition = clampRatio(ratio) * stableLength;
+        return Math.min(rawPosition, stableLength * 0.99);
     }
 
     function updatePreviewFromMouse(mouseX, width) {
-        if (!activePlayer || activePlayer.length <= 0 || width <= 0)
+        if (!activePlayer || stableLength <= 0 || width <= 0)
             return;
         seekPreviewRatio = clampRatio(mouseX / width);
     }
@@ -68,7 +86,7 @@ Item {
         mouseArea.pressX = mouse.x;
         clearCommittedSeekPreview();
         holdTimer.restart();
-        if (activePlayer && activePlayer.length > 0 && activePlayer.canSeek) {
+        if (activePlayer && stableLength > 0 && activePlayer.canSeek) {
             updatePreviewFromMouse(mouse.x, width);
             mouseArea.pendingSeekPosition = positionForRatio(seekPreviewRatio);
         }
@@ -78,8 +96,8 @@ Item {
         holdTimer.stop();
         isSeeking = false;
         isDraggingSeek = false;
-        if (mouseArea.pendingSeekPosition >= 0 && activePlayer && activePlayer.canSeek && activePlayer.length > 0) {
-            const clamped = Math.min(mouseArea.pendingSeekPosition, activePlayer.length * 0.99);
+        if (mouseArea.pendingSeekPosition >= 0 && activePlayer && activePlayer.canSeek && stableLength > 0) {
+            const clamped = Math.min(mouseArea.pendingSeekPosition, stableLength * 0.99);
             activePlayer.position = Math.max(0.1, clamped);
             mouseArea.pendingSeekPosition = -1;
             beginCommittedSeekPreview(clamped);
@@ -89,7 +107,7 @@ Item {
     }
 
     function handleSeekPositionChanged(mouse, width, mouseArea) {
-        if (mouseArea.pressed && isSeeking && activePlayer && activePlayer.length > 0 && activePlayer.canSeek) {
+        if (mouseArea.pressed && isSeeking && activePlayer && stableLength > 0 && activePlayer.canSeek) {
             if (!isDraggingSeek && Math.abs(mouse.x - mouseArea.pressX) >= dragThreshold)
                 isDraggingSeek = true;
             updatePreviewFromMouse(mouse.x, width);
@@ -129,7 +147,7 @@ Item {
 
     Loader {
         anchors.fill: parent
-        visible: activePlayer && activePlayer.length > 0
+        visible: activePlayer && stableLength > 0
         sourceComponent: SettingsData.waveProgressEnabled ? waveProgressComponent : flatProgressComponent
         z: 1
 
@@ -148,7 +166,7 @@ Item {
                     anchors.fill: parent
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
-                    enabled: activePlayer && activePlayer.canSeek && activePlayer.length > 0
+                    enabled: activePlayer && activePlayer.canSeek && stableLength > 0
 
                     property real pendingSeekPosition: -1
                     property real pressX: 0
@@ -236,7 +254,7 @@ Item {
                     anchors.fill: parent
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
-                    enabled: activePlayer && activePlayer.canSeek && activePlayer.length > 0
+                    enabled: activePlayer && activePlayer.canSeek && stableLength > 0
 
                     property real pendingSeekPosition: -1
                     property real pressX: 0

--- a/quickshell/Widgets/DankSeekbar.qml
+++ b/quickshell/Widgets/DankSeekbar.qml
@@ -80,7 +80,7 @@ Item {
         isDraggingSeek = false;
         if (mouseArea.pendingSeekPosition >= 0 && activePlayer && activePlayer.canSeek && activePlayer.length > 0) {
             const clamped = Math.min(mouseArea.pendingSeekPosition, activePlayer.length * 0.99);
-            activePlayer.position = clamped;
+            activePlayer.position = Math.max(0.1, clamped);
             mouseArea.pendingSeekPosition = -1;
             beginCommittedSeekPreview(clamped);
         } else {


### PR DESCRIPTION
### What

* **Hover-to-show**: Adds hover-to-show and hover-to-hide behavior to the Media Players and Audio Output Devices dropdowns, matching the Volume dropdown behavior.
* **Click-to-cycle**: Clicking the Media Players or Audio Output Devices button while expanded now cycles to the next available media player or audio output device, instead of closing the dropdown.
* **Dynamic Bindings**: Replaced static argument passing with dynamic `Qt.binding()` to MPRIS controller singletons, fixing a display bug where player lists became stale/stalled upon switching.
* **Artwork Cache Reset**: Added a listener to reset the `lastValidArtUrl` buffer in `DankAlbumArt` when the active player changes, resolving a bug where a previous player's artwork would incorrectly persist on players that have no artwork.
* **Visual Consistency**: Set the Audio Output Devices button icon to always display `"speaker"` (rather than toggling to `"expand_less"` when open), ensuring a uniform design across all media control buttons.
* **Tooltip Cleanup**: Removed redundant helper tooltips ("Output Device" and "Media Players") to declutter the UI.
* **Audio Metadata Decoupling (New)**: Fixed a binding typo in `MediaPlayerTab` where the artist label incorrectly pointed to `trackTitle`, causing the song title and artist name to be duplicated when displaying media info.
* **Minimalist Player Subtitle (New)**: Cleaned up the player selection subtitle to display purely the artist name if available, or `"Unknown Artist"` if absent, aligning with other standard media info displays.
* **Audio Output Volume Indicators (New)**: Replaced the redundant "Active / Available" text in the Audio Output Devices list with the device's actual volume percentage (e.g. `80%`) or `Muted` status, providing highly useful real-time information.
* **Keyboard Shortcuts (New)**: Added a robust set of intuitive keyboard controls to the Media popout when active:
  - `0` - `9`: Seek to the corresponding percentage of the track (`0%` - `90%`).
  - `Left` / `Right` Arrow keys: Seek backward / forward by 5 seconds.
  - `Up` / `Down` Arrow keys: Increase / decrease player volume by 5% and **automatically open the volume dropdown overlay** (auto-hides after inactivity) to give real-time visual feedback.
  - `Spacebar`: Toggle play/pause playback.
  - `M` key: Toggle volume mute/unmute and automatically trigger the volume dropdown overlay.
* **Browser Seek Reset Fix (New)**: Clamped the minimum seek position (via keyboard/drag actions) to `0.1s` rather than exactly `0s`. This prevents the MPRIS bridge of browser-based players (like YouTube on Firefox/Chrome) from thinking the stream is uninitialized or needs a full reload, which temporarily reset the track duration metadata to `1s`.

### Why

Unifies the interaction model and improves the user experience by resolving inconsistencies in hover/click behaviors, dynamic list rendering, and icon states in the Control Center media widgets. Additionally, fixes track metadata duplication, provides useful device volume levels, and adds keyboard shortcuts for convenient media popout controls.

### How tested

Verified locally in the QuickShell environment by hovering, clicking, and cycling through active media players and audio devices, confirming smooth transitions, correct artwork clearing, and real-time list updates. Also tested keyboard shortcuts (0-9 seeking, arrow keys, spacebar) and volume percentage displays across multiple simulated players and audio sinks.

https://github.com/user-attachments/assets/1fb8de7e-3366-4816-92fd-76b3487bc919
