### PR TITLE
fix(CavaService): prevent 100% CPU EOF spin loop by using temp file

### DIFF
--- a/quickshell/Services/CavaService.qml
+++ b/quickshell/Services/CavaService.qml
@@ -30,7 +30,7 @@ Singleton {
         id: cavaProcess
 
         running: root.cavaAvailable && root.refCount > 0
-        command: ["sh", "-c", `cat <<'CAVACONF' | cava -p /dev/stdin
+        command: ["sh", "-c", `cat <<'CAVACONF' > /tmp/dms-cava.conf
 [general]
 framerate=25
 bars=6
@@ -52,7 +52,8 @@ integral=90
 gravity=95
 ignore=2
 monstercat=1.5
-CAVACONF`]
+CAVACONF
+exec cava -p /tmp/dms-cava.conf < /dev/null`]
 
         onRunningChanged: {
             if (!running) {

--- a/quickshell/Services/CavaService.qml
+++ b/quickshell/Services/CavaService.qml
@@ -1,9 +1,11 @@
 pragma Singleton
 pragma ComponentBehavior: Bound
 
+import QtCore
 import QtQuick
 import Quickshell
 import Quickshell.Io
+import qs.Common
 
 Singleton {
     id: root
@@ -11,6 +13,7 @@ Singleton {
     property list<int> values: Array(6)
     property int refCount: 0
     property bool cavaAvailable: false
+    readonly property string _confPath: `${Paths.strip(StandardPaths.writableLocation(StandardPaths.TempLocation))}/dms-cava-${Date.now()}-${Math.floor(Math.random() * 1000000)}.conf`
 
     Process {
         id: cavaCheck
@@ -30,7 +33,7 @@ Singleton {
         id: cavaProcess
 
         running: root.cavaAvailable && root.refCount > 0
-        command: ["sh", "-c", `cat <<'CAVACONF' > /tmp/dms-cava.conf
+        command: ["sh", "-c", `cat <<'CAVACONF' > ${root._confPath}
 [general]
 framerate=25
 bars=6
@@ -53,7 +56,7 @@ gravity=95
 ignore=2
 monstercat=1.5
 CAVACONF
-exec cava -p /tmp/dms-cava.conf < /dev/null`]
+exec cava -p ${root._confPath} < /dev/null`]
 
         onRunningChanged: {
             if (!running) {


### PR DESCRIPTION
# Fix `CavaService` 100% CPU EOF spin loop

## Description
This pull request resolves a critical performance issue in `CavaService.qml` where the visualizer process would hit an `EOF` on `stdin` and spin infinitely at 100% CPU usage.

When `Quickshell.Io.Process` executes the command `cat <<'CAVACONF' | cava -p /dev/stdin`, `cat` finishes writing the config quickly and exits, causing a broken pipe/EOF on `cava`'s standard input. `cava` spins in a tight loop attempting to read from the closed stream, consuming 100% CPU and flooding the shell with thousands of zeroed visualizer frames per second. This in turn drives the compositor and Qt quickshell usage to ~80% CPU and heavily overheats integrated GPUs.

## Changes
- Updated the shell command in `CavaService.qml` to write the configuration to a temporary file (`/tmp/dms-cava.conf`) instead of relying on a `stdin` pipe.
- `cava` is now invoked with `exec cava -p /tmp/dms-cava.conf < /dev/null`, completely decoupling its `stdin` from the configuration stream and eliminating the EOF spin loop bug.

## Testing
- Verified that `cava` now correctly idles around ~8% CPU instead of locking a core at 100%.
- Verified `cava` continues to produce audio visualization frames properly using the temporary configuration file.
