### PR TITLE
fix: Make matugen switch pywalfox dark/light mode

### DIFF
--- a/quickshell/matugen/configs/pywalfox.toml
+++ b/quickshell/matugen/configs/pywalfox.toml
@@ -1,4 +1,4 @@
 [templates.dmspywalfox]
 input_path = 'SHELL_DIR/matugen/templates/pywalfox-colors.json'
 output_path = 'CACHE_DIR/wal/dank-pywalfox.json'
-post_hook = 'sh -c "command -v pywalfox && test -f ~/.cache/wal/colors.json && pywalfox update"'
+post_hook = 'sh -c "command -v pywalfox && test -f ~/.cache/wal/colors.json && pywalfox {{ mode }} && pywalfox update"'


### PR DESCRIPTION
Currently, when switching dark/light theme in DMS, pywalfox's mode does not get updated as the `pywalfox update` command only updates the colors but not the mode. This commit adds `pywalfox {{ mode }}` to the matugen post_hook to fix that. (The `mode` template variable evaluates to `dark`/`light`).

Thank you for your time!