### PR TITLE
fix(toast): align dimensions to whole pixels to avoid blurry rendering

### DIFF
--- a/quickshell/Modules/Toast.qml
+++ b/quickshell/Modules/Toast.qml
@@ -50,8 +50,8 @@ PanelWindow {
     WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
     color: "transparent"
 
-    readonly property real toastWidth: shouldBeVisible ? Math.min(900, messageText.implicitWidth + statusIcon.width + Theme.spacingM + (ToastService.hasDetails ? (expandButton.width + closeButton.width + 4) : (ToastService.currentLevel === ToastService.levelError ? closeButton.width + Theme.spacingS : 0)) + Theme.spacingL * 2 + Theme.spacingM * 2) : frozenWidth
-    readonly property real toastHeight: toastContent.height + Theme.spacingL * 2
+    readonly property real toastWidth: shouldBeVisible ? Theme.px(Math.min(900, messageText.implicitWidth + statusIcon.width + Theme.spacingM + (ToastService.hasDetails ? (expandButton.width + closeButton.width + 4) : (ToastService.currentLevel === ToastService.levelError ? closeButton.width + Theme.spacingS : 0)) + Theme.spacingL * 2 + Theme.spacingM * 2), dpr) : frozenWidth
+    readonly property real toastHeight: Theme.px(toastContent.height + Theme.spacingL * 2, dpr)
 
     anchors {
         top: true
@@ -63,8 +63,8 @@ PanelWindow {
         top: Math.max(0, Theme.snap(toastY - shadowBuffer, dpr))
     }
 
-    implicitWidth: toastWidth + (shadowBuffer * 2)
-    implicitHeight: toastHeight + (shadowBuffer * 2)
+    implicitWidth: Theme.px(toastWidth + (shadowBuffer * 2), dpr)
+    implicitHeight: Theme.px(toastHeight + (shadowBuffer * 2), dpr)
 
     Rectangle {
         id: toast


### PR DESCRIPTION
## Summary

The toast popup (`Modules/Toast.qml`) renders blurry under fractional-scale-aware compositors (reproduced on niri 26.04 at scale 1.0). Other DMS surfaces such as `NotificationPopup.qml` render crisply, because they already round their layer-surface dimensions to whole device pixels.

## Root cause

The toast Rectangle has `layer.enabled: true`, so Qt renders it to a texture before compositing. The dimensions feeding that texture come from text and icon metrics:

```qml
readonly property real toastWidth: ... messageText.implicitWidth + ...
readonly property real toastHeight: toastContent.height + Theme.spacingL * 2

implicitWidth: toastWidth + (shadowBuffer * 2)
implicitHeight: toastHeight + (shadowBuffer * 2)
```

These values are fractional. The cached texture is then sampled with sub-pixel interpolation when the compositor draws the surface, which is what shows up as a soft/blurry toast.

`NotificationPopup.qml` avoids this by funnelling its surface dimensions through `Theme.px(value, dpr)`, which rounds to whole device pixels.