### PR TITLE
fix: awk in new greeter

### DIFF
--- a/quickshell/Services/GreeterUsersService.qml
+++ b/quickshell/Services/GreeterUsersService.qml
@@ -77,7 +77,7 @@ Singleton {
     }
 
     function _loadUsers() {
-        Proc.runCommand("greeterUsersService-loadUsers", ["sh", "-c", "getent passwd | awk -F: '$3>=1000 && $3<60000 && $1!=\"nobody\" {print $1\":\"$3\":\"$5\":\"$6\":\"$7}'"], (output, exitCode) => {
+        Proc.runCommand("greeterUsersService-loadUsers", ["sh", "-c", "getent passwd | awk -F: '$3>=1000 && $3<60000 && $1!=\"nobody\" && $7!~/(nologin|false)$/ && $6!=\"/var/empty\" {print $1\":\"$3\":\"$5\":\"$6\":\"$7}'"], (output, exitCode) => {
             const lines = (output || "").trim().split("\n").filter(l => l.length > 0);
             const list = [];
             const names = [];

--- a/quickshell/Services/UsersService.qml
+++ b/quickshell/Services/UsersService.qml
@@ -91,7 +91,7 @@ Singleton {
     }
 
     function _loadUsers() {
-        Proc.runCommand("usersService-loadUsers", ["sh", "-c", "getent passwd | awk -F: '$3>=1000 && $3<60000 && $1!=\"nobody\" {print $1\":\"$3\":\"$5\":\"$6\":\"$7}'"], (output, exitCode) => {
+        Proc.runCommand("usersService-loadUsers", ["sh", "-c", "getent passwd | awk -F: '$3>=1000 && $3<60000 && $1!=\"nobody\" && $7!~/(nologin|false)$/ && $6!=\"/var/empty\" {print $1\":\"$3\":\"$5\":\"$6\":\"$7}'"], (output, exitCode) => {
             const lines = (output || "").trim().split("\n").filter(l => l.length > 0);
             const list = [];
             const adminSet = {};


### PR DESCRIPTION
The new greeter is great! But the current way it populates the user list results in many accounts showing up on NixOS, largely because it does not check for nologin. 

Before: 
```
❯ getent passwd | awk -F: '$3>=1000 && $3<60000 && $1!="nobody" {print $1":"$3":"$5":"$6":"$7}'
e-work:1001:ethan-work:/home/e-work:/run/current-system/sw/bin/bash
e-play:1003:ethan-play:/home/e-play:/run/current-system/sw/bin/bash
nixbld1:30001:Nix build user 1:/var/empty:/run/current-system/sw/bin/nologin
nixbld2:30002:Nix build user 2:/var/empty:/run/current-system/sw/bin/nologin
nixbld3:30003:Nix build user 3:/var/empty:/run/current-system/sw/bin/nologin
nixbld4:30004:Nix build user 4:/var/empty:/run/current-system/sw/bin/nologin
nixbld5:30005:Nix build user 5:/var/empty:/run/current-system/sw/bin/nologin
nixbld6:30006:Nix build user 6:/var/empty:/run/current-system/sw/bin/nologin
nixbld7:30007:Nix build user 7:/var/empty:/run/current-system/sw/bin/nologin
nixbld8:30008:Nix build user 8:/var/empty:/run/current-system/sw/bin/nologin
nixbld9:30009:Nix build user 9:/var/empty:/run/current-system/sw/bin/nologin
nixbld10:30010:Nix build user 10:/var/empty:/run/current-system/sw/bin/nologin
nixbld11:30011:Nix build user 11:/var/empty:/run/current-system/sw/bin/nologin
nixbld12:30012:Nix build user 12:/var/empty:/run/current-system/sw/bin/nologin
nixbld13:30013:Nix build user 13:/var/empty:/run/current-system/sw/bin/nologin
nixbld14:30014:Nix build user 14:/var/empty:/run/current-system/sw/bin/nologin
nixbld15:30015:Nix build user 15:/var/empty:/run/current-system/sw/bin/nologin
nixbld16:30016:Nix build user 16:/var/empty:/run/current-system/sw/bin/nologin
nixbld17:30017:Nix build user 17:/var/empty:/run/current-system/sw/bin/nologin
nixbld18:30018:Nix build user 18:/var/empty:/run/current-system/sw/bin/nologin
nixbld19:30019:Nix build user 19:/var/empty:/run/current-system/sw/bin/nologin
nixbld20:30020:Nix build user 20:/var/empty:/run/current-system/sw/bin/nologin
nixbld21:30021:Nix build user 21:/var/empty:/run/current-system/sw/bin/nologin
nixbld22:30022:Nix build user 22:/var/empty:/run/current-system/sw/bin/nologin
nixbld23:30023:Nix build user 23:/var/empty:/run/current-system/sw/bin/nologin
nixbld24:30024:Nix build user 24:/var/empty:/run/current-system/sw/bin/nologin
nixbld25:30025:Nix build user 25:/var/empty:/run/current-system/sw/bin/nologin
nixbld26:30026:Nix build user 26:/var/empty:/run/current-system/sw/bin/nologin
nixbld27:30027:Nix build user 27:/var/empty:/run/current-system/sw/bin/nologin
nixbld28:30028:Nix build user 28:/var/empty:/run/current-system/sw/bin/nologin
nixbld29:30029:Nix build user 29:/var/empty:/run/current-system/sw/bin/nologin
nixbld30:30030:Nix build user 30:/var/empty:/run/current-system/sw/bin/nologin
nixbld31:30031:Nix build user 31:/var/empty:/run/current-system/sw/bin/nologin
nixbld32:30032:Nix build user 32:/var/empty:/run/current-system/sw/bin/nologin
```
After:
```
❯ getent passwd | awk -F: '$3>=1000 && $3<60000 && $1!="nobody" && $7!~/(nologin|false)$/ && $6!="/var/empty" {print $1":"$3":"$5":"$6":"$7}'
e-work:1001:ethan-work:/home/e-work:/run/current-system/sw/bin/bash
e-play:1003:ethan-play:/home/e-play:/run/current-system/sw/bin/bash
```