### PR TITLE
feat(DiskUsage): updated dynamic width options for DiskUsage widget

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/DiskUsage.qml
+++ b/quickshell/Modules/DankBar/Widgets/DiskUsage.qml
@@ -9,9 +9,9 @@ BasePill {
 
     property var widgetData: null
     property string mountPath: (widgetData && widgetData.mountPath !== undefined) ? widgetData.mountPath : "/"
-    property int diskUsageMode: (widgetData && widgetData.diskUsageMode !== undefined) ? widgetData.diskUsageMode : 0
     property bool isHovered: mouseArea.containsMouse
     property bool isAutoHideBar: false
+    property bool minimumWidth: (widgetData && widgetData.minimumWidth !== undefined) ? widgetData.minimumWidth : true
 
     property var selectedMount: {
         if (!DgopService.diskMounts || DgopService.diskMounts.length === 0) {
@@ -39,6 +39,7 @@ BasePill {
         if (!selectedMount || !selectedMount.percent) {
             return 0;
         }
+
         const percentStr = selectedMount.percent.replace("%", "");
         return parseFloat(percentStr) || 0;
     }
@@ -46,6 +47,7 @@ BasePill {
     Component.onCompleted: {
         DgopService.addRef(["diskmounts"]);
     }
+
     Component.onDestruction: {
         DgopService.removeRef(["diskmounts"]);
     }
@@ -69,6 +71,8 @@ BasePill {
     }
 
     Connections {
+        target: SettingsData
+
         function onWidgetDataChanged() {
             root.mountPath = Qt.binding(() => {
                 return (root.widgetData && root.widgetData.mountPath !== undefined) ? root.widgetData.mountPath : "/";
@@ -96,33 +100,38 @@ BasePill {
                 return DgopService.diskMounts[0] || null;
             });
         }
-
-        target: SettingsData
     }
 
     content: Component {
         Item {
             implicitWidth: root.isVerticalOrientation ? (root.widgetThickness - root.horizontalPadding * 2) : diskContent.implicitWidth
-            implicitHeight: root.isVerticalOrientation ? diskColumn.implicitHeight : (root.widgetThickness - root.horizontalPadding * 2)
+
+            implicitHeight: root.isVerticalOrientation ? diskColumn.implicitHeight : diskContent.implicitHeight
 
             Column {
                 id: diskColumn
+
                 visible: root.isVerticalOrientation
                 anchors.centerIn: parent
                 spacing: 1
 
                 DankIcon {
                     name: "storage"
+
                     size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.maximizeWidgetIcons, root.barConfig?.iconScale)
+
                     color: {
                         if (root.diskUsagePercent > 90) {
                             return Theme.tempDanger;
                         }
+
                         if (root.diskUsagePercent > 75) {
                             return Theme.tempWarning;
                         }
-                        return Theme.surfaceText;
+
+                        return Theme.widgetIconColor;
                     }
+
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
 
@@ -131,20 +140,12 @@ BasePill {
                         if (root.diskUsagePercent === undefined || root.diskUsagePercent === null || root.diskUsagePercent === 0) {
                             return "--";
                         }
-                        if (!root.selectedMount)
-                            return "--";
-                        switch (root.diskUsageMode) {
-                        case 1:
-                            return root.selectedMount.size || "--";
-                        case 2:
-                            return root.selectedMount.avail || "--";
-                        case 3:
-                            return (root.selectedMount.avail || "--") + " / " + (root.selectedMount.size || "--");
-                        default:
-                            return root.diskUsagePercent.toFixed(0);
-                        }
+
+                        return root.diskUsagePercent.toFixed(0);
                     }
+
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
+
                     color: Theme.widgetTextColor
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
@@ -152,80 +153,104 @@ BasePill {
 
             Row {
                 id: diskContent
+
                 visible: !root.isVerticalOrientation
                 anchors.centerIn: parent
-                spacing: 3
+                spacing: Theme.spacingXS
 
                 DankIcon {
+                    id: diskIcon
+
                     name: "storage"
+
                     size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.maximizeWidgetIcons, root.barConfig?.iconScale)
+
                     color: {
                         if (root.diskUsagePercent > 90) {
                             return Theme.tempDanger;
                         }
+
                         if (root.diskUsagePercent > 75) {
                             return Theme.tempWarning;
                         }
-                        return Theme.surfaceText;
+
+                        return Theme.widgetIconColor;
                     }
+
                     anchors.verticalCenter: parent.verticalCenter
                 }
 
                 StyledText {
+                    id: mountText
+
                     text: {
                         if (!root.selectedMount) {
                             return "--";
                         }
+
                         return root.selectedMount.mount;
                     }
+
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
+
                     color: Theme.widgetTextColor
+
                     anchors.verticalCenter: parent.verticalCenter
                     horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignVCenter
                     elide: Text.ElideNone
+                    wrapMode: Text.NoWrap
                 }
 
-                StyledText {
-                    text: {
-                        if (root.diskUsagePercent === undefined || root.diskUsagePercent === null || root.diskUsagePercent === 0) {
-                            return "--%";
-                        }
-                        if (!root.selectedMount)
-                            return "--%";
-                        switch (root.diskUsageMode) {
-                        case 1:
-                            return root.selectedMount.size || "--";
-                        case 2:
-                            return root.selectedMount.avail || "--";
-                        case 3:
-                            return (root.selectedMount.avail || "--") + " / " + (root.selectedMount.size || "--");
-                        default:
-                            return root.diskUsagePercent.toFixed(0) + "%";
-                        }
-                    }
-                    font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
-                    color: Theme.widgetTextColor
+                Item {
+                    id: textBox
+
                     anchors.verticalCenter: parent.verticalCenter
-                    horizontalAlignment: Text.AlignLeft
-                    elide: Text.ElideNone
+
+                    implicitWidth: root.minimumWidth ? Math.max(diskBaseline.width, diskCurrent.width) : diskCurrent.width
+
+                    implicitHeight: diskText.implicitHeight
+
+                    width: implicitWidth
+                    height: implicitHeight
 
                     StyledTextMetrics {
                         id: diskBaseline
+
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
-                        text: {
-                            switch (root.diskUsageMode) {
-                            case 3:
-                                return "888.8G / 888.8G";
-                            case 1:
-                            case 2:
-                                return "888.8G";
-                            default:
-                                return "100%";
-                            }
-                        }
+
+                        text: "100%"
                     }
 
-                    width: Math.max(diskBaseline.width, paintedWidth)
+                    StyledTextMetrics {
+                        id: diskCurrent
+
+                        font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
+
+                        text: diskText.text
+                    }
+
+                    StyledText {
+                        id: diskText
+
+                        text: {
+                            if (root.diskUsagePercent === undefined || root.diskUsagePercent === null || root.diskUsagePercent === 0) {
+                                return "--%";
+                            }
+
+                            return root.diskUsagePercent.toFixed(0) + "%";
+                        }
+
+                        font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
+
+                        color: Theme.widgetTextColor
+
+                        anchors.fill: parent
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        elide: Text.ElideNone
+                        wrapMode: Text.NoWrap
+                    }
                 }
             }
         }
@@ -233,35 +258,47 @@ BasePill {
 
     Loader {
         id: tooltipLoader
+
         active: false
+
         sourceComponent: DankTooltip {}
     }
 
     MouseArea {
         id: mouseArea
+
         z: 1
         anchors.fill: parent
         hoverEnabled: root.isVerticalOrientation
+
         onEntered: {
             if (root.isVerticalOrientation && root.selectedMount) {
                 tooltipLoader.active = true;
+
                 if (tooltipLoader.item) {
                     const globalPos = mapToGlobal(width / 2, height / 2);
                     const currentScreen = root.parentScreen || Screen;
+
                     const screenX = currentScreen ? currentScreen.x : 0;
                     const screenY = currentScreen ? currentScreen.y : 0;
+
                     const relativeY = globalPos.y - screenY;
                     const adjustedY = relativeY + root.minTooltipY;
+
                     const tooltipX = root.axis?.edge === "left" ? (root.barThickness + root.barSpacing + Theme.spacingXS) : (currentScreen.width - root.barThickness - root.barSpacing - Theme.spacingXS);
+
                     const isLeft = root.axis?.edge === "left";
+
                     tooltipLoader.item.show(root.selectedMount.mount, screenX + tooltipX, adjustedY, currentScreen, isLeft, !isLeft);
                 }
             }
         }
+
         onExited: {
             if (tooltipLoader.item) {
                 tooltipLoader.item.hide();
             }
+
             tooltipLoader.active = false;
         }
     }

--- a/quickshell/Modules/DankBar/Widgets/DiskUsage.qml
+++ b/quickshell/Modules/DankBar/Widgets/DiskUsage.qml
@@ -9,6 +9,7 @@ BasePill {
 
     property var widgetData: null
     property string mountPath: (widgetData && widgetData.mountPath !== undefined) ? widgetData.mountPath : "/"
+    property int diskUsageMode: (widgetData && widgetData.diskUsageMode !== undefined) ? widgetData.diskUsageMode : 0
     property bool isHovered: mouseArea.containsMouse
     property bool isAutoHideBar: false
     property bool minimumWidth: (widgetData && widgetData.minimumWidth !== undefined) ? widgetData.minimumWidth : true
@@ -39,7 +40,6 @@ BasePill {
         if (!selectedMount || !selectedMount.percent) {
             return 0;
         }
-
         const percentStr = selectedMount.percent.replace("%", "");
         return parseFloat(percentStr) || 0;
     }
@@ -47,7 +47,6 @@ BasePill {
     Component.onCompleted: {
         DgopService.addRef(["diskmounts"]);
     }
-
     Component.onDestruction: {
         DgopService.removeRef(["diskmounts"]);
     }
@@ -105,21 +104,17 @@ BasePill {
     content: Component {
         Item {
             implicitWidth: root.isVerticalOrientation ? (root.widgetThickness - root.horizontalPadding * 2) : diskContent.implicitWidth
-
             implicitHeight: root.isVerticalOrientation ? diskColumn.implicitHeight : diskContent.implicitHeight
 
             Column {
                 id: diskColumn
-
                 visible: root.isVerticalOrientation
                 anchors.centerIn: parent
                 spacing: 1
 
                 DankIcon {
                     name: "storage"
-
                     size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.maximizeWidgetIcons, root.barConfig?.iconScale)
-
                     color: {
                         if (root.diskUsagePercent > 90) {
                             return Theme.tempDanger;
@@ -131,7 +126,6 @@ BasePill {
 
                         return Theme.widgetIconColor;
                     }
-
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
 
@@ -140,12 +134,20 @@ BasePill {
                         if (root.diskUsagePercent === undefined || root.diskUsagePercent === null || root.diskUsagePercent === 0) {
                             return "--";
                         }
-
-                        return root.diskUsagePercent.toFixed(0);
+                        if (!root.selectedMount)
+                            return "--";
+                        switch (root.diskUsageMode) {
+                        case 1:
+                            return root.selectedMount.size || "--";
+                        case 2:
+                            return root.selectedMount.avail || "--";
+                        case 3:
+                            return (root.selectedMount.avail || "--") + " / " + (root.selectedMount.size || "--");
+                        default:
+                            return root.diskUsagePercent.toFixed(0);
+                        }
                     }
-
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
-
                     color: Theme.widgetTextColor
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
@@ -153,18 +155,14 @@ BasePill {
 
             Row {
                 id: diskContent
-
                 visible: !root.isVerticalOrientation
                 anchors.centerIn: parent
                 spacing: Theme.spacingXS
 
                 DankIcon {
                     id: diskIcon
-
                     name: "storage"
-
                     size: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.maximizeWidgetIcons, root.barConfig?.iconScale)
-
                     color: {
                         if (root.diskUsagePercent > 90) {
                             return Theme.tempDanger;
@@ -176,25 +174,19 @@ BasePill {
 
                         return Theme.widgetIconColor;
                     }
-
                     anchors.verticalCenter: parent.verticalCenter
                 }
 
                 StyledText {
                     id: mountText
-
                     text: {
                         if (!root.selectedMount) {
                             return "--";
                         }
-
                         return root.selectedMount.mount;
                     }
-
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
-
                     color: Theme.widgetTextColor
-
                     anchors.verticalCenter: parent.verticalCenter
                     horizontalAlignment: Text.AlignLeft
                     verticalAlignment: Text.AlignVCenter
@@ -204,11 +196,9 @@ BasePill {
 
                 Item {
                     id: textBox
-
                     anchors.verticalCenter: parent.verticalCenter
 
                     implicitWidth: root.minimumWidth ? Math.max(diskBaseline.width, diskCurrent.width) : diskCurrent.width
-
                     implicitHeight: diskText.implicitHeight
 
                     width: implicitWidth
@@ -216,33 +206,46 @@ BasePill {
 
                     StyledTextMetrics {
                         id: diskBaseline
-
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
-
-                        text: "100%"
+                        text: {
+                            switch (root.diskUsageMode) {
+                            case 3:
+                                return "888.8G / 888.8G";
+                            case 1:
+                            case 2:
+                                return "888.8G";
+                            default:
+                                return "100%";
+                            }
+                        }
                     }
 
                     StyledTextMetrics {
                         id: diskCurrent
-
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
-
                         text: diskText.text
                     }
 
                     StyledText {
                         id: diskText
-
                         text: {
                             if (root.diskUsagePercent === undefined || root.diskUsagePercent === null || root.diskUsagePercent === 0) {
                                 return "--%";
                             }
-
-                            return root.diskUsagePercent.toFixed(0) + "%";
+                            if (!root.selectedMount)
+                                return "--%";
+                            switch (root.diskUsageMode) {
+                            case 1:
+                                return root.selectedMount.size || "--";
+                            case 2:
+                                return root.selectedMount.avail || "--";
+                            case 3:
+                                return (root.selectedMount.avail || "--") + " / " + (root.selectedMount.size || "--");
+                            default:
+                                return root.diskUsagePercent.toFixed(0) + "%";
+                            }
                         }
-
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
-
                         color: Theme.widgetTextColor
 
                         anchors.fill: parent
@@ -258,47 +261,35 @@ BasePill {
 
     Loader {
         id: tooltipLoader
-
         active: false
-
         sourceComponent: DankTooltip {}
     }
 
     MouseArea {
         id: mouseArea
-
         z: 1
         anchors.fill: parent
         hoverEnabled: root.isVerticalOrientation
-
         onEntered: {
             if (root.isVerticalOrientation && root.selectedMount) {
                 tooltipLoader.active = true;
-
                 if (tooltipLoader.item) {
                     const globalPos = mapToGlobal(width / 2, height / 2);
                     const currentScreen = root.parentScreen || Screen;
-
                     const screenX = currentScreen ? currentScreen.x : 0;
                     const screenY = currentScreen ? currentScreen.y : 0;
-
                     const relativeY = globalPos.y - screenY;
                     const adjustedY = relativeY + root.minTooltipY;
-
                     const tooltipX = root.axis?.edge === "left" ? (root.barThickness + root.barSpacing + Theme.spacingXS) : (currentScreen.width - root.barThickness - root.barSpacing - Theme.spacingXS);
-
                     const isLeft = root.axis?.edge === "left";
-
                     tooltipLoader.item.show(root.selectedMount.mount, screenX + tooltipX, adjustedY, currentScreen, isLeft, !isLeft);
                 }
             }
         }
-
         onExited: {
             if (tooltipLoader.item) {
                 tooltipLoader.item.hide();
             }
-
             tooltipLoader.active = false;
         }
     }

--- a/quickshell/Modules/Settings/WidgetsTab.qml
+++ b/quickshell/Modules/Settings/WidgetsTab.qml
@@ -404,7 +404,7 @@ Item {
             widgetObj.mountPath = "/";
             widgetObj.diskUsageMode = 0;
         }
-        if (widgetId === "cpuUsage" || widgetId === "memUsage" || widgetId === "cpuTemp" || widgetId === "gpuTemp")
+        if (widgetId === "cpuUsage" || widgetId === "memUsage" || widgetId === "cpuTemp" || widgetId === "gpuTemp" || widgetId === "diskUsage")
             widgetObj.minimumWidth = true;
         if (widgetId === "memUsage")
             widgetObj.showInGb = false;

--- a/quickshell/Modules/Settings/WidgetsTabSection.qml
+++ b/quickshell/Modules/Settings/WidgetsTabSection.qml
@@ -320,7 +320,7 @@ Column {
                         DankActionButton {
                             id: minimumWidthButton
                             buttonSize: 28
-                            visible: modelData.id === "cpuUsage" || modelData.id === "memUsage" || modelData.id === "cpuTemp" || modelData.id === "gpuTemp"
+                            visible: modelData.id === "cpuUsage" || modelData.id === "memUsage" || modelData.id === "cpuTemp" || modelData.id === "gpuTemp" || modelData.id === "diskUsage"
                             iconName: "straighten"
                             iconSize: 16
                             iconColor: (modelData.minimumWidth !== undefined ? modelData.minimumWidth : true) ? Theme.primary : Theme.outline


### PR DESCRIPTION
<img width="725" height="146" alt="image" src="https://github.com/user-attachments/assets/093ae536-791a-45a5-a552-d49d929c8e1c" />

Added these button

<img width="291" height="65" alt="image" src="https://github.com/user-attachments/assets/a055c65e-fd86-48b6-94d9-3b8dd74dee7c" />

Now sizing looks clean and the same