### PR TITLE
fix(settings): make desktop widget group delete button clickable

### DIFF
--- a/quickshell/Modules/Settings/DesktopWidgetsTab.qml
+++ b/quickshell/Modules/Settings/DesktopWidgetsTab.qml
@@ -231,6 +231,8 @@ Item {
                                     DankActionButton {
                                         id: deleteGroupBtn
                                         iconName: "delete"
+                                        backgroundColor: Theme.withAlpha(Theme.error, 0.15)
+                                        iconColor: Theme.error
                                         anchors.verticalCenter: parent.verticalCenter
                                         onClicked: {
                                             SettingsData.removeDesktopWidgetGroup(groupItem.modelData.id);
@@ -242,6 +244,7 @@ Item {
                                 MouseArea {
                                     id: groupMouseArea
                                     anchors.fill: parent
+                                    z: -1
                                     hoverEnabled: true
                                     onDoubleClicked: root.editingGroupId = groupItem.modelData.id
                                 }


### PR DESCRIPTION
The row-level MouseArea was covering the delete action button, so clicks were handled by the row instead of the button. This moves the row click area behind the controls and styles the delete button consistently with other destructive actions.