### PR TITLE
fix: Display Configurator in Hyprland

### DIFF
--- a/quickshell/Modules/Settings/DisplayConfig/DisplayConfigState.qml
+++ b/quickshell/Modules/Settings/DisplayConfig/DisplayConfigState.qml
@@ -1670,7 +1670,7 @@ Singleton {
 
     function getHyprlandOutputIdentifier(output, outputName) {
         if (SettingsData.displayNameMode === "model" && output?.make && output?.model)
-            return ("desc:" + output.make + " " + output.model + " " + (output?.serial || "Unknown")).replace(",", "");
+            return ("desc:" + output.make + " " + output.model + " " + (output?.serial || "Unknown")).replace(/,/g, "");
         return outputName;
     }
 

--- a/quickshell/Modules/Settings/DisplayConfig/DisplayConfigState.qml
+++ b/quickshell/Modules/Settings/DisplayConfig/DisplayConfigState.qml
@@ -997,6 +997,8 @@ Singleton {
                 const id = (o.make + " " + o.model + " " + serial).trim();
                 liveByIdentifier[id] = true;
                 liveByIdentifier[o.make + " " + o.model] = true;
+                if (CompositorService.isHyprland)
+                    liveByIdentifier[getHyprlandOutputIdentifier(o, name)] = true;
             }
             liveByIdentifier[name] = true;
         }
@@ -1132,11 +1134,13 @@ Singleton {
                 "scale": typeof scaleValue === "number" ? scaleValue : 1.0,
                 "transform": hyprlandToTransform(transform)
             },
-            "modes": modeMatch ? [{
-                        "width": parseInt(modeMatch[1]),
-                        "height": parseInt(modeMatch[2]),
-                        "refresh_rate": Math.round(parseFloat(modeMatch[3]) * 1000)
-                    }] : [],
+            "modes": modeMatch ? [
+                {
+                    "width": parseInt(modeMatch[1]),
+                    "height": parseInt(modeMatch[2]),
+                    "refresh_rate": Math.round(parseFloat(modeMatch[3]) * 1000)
+                }
+            ] : [],
             "current_mode": modeMatch ? 0 : -1,
             "vrr_enabled": vrrMode >= 1,
             "vrr_supported": vrrMode > 0,
@@ -1666,7 +1670,7 @@ Singleton {
 
     function getHyprlandOutputIdentifier(output, outputName) {
         if (SettingsData.displayNameMode === "model" && output?.make && output?.model)
-            return "desc:" + output.make + " " + output.model + " " + (output?.serial || "Unknown");
+            return ("desc:" + output.make + " " + output.model + " " + (output?.serial || "Unknown")).replace(",", "");
         return outputName;
     }
 

--- a/quickshell/Services/HyprlandService.qml
+++ b/quickshell/Services/HyprlandService.qml
@@ -58,7 +58,7 @@ Singleton {
 
     function getOutputIdentifier(output, outputName) {
         if (SettingsData.displayNameMode === "model" && output.make && output.model)
-            return "desc:" + output.make + " " + output.model + " " + (output.serial || "Unknown");
+            return ("desc:" + output.make + " " + output.model + " " + (output.serial || "Unknown")).replace(",", "");
         return outputName;
     }
 

--- a/quickshell/Services/HyprlandService.qml
+++ b/quickshell/Services/HyprlandService.qml
@@ -58,7 +58,7 @@ Singleton {
 
     function getOutputIdentifier(output, outputName) {
         if (SettingsData.displayNameMode === "model" && output.make && output.model)
-            return ("desc:" + output.make + " " + output.model + " " + (output.serial || "Unknown")).replace(",", "");
+            return ("desc:" + output.make + " " + output.model + " " + (output.serial || "Unknown")).replace(/,/g, "");
         return outputName;
     }
 


### PR DESCRIPTION
Fixes: #2119

Hyprland sanitizes monitor descriptions by removing commas from the description (see https://github.com/hyprwm/Hyprland/blob/f3d81e017de7fa2349c4934c16d68a34e6934420/src/helpers/Monitor.cpp#L217-L218). In DMS, Hyprland output identifiers are written as desc:<make> <model> <serial>, but the disconnected-output detection compared saved output keys against live wlr output identifiers without accounting for the desc: prefix and Hyprland’s sanitization. This caused connected displays to be incorrectly shown as disconnected in the display settings UI and changes didn't get applied if the description mismatches hyprland monitors description.