### PR TITLE
Wait for location capability before requesting state

### DIFF
--- a/quickshell/Services/LocationService.qml
+++ b/quickshell/Services/LocationService.qml
@@ -7,7 +7,7 @@ import Quickshell
 Singleton {
     id: root
 
-    readonly property bool locationAvailable: DMSService.isConnected && (DMSService.capabilities.length === 0 || DMSService.capabilities.includes("location"))
+    readonly property bool locationAvailable: DMSService.isConnected && DMSService.capabilities.includes("location")
     readonly property bool valid: latitude !== 0 || longitude !== 0
 
     property var latitude: 0.0


### PR DESCRIPTION
This avoids asking the backend for location state before the location manager is available.

On startup, the shell can connect before every capability has been advertised. Treating an empty capability list as “location is available” can produce a `location manager not initialized` error. This waits for the explicit `location` capability instead.

make lint-qml passes.