### PR TITLE
greeter: remove keep-max-bpc-unchanged option

### DIFF
--- a/quickshell/Modules/Greetd/assets/dms-greeter
+++ b/quickshell/Modules/Greetd/assets/dms-greeter
@@ -263,10 +263,6 @@ environment {
     DMS_RUN_GREETER "1"
 }
 
-debug {
-  keep-max-bpc-unchanged
-}
-
 gestures {
    hot-corners {
      off

--- a/quickshell/Modules/Greetd/assets/dms-niri.kdl
+++ b/quickshell/Modules/Greetd/assets/dms-niri.kdl
@@ -8,10 +8,6 @@ environment {
 
 spawn-at-startup "sh" "-c" "qs -p _DMS_PATH_; niri msg action quit --skip-confirmation"
 
-debug {
-  keep-max-bpc-unchanged
-}
-
 gestures {
    hot-corners {
      off


### PR DESCRIPTION
Closes #2525

Removes debug option `keep-max-bpc-unchanged` from the greeter, since that option was removed in latest niri commit https://github.com/niri-wm/niri/commit/f9f43d826ab4014a7c302be28d7da33e12f5be37.