### PR TITLE
fix(clipboard): prefer image MIME types over text fallbacks

### DIFF
--- a/core/internal/server/clipboard/manager.go
+++ b/core/internal/server/clipboard/manager.go
@@ -572,16 +572,16 @@ func (m *Manager) hasSensitiveMimeType(mimes []string) bool {
 func (m *Manager) selectMimeType(mimes []string) string {
 	preferredTypes := []string{
 		"text/uri-list",
-		"text/plain;charset=utf-8",
-		"text/plain",
-		"UTF8_STRING",
-		"STRING",
-		"TEXT",
 		"image/png",
 		"image/jpeg",
 		"image/gif",
 		"image/bmp",
 		"image/tiff",
+		"text/plain;charset=utf-8",
+		"text/plain",
+		"UTF8_STRING",
+		"STRING",
+		"TEXT",
 	}
 
 	for _, pref := range preferredTypes {

--- a/core/internal/server/clipboard/manager_test.go
+++ b/core/internal/server/clipboard/manager_test.go
@@ -410,6 +410,8 @@ func TestSelectMimeType(t *testing.T) {
 		{[]string{"text/plain;charset=utf-8", "text/html"}, "text/plain;charset=utf-8"},
 		{[]string{"text/html", "text/plain"}, "text/plain"},
 		{[]string{"text/html", "image/png"}, "image/png"},
+		{[]string{"image/png", "text/plain"}, "image/png"},
+		{[]string{"text/plain", "image/png"}, "image/png"},
 		{[]string{"image/png", "image/jpeg"}, "image/png"},
 		{[]string{"image/png"}, "image/png"},
 		{[]string{"application/octet-stream"}, "application/octet-stream"},


### PR DESCRIPTION
This fixes the MIME selection bug that caused image clipboard entries to be stored as text when a text fallback was present.

Preserving all offered MIME types is a reasonable follow-up for better website clipboard history support, but it is not included in this fix because it would require broader changes to clipboard storage, retrieval, and replay behavior.

fix #2548 