### PR TITLE
fix(osd): size from PanelWindow.screen

### DIFF
--- a/quickshell/Modules/OSD/AudioOutputOSD.qml
+++ b/quickshell/Modules/OSD/AudioOutputOSD.qml
@@ -9,7 +9,7 @@ DankOSD {
     property string deviceName: ""
     property string deviceIcon: "speaker"
 
-    osdWidth: Math.min(Math.max(120, Theme.iconSize + textMetrics.width + Theme.spacingS * 4), Screen.width - Theme.spacingM * 2)
+    osdWidth: Math.min(Math.max(120, Theme.iconSize + textMetrics.width + Theme.spacingS * 4), screenWidth - Theme.spacingM * 2)
     osdHeight: 40 + Theme.spacingS * 2
     autoHideInterval: 2500
     enableMouseInteraction: false

--- a/quickshell/Modules/OSD/BrightnessOSD.qml
+++ b/quickshell/Modules/OSD/BrightnessOSD.qml
@@ -13,8 +13,8 @@ DankOSD {
         _displayBrightness = DisplayService.brightnessLevel;
     }
 
-    osdWidth: useVertical ? (40 + Theme.spacingS * 2) : Math.min(260, Screen.width - Theme.spacingM * 2)
-    osdHeight: useVertical ? Math.min(260, Screen.height - Theme.spacingM * 2) : (40 + Theme.spacingS * 2)
+    osdWidth: useVertical ? (40 + Theme.spacingS * 2) : Math.min(260, screenWidth - Theme.spacingM * 2)
+    osdHeight: useVertical ? Math.min(260, screenHeight - Theme.spacingM * 2) : (40 + Theme.spacingS * 2)
     autoHideInterval: 3000
     enableMouseInteraction: true
 

--- a/quickshell/Modules/OSD/MediaPlaybackOSD.qml
+++ b/quickshell/Modules/OSD/MediaPlaybackOSD.qml
@@ -11,7 +11,7 @@ DankOSD {
     readonly property bool useVertical: isVerticalLayout
     readonly property var player: MprisController.activePlayer
 
-    osdWidth: useVertical ? (40 + Theme.spacingS * 2) : Math.min(280, Screen.width - Theme.spacingM * 2)
+    osdWidth: useVertical ? (40 + Theme.spacingS * 2) : Math.min(280, screenWidth - Theme.spacingM * 2)
     osdHeight: useVertical ? (Theme.iconSize * 2) : (40 + Theme.spacingS * 2)
     autoHideInterval: 3000
     enableMouseInteraction: true

--- a/quickshell/Modules/OSD/MediaVolumeOSD.qml
+++ b/quickshell/Modules/OSD/MediaVolumeOSD.qml
@@ -30,8 +30,8 @@ DankOSD {
         onTriggered: _suppressNewPlayer = false
     }
 
-    osdWidth: useVertical ? (40 + Theme.spacingS * 2) : Math.min(260, Screen.width - Theme.spacingM * 2)
-    osdHeight: useVertical ? Math.min(260, Screen.height - Theme.spacingM * 2) : (40 + Theme.spacingS * 2)
+    osdWidth: useVertical ? (40 + Theme.spacingS * 2) : Math.min(260, screenWidth - Theme.spacingM * 2)
+    osdHeight: useVertical ? Math.min(260, screenHeight - Theme.spacingM * 2) : (40 + Theme.spacingS * 2)
     autoHideInterval: 3000
     enableMouseInteraction: true
 

--- a/quickshell/Modules/OSD/MicVolumeOSD.qml
+++ b/quickshell/Modules/OSD/MicVolumeOSD.qml
@@ -15,8 +15,8 @@ DankOSD {
         _displayVolume = Math.round(AudioService.source.audio.volume * 100);
     }
 
-    osdWidth: useVertical ? (40 + Theme.spacingS * 2) : Math.min(260, Screen.width - Theme.spacingM * 2)
-    osdHeight: useVertical ? Math.min(260, Screen.height - Theme.spacingM * 2) : (40 + Theme.spacingS * 2)
+    osdWidth: useVertical ? (40 + Theme.spacingS * 2) : Math.min(260, screenWidth - Theme.spacingM * 2)
+    osdHeight: useVertical ? Math.min(260, screenHeight - Theme.spacingM * 2) : (40 + Theme.spacingS * 2)
     autoHideInterval: 3000
     enableMouseInteraction: true
 

--- a/quickshell/Modules/OSD/VolumeOSD.qml
+++ b/quickshell/Modules/OSD/VolumeOSD.qml
@@ -15,8 +15,8 @@ DankOSD {
         _displayVolume = Math.min(AudioService.sinkMaxVolume, Math.round(AudioService.sink.audio.volume * 100));
     }
 
-    osdWidth: useVertical ? (40 + Theme.spacingS * 2) : Math.min(260, Screen.width - Theme.spacingM * 2)
-    osdHeight: useVertical ? Math.min(260, Screen.height - Theme.spacingM * 2) : (40 + Theme.spacingS * 2)
+    osdWidth: useVertical ? (40 + Theme.spacingS * 2) : Math.min(260, screenWidth - Theme.spacingM * 2)
+    osdHeight: useVertical ? Math.min(260, screenHeight - Theme.spacingM * 2) : (40 + Theme.spacingS * 2)
     autoHideInterval: 3000
     enableMouseInteraction: true
 


### PR DESCRIPTION
## Description

After disconnecting and reconnecting a monitor, OSDs (volume, brightness, mic, media) stop appearing until the shell is restarted.

The OSDs sized themselves from the Qt-attached `Screen` property, which resolves to the primary screen. During a single-output hotplug Qt briefly makes a 0x0 placeholder the primary screen, and `Screen` stays stuck on it.

Quickshell's `screen` (the OSD's own `PanelWindow.screen`, exposed by DankOSD as `screenWidth`/`screenHeight`) recovers correctly, so this sizes from that instead.

tldr: `screen` vs `Screen`.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
