### PR TITLE
fix(lock): wake monitors on input when powered off by lock

### DIFF
--- a/quickshell/Services/IdleService.qml
+++ b/quickshell/Services/IdleService.qml
@@ -138,6 +138,20 @@ Singleton {
         }
     }
 
+    // Wakes monitors powered off by the "power off monitors on lock" path.
+    // Lock.qml's own wake handlers sit outside the session-lock surface and
+    // never receive input, so wake on input via seat-level idle-notify instead.
+    IdleMonitor {
+        id: lockWakeMonitor
+        timeout: 1
+        respectInhibitors: false
+        enabled: root.enabled && root.isShellLocked && root.monitorsOff && SettingsData.lockScreenPowerOffMonitorsOnLock
+        onIsIdleChanged: {
+            if (!isIdle && root.monitorsOff)
+                root.requestMonitorOn();
+        }
+    }
+
     Connections {
         target: root
         function onRequestMonitorOff() {


### PR DESCRIPTION
## Problem

With **\"Power off monitors on lock\"** enabled, the screen never wakes on keyboard/mouse input while locked on some compositors. The only way to get the display back is blind-typing the password to unlock.

## Root cause

The immediate power-off path's wake handlers (\`MouseArea\` + \`Keys\` on a \`FocusScope\`) live at \`Lock.qml\`'s root \`Scope\` level — **outside the \`WlSessionLock\` surface**. A \`Scope\` has no surface, so those handlers never receive any input events while the session is locked (verified with instrumentation: password input reaches \`LockSurface\` inside the lock surface, the root-level handlers receive nothing).

The feature only ever appeared to work on compositors that automatically restore output power on input after a DPMS-off. Compositors that fully tear the output down (e.g. MangoWC's \`disable_monitor\`) leave the screen off until unlock. The bug is compositor-agnostic — the wake handlers are dead code everywhere; behavior just differs by how each compositor handles output power.

## Fix

Add a seat-level \`IdleMonitor\` (\`ext-idle-notify\`) in \`IdleService.qml\` that requests monitor power-on upon any keyboard/pointer activity. Idle-notify is seat-based, so it works independent of surfaces and compositor output-power behavior — same mechanism the existing \`postLockMonitorOffMonitor\` already uses successfully.

Gated on \`isShellLocked && monitorsOff && lockScreenPowerOffMonitorsOnLock\`, so it is inert unless the lock power-off path actually turned the monitors off.

## Testing

On MangoWC: lock → monitors power off immediately → any key press or mouse movement wakes both monitors to the lock screen. Previously the screen stayed off until blind unlock.
