### PR TITLE
fix(IconTheme): apply stored icon theme at startup

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1383,6 +1383,7 @@ Singleton {
             _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
             _hasLoaded = true;
             applyStoredTheme();
+            applyStoredIconTheme();
             updateCompositorCursor();
             Processes.detectQtTools();
 
@@ -1393,6 +1394,7 @@ Singleton {
             log.error("Failed to parse settings.json - file will not be overwritten. Error:", msg);
             Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse settings.json"), msg));
             applyStoredTheme();
+            applyStoredIconTheme();
         } finally {
             _loading = false;
         }
@@ -3151,6 +3153,7 @@ Singleton {
                 _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
                 _hasLoaded = true;
                 applyStoredTheme();
+                applyStoredIconTheme();
                 updateCompositorCursor();
             } catch (e) {
                 _parseError = true;
@@ -3164,6 +3167,7 @@ Singleton {
         onLoadFailed: error => {
             if (!isGreeterMode) {
                 applyStoredTheme();
+                applyStoredIconTheme();
             }
         }
         onSaveFailed: error => {


### PR DESCRIPTION
## Summary

Fixes #2510 — icon theme not being applied at DMS startup, causing it to revert after every reboot.

## Root Cause

`applyStoredIconTheme()` and its `_hooks` entry already existed in the codebase, but the function was never called — it was effectively dead code. `applyStoredTheme()` had calls in `loadSettings()`, `onLoaded`, and `onLoadFailed`, but the icon theme counterpart was missing from all of them.

## Changes

Single file: `Common/SettingsData.qml` — 4 lines added.

Added `applyStoredIconTheme()` calls alongside every existing `applyStoredTheme()` call — in `loadSettings()` (success + error paths), `onLoaded`, and `onLoadFailed`. No new functions, no shell.qml modifications.

## AI-Assisted Development

- **Implemented by**: Claude Code (Claude Opus 4.7)
- **Code reviewed by**: Claude Code — 0 findings on final review
- **Manually tested**: Icon theme persists correctly after reboot on niri + DMS
- **Request**: Human review appreciated before merge

Closes #2510

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>