### PR TITLE
Add native Triad IPC support

### DIFF
--- a/quickshell/DMSShellIPC.qml
+++ b/quickshell/DMSShellIPC.qml
@@ -229,6 +229,9 @@ Item {
             if (CompositorService.isNiri && NiriService.currentOutput) {
                 return NiriService.currentOutput;
             }
+            if (CompositorService.isTriad && TriadService.currentOutput) {
+                return TriadService.currentOutput;
+            }
             if ((CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle) && I3.workspaces?.values) {
                 const focusedWs = I3.workspaces.values.find(ws => ws.focused === true);
                 return focusedWs?.monitor?.name || "";
@@ -1614,6 +1617,8 @@ Item {
 
     IpcHandler {
         function open(): string {
+            if (!CompositorService.isNiri)
+                return "WORKSPACE_RENAME_NIRI_ONLY";
             root.workspaceRenameModalLoader.active = true;
             if (root.workspaceRenameModalLoader.item) {
                 const ws = NiriService.workspaces[NiriService.focusedWorkspaceId];
@@ -1632,6 +1637,8 @@ Item {
         }
 
         function toggle(): string {
+            if (!CompositorService.isNiri)
+                return "WORKSPACE_RENAME_NIRI_ONLY";
             root.workspaceRenameModalLoader.active = true;
             if (root.workspaceRenameModalLoader.item) {
                 if (root.workspaceRenameModalLoader.item.visible) {

--- a/quickshell/Modals/DankLauncherV2/LauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/LauncherContent.qml
@@ -113,6 +113,8 @@ FocusScope {
             }
             if (SettingsData.spotlightCloseNiriOverview && NiriService.inOverview) {
                 NiriService.toggleOverview();
+            } else if (SettingsData.spotlightCloseNiriOverview && TriadService.inOverview) {
+                TriadService.toggleOverview();
             }
         }
     }

--- a/quickshell/Modals/DankLauncherV2/SpotlightLauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/SpotlightLauncherContent.qml
@@ -211,6 +211,8 @@ FocusScope {
             root.parentModal?.hide();
             if (SettingsData.spotlightCloseNiriOverview && NiriService.inOverview)
                 NiriService.toggleOverview();
+            else if (SettingsData.spotlightCloseNiriOverview && TriadService.inOverview)
+                TriadService.toggleOverview();
         }
     }
 

--- a/quickshell/Modules/DankBar/DankBar.qml
+++ b/quickshell/Modules/DankBar/DankBar.qml
@@ -105,6 +105,8 @@ Item {
             focusedScreenName = Hyprland.focusedWorkspace.monitor.name;
         } else if (CompositorService.isNiri && NiriService.currentOutput) {
             focusedScreenName = NiriService.currentOutput;
+        } else if (CompositorService.isTriad && TriadService.currentOutput) {
+            focusedScreenName = TriadService.currentOutput;
         } else if (CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle) {
             const focusedWs = I3.workspaces?.values?.find(ws => ws.focused === true);
             focusedScreenName = focusedWs?.monitor?.name || "";
@@ -134,6 +136,8 @@ Item {
             focusedScreenName = Hyprland.focusedWorkspace.monitor.name;
         } else if (CompositorService.isNiri && NiriService.currentOutput) {
             focusedScreenName = NiriService.currentOutput;
+        } else if (CompositorService.isTriad && TriadService.currentOutput) {
+            focusedScreenName = TriadService.currentOutput;
         } else if (CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle) {
             const focusedWs = I3.workspaces?.values?.find(ws => ws.focused === true);
             focusedScreenName = focusedWs?.monitor?.name || "";

--- a/quickshell/Modules/DankBar/DankBarContent.qml
+++ b/quickshell/Modules/DankBar/DankBarContent.qml
@@ -161,6 +161,20 @@ Item {
             }
             const workspaces = NiriService.allWorkspaces.filter(ws => ws.output === screenName);
             return workspaces.length > 0 ? workspaces : fallbackWorkspaces;
+        } else if (CompositorService.isTriad) {
+            const fallbackWorkspaces = [
+                {
+                    "id": 1,
+                    "idx": 1,
+                    "name": ""
+                }
+            ];
+            if (!screenName || SettingsData.workspaceFollowFocus) {
+                const currentWorkspaces = TriadService.getCurrentOutputWorkspaces();
+                return currentWorkspaces.length > 0 ? currentWorkspaces : fallbackWorkspaces;
+            }
+            const workspaces = TriadService.allWorkspaces.filter(ws => ws.output === screenName);
+            return workspaces.length > 0 ? workspaces : fallbackWorkspaces;
         } else if (CompositorService.isHyprland) {
             const workspaces = Hyprland.workspaces?.values || [];
 
@@ -230,6 +244,12 @@ Item {
             }
             const activeWs = NiriService.allWorkspaces.find(ws => ws.output === screenName && ws.is_active);
             return activeWs ? activeWs.idx : 1;
+        } else if (CompositorService.isTriad) {
+            if (!screenName || SettingsData.workspaceFollowFocus) {
+                return TriadService.getCurrentWorkspaceNumber();
+            }
+            const activeWs = TriadService.allWorkspaces.find(ws => ws.output === screenName && ws.is_active);
+            return activeWs ? activeWs.idx : 1;
         } else if (CompositorService.isHyprland) {
             const monitors = Hyprland.monitors?.values || [];
             const currentMonitor = monitors.find(monitor => monitor.name === screenName);
@@ -272,6 +292,19 @@ Item {
                     return;
                 }
                 NiriService.switchToWorkspace(nextWorkspace.id);
+            }
+        } else if (CompositorService.isTriad) {
+            const currentWs = getCurrentWorkspace();
+            const currentIndex = realWorkspaces.findIndex(ws => ws && ws.idx === currentWs);
+            const validIndex = currentIndex === -1 ? 0 : currentIndex;
+            const nextIndex = direction > 0 ? Math.min(validIndex + 1, realWorkspaces.length - 1) : Math.max(validIndex - 1, 0);
+
+            if (nextIndex !== validIndex) {
+                const nextWorkspace = realWorkspaces[nextIndex];
+                if (!nextWorkspace || nextWorkspace.id === undefined) {
+                    return;
+                }
+                TriadService.switchToWorkspace(nextWorkspace.id);
             }
         } else if (CompositorService.isHyprland) {
             const currentWs = getCurrentWorkspace();

--- a/quickshell/Modules/DankBar/DankBarWindow.qml
+++ b/quickshell/Modules/DankBar/DankBarWindow.qml
@@ -340,14 +340,14 @@ PanelWindow {
             hasMaximizedToplevel = false;
             return;
         }
-        if (!CompositorService.isHyprland && !CompositorService.isNiri) {
+        if (!CompositorService.isHyprland && !CompositorService.isNiri && !CompositorService.isTriad) {
             hasMaximizedToplevel = false;
             return;
         }
 
         const filtered = CompositorService.filterCurrentWorkspace(CompositorService.sortedToplevels, screenName);
         for (let i = 0; i < filtered.length; i++) {
-            if (filtered[i]?.maximized) {
+            if (filtered[i]?.maximized || filtered[i]?.triadMaximized) {
                 hasMaximizedToplevel = true;
                 return;
             }
@@ -364,7 +364,7 @@ PanelWindow {
             shouldHideForWindows = false;
             return;
         }
-        if (!CompositorService.isNiri && !CompositorService.isHyprland) {
+        if (!CompositorService.isNiri && !CompositorService.isTriad && !CompositorService.isHyprland) {
             shouldHideForWindows = false;
             return;
         }
@@ -421,6 +421,66 @@ PanelWindow {
                 case SettingsData.Position.Right:
                     const screenWidth = barWindow.screen?.width ?? 0;
                     if (tilePos[0] + winSize[0] > screenWidth - barThickness)
+                        hasFloatingTouchingBar = true;
+                    break;
+                }
+            }
+
+            shouldHideForWindows = hasTiled || hasFloatingTouchingBar;
+            return;
+        }
+
+        if (CompositorService.isTriad) {
+            let currentWorkspaceId = null;
+            for (let i = 0; i < TriadService.allWorkspaces.length; i++) {
+                const ws = TriadService.allWorkspaces[i];
+                if (ws.output === screenName && ws.is_active) {
+                    currentWorkspaceId = ws.id;
+                    break;
+                }
+            }
+
+            if (currentWorkspaceId === null) {
+                shouldHideForWindows = false;
+                return;
+            }
+
+            let hasTiled = false;
+            let hasFloatingTouchingBar = false;
+            const pos = barConfig?.position ?? 0;
+            const barThickness = barWindow.effectiveBarThickness + (barConfig?.spacing ?? 4);
+
+            for (let i = 0; i < TriadService.windows.length; i++) {
+                const win = TriadService.windows[i];
+                if (win.workspace_id !== currentWorkspaceId)
+                    continue;
+
+                if (!win.is_floating) {
+                    hasTiled = true;
+                    continue;
+                }
+
+                const geom = win.floating_geometry;
+                if (!geom)
+                    continue;
+
+                switch (pos) {
+                case SettingsData.Position.Top:
+                    if (geom.y < barThickness)
+                        hasFloatingTouchingBar = true;
+                    break;
+                case SettingsData.Position.Bottom:
+                    const screenHeight = barWindow.screen?.height ?? 0;
+                    if (geom.y + geom.height > screenHeight - barThickness)
+                        hasFloatingTouchingBar = true;
+                    break;
+                case SettingsData.Position.Left:
+                    if (geom.x < barThickness)
+                        hasFloatingTouchingBar = true;
+                    break;
+                case SettingsData.Position.Right:
+                    const screenWidth = barWindow.screen?.width ?? 0;
+                    if (geom.x + geom.width > screenWidth - barThickness)
                         hasFloatingTouchingBar = true;
                     break;
                 }
@@ -617,7 +677,7 @@ PanelWindow {
     }
 
     Connections {
-        target: NiriService
+        target: CompositorService.isNiri ? NiriService : CompositorService.isTriad ? TriadService : null
         function onAllWorkspacesChanged() {
             barWindow._updateHasMaximizedToplevel();
             barWindow._updateShouldHideForWindows();
@@ -652,7 +712,7 @@ PanelWindow {
 
         readonly property int barThickness: Theme.px(barWindow.effectiveBarThickness + barWindow.effectiveSpacing, barWindow._dpr)
 
-        readonly property bool inOverviewWithShow: CompositorService.isNiri && NiriService.inOverview && barWindow.effectiveOpenOnOverview
+        readonly property bool inOverviewWithShow: CompositorService.inOverview && barWindow.effectiveOpenOnOverview
         readonly property bool effectiveVisible: (barConfig?.visible ?? true) || inOverviewWithShow
         readonly property bool showing: effectiveVisible && (topBarCore.reveal || inOverviewWithShow || !topBarCore.autoHide)
 
@@ -833,18 +893,18 @@ PanelWindow {
         }
 
         property bool reveal: {
-            const inOverviewWithShow = CompositorService.isNiri && NiriService.inOverview && barWindow.effectiveOpenOnOverview;
+            const inOverviewWithShow = CompositorService.inOverview && barWindow.effectiveOpenOnOverview;
             if (inOverviewWithShow)
                 return true;
 
             const showOnWindowsSetting = barConfig?.showOnWindowsOpen ?? false;
-            if (showOnWindowsSetting && autoHide && (CompositorService.isNiri || CompositorService.isHyprland)) {
+            if (showOnWindowsSetting && autoHide && (CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland)) {
                 if (barWindow.shouldHideForWindows)
                     return topBarMouseArea.containsMouse || popoutPinsReveal || revealSticky || ipcReveal;
                 return true;
             }
 
-            if (CompositorService.isNiri && NiriService.inOverview)
+            if (CompositorService.inOverview)
                 return topBarMouseArea.containsMouse || popoutPinsReveal || revealSticky || ipcReveal;
 
             return (barConfig?.visible ?? true) && (!autoHide || topBarMouseArea.containsMouse || popoutPinsReveal || revealSticky || ipcReveal);
@@ -900,7 +960,7 @@ PanelWindow {
                 top: barWindow.isVertical ? parent.top : undefined
                 bottom: barWindow.isVertical ? parent.bottom : undefined
             }
-            readonly property bool inOverview: CompositorService.isNiri && NiriService.inOverview && barWindow.effectiveOpenOnOverview
+            readonly property bool inOverview: CompositorService.inOverview && barWindow.effectiveOpenOnOverview
             hoverEnabled: (barConfig?.autoHide ?? false) && !inOverview && !topBarCore.popoutPinsReveal
             acceptedButtons: Qt.NoButton
             enabled: (barConfig?.autoHide ?? false) && !inOverview
@@ -981,12 +1041,19 @@ PanelWindow {
                                 topBarContent.switchWorkspace(direction);
                                 return true;
                             case "column":
-                                if (!CompositorService.isNiri)
+                                if (!CompositorService.isNiri && !CompositorService.isTriad)
                                     return false;
-                                if (direction > 0)
-                                    NiriService.moveColumnRight();
-                                else
-                                    NiriService.moveColumnLeft();
+                                if (direction > 0) {
+                                    if (CompositorService.isTriad)
+                                        TriadService.moveColumnRight();
+                                    else
+                                        NiriService.moveColumnRight();
+                                } else {
+                                    if (CompositorService.isTriad)
+                                        TriadService.moveColumnLeft();
+                                    else
+                                        NiriService.moveColumnLeft();
+                                }
                                 return true;
                             default:
                                 return false;
@@ -1007,7 +1074,7 @@ PanelWindow {
                             const yBehavior = barConfig?.scrollYBehavior ?? "workspace";
                             const reverse = SettingsData.reverseScrolling ? -1 : 1;
 
-                            if (CompositorService.isNiri && xBehavior !== "none" && Math.abs(deltaX) > Math.abs(deltaY)) {
+                            if ((CompositorService.isNiri || CompositorService.isTriad) && xBehavior !== "none" && Math.abs(deltaX) > Math.abs(deltaY)) {
                                 if (isTouchpadX) {
                                     touchpadAccumulatorX += deltaX;
                                     if (Math.abs(touchpadAccumulatorX) >= 500) {

--- a/quickshell/Modules/DankBar/Widgets/FocusedApp.qml
+++ b/quickshell/Modules/DankBar/Widgets/FocusedApp.qml
@@ -58,6 +58,9 @@ BasePill {
                 if (CompositorService.isNiri) {
                     if (NiriService.currentOutput === (parentScreen?.name ?? ""))
                         activeWindow = null;
+                } else if (CompositorService.isTriad) {
+                    if (TriadService.currentOutput === (parentScreen?.name ?? ""))
+                        activeWindow = null;
                 } else {
                     const alive = ToplevelManager.toplevels?.values;
                     if (alive && !Array.from(alive).some(t => t === activeWindow))
@@ -84,7 +87,7 @@ BasePill {
     Connections {
         target: ToplevelManager
         function onActiveToplevelChanged() {
-            if (!CompositorService.isNiri)
+            if (!CompositorService.isNiri && !CompositorService.isTriad)
                 root.updateActiveWindow();
         }
     }
@@ -97,7 +100,7 @@ BasePill {
     }
 
     Connections {
-        target: CompositorService.isNiri ? NiriService : null
+        target: CompositorService.isNiri ? NiriService : CompositorService.isTriad ? TriadService : null
         function onWindowsChanged() {
             root.updateActiveWindow();
         }
@@ -145,6 +148,18 @@ BasePill {
             if (!focusedWin)
                 return false;
             const screenWsIds = new Set(NiriService.allWorkspaces.filter(ws => ws.output === parentScreen.name).map(ws => ws.id));
+            return screenWsIds.has(focusedWin.workspace_id);
+        }
+
+        if (CompositorService.isTriad) {
+            if (!activeWindow || !(activeWindow.title || activeWindow.appId))
+                return false;
+            if (TriadService.currentOutput !== (parentScreen?.name ?? ""))
+                return true;
+            const focusedWin = TriadService.windows.find(w => w.is_focused);
+            if (!focusedWin)
+                return false;
+            const screenWsIds = new Set(TriadService.allWorkspaces.filter(ws => ws.output === parentScreen.name).map(ws => ws.id));
             return screenWsIds.has(focusedWin.workspace_id);
         }
 

--- a/quickshell/Modules/DankBar/Widgets/KeyboardLayoutName.qml
+++ b/quickshell/Modules/DankBar/Widgets/KeyboardLayoutName.qml
@@ -111,6 +111,8 @@ BasePill {
     property string currentLayout: {
         if (CompositorService.isNiri) {
             return NiriService.getCurrentKeyboardLayoutName();
+        } else if (CompositorService.isTriad) {
+            return TriadService.getCurrentKeyboardLayoutName();
         } else if (CompositorService.isDwl) {
             return DwlService.currentKeyboardLayout;
         }
@@ -195,6 +197,8 @@ BasePill {
         onClicked: {
             if (CompositorService.isNiri) {
                 NiriService.cycleKeyboardLayout();
+            } else if (CompositorService.isTriad) {
+                TriadService.cycleKeyboardLayout();
             } else if (CompositorService.isHyprland) {
                 Quickshell.execDetached(["hyprctl", "switchxkblayout", root.hyprlandKeyboard, "next"]);
             } else if (CompositorService.isDwl) {

--- a/quickshell/Modules/DankBar/Widgets/LauncherButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/LauncherButton.qml
@@ -55,7 +55,7 @@ BasePill {
             }
 
             IconImage {
-                visible: SettingsData.launcherLogoMode === "compositor" && (CompositorService.isNiri || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle || CompositorService.isLabwc)
+                visible: SettingsData.launcherLogoMode === "compositor" && (CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle || CompositorService.isLabwc)
                 anchors.centerIn: parent
                 width: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset, root.barConfig?.maximizeWidgetIcons, root.barConfig?.iconScale)
                 height: Theme.barIconSize(root.barThickness, SettingsData.launcherLogoSizeOffset, root.barConfig?.maximizeWidgetIcons, root.barConfig?.iconScale)
@@ -64,6 +64,8 @@ BasePill {
                 source: {
                     if (CompositorService.isNiri) {
                         return "file://" + Theme.shellDir + "/assets/niri.svg";
+                    } else if (CompositorService.isTriad) {
+                        return "file://" + Theme.shellDir + "/assets/danklogo.svg";
                     } else if (CompositorService.isHyprland) {
                         return "file://" + Theme.shellDir + "/assets/hyprland.svg";
                     } else if (CompositorService.isDwl) {
@@ -116,6 +118,8 @@ BasePill {
     onRightClicked: {
         if (CompositorService.isNiri) {
             NiriService.toggleOverview();
+        } else if (CompositorService.isTriad) {
+            TriadService.toggleOverview();
         } else if (root.hyprlandOverviewLoader?.item) {
             root.hyprlandOverviewLoader.item.overviewOpen = !root.hyprlandOverviewLoader.item.overviewOpen;
         }

--- a/quickshell/Modules/DankBar/Widgets/NotepadButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/NotepadButton.qml
@@ -10,7 +10,7 @@ import qs.Widgets
 BasePill {
     id: root
 
-    readonly property string focusedScreenName: (CompositorService.isHyprland && typeof Hyprland !== "undefined" && Hyprland.focusedWorkspace && Hyprland.focusedWorkspace.monitor ? (Hyprland.focusedWorkspace.monitor.name || "") : CompositorService.isNiri && typeof NiriService !== "undefined" && NiriService.currentOutput ? NiriService.currentOutput : "")
+    readonly property string focusedScreenName: (CompositorService.isHyprland && typeof Hyprland !== "undefined" && Hyprland.focusedWorkspace && Hyprland.focusedWorkspace.monitor ? (Hyprland.focusedWorkspace.monitor.name || "") : CompositorService.focusedOutputName)
     readonly property string targetScreenName: parentScreen?.name || focusedScreenName
 
     function resolveNotepadInstance() {

--- a/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
+++ b/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
@@ -73,6 +73,8 @@ Item {
         switch (CompositorService.compositor) {
         case "niri":
             return NiriService.currentOutput || root.screenName;
+        case "triad":
+            return TriadService.currentOutput || root.screenName;
         case "hyprland":
             return Hyprland.focusedWorkspace?.monitor?.name || root.screenName;
         case "dwl":
@@ -93,6 +95,7 @@ Item {
             return (WindowManager.windowsets?.length ?? 0) > 0;
         switch (CompositorService.compositor) {
         case "niri":
+        case "triad":
         case "hyprland":
         case "dwl":
         case "sway":
@@ -118,6 +121,8 @@ Item {
         switch (CompositorService.compositor) {
         case "niri":
             return getNiriActiveWorkspace();
+        case "triad":
+            return getTriadActiveWorkspace();
         case "hyprland":
             return getHyprlandActiveWorkspace();
         case "dwl":
@@ -147,6 +152,9 @@ Item {
         switch (CompositorService.compositor) {
         case "niri":
             baseList = getNiriWorkspaces();
+            break;
+        case "triad":
+            baseList = getTriadWorkspaces();
             break;
         case "hyprland":
             baseList = getHyprlandWorkspaces();
@@ -286,6 +294,11 @@ Item {
                 }
                 targetWorkspaceId = ws.id;
             }
+        } else if (CompositorService.isTriad) {
+            if (!ws || typeof ws !== "object" || ws.id === undefined || ws.id === -1 || ws.idx === -1) {
+                return [];
+            }
+            targetWorkspaceId = ws.id;
         } else if (CompositorService.isHyprland) {
             targetWorkspaceId = ws.id !== undefined ? ws.id : ws;
         } else if (CompositorService.isDwl) {
@@ -299,12 +312,14 @@ Item {
             return [];
         }
 
-        const wins = CompositorService.isNiri ? (NiriService.windows || []) : CompositorService.sortedToplevels;
+        const wins = CompositorService.isNiri ? (NiriService.windows || []) : CompositorService.isTriad ? (TriadService.windows || []) : CompositorService.sortedToplevels;
 
         const byApp = {};
         let isActiveWs = false;
         if (CompositorService.isNiri) {
             isActiveWs = NiriService.allWorkspaces.some(ws => ws.id === targetWorkspaceId && ws.is_active);
+        } else if (CompositorService.isTriad) {
+            isActiveWs = TriadService.allWorkspaces.some(ws => ws.id === targetWorkspaceId && ws.is_active);
         } else if (CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle) {
             const focusedWs = I3.workspaces?.values?.find(ws => ws.focused === true);
             isActiveWs = focusedWs ? (focusedWs.num === targetWorkspaceId) : false;
@@ -325,6 +340,8 @@ Item {
 
             let winWs = null;
             if (CompositorService.isNiri) {
+                winWs = w.workspace_id;
+            } else if (CompositorService.isTriad) {
                 winWs = w.workspace_id;
             } else if (CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle) {
                 winWs = w.workspace?.num;
@@ -353,14 +370,14 @@ Item {
                     "icon": icon,
                     "isQuickshell": isQuickshell,
                     "isSteamApp": isSteamApp,
-                    "active": !!((w.activated || w.is_focused) || (CompositorService.isNiri && w.is_focused)),
+                    "active": !!((w.activated || w.is_focused || w.triadFocused) || (CompositorService.isNiri && w.is_focused)),
                     "count": 1,
                     "windowId": w.address || w.id,
                     "fallbackText": appName || ""
                 };
             } else {
                 byApp[key].count++;
-                if ((w.activated || w.is_focused) || (CompositorService.isNiri && w.is_focused)) {
+                if ((w.activated || w.is_focused || w.triadFocused) || (CompositorService.isNiri && w.is_focused)) {
                     byApp[key].active = true;
                 }
             }
@@ -380,6 +397,12 @@ Item {
                 "_placeholder": true
             };
         } else if (CompositorService.isNiri) {
+            placeholder = {
+                "id": -1,
+                "idx": -1,
+                "name": ""
+            };
+        } else if (CompositorService.isTriad) {
             placeholder = {
                 "id": -1,
                 "idx": -1,
@@ -471,6 +494,56 @@ Item {
         return activeWs ? activeWs.idx : 1;
     }
 
+    function getTriadWorkspaces() {
+        if (TriadService.allWorkspaces.length === 0) {
+            return [
+                {
+                    "id": 1,
+                    "idx": 1,
+                    "name": ""
+                }
+            ];
+        }
+
+        const fallbackWorkspaces = [
+            {
+                "id": 1,
+                "idx": 1,
+                "name": ""
+            }
+        ];
+
+        let workspaces;
+        if (!root.screenName || SettingsData.workspaceFollowFocus) {
+            const currentWorkspaces = TriadService.getCurrentOutputWorkspaces();
+            workspaces = currentWorkspaces.length > 0 ? currentWorkspaces : fallbackWorkspaces;
+        } else {
+            const displayWorkspaces = TriadService.allWorkspaces.filter(ws => ws.output === root.screenName);
+            workspaces = displayWorkspaces.length > 0 ? displayWorkspaces : fallbackWorkspaces;
+        }
+
+        workspaces = workspaces.slice().sort((a, b) => a.idx - b.idx);
+
+        if (!SettingsData.showOccupiedWorkspacesOnly) {
+            return workspaces;
+        }
+
+        return workspaces.filter(ws => ws.is_active || ws.occupied || (TriadService.windows?.some(win => win.workspace_id === ws.id) ?? false));
+    }
+
+    function getTriadActiveWorkspace() {
+        if (TriadService.allWorkspaces.length === 0) {
+            return 1;
+        }
+
+        if (!root.screenName || SettingsData.workspaceFollowFocus) {
+            return TriadService.getCurrentWorkspaceNumber();
+        }
+
+        const activeWs = TriadService.allWorkspaces.find(ws => ws.output === root.screenName && ws.is_active);
+        return activeWs ? activeWs.idx : 1;
+    }
+
     function getDwlTags() {
         if (!DwlService.dwlAvailable)
             return [];
@@ -554,6 +627,8 @@ Item {
                 return ws && !ws._placeholder;
             if (CompositorService.isNiri)
                 return ws && ws.idx !== -1;
+            if (CompositorService.isTriad)
+                return ws && ws.idx !== -1;
             if (CompositorService.isHyprland)
                 return ws && ws.id !== -1;
             if (CompositorService.isDwl)
@@ -578,6 +653,10 @@ Item {
         case "niri":
             if (data.id !== undefined)
                 NiriService.switchToWorkspace(data.id);
+            break;
+        case "triad":
+            if (data.id !== undefined)
+                TriadService.switchToWorkspace(data.id);
             break;
         case "hyprland":
             if (data.id) {
@@ -657,6 +736,25 @@ Item {
                 return;
             }
             NiriService.switchToWorkspace(nextWorkspace.id);
+        } else if (CompositorService.isTriad) {
+            const realWorkspaces = getRealWorkspaces();
+            if (realWorkspaces.length < 2) {
+                return;
+            }
+
+            const currentIndex = realWorkspaces.findIndex(ws => ws && ws.idx === root.currentWorkspace);
+            const validIndex = currentIndex === -1 ? 0 : currentIndex;
+            const nextIndex = direction > 0 ? Math.min(validIndex + 1, realWorkspaces.length - 1) : Math.max(validIndex - 1, 0);
+
+            if (nextIndex === validIndex) {
+                return;
+            }
+
+            const nextWorkspace = realWorkspaces[nextIndex];
+            if (!nextWorkspace || nextWorkspace.id === undefined) {
+                return;
+            }
+            TriadService.switchToWorkspace(nextWorkspace.id);
         } else if (CompositorService.isHyprland) {
             const realWorkspaces = getRealWorkspaces();
             if (realWorkspaces.length < 2) {
@@ -712,6 +810,8 @@ Item {
             return index + 1;
         if (CompositorService.isNiri)
             return (modelData?.idx !== undefined && modelData?.idx !== -1) ? modelData.idx : "";
+        if (CompositorService.isTriad)
+            return (modelData?.idx !== undefined && modelData?.idx !== -1) ? modelData.idx : "";
         if (CompositorService.isHyprland)
             return modelData?.id || "";
         if (CompositorService.isDwl)
@@ -726,6 +826,8 @@ Item {
         if (root.useExtWorkspace) {
             isPlaceholder = modelData?.hidden === true;
         } else if (CompositorService.isNiri) {
+            isPlaceholder = modelData?.idx === -1;
+        } else if (CompositorService.isTriad) {
             isPlaceholder = modelData?.idx === -1;
         } else if (CompositorService.isHyprland) {
             isPlaceholder = modelData?.id === -1;
@@ -764,7 +866,7 @@ Item {
         return getWorkspaceIndexFallback(modelData, index);
     }
 
-    readonly property bool hasNativeWorkspaceSupport: CompositorService.isNiri || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle
+    readonly property bool hasNativeWorkspaceSupport: CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle
     readonly property bool hasWorkspaces: getRealWorkspaces().length > 0
     readonly property bool shouldShow: hasNativeWorkspaceSupport || (useExtWorkspace && hasWorkspaces)
 
@@ -860,6 +962,8 @@ Item {
             case Qt.RightButton:
                 if (CompositorService.isNiri) {
                     NiriService.toggleOverview();
+                } else if (CompositorService.isTriad) {
+                    TriadService.toggleOverview();
                 } else if (CompositorService.isHyprland && root.hyprlandOverviewLoader?.item) {
                     root.hyprlandOverviewLoader.item.overviewOpen = !root.hyprlandOverviewLoader.item.overviewOpen;
                 }
@@ -980,6 +1084,8 @@ Item {
                         return (modelData?.id || modelData?.name) === root.currentWorkspace;
                     if (CompositorService.isNiri)
                         return !!(modelData && modelData.idx === root.currentWorkspace);
+                    if (CompositorService.isTriad)
+                        return !!(modelData && modelData.idx === root.currentWorkspace);
                     if (CompositorService.isHyprland)
                         return !!(modelData && modelData.id === root.currentWorkspace);
                     if (CompositorService.isDwl)
@@ -997,12 +1103,16 @@ Item {
                         const workspace = NiriService.allWorkspaces.find(ws => ws.idx + 1 === modelData && ws.output === root.effectiveScreenName);
                         return workspace ? (NiriService.windows?.some(win => win.workspace_id === workspace.id) ?? false) : false;
                     }
+                    if (CompositorService.isTriad)
+                        return modelData?.occupied ?? false;
                     return false;
                 }
                 property bool isPlaceholder: {
                     if (root.useExtWorkspace)
                         return !!(modelData && modelData._placeholder);
                     if (CompositorService.isNiri)
+                        return !!(modelData && modelData.idx === -1);
+                    if (CompositorService.isTriad)
                         return !!(modelData && modelData.idx === -1);
                     if (CompositorService.isHyprland)
                         return !!(modelData && modelData.id === -1);
@@ -1022,6 +1132,8 @@ Item {
                     if (CompositorService.isHyprland)
                         return modelData?.urgent ?? false;
                     if (CompositorService.isNiri)
+                        return loadedIsUrgent;
+                    if (CompositorService.isTriad)
                         return loadedIsUrgent;
                     if (CompositorService.isDwl)
                         return modelData?.state === 2;
@@ -1049,6 +1161,8 @@ Item {
                         targetWorkspaceId = modelData?.id || modelData?.name;
                     } else if (CompositorService.isNiri) {
                         targetWorkspaceId = modelData?.id;
+                    } else if (CompositorService.isTriad) {
+                        targetWorkspaceId = modelData?.id;
                     } else if (CompositorService.isHyprland) {
                         targetWorkspaceId = modelData?.id;
                     } else if (CompositorService.isDwl) {
@@ -1059,7 +1173,7 @@ Item {
                     if (targetWorkspaceId === undefined || targetWorkspaceId === null)
                         return 0;
 
-                    const wins = CompositorService.isNiri ? (NiriService.windows || []) : CompositorService.sortedToplevels;
+                    const wins = CompositorService.isNiri ? (NiriService.windows || []) : CompositorService.isTriad ? (TriadService.windows || []) : CompositorService.sortedToplevels;
                     const seen = {};
                     let groupedCount = 0;
                     let totalCount = 0;
@@ -1071,6 +1185,8 @@ Item {
 
                         let winWs = null;
                         if (CompositorService.isNiri) {
+                            winWs = w.workspace_id;
+                        } else if (CompositorService.isTriad) {
                             winWs = w.workspace_id;
                         } else if (CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle) {
                             winWs = w.workspace?.num;
@@ -1097,7 +1213,7 @@ Item {
                 readonly property real baseWidth: root.isVertical ? (SettingsData.showWorkspaceApps ? Math.max(widgetHeight * 0.7, root.appIconSize + Theme.spacingXS * 2) : widgetHeight * 0.5) : (isActive ? Math.max(root.widgetHeight * 1.05, root.appIconSize * 1.6) : Math.max(root.widgetHeight * 0.7, root.appIconSize * 1.2))
                 readonly property real baseHeight: root.isVertical ? (isActive ? Math.max(root.widgetHeight * 1.05, root.appIconSize * 1.6) : Math.max(root.widgetHeight * 0.7, root.appIconSize * 1.2)) : (SettingsData.showWorkspaceApps ? Math.max(widgetHeight * 0.7, root.appIconSize + Theme.spacingXS * 2) : widgetHeight * 0.5)
                 readonly property bool hasWorkspaceName: SettingsData.showWorkspaceName && modelData?.name && modelData.name !== ""
-                readonly property bool workspaceNamesEnabled: SettingsData.showWorkspaceName && (CompositorService.isNiri || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle)
+                readonly property bool workspaceNamesEnabled: SettingsData.showWorkspaceName && (CompositorService.isNiri || CompositorService.isTriad || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle)
                 readonly property real contentImplicitWidth: appIconsLoader.item?.contentWidth ?? 0
                 readonly property real contentImplicitHeight: appIconsLoader.item?.contentHeight ?? 0
 
@@ -1308,6 +1424,10 @@ Item {
                                 if (modelData && modelData.id !== undefined) {
                                     NiriService.switchToWorkspace(modelData.id);
                                 }
+                            } else if (CompositorService.isTriad) {
+                                if (modelData && modelData.id !== undefined) {
+                                    TriadService.switchToWorkspace(modelData.id);
+                                }
                             } else if (CompositorService.isHyprland && modelData?.id) {
                                 HyprlandService.focusWorkspace(modelData.id);
                             } else if (CompositorService.isDwl && modelData?.tag !== undefined) {
@@ -1320,6 +1440,8 @@ Item {
                         } else if (mouse.button === Qt.RightButton) {
                             if (CompositorService.isNiri) {
                                 NiriService.toggleOverview();
+                            } else if (CompositorService.isTriad) {
+                                TriadService.toggleOverview();
                             } else if (CompositorService.isHyprland && root.hyprlandOverviewLoader?.item) {
                                 root.hyprlandOverviewLoader.item.overviewOpen = !root.hyprlandOverviewLoader.item.overviewOpen;
                             } else if (CompositorService.isDwl && modelData?.tag !== undefined) {
@@ -1345,6 +1467,8 @@ Item {
                             wsData = modelData;
                         } else if (CompositorService.isNiri) {
                             wsData = modelData || null;
+                        } else if (CompositorService.isTriad) {
+                            wsData = modelData || null;
                         } else if (CompositorService.isHyprland) {
                             wsData = modelData;
                         } else if (CompositorService.isDwl) {
@@ -1356,6 +1480,8 @@ Item {
                         if (CompositorService.isNiri) {
                             const workspaceId = wsData?.id;
                             delegateRoot.loadedIsUrgent = workspaceId ? NiriService.windows.some(w => w.workspace_id === workspaceId && w.is_urgent) : false;
+                        } else if (CompositorService.isTriad) {
+                            delegateRoot.loadedIsUrgent = wsData?.is_urgent ?? false;
                         } else {
                             delegateRoot.loadedIsUrgent = wsData?.urgent ?? false;
                         }
@@ -1364,6 +1490,8 @@ Item {
                             if (CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle) {
                                 delegateRoot.loadedIcons = root.getWorkspaceIcons(modelData);
                             } else if (CompositorService.isNiri) {
+                                delegateRoot.loadedIcons = root.getWorkspaceIcons(isPlaceholder ? null : modelData);
+                            } else if (CompositorService.isTriad) {
                                 delegateRoot.loadedIcons = root.getWorkspaceIcons(isPlaceholder ? null : modelData);
                             } else {
                                 delegateRoot.loadedIcons = root.getWorkspaceIcons(CompositorService.isHyprland ? modelData : (modelData === -1 ? null : modelData));
@@ -1675,6 +1803,8 @@ Item {
                                                         HyprlandService.focusWindow(winId);
                                                     } else if (CompositorService.isNiri) {
                                                         NiriService.focusWindow(winId);
+                                                    } else if (CompositorService.isTriad) {
+                                                        TriadService.focusWindow(winId);
                                                     }
                                                 }
                                             }
@@ -1844,6 +1974,8 @@ Item {
                                                         HyprlandService.focusWindow(winId);
                                                     } else if (CompositorService.isNiri) {
                                                         NiriService.focusWindow(winId);
+                                                    } else if (CompositorService.isTriad) {
+                                                        TriadService.focusWindow(winId);
                                                     }
                                                 }
                                             }
@@ -1886,6 +2018,19 @@ Item {
                 Connections {
                     target: NiriService
                     enabled: CompositorService.isNiri
+                    function onAllWorkspacesChanged() {
+                        delegateRoot.updateAllData();
+                    }
+                    function onWindowUrgentChanged() {
+                        delegateRoot.updateAllData();
+                    }
+                    function onWindowsChanged() {
+                        delegateRoot.updateAllData();
+                    }
+                }
+                Connections {
+                    target: TriadService
+                    enabled: CompositorService.isTriad
                     function onAllWorkspacesChanged() {
                         delegateRoot.updateAllData();
                     }

--- a/quickshell/Modules/Dock/Dock.qml
+++ b/quickshell/Modules/Dock/Dock.qml
@@ -227,7 +227,7 @@ Variants {
         readonly property bool shouldHideForWindows: {
             if (!SettingsData.dockSmartAutoHide)
                 return false;
-            if (!CompositorService.isNiri && !CompositorService.isHyprland)
+            if (!CompositorService.isNiri && !CompositorService.isTriad && !CompositorService.isHyprland)
                 return false;
 
             const screenName = dock.modelData?.name ?? "";
@@ -291,6 +291,54 @@ Variants {
                 return false;
             }
 
+            if (CompositorService.isTriad) {
+                TriadService.windows;
+
+                let currentWorkspaceId = null;
+                for (let i = 0; i < TriadService.allWorkspaces.length; i++) {
+                    const ws = TriadService.allWorkspaces[i];
+                    if (ws.output === screenName && ws.is_active) {
+                        currentWorkspaceId = ws.id;
+                        break;
+                    }
+                }
+
+                if (currentWorkspaceId === null)
+                    return false;
+
+                for (let i = 0; i < TriadService.windows.length; i++) {
+                    const win = TriadService.windows[i];
+                    if (win.workspace_id !== currentWorkspaceId)
+                        continue;
+
+                    const geom = win.floating_geometry;
+                    if (geom) {
+                        switch (SettingsData.dockPosition) {
+                        case SettingsData.Position.Top:
+                            if (geom.y < dockThickness)
+                                return true;
+                            break;
+                        case SettingsData.Position.Bottom:
+                            if (geom.y + geom.height > screenHeight - dockThickness)
+                                return true;
+                            break;
+                        case SettingsData.Position.Left:
+                            if (geom.x < dockThickness)
+                                return true;
+                            break;
+                        case SettingsData.Position.Right:
+                            if (geom.x + geom.width > screenWidth - dockThickness)
+                                return true;
+                            break;
+                        }
+                    } else if (!win.is_floating) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
             // Hyprland implementation (current workspace + visible special workspaces)
             Hyprland.focusedWorkspace;
             Hyprland.toplevels;
@@ -315,7 +363,7 @@ Variants {
             if (_modalRetractActive)
                 return false;
 
-            if (CompositorService.isNiri && NiriService.inOverview && SettingsData.dockOpenOnOverview) {
+            if (CompositorService.inOverview && SettingsData.dockOpenOnOverview) {
                 return true;
             }
 
@@ -369,7 +417,7 @@ Variants {
 
         screen: modelData
         visible: {
-            if (CompositorService.isNiri && NiriService.inOverview) {
+            if (CompositorService.inOverview) {
                 return SettingsData.dockOpenOnOverview;
             }
             return SettingsData.showDock;

--- a/quickshell/Modules/Dock/DockLauncherButton.qml
+++ b/quickshell/Modules/Dock/DockLauncherButton.qml
@@ -236,7 +236,7 @@ Item {
             }
 
             IconImage {
-                visible: SettingsData.dockLauncherLogoMode === "compositor" && (CompositorService.isNiri || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle || CompositorService.isLabwc)
+                visible: SettingsData.dockLauncherLogoMode === "compositor" && (CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle || CompositorService.isLabwc)
                 anchors.centerIn: parent
                 width: actualIconSize + SettingsData.dockLauncherLogoSizeOffset
                 height: actualIconSize + SettingsData.dockLauncherLogoSizeOffset
@@ -245,6 +245,8 @@ Item {
                 source: {
                     if (CompositorService.isNiri) {
                         return "file://" + Theme.shellDir + "/assets/niri.svg";
+                    } else if (CompositorService.isTriad) {
+                        return "file://" + Theme.shellDir + "/assets/danklogo.svg";
                     } else if (CompositorService.isHyprland) {
                         return "file://" + Theme.shellDir + "/assets/hyprland.svg";
                     } else if (CompositorService.isDwl) {

--- a/quickshell/Modules/Greetd/GreeterContent.qml
+++ b/quickshell/Modules/Greetd/GreeterContent.qml
@@ -1223,6 +1223,8 @@ Item {
                 visible: {
                     if (CompositorService.isNiri) {
                         return NiriService.keyboardLayoutNames.length > 1;
+                    } else if (CompositorService.isTriad) {
+                        return TriadService.keyboardLayoutNames.length > 1;
                     } else if (CompositorService.isHyprland) {
                         return hyprlandLayoutCount > 1;
                     }
@@ -1260,6 +1262,15 @@ Item {
                                         return parts[0].substring(0, 2).toUpperCase();
                                     }
                                     return layout.substring(0, 2).toUpperCase();
+                                } else if (CompositorService.isTriad) {
+                                    const layout = TriadService.getCurrentKeyboardLayoutName();
+                                    if (!layout)
+                                        return "";
+                                    const parts = layout.split(" ");
+                                    if (parts.length > 0) {
+                                        return parts[0].substring(0, 2).toUpperCase();
+                                    }
+                                    return layout.substring(0, 2).toUpperCase();
                                 } else if (CompositorService.isHyprland) {
                                     return hyprlandCurrentLayout;
                                 }
@@ -1281,6 +1292,8 @@ Item {
                     onClicked: {
                         if (CompositorService.isNiri) {
                             NiriService.cycleKeyboardLayout();
+                        } else if (CompositorService.isTriad) {
+                            TriadService.cycleKeyboardLayout();
                         } else if (CompositorService.isHyprland) {
                             Quickshell.execDetached(["hyprctl", "switchxkblayout", hyprlandKeyboard, "next"]);
                             updateHyprlandLayout();
@@ -1295,7 +1308,7 @@ Item {
                 color: Qt.rgba(255, 255, 255, 0.2)
                 anchors.verticalCenter: parent.verticalCenter
                 visible: {
-                    const keyboardVisible = (CompositorService.isNiri && NiriService.keyboardLayoutNames.length > 1) || (CompositorService.isHyprland && hyprlandLayoutCount > 1);
+                    const keyboardVisible = (CompositorService.isNiri && NiriService.keyboardLayoutNames.length > 1) || (CompositorService.isTriad && TriadService.keyboardLayoutNames.length > 1) || (CompositorService.isHyprland && hyprlandLayoutCount > 1);
                     return keyboardVisible && GreetdSettings.weatherEnabled && WeatherService.weather.available;
                 }
             }

--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -1169,6 +1169,8 @@ Item {
                 visible: {
                     if (CompositorService.isNiri) {
                         return NiriService.keyboardLayoutNames.length > 1;
+                    } else if (CompositorService.isTriad) {
+                        return TriadService.keyboardLayoutNames.length > 1;
                     } else if (CompositorService.isHyprland) {
                         return hyprlandLayoutCount > 1;
                     }
@@ -1206,6 +1208,15 @@ Item {
                                         return parts[0].substring(0, 2).toUpperCase();
                                     }
                                     return layout.substring(0, 2).toUpperCase();
+                                } else if (CompositorService.isTriad) {
+                                    const layout = TriadService.getCurrentKeyboardLayoutName();
+                                    if (!layout)
+                                        return "";
+                                    const parts = layout.split(" ");
+                                    if (parts.length > 0) {
+                                        return parts[0].substring(0, 2).toUpperCase();
+                                    }
+                                    return layout.substring(0, 2).toUpperCase();
                                 } else if (CompositorService.isHyprland) {
                                     return hyprlandCurrentLayout;
                                 }
@@ -1228,6 +1239,8 @@ Item {
                     onClicked: {
                         if (CompositorService.isNiri) {
                             NiriService.cycleKeyboardLayout();
+                        } else if (CompositorService.isTriad) {
+                            TriadService.cycleKeyboardLayout();
                         } else if (CompositorService.isHyprland) {
                             Quickshell.execDetached(["hyprctl", "switchxkblayout", hyprlandKeyboard, "next"]);
                             updateHyprlandLayout();

--- a/quickshell/Modules/Plugins/DesktopPluginWrapper.qml
+++ b/quickshell/Modules/Plugins/DesktopPluginWrapper.qml
@@ -25,7 +25,7 @@ Item {
     readonly property bool showOnOverlay: instanceData?.config?.showOnOverlay ?? false
     readonly property bool showOnOverview: instanceData?.config?.showOnOverview ?? false
     readonly property bool showOnOverviewOnly: instanceData?.config?.showOnOverviewOnly ?? false
-    readonly property bool overviewActive: CompositorService.isNiri && NiriService.inOverview
+    readonly property bool overviewActive: CompositorService.inOverview
     readonly property bool clickThrough: instanceData?.config?.clickThrough ?? false
     readonly property bool syncPositionAcrossScreens: instanceData?.config?.syncPositionAcrossScreens ?? false
 

--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -705,11 +705,11 @@ Item {
                     height: 1
                     color: Theme.outline
                     opacity: 0.15
-                    visible: CompositorService.isNiri
+                    visible: CompositorService.isNiri || CompositorService.isTriad
                 }
 
                 SettingsToggleRow {
-                    visible: CompositorService.isNiri
+                    visible: CompositorService.isNiri || CompositorService.isTriad
                     enabled: !SettingsData.frameEnabled
                     opacity: SettingsData.frameEnabled ? 0.5 : 1.0
                     text: I18n.tr("Show on Overview")
@@ -1122,7 +1122,7 @@ Item {
                 iconName: "fit_screen"
                 title: I18n.tr("Maximize Detection")
                 description: I18n.tr("Remove gaps and border when windows are maximized")
-                visible: selectedBarConfig?.enabled && (CompositorService.isNiri || CompositorService.isHyprland)
+                visible: selectedBarConfig?.enabled && (CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland)
                 checked: selectedBarConfig?.maximizeDetection ?? true
                 onToggled: checked => SettingsData.updateBarConfig(selectedBarId, {
                         maximizeDetection: checked
@@ -1658,7 +1658,7 @@ Item {
 
                 SettingsButtonGroupRow {
                     text: I18n.tr("Y Axis")
-                    model: CompositorService.isNiri ? [I18n.tr("None"), I18n.tr("Workspace"), I18n.tr("Column")] : [I18n.tr("None"), I18n.tr("Workspace")]
+                    model: (CompositorService.isNiri || CompositorService.isTriad) ? [I18n.tr("None"), I18n.tr("Workspace"), I18n.tr("Column")] : [I18n.tr("None"), I18n.tr("Workspace")]
                     currentIndex: {
                         switch (selectedBarConfig?.scrollYBehavior || "workspace") {
                         case "none":
@@ -1694,7 +1694,7 @@ Item {
 
                 SettingsButtonGroupRow {
                     text: I18n.tr("X Axis")
-                    visible: CompositorService.isNiri
+                    visible: CompositorService.isNiri || CompositorService.isTriad
                     model: [I18n.tr("None"), I18n.tr("Workspace"), I18n.tr("Column")]
                     currentIndex: {
                         switch (selectedBarConfig?.scrollXBehavior || "column") {

--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -656,7 +656,7 @@ Item {
 
                     SettingsToggleRow {
                         width: parent.width - parent.leftPadding
-                        visible: CompositorService.isNiri || CompositorService.isHyprland
+                        visible: CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland
                         text: I18n.tr("Hide When Windows Open")
                         checked: selectedBarConfig?.showOnWindowsOpen ?? false
                         onToggled: toggled => {

--- a/quickshell/Modules/Settings/DockTab.qml
+++ b/quickshell/Modules/Settings/DockTab.qml
@@ -70,7 +70,7 @@ Item {
                     text: I18n.tr("Intelligent Auto-hide")
                     description: I18n.tr("Show dock when floating windows don't overlap its area")
                     checked: SettingsData.dockSmartAutoHide
-                    visible: SettingsData.showDock && (CompositorService.isNiri || CompositorService.isHyprland)
+                    visible: SettingsData.showDock && (CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland)
                     onToggled: checked => {
                         if (checked && SettingsData.dockAutoHide) {
                             SettingsData.set("dockAutoHide", false);
@@ -81,11 +81,11 @@ Item {
 
                 SettingsToggleRow {
                     settingKey: "dockOpenOnOverview"
-                    tags: ["dock", "overview", "niri"]
+                    tags: ["dock", "overview", "niri", "triad"]
                     text: I18n.tr("Show on Overview")
-                    description: I18n.tr("Always show the dock when niri's overview is open")
+                    description: I18n.tr("Always show the dock when the compositor overview is open")
                     checked: SettingsData.dockOpenOnOverview
-                    visible: CompositorService.isNiri
+                    visible: CompositorService.isNiri || CompositorService.isTriad
                     onToggled: checked => SettingsData.set("dockOpenOnOverview", checked)
                 }
 
@@ -280,6 +280,8 @@ Item {
                                     const modes = [I18n.tr("Apps Icon"), I18n.tr("OS Logo"), I18n.tr("Dank")];
                                     if (CompositorService.isNiri) {
                                         modes.push("niri");
+                                    } else if (CompositorService.isTriad) {
+                                        modes.push("Triad");
                                     } else if (CompositorService.isHyprland) {
                                         modes.push("Hyprland");
                                     } else if (CompositorService.isDwl) {

--- a/quickshell/Modules/Settings/LauncherTab.qml
+++ b/quickshell/Modules/Settings/LauncherTab.qml
@@ -735,14 +735,14 @@ Item {
             SettingsCard {
                 width: parent.width
                 iconName: "open_in_new"
-                title: I18n.tr("Niri Integration").replace("Niri", "niri")
-                visible: CompositorService.isNiri
+                title: I18n.tr("Overview Integration")
+                visible: CompositorService.isNiri || CompositorService.isTriad
 
                 SettingsToggleRow {
                     settingKey: "spotlightCloseNiriOverview"
-                    tags: ["launcher", "niri", "overview", "close", "launch"]
+                    tags: ["launcher", "niri", "triad", "overview", "close", "launch"]
                     text: I18n.tr("Close Overview on Launch")
-                    description: I18n.tr("Auto-close Niri overview when launching apps.")
+                    description: I18n.tr("Auto-close compositor overview when launching apps.")
                     checked: SettingsData.spotlightCloseNiriOverview
                     onToggled: checked => SettingsData.set("spotlightCloseNiriOverview", checked)
                 }
@@ -753,6 +753,7 @@ Item {
                     text: I18n.tr("Enable Overview Overlay")
                     description: I18n.tr("Show launcher overlay when typing in Niri overview. Disable to use another launcher.")
                     checked: SettingsData.niriOverviewOverlayEnabled
+                    visible: CompositorService.isNiri
                     onToggled: checked => SettingsData.set("niriOverviewOverlayEnabled", checked)
                 }
             }

--- a/quickshell/Modules/Settings/WallpaperTab.qml
+++ b/quickshell/Modules/Settings/WallpaperTab.qml
@@ -771,16 +771,16 @@ Item {
                     height: 1
                     color: Theme.outline
                     opacity: 0.2
-                    visible: CompositorService.isNiri
+                    visible: CompositorService.isNiri || CompositorService.isTriad
                 }
 
                 SettingsToggleRow {
                     tab: "wallpaper"
-                    tags: ["blur", "overview", "niri"]
+                    tags: ["blur", "overview", "niri", "triad"]
                     settingKey: "blurWallpaperOnOverview"
-                    visible: CompositorService.isNiri
+                    visible: CompositorService.isNiri || CompositorService.isTriad
                     text: I18n.tr("Blur on Overview")
-                    description: I18n.tr("Blur wallpaper when niri overview is open")
+                    description: I18n.tr("Blur wallpaper when the compositor overview is open")
                     checked: SettingsData.blurWallpaperOnOverview
                     onToggled: checked => SettingsData.set("blurWallpaperOnOverview", checked)
                 }

--- a/quickshell/Modules/Settings/WorkspacesTab.qml
+++ b/quickshell/Modules/Settings/WorkspacesTab.qml
@@ -59,7 +59,7 @@ Item {
                     text: I18n.tr("Show Workspace Apps")
                     description: I18n.tr("Display application icons in workspace indicators")
                     checked: SettingsData.showWorkspaceApps
-                    visible: CompositorService.isNiri || CompositorService.isHyprland
+                    visible: CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland
                     onToggled: checked => SettingsData.set("showWorkspaceApps", checked)
                 }
 
@@ -141,7 +141,7 @@ Item {
                     text: I18n.tr("Follow Monitor Focus")
                     description: I18n.tr("Show workspaces of the currently focused monitor")
                     checked: SettingsData.workspaceFollowFocus
-                    visible: CompositorService.isNiri || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle
+                    visible: CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle
                     onToggled: checked => SettingsData.set("workspaceFollowFocus", checked)
                 }
 
@@ -151,7 +151,7 @@ Item {
                     text: I18n.tr("Show Occupied Workspaces Only")
                     description: I18n.tr("Display only workspaces that contain windows")
                     checked: SettingsData.showOccupiedWorkspacesOnly
-                    visible: CompositorService.isNiri || CompositorService.isHyprland
+                    visible: CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland
                     onToggled: checked => SettingsData.set("showOccupiedWorkspacesOnly", checked)
                 }
 
@@ -161,7 +161,7 @@ Item {
                     text: I18n.tr("Reverse Scrolling Direction")
                     description: I18n.tr("Reverse workspace switch direction when scrolling over the bar")
                     checked: SettingsData.reverseScrolling
-                    visible: CompositorService.isNiri || CompositorService.isHyprland
+                    visible: CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland
                     onToggled: checked => SettingsData.set("reverseScrolling", checked)
                 }
 
@@ -233,7 +233,7 @@ Item {
                 SettingsButtonGroupRow {
                     text: I18n.tr("Occupied Color")
                     model: ["none", "sec", "s", "sc", "sch", "schh"]
-                    visible: CompositorService.isNiri || CompositorService.isHyprland || CompositorService.isDwl
+                    visible: CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland || CompositorService.isDwl
                     buttonHeight: 22
                     minButtonWidth: 36
                     buttonPadding: Theme.spacingS
@@ -269,7 +269,7 @@ Item {
                     height: 1
                     color: Theme.outline
                     opacity: 0.15
-                    visible: CompositorService.isNiri || CompositorService.isHyprland || CompositorService.isDwl
+                    visible: CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland || CompositorService.isDwl
                 }
 
                 SettingsButtonGroupRow {
@@ -306,12 +306,12 @@ Item {
                     height: 1
                     color: Theme.outline
                     opacity: 0.15
-                    visible: CompositorService.isNiri || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle
+                    visible: CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle
                 }
 
                 SettingsButtonGroupRow {
                     text: I18n.tr("Urgent Color")
-                    visible: CompositorService.isNiri || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle
+                    visible: CompositorService.isNiri || CompositorService.isTriad || CompositorService.isHyprland || CompositorService.isDwl || CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle
                     model: ["err", "pri", "sec", "s", "sc"]
                     buttonHeight: 22
                     minButtonWidth: 36

--- a/quickshell/Modules/WallpaperBackground.qml
+++ b/quickshell/Modules/WallpaperBackground.qml
@@ -89,7 +89,7 @@ Variants {
             property bool useNextForEffect: false
             property string pendingWallpaper: ""
             property string _deferredSource: ""
-            readonly property bool overviewBlurActive: CompositorService.isNiri && SettingsData.blurWallpaperOnOverview && NiriService.inOverview && currentWallpaper.source !== ""
+            readonly property bool overviewBlurActive: CompositorService.inOverview && SettingsData.blurWallpaperOnOverview && currentWallpaper.source !== ""
 
             Connections {
                 target: currentWallpaper
@@ -148,7 +148,7 @@ Variants {
             }
 
             Connections {
-                target: NiriService
+                target: CompositorService
                 function onInOverviewChanged() {
                     root._overviewBlurSettling = true;
                     overviewBlurSettleTimer.restart();

--- a/quickshell/Services/BarWidgetService.qml
+++ b/quickshell/Services/BarWidgetService.qml
@@ -73,8 +73,8 @@ Singleton {
     function getFocusedScreenName() {
         if (CompositorService.isHyprland && Hyprland.focusedWorkspace?.monitor)
             return Hyprland.focusedWorkspace.monitor.name;
-        if (CompositorService.isNiri && NiriService.currentOutput)
-            return NiriService.currentOutput;
+        if (CompositorService.focusedOutputName)
+            return CompositorService.focusedOutputName;
         if (CompositorService.isSway || CompositorService.isScroll || CompositorService.isMiracle) {
             const focusedWs = I3.workspaces?.values?.find(ws => ws.focused === true);
             return focusedWs?.monitor?.name || "";

--- a/quickshell/Services/CompositorService.qml
+++ b/quickshell/Services/CompositorService.qml
@@ -40,6 +40,16 @@ Singleton {
     readonly property string labwcPid: Quickshell.env("LABWC_PID")
     property bool useNiriSorting: isNiri && NiriService
     property bool useTriadSorting: isTriad && TriadService
+    readonly property string focusedOutputName: {
+        if (isNiri && NiriService.currentOutput)
+            return NiriService.currentOutput;
+        if (isTriad && TriadService.currentOutput)
+            return TriadService.currentOutput;
+        if (isDwl && DwlService.activeOutput)
+            return DwlService.activeOutput;
+        return "";
+    }
+    readonly property bool inOverview: (isNiri && NiriService.inOverview) || (isTriad && TriadService.inOverview)
 
     property var randrScales: ({})
     property bool randrReady: false
@@ -541,7 +551,7 @@ Singleton {
 
             const filtered = filterCurrentWorkspace(sortedToplevels, screenName);
             for (let i = 0; i < filtered.length; i++) {
-                if (filtered[i]?.fullscreen)
+                if (filtered[i]?.fullscreen || filtered[i]?.triadFullscreen)
                     return true;
             }
             return false;

--- a/quickshell/Services/CompositorService.qml
+++ b/quickshell/Services/CompositorService.qml
@@ -15,6 +15,7 @@ Singleton {
 
     property bool isHyprland: false
     property bool isNiri: false
+    property bool isTriad: false
     property bool isDwl: false
     property bool isSway: false
     property bool isScroll: false
@@ -25,11 +26,20 @@ Singleton {
 
     readonly property string hyprlandSignature: Quickshell.env("HYPRLAND_INSTANCE_SIGNATURE")
     readonly property string niriSocket: Quickshell.env("NIRI_SOCKET")
+    readonly property string triadSocketEnv: Quickshell.env("TRIAD_SOCKET")
+    readonly property string triadSocket: {
+        if (triadSocketEnv && triadSocketEnv.length > 0)
+            return triadSocketEnv;
+        const runtimeDir = Quickshell.env("XDG_RUNTIME_DIR");
+        return runtimeDir && runtimeDir.length > 0 ? `${runtimeDir}/triad.sock` : "";
+    }
+    readonly property string currentDesktop: `${Quickshell.env("XDG_CURRENT_DESKTOP")} ${Quickshell.env("XDG_SESSION_DESKTOP")} ${Quickshell.env("DESKTOP_SESSION")}`.toLowerCase()
     readonly property string swaySocket: Quickshell.env("SWAYSOCK")
     readonly property string scrollSocket: Quickshell.env("SWAYSOCK")
     readonly property string miracleSocket: Quickshell.env("MIRACLESOCK")
     readonly property string labwcPid: Quickshell.env("LABWC_PID")
     property bool useNiriSorting: isNiri && NiriService
+    property bool useTriadSorting: isTriad && TriadService
 
     property var randrScales: ({})
     property bool randrReady: false
@@ -88,6 +98,12 @@ Singleton {
                 return niriScale;
         }
 
+        if (isTriad && screen) {
+            const triadScale = TriadService.displayScales[screen.name];
+            if (triadScale !== undefined)
+                return triadScale;
+        }
+
         if (isHyprland && screen) {
             const hyprlandMonitor = Hyprland.monitors.values.find(m => m.name === screen.name);
             if (hyprlandMonitor?.scale !== undefined)
@@ -109,6 +125,8 @@ Singleton {
             screenName = Hyprland.focusedWorkspace.monitor.name;
         else if (isNiri && NiriService.currentOutput)
             screenName = NiriService.currentOutput;
+        else if (isTriad && TriadService.currentOutput)
+            screenName = TriadService.currentOutput;
         else if (isSway || isScroll || isMiracle) {
             const focusedWs = I3.workspaces?.values?.find(ws => ws.focused === true);
             screenName = focusedWs?.monitor?.name || "";
@@ -172,6 +190,15 @@ Singleton {
             root.scheduleSort();
         }
     }
+    Connections {
+        target: TriadService
+        function onWindowsChanged() {
+            root.scheduleSort();
+        }
+        function onAllWorkspacesChanged() {
+            root.scheduleSort();
+        }
+    }
 
     Component.onCompleted: {
         fetchRandrData();
@@ -188,7 +215,7 @@ Singleton {
     Connections {
         target: DwlService
         function onStateChanged() {
-            if (isDwl && !isHyprland && !isNiri) {
+            if (isDwl && !isHyprland && !isNiri && !isTriad) {
                 scheduleSort();
             }
         }
@@ -200,6 +227,9 @@ Singleton {
 
         if (useNiriSorting)
             return NiriService.sortToplevels(ToplevelManager.toplevels.values);
+
+        if (useTriadSorting)
+            return TriadService.sortToplevels(ToplevelManager.toplevels.values);
 
         if (isHyprland)
             return sortHyprlandToplevelsSafe();
@@ -450,6 +480,8 @@ Singleton {
     function filterCurrentWorkspace(toplevels, screen) {
         if (useNiriSorting)
             return NiriService.filterCurrentWorkspace(toplevels, screen);
+        if (useTriadSorting)
+            return TriadService.filterCurrentWorkspace(toplevels, screen);
         if (isHyprland)
             return filterHyprlandCurrentWorkspaceSafe(toplevels, screen);
         return toplevels;
@@ -471,6 +503,8 @@ Singleton {
             }
             return NiriService.filterCurrentDisplay(toplevels, screenName);
         }
+        if (useTriadSorting)
+            return TriadService.filterCurrentDisplay(toplevels, screenName);
         if (isHyprland)
             return filterHyprlandCurrentDisplaySafe(toplevels, screenName);
         return toplevels;
@@ -500,7 +534,7 @@ Singleton {
         if (!screenName)
             return false;
 
-        if (isNiri) {
+        if (isNiri || isTriad) {
             const active = ToplevelManager.activeToplevel;
             if (active?.fullscreen && active?.activated && _toplevelOnScreen(active, screenName))
                 return true;
@@ -795,9 +829,29 @@ Singleton {
     }
 
     function detectCompositor() {
+        const desktopLooksTriad = currentDesktop.indexOf("triad") >= 0;
+        if ((triadSocketEnv && triadSocketEnv.length > 0) || desktopLooksTriad) {
+            Proc.runCommand("triadSocketCheck", ["test", "-S", triadSocket], (output, exitCode) => {
+                if (exitCode === 0 || desktopLooksTriad) {
+                    isTriad = true;
+                    isHyprland = false;
+                    isNiri = false;
+                    isDwl = false;
+                    isSway = false;
+                    isScroll = false;
+                    isMiracle = false;
+                    isLabwc = false;
+                    compositor = "triad";
+                    log.info("Detected Triad with socket:", triadSocket);
+                }
+            }, 0);
+            return;
+        }
+
         if (hyprlandSignature && hyprlandSignature.length > 0 && !niriSocket && !swaySocket && !scrollSocket && !miracleSocket && !labwcPid) {
             isHyprland = true;
             isNiri = false;
+            isTriad = false;
             isDwl = false;
             isSway = false;
             isScroll = false;
@@ -813,6 +867,7 @@ Singleton {
                 if (exitCode === 0) {
                     isNiri = true;
                     isHyprland = false;
+                    isTriad = false;
                     isDwl = false;
                     isSway = false;
                     isScroll = false;
@@ -831,6 +886,7 @@ Singleton {
                 if (exitCode === 0) {
                     isNiri = false;
                     isHyprland = false;
+                    isTriad = false;
                     isDwl = false;
                     isSway = true;
                     isScroll = false;
@@ -848,6 +904,7 @@ Singleton {
                 if (exitCode === 0) {
                     isNiri = false;
                     isHyprland = false;
+                    isTriad = false;
                     isDwl = false;
                     isSway = false;
                     isScroll = false;
@@ -865,6 +922,7 @@ Singleton {
                 if (exitCode === 0) {
                     isNiri = false;
                     isHyprland = false;
+                    isTriad = false;
                     isDwl = false;
                     isSway = false;
                     isScroll = true;
@@ -880,6 +938,7 @@ Singleton {
         if (labwcPid && labwcPid.length > 0) {
             isHyprland = false;
             isNiri = false;
+            isTriad = false;
             isDwl = false;
             isSway = false;
             isScroll = false;
@@ -895,6 +954,7 @@ Singleton {
         } else {
             isHyprland = false;
             isNiri = false;
+            isTriad = false;
             isDwl = false;
             isSway = false;
             isScroll = false;
@@ -908,7 +968,7 @@ Singleton {
     Connections {
         target: DMSService
         function onCapabilitiesReceived() {
-            if (!isHyprland && !isNiri && !isDwl && !isLabwc) {
+            if (!isHyprland && !isNiri && !isTriad && !isDwl && !isLabwc) {
                 checkForDwl();
             }
         }
@@ -918,6 +978,7 @@ Singleton {
         if (DMSService.apiVersion >= 12 && DMSService.capabilities.includes("dwl")) {
             isHyprland = false;
             isNiri = false;
+            isTriad = false;
             isDwl = true;
             isSway = false;
             isScroll = false;
@@ -931,6 +992,8 @@ Singleton {
     function powerOffMonitors() {
         if (isNiri)
             return NiriService.powerOffMonitors();
+        if (isTriad)
+            return TriadService.powerOffMonitors();
         if (isHyprland)
             return HyprlandService.dpmsOff();
         if (isDwl)
@@ -950,6 +1013,8 @@ Singleton {
     function powerOnMonitors() {
         if (isNiri)
             return NiriService.powerOnMonitors();
+        if (isTriad)
+            return TriadService.powerOnMonitors();
         if (isHyprland)
             return HyprlandService.dpmsOn();
         if (isDwl)

--- a/quickshell/Services/SessionService.qml
+++ b/quickshell/Services/SessionService.qml
@@ -314,6 +314,11 @@ Singleton {
                 return;
             }
 
+            if (CompositorService.isTriad) {
+                TriadService.quit();
+                return;
+            }
+
             if (CompositorService.isDwl) {
                 DwlService.quit();
                 return;

--- a/quickshell/Services/TriadService.qml
+++ b/quickshell/Services/TriadService.qml
@@ -136,6 +136,14 @@ Singleton {
         return action("toggle-overview");
     }
 
+    function moveColumnLeft() {
+        return action("move-column-left");
+    }
+
+    function moveColumnRight() {
+        return action("move-column-right");
+    }
+
     function powerOffMonitors() {
         return action("power-off-monitors");
     }
@@ -146,6 +154,19 @@ Singleton {
 
     function cycleKeyboardLayout() {
         return action("switch-keyboard-layout", {"layout": "next"});
+    }
+
+    function getCurrentKeyboardLayoutName() {
+        if (!keyboardLayoutNames || keyboardLayoutNames.length === 0)
+            return "";
+        const idx = currentKeyboardLayoutIndex;
+        if (idx >= 0 && idx < keyboardLayoutNames.length)
+            return keyboardLayoutNames[idx];
+        return keyboardLayoutNames[0] || "";
+    }
+
+    function quit() {
+        return action("exit-session");
     }
 
     function applyState(state) {
@@ -270,8 +291,10 @@ Singleton {
             "is_focused": windowData.is_focused === true,
             "activated": windowData.is_focused === true,
             "is_floating": windowData.is_floating === true,
+            "is_maximized": windowData.is_maximized === true,
             "is_fullscreen": windowData.is_fullscreen === true,
             "fullscreen": windowData.is_fullscreen === true,
+            "floating_geometry": windowData.floating_geometry || null,
             "is_urgent": false
         };
     }
@@ -338,6 +361,7 @@ Singleton {
                 toplevel.triadOutput = win.output;
                 toplevel.triadFocused = win.is_focused;
                 toplevel.triadFullscreen = win.is_fullscreen;
+                toplevel.triadMaximized = win.is_maximized;
             }
             enriched.push(toplevel);
         }

--- a/quickshell/Services/TriadService.qml
+++ b/quickshell/Services/TriadService.qml
@@ -1,4 +1,5 @@
 pragma Singleton
+
 pragma ComponentBehavior: Bound
 
 import QtQuick
@@ -12,11 +13,11 @@ Singleton {
     readonly property var log: Log.scoped("TriadService")
 
     readonly property string socketPath: {
-        const explicitSocket = Quickshell.env("TRIAD_SOCKET");
+        const explicitSocket = Quickshell.env("TRIAD_SOCKET")
         if (explicitSocket && explicitSocket.length > 0)
-            return explicitSocket;
-        const runtimeDir = Quickshell.env("XDG_RUNTIME_DIR");
-        return runtimeDir && runtimeDir.length > 0 ? `${runtimeDir}/triad.sock` : "";
+        return explicitSocket
+        const runtimeDir = Quickshell.env("XDG_RUNTIME_DIR")
+        return runtimeDir && runtimeDir.length > 0 ? `${runtimeDir}/triad.sock` : ""
     }
 
     property var workspaces: ({})
@@ -44,12 +45,12 @@ Singleton {
         onConnectionStateChanged: {
             if (connected) {
                 send({
-                    "triad": {
-                        "version": 1,
-                        "request": "event-stream",
-                        "events": ["state", "layout", "window"]
-                    }
-                });
+                         "triad": {
+                             "version": 1,
+                             "request": "event-stream",
+                             "events": ["state", "layout", "window"]
+                         }
+                     })
             }
         }
 
@@ -66,39 +67,39 @@ Singleton {
 
     function handleMessage(line) {
         if (!line || line.trim().length === 0)
-            return;
+            return
         try {
-            const message = JSON.parse(line);
-            const payload = message.triad;
+            const message = JSON.parse(line)
+            const payload = message.triad
             if (!payload)
-                return;
+                return
 
             if (payload.type === "state" && payload.state) {
-                applyState(payload.state);
-                return;
+                applyState(payload.state)
+                return
             }
 
             switch (payload.event) {
             case "state-changed":
-                applyState(payload.state);
-                break;
+                applyState(payload.state)
+                break
             case "layout-state-changed":
-                applyLayoutState(payload.state);
-                break;
+                applyLayoutState(payload.state)
+                break
             case "window-changed":
-                mergeWindow(payload.window);
-                break;
+                mergeWindow(payload.window)
+                break
             }
         } catch (e) {
-            log.warn("Failed to parse Triad IPC message:", line, e);
+            log.warn("Failed to parse Triad IPC message:", line, e)
         }
     }
 
     function send(request) {
         if (!CompositorService.isTriad || !requestSocket.connected)
-            return false;
-        requestSocket.send(request);
-        return true;
+            return false
+        requestSocket.send(request)
+        return true
     }
 
     function action(name, fields) {
@@ -108,129 +109,135 @@ Singleton {
                 "request": "action",
                 "action": name
             }
-        };
+        }
         if (fields) {
             for (const key in fields) {
-                payload.triad[key] = fields[key];
+                payload.triad[key] = fields[key]
             }
         }
-        return send(payload);
+        return send(payload)
     }
 
     function switchToWorkspace(workspaceId) {
-        const workspace = allWorkspaces.find(ws => ws.id === workspaceId || String(ws.id) === String(workspaceId));
-        const idx = workspace?.idx ?? Number(workspaceId);
+        const workspace = allWorkspaces.find(ws => ws.id === workspaceId || String(ws.id) === String(workspaceId))
+        const idx = workspace?.idx ?? Number(workspaceId)
         if (idx > 0)
-            return action("focus-workspace", {"workspace_idx": idx});
-        return false;
+            return action("focus-workspace", {
+                              "workspace_idx": idx
+                          })
+        return false
     }
 
     function focusWindow(windowId) {
-        const id = Number(windowId);
+        const id = Number(windowId)
         if (id > 0)
-            return action("focus-window", {"id": id});
-        return false;
+            return action("focus-window", {
+                              "id": id
+                          })
+        return false
     }
 
     function toggleOverview() {
-        return action("toggle-overview");
+        return action("toggle-overview")
     }
 
     function moveColumnLeft() {
-        return action("move-column-left");
+        return action("move-column-left")
     }
 
     function moveColumnRight() {
-        return action("move-column-right");
+        return action("move-column-right")
     }
 
     function powerOffMonitors() {
-        return action("power-off-monitors");
+        return action("power-off-monitors")
     }
 
     function powerOnMonitors() {
-        return action("power-on-monitors");
+        return action("power-on-monitors")
     }
 
     function cycleKeyboardLayout() {
-        return action("switch-keyboard-layout", {"layout": "next"});
+        return action("switch-keyboard-layout", {
+                          "layout": "next"
+                      })
     }
 
     function getCurrentKeyboardLayoutName() {
         if (!keyboardLayoutNames || keyboardLayoutNames.length === 0)
-            return "";
-        const idx = currentKeyboardLayoutIndex;
+            return ""
+        const idx = currentKeyboardLayoutIndex
         if (idx >= 0 && idx < keyboardLayoutNames.length)
-            return keyboardLayoutNames[idx];
-        return keyboardLayoutNames[0] || "";
+            return keyboardLayoutNames[idx]
+        return keyboardLayoutNames[0] || ""
     }
 
     function quit() {
-        return action("exit-session");
+        return action("exit-session")
     }
 
     function applyState(state) {
         if (!state)
-            return;
-        applyOutputs(state.outputs || []);
+            return
+        applyOutputs(state.outputs || [])
         if (state.overview)
-            inOverview = state.overview.is_open === true;
-        keyboardLayoutNames = state.keyboard_layouts || [];
-        currentKeyboardLayoutIndex = state.current_keyboard_layout_idx ?? 0;
-        applyWindows(state.windows || []);
-        applyLayoutState(state.layout);
+            inOverview = state.overview.is_open === true
+        keyboardLayoutNames = state.keyboard_layouts || []
+        currentKeyboardLayoutIndex = state.current_keyboard_layout_idx ?? 0
+        applyWindows(state.windows || [])
+        applyLayoutState(state.layout)
     }
 
     function applyOutputs(outputList) {
-        const nextOutputs = {};
-        const nextScales = {};
+        const nextOutputs = {}
+        const nextScales = {}
         for (const output of outputList || []) {
             if (!output?.name)
-                continue;
-            nextOutputs[output.name] = output;
+                continue
+            nextOutputs[output.name] = output
             if (output.scale !== undefined && output.scale > 0)
-                nextScales[output.name] = output.scale;
+                nextScales[output.name] = output.scale
         }
-        outputs = nextOutputs;
-        displayScales = nextScales;
+        outputs = nextOutputs
+        displayScales = nextScales
     }
 
     function applyLayoutState(layout) {
         if (!layout)
-            return;
-        focusedWorkspaceIndex = layout.active_workspace_idx || 1;
-        focusedWorkspaceId = layout.active_tag ?? null;
-        setWorkspaces(layout.workspaces || []);
+            return
+        focusedWorkspaceIndex = layout.active_workspace_idx || 1
+        focusedWorkspaceId = layout.active_tag ?? null
+        setWorkspaces(layout.workspaces || [])
     }
 
     function setWorkspaces(workspaceList) {
-        const next = {};
-        const mapped = [];
+        const next = {}
+        const mapped = []
         for (const workspace of workspaceList || []) {
-            const normalized = normalizeWorkspace(workspace);
+            const normalized = normalizeWorkspace(workspace)
             if (!normalized)
-                continue;
-            next[String(normalized.id)] = normalized;
-            mapped.push(normalized);
+                continue
+            next[String(normalized.id)] = normalized
+            mapped.push(normalized)
         }
 
         mapped.sort((a, b) => {
-            if (a.output !== b.output)
-                return a.output.localeCompare(b.output);
-            return a.idx - b.idx;
-        });
-        workspaces = next;
-        allWorkspaces = mapped;
-        updateCurrentOutput();
+                        if (a.output !== b.output)
+                        return a.output.localeCompare(b.output)
+                        return a.idx - b.idx
+                    })
+        workspaces = next
+        allWorkspaces = mapped
+        updateCurrentOutput()
     }
 
     function normalizeWorkspace(workspace) {
         if (!workspace)
-            return null;
-        const idx = Number(workspace.workspace_idx || 0);
-        const id = workspace.tag_id ?? idx;
+            return null
+        const idx = Number(workspace.workspace_idx || 0)
+        const id = workspace.tag_id ?? idx
         if (!id && idx <= 0)
-            return null;
+            return null
         return {
             "id": id,
             "idx": idx,
@@ -244,41 +251,41 @@ Singleton {
             "layout": workspace.layout || "",
             "tag_id": id,
             "workspace_idx": idx
-        };
+        }
     }
 
     function updateCurrentOutput() {
-        let focused = allWorkspaces.find(ws => ws.is_focused);
+        let focused = allWorkspaces.find(ws => ws.is_focused)
         if (!focused)
-            focused = allWorkspaces.find(ws => ws.is_active);
+            focused = allWorkspaces.find(ws => ws.is_active)
         if (!focused && allWorkspaces.length > 0)
-            focused = allWorkspaces[0];
-        currentOutput = focused?.output || "";
-        currentOutputWorkspaces = currentOutput ? allWorkspaces.filter(ws => ws.output === currentOutput) : [];
+            focused = allWorkspaces[0]
+        currentOutput = focused?.output || ""
+        currentOutputWorkspaces = currentOutput ? allWorkspaces.filter(ws => ws.output === currentOutput) : []
     }
 
     function applyWindows(windowList) {
-        windows = sortWindows((windowList || []).map(normalizeWindow).filter(w => w !== null));
+        windows = sortWindows((windowList || []).map(normalizeWindow).filter(w => w !== null))
     }
 
     function mergeWindow(windowData) {
-        const normalized = normalizeWindow(windowData);
+        const normalized = normalizeWindow(windowData)
         if (!normalized)
-            return;
-        const next = windows.slice();
-        const index = next.findIndex(win => win.id === normalized.id);
+            return
+        const next = windows.slice()
+        const index = next.findIndex(win => win.id === normalized.id)
         if (index >= 0)
-            next[index] = Object.assign({}, next[index], normalized);
+            next[index] = Object.assign({}, next[index], normalized)
         else
-            next.push(normalized);
-        windows = sortWindows(next);
+            next.push(normalized)
+        windows = sortWindows(next)
     }
 
     function normalizeWindow(windowData) {
         if (!windowData || windowData.id === undefined || windowData.id === null)
-            return null;
-        const id = Number(windowData.id);
-        const appId = windowData.app_id || "";
+            return null
+        const id = Number(windowData.id)
+        const appId = windowData.app_id || ""
         return {
             "id": id,
             "title": windowData.title || "",
@@ -296,92 +303,92 @@ Singleton {
             "fullscreen": windowData.is_fullscreen === true,
             "floating_geometry": windowData.floating_geometry || null,
             "is_urgent": false
-        };
+        }
     }
 
     function sortWindows(windowList) {
         return windowList.slice().sort((a, b) => {
-            if (a.output !== b.output)
-                return a.output.localeCompare(b.output);
-            if ((a.workspace_idx || 0) !== (b.workspace_idx || 0))
-                return (a.workspace_idx || 0) - (b.workspace_idx || 0);
-            const aColumn = a.position?.column_idx ?? 0;
-            const bColumn = b.position?.column_idx ?? 0;
-            if (aColumn !== bColumn)
-                return aColumn - bColumn;
-            const aWindow = a.position?.window_idx ?? 0;
-            const bWindow = b.position?.window_idx ?? 0;
-            if (aWindow !== bWindow)
-                return aWindow - bWindow;
-            return String(a.title || "").localeCompare(String(b.title || ""));
-        });
+                                           if (a.output !== b.output)
+                                           return a.output.localeCompare(b.output)
+                                           if ((a.workspace_idx || 0) !== (b.workspace_idx || 0))
+                                           return (a.workspace_idx || 0) - (b.workspace_idx || 0)
+                                           const aColumn = a.position?.column_idx ?? 0
+                                           const bColumn = b.position?.column_idx ?? 0
+                                           if (aColumn !== bColumn)
+                                           return aColumn - bColumn
+                                           const aWindow = a.position?.window_idx ?? 0
+                                           const bWindow = b.position?.window_idx ?? 0
+                                           if (aWindow !== bWindow)
+                                           return aWindow - bWindow
+                                           return String(a.title || "").localeCompare(String(b.title || ""))
+                                       })
     }
 
     function getCurrentOutputWorkspaces() {
-        return currentOutputWorkspaces;
+        return currentOutputWorkspaces
     }
 
     function getCurrentWorkspaceNumber() {
-        return focusedWorkspaceIndex;
+        return focusedWorkspaceIndex
     }
 
     function sortToplevels(toplevels) {
-        return matchAndEnrichToplevels(Array.from(toplevels || []));
+        return matchAndEnrichToplevels(Array.from(toplevels || []))
     }
 
     function filterCurrentWorkspace(toplevels, screenName) {
         if (!toplevels || toplevels.length === 0)
-            return toplevels;
+            return toplevels
 
-        const workspace = screenName ? allWorkspaces.find(ws => ws.output === screenName && ws.is_active) : allWorkspaces.find(ws => ws.is_focused);
-        const workspaceId = workspace?.id ?? focusedWorkspaceId;
+        const workspace = screenName ? allWorkspaces.find(ws => ws.output === screenName && ws.is_active) : allWorkspaces.find(ws => ws.is_focused)
+        const workspaceId = workspace?.id ?? focusedWorkspaceId
         if (workspaceId === undefined || workspaceId === null)
-            return toplevels;
+            return toplevels
 
-        return matchAndEnrichToplevels(toplevels).filter(tl => tl?.triadWorkspaceId === workspaceId);
+        return matchAndEnrichToplevels(toplevels).filter(tl => tl?.triadWorkspaceId === workspaceId)
     }
 
     function filterCurrentDisplay(toplevels, screenName) {
         if (!toplevels || toplevels.length === 0 || !screenName)
-            return toplevels;
-        return matchAndEnrichToplevels(toplevels).filter(tl => tl?.triadOutput === screenName);
+            return toplevels
+        return matchAndEnrichToplevels(toplevels).filter(tl => tl?.triadOutput === screenName)
     }
 
     function matchAndEnrichToplevels(toplevels) {
-        const used = {};
-        const enriched = [];
+        const used = {}
+        const enriched = []
         for (const toplevel of toplevels || []) {
             if (!toplevel)
-                continue;
-            const win = findMatchingWindow(toplevel, used);
+                continue
+            const win = findMatchingWindow(toplevel, used)
             if (win) {
-                used[win.id] = true;
-                toplevel.triadWindowId = win.id;
-                toplevel.triadWorkspaceId = win.workspace_id;
-                toplevel.triadOutput = win.output;
-                toplevel.triadFocused = win.is_focused;
-                toplevel.triadFullscreen = win.is_fullscreen;
-                toplevel.triadMaximized = win.is_maximized;
+                used[win.id] = true
+                toplevel.triadWindowId = win.id
+                toplevel.triadWorkspaceId = win.workspace_id
+                toplevel.triadOutput = win.output
+                toplevel.triadFocused = win.is_focused
+                toplevel.triadFullscreen = win.is_fullscreen
+                toplevel.triadMaximized = win.is_maximized
             }
-            enriched.push(toplevel);
+            enriched.push(toplevel)
         }
-        return enriched;
+        return enriched
     }
 
     function findMatchingWindow(toplevel, used) {
-        const appId = toplevel.app_id || toplevel.appId || toplevel.class || toplevel.windowClass || "";
-        const title = toplevel.title || "";
-        let fallback = null;
+        const appId = toplevel.app_id || toplevel.appId || toplevel.class || toplevel.windowClass || ""
+        const title = toplevel.title || ""
+        let fallback = null
         for (const win of windows) {
             if (!win || used[win.id])
-                continue;
+                continue
             if (appId && win.app_id && appId !== win.app_id)
-                continue;
+                continue
             if (title && win.title && title === win.title)
-                return win;
+                return win
             if (!fallback)
-                fallback = win;
+                fallback = win
         }
-        return fallback;
+        return fallback
     }
 }

--- a/quickshell/Services/TriadService.qml
+++ b/quickshell/Services/TriadService.qml
@@ -1,0 +1,363 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Common
+import qs.Services
+
+Singleton {
+    id: root
+    readonly property var log: Log.scoped("TriadService")
+
+    readonly property string socketPath: {
+        const explicitSocket = Quickshell.env("TRIAD_SOCKET");
+        if (explicitSocket && explicitSocket.length > 0)
+            return explicitSocket;
+        const runtimeDir = Quickshell.env("XDG_RUNTIME_DIR");
+        return runtimeDir && runtimeDir.length > 0 ? `${runtimeDir}/triad.sock` : "";
+    }
+
+    property var workspaces: ({})
+    property var allWorkspaces: []
+    property int focusedWorkspaceIndex: 1
+    property var focusedWorkspaceId: null
+    property var currentOutputWorkspaces: []
+    property string currentOutput: ""
+
+    property var outputs: ({})
+    property var windows: []
+    property var displayScales: ({})
+
+    property bool inOverview: false
+    property int currentKeyboardLayoutIndex: 0
+    property var keyboardLayoutNames: []
+
+    signal windowUrgentChanged
+
+    DankSocket {
+        id: eventStreamSocket
+        path: root.socketPath
+        connected: CompositorService.isTriad && root.socketPath.length > 0
+
+        onConnectionStateChanged: {
+            if (connected) {
+                send({
+                    "triad": {
+                        "version": 1,
+                        "request": "event-stream",
+                        "events": ["state", "layout", "window"]
+                    }
+                });
+            }
+        }
+
+        parser: SplitParser {
+            onRead: line => root.handleMessage(line)
+        }
+    }
+
+    DankSocket {
+        id: requestSocket
+        path: root.socketPath
+        connected: CompositorService.isTriad && root.socketPath.length > 0
+    }
+
+    function handleMessage(line) {
+        if (!line || line.trim().length === 0)
+            return;
+        try {
+            const message = JSON.parse(line);
+            const payload = message.triad;
+            if (!payload)
+                return;
+
+            if (payload.type === "state" && payload.state) {
+                applyState(payload.state);
+                return;
+            }
+
+            switch (payload.event) {
+            case "state-changed":
+                applyState(payload.state);
+                break;
+            case "layout-state-changed":
+                applyLayoutState(payload.state);
+                break;
+            case "window-changed":
+                mergeWindow(payload.window);
+                break;
+            }
+        } catch (e) {
+            log.warn("Failed to parse Triad IPC message:", line, e);
+        }
+    }
+
+    function send(request) {
+        if (!CompositorService.isTriad || !requestSocket.connected)
+            return false;
+        requestSocket.send(request);
+        return true;
+    }
+
+    function action(name, fields) {
+        const payload = {
+            "triad": {
+                "version": 1,
+                "request": "action",
+                "action": name
+            }
+        };
+        if (fields) {
+            for (const key in fields) {
+                payload.triad[key] = fields[key];
+            }
+        }
+        return send(payload);
+    }
+
+    function switchToWorkspace(workspaceId) {
+        const workspace = allWorkspaces.find(ws => ws.id === workspaceId || String(ws.id) === String(workspaceId));
+        const idx = workspace?.idx ?? Number(workspaceId);
+        if (idx > 0)
+            return action("focus-workspace", {"workspace_idx": idx});
+        return false;
+    }
+
+    function focusWindow(windowId) {
+        const id = Number(windowId);
+        if (id > 0)
+            return action("focus-window", {"id": id});
+        return false;
+    }
+
+    function toggleOverview() {
+        return action("toggle-overview");
+    }
+
+    function powerOffMonitors() {
+        return action("power-off-monitors");
+    }
+
+    function powerOnMonitors() {
+        return action("power-on-monitors");
+    }
+
+    function cycleKeyboardLayout() {
+        return action("switch-keyboard-layout", {"layout": "next"});
+    }
+
+    function applyState(state) {
+        if (!state)
+            return;
+        applyOutputs(state.outputs || []);
+        if (state.overview)
+            inOverview = state.overview.is_open === true;
+        keyboardLayoutNames = state.keyboard_layouts || [];
+        currentKeyboardLayoutIndex = state.current_keyboard_layout_idx ?? 0;
+        applyWindows(state.windows || []);
+        applyLayoutState(state.layout);
+    }
+
+    function applyOutputs(outputList) {
+        const nextOutputs = {};
+        const nextScales = {};
+        for (const output of outputList || []) {
+            if (!output?.name)
+                continue;
+            nextOutputs[output.name] = output;
+            if (output.scale !== undefined && output.scale > 0)
+                nextScales[output.name] = output.scale;
+        }
+        outputs = nextOutputs;
+        displayScales = nextScales;
+    }
+
+    function applyLayoutState(layout) {
+        if (!layout)
+            return;
+        focusedWorkspaceIndex = layout.active_workspace_idx || 1;
+        focusedWorkspaceId = layout.active_tag ?? null;
+        setWorkspaces(layout.workspaces || []);
+    }
+
+    function setWorkspaces(workspaceList) {
+        const next = {};
+        const mapped = [];
+        for (const workspace of workspaceList || []) {
+            const normalized = normalizeWorkspace(workspace);
+            if (!normalized)
+                continue;
+            next[String(normalized.id)] = normalized;
+            mapped.push(normalized);
+        }
+
+        mapped.sort((a, b) => {
+            if (a.output !== b.output)
+                return a.output.localeCompare(b.output);
+            return a.idx - b.idx;
+        });
+        workspaces = next;
+        allWorkspaces = mapped;
+        updateCurrentOutput();
+    }
+
+    function normalizeWorkspace(workspace) {
+        if (!workspace)
+            return null;
+        const idx = Number(workspace.workspace_idx || 0);
+        const id = workspace.tag_id ?? idx;
+        if (!id && idx <= 0)
+            return null;
+        return {
+            "id": id,
+            "idx": idx,
+            "name": workspace.name || "",
+            "output": workspace.output || "",
+            "is_active": workspace.is_output_visible === true,
+            "is_focused": workspace.is_active === true,
+            "is_urgent": workspace.is_urgent === true,
+            "occupied": workspace.occupied === true,
+            "active_window_id": workspace.focused_window_id ?? null,
+            "layout": workspace.layout || "",
+            "tag_id": id,
+            "workspace_idx": idx
+        };
+    }
+
+    function updateCurrentOutput() {
+        let focused = allWorkspaces.find(ws => ws.is_focused);
+        if (!focused)
+            focused = allWorkspaces.find(ws => ws.is_active);
+        if (!focused && allWorkspaces.length > 0)
+            focused = allWorkspaces[0];
+        currentOutput = focused?.output || "";
+        currentOutputWorkspaces = currentOutput ? allWorkspaces.filter(ws => ws.output === currentOutput) : [];
+    }
+
+    function applyWindows(windowList) {
+        windows = sortWindows((windowList || []).map(normalizeWindow).filter(w => w !== null));
+    }
+
+    function mergeWindow(windowData) {
+        const normalized = normalizeWindow(windowData);
+        if (!normalized)
+            return;
+        const next = windows.slice();
+        const index = next.findIndex(win => win.id === normalized.id);
+        if (index >= 0)
+            next[index] = Object.assign({}, next[index], normalized);
+        else
+            next.push(normalized);
+        windows = sortWindows(next);
+    }
+
+    function normalizeWindow(windowData) {
+        if (!windowData || windowData.id === undefined || windowData.id === null)
+            return null;
+        const id = Number(windowData.id);
+        const appId = windowData.app_id || "";
+        return {
+            "id": id,
+            "title": windowData.title || "",
+            "app_id": appId,
+            "appId": appId,
+            "workspace_id": windowData.tag_id ?? null,
+            "workspace_idx": windowData.workspace_idx ?? null,
+            "output": windowData.output || "",
+            "position": windowData.position || {},
+            "is_focused": windowData.is_focused === true,
+            "activated": windowData.is_focused === true,
+            "is_floating": windowData.is_floating === true,
+            "is_fullscreen": windowData.is_fullscreen === true,
+            "fullscreen": windowData.is_fullscreen === true,
+            "is_urgent": false
+        };
+    }
+
+    function sortWindows(windowList) {
+        return windowList.slice().sort((a, b) => {
+            if (a.output !== b.output)
+                return a.output.localeCompare(b.output);
+            if ((a.workspace_idx || 0) !== (b.workspace_idx || 0))
+                return (a.workspace_idx || 0) - (b.workspace_idx || 0);
+            const aColumn = a.position?.column_idx ?? 0;
+            const bColumn = b.position?.column_idx ?? 0;
+            if (aColumn !== bColumn)
+                return aColumn - bColumn;
+            const aWindow = a.position?.window_idx ?? 0;
+            const bWindow = b.position?.window_idx ?? 0;
+            if (aWindow !== bWindow)
+                return aWindow - bWindow;
+            return String(a.title || "").localeCompare(String(b.title || ""));
+        });
+    }
+
+    function getCurrentOutputWorkspaces() {
+        return currentOutputWorkspaces;
+    }
+
+    function getCurrentWorkspaceNumber() {
+        return focusedWorkspaceIndex;
+    }
+
+    function sortToplevels(toplevels) {
+        return matchAndEnrichToplevels(Array.from(toplevels || []));
+    }
+
+    function filterCurrentWorkspace(toplevels, screenName) {
+        if (!toplevels || toplevels.length === 0)
+            return toplevels;
+
+        const workspace = screenName ? allWorkspaces.find(ws => ws.output === screenName && ws.is_active) : allWorkspaces.find(ws => ws.is_focused);
+        const workspaceId = workspace?.id ?? focusedWorkspaceId;
+        if (workspaceId === undefined || workspaceId === null)
+            return toplevels;
+
+        return matchAndEnrichToplevels(toplevels).filter(tl => tl?.triadWorkspaceId === workspaceId);
+    }
+
+    function filterCurrentDisplay(toplevels, screenName) {
+        if (!toplevels || toplevels.length === 0 || !screenName)
+            return toplevels;
+        return matchAndEnrichToplevels(toplevels).filter(tl => tl?.triadOutput === screenName);
+    }
+
+    function matchAndEnrichToplevels(toplevels) {
+        const used = {};
+        const enriched = [];
+        for (const toplevel of toplevels || []) {
+            if (!toplevel)
+                continue;
+            const win = findMatchingWindow(toplevel, used);
+            if (win) {
+                used[win.id] = true;
+                toplevel.triadWindowId = win.id;
+                toplevel.triadWorkspaceId = win.workspace_id;
+                toplevel.triadOutput = win.output;
+                toplevel.triadFocused = win.is_focused;
+                toplevel.triadFullscreen = win.is_fullscreen;
+            }
+            enriched.push(toplevel);
+        }
+        return enriched;
+    }
+
+    function findMatchingWindow(toplevel, used) {
+        const appId = toplevel.app_id || toplevel.appId || toplevel.class || toplevel.windowClass || "";
+        const title = toplevel.title || "";
+        let fallback = null;
+        for (const win of windows) {
+            if (!win || used[win.id])
+                continue;
+            if (appId && win.app_id && appId !== win.app_id)
+                continue;
+            if (title && win.title && title === win.title)
+                return win;
+            if (!fallback)
+                fallback = win;
+        }
+        return fallback;
+    }
+}


### PR DESCRIPTION
This adds native Triad IPC support to DMS.

Triad is a programmable Wayland window manager with per-workspace layouts, a native IPC, and a Niri-compatible IPC facade. The repo is here: https://github.com/greenm01/triad

DMS already works on Triad through the Niri-compatible path. This adds a native backend for sessions that expose TRIAD_SOCKET, so DMS can read Triad’s workspace, output, window, overview, and keyboard-layout state directly.

The Niri service is left alone. Triad detection only kicks in when TRIAD_SOCKET is set, or when the desktop session identifies itself as Triad, so existing Niri behavior should stay as-is.

Tested in a live Triad session with niri-compat disabled for the Dank profile. make lint-qml passes.