### PR TITLE
fix(control-center): honor plugin ccDetailHeight for detail section sizing

### DIFF
--- a/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
+++ b/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
@@ -38,6 +38,9 @@ Column {
     property real currentRowWidth: 0
     property int expandedRowIndex: -1
     property var colorPickerModal: null
+    // Detail instance of the currently expanded plugin section, so the grid can
+    // honor its dynamic ccDetailHeight instead of a fixed slot size.
+    property var activePluginDetailInstance: null
 
     readonly property real _maxDetailHeight: {
         const rows = layoutResult.rows;
@@ -79,8 +82,10 @@ Column {
             return Math.min(350, _maxDetailHeight);
         if (section.startsWith("brightnessSlider_"))
             return Math.min(400, _maxDetailHeight);
-        if (section.startsWith("plugin_"))
-            return Math.min(250, _maxDetailHeight);
+        if (section.startsWith("plugin_")) {
+            const h = activePluginDetailInstance ? activePluginDetailInstance.ccDetailHeight : 0;
+            return Math.min(h > 0 ? h : 250, _maxDetailHeight);
+        }
         return Math.min(250, _maxDetailHeight);
     }
 
@@ -258,7 +263,19 @@ Column {
                     retainedWidgetData = root.expandedWidgetData;
                 }
 
-                onActiveChanged: retainActiveDetail()
+                function syncActivePluginDetail() {
+                    if (active) {
+                        root.activePluginDetailInstance = pluginDetailInstance;
+                    } else if (root.activePluginDetailInstance === pluginDetailInstance) {
+                        root.activePluginDetailInstance = null;
+                    }
+                }
+
+                onActiveChanged: {
+                    retainActiveDetail();
+                    syncActivePluginDetail();
+                }
+                onPluginDetailInstanceChanged: syncActivePluginDetail()
                 onHeightChanged: {
                     if (!active && height <= 0.5) {
                         retainedSection = "";


### PR DESCRIPTION
## Summary

Plugin detail sections in the Control Center were hardcoded to a fixed 250px height (`DragDropGrid.detailHeightForSection()`), ignoring the `ccDetailHeight` that `PluginComponent` already exposes. `DetailHost` already honors `ccDetailHeight` via `getDetailHeight()`, but the grid which actually drives both the `DetailHost` height and the popout's `targetImplicitHeight` did not, so the plugin value never took effect.

This produced two visible bugs:

- **Wasted space:** details shorter than 250px (e.g. a plugin in a  collapsed/disconnected state) left a large empty gap below the content.
- **Clipped controls:** details taller than 250px were cut off, hiding  anything anchored at the bottom (e.g. action buttons rendered below a  scrollable list).


## Before:

<img width="547" height="347" alt="image" src="https://github.com/user-attachments/assets/29a9b15b-4725-4fa9-a05f-852d8dccf77d" />

<img width="547" height="347" alt="image" src="https://github.com/user-attachments/assets/c8f3c9d8-6f55-4d19-9ffd-bdc3e5819bf8" />



## After:

<img width="534" height="401" alt="image" src="https://github.com/user-attachments/assets/fce4f7a4-e95b-44f9-a2b7-641caa87b891" />
<img width="544" height="244" alt="image" src="https://github.com/user-attachments/assets/7e6c3879-8fd8-4365-aa6a-1edfeaf6658e" />
 