### PR TITLE
add local to-do planner / tasks to calendar overvie…

### DIFF
--- a/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
+++ b/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
@@ -433,198 +433,442 @@ Rectangle {
             }
         }
 
-        DankListView {
+        Flickable {
+            id: flickableArea
             width: parent.width - Theme.spacingS * 2
             height: parent.height - (showEventDetails ? 40 + 42 : 28 + 18) - Theme.spacingS
             anchors.horizontalCenter: parent.horizontalCenter
-            model: selectedDateEvents
             visible: showEventDetails
             clip: true
-            spacing: Theme.spacingXS
+            contentWidth: width
+            contentHeight: listViewContainer.height
 
-            delegate: Rectangle {
-                width: parent ? parent.width : 0
-                height: eventContent.implicitHeight + Theme.spacingS
-                radius: Theme.cornerRadius
-                color: {
-                    if (modelData.url && eventMouseArea.containsMouse) {
-                        return Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12);
-                    } else if (eventMouseArea.containsMouse) {
-                        return Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.06);
+            Item {
+                id: listViewContainer
+                width: parent.width
+                height: 100
+                
+                property var draggedItem: null
+                property bool orderChanged: false
+                
+                function resetAndLayout() {
+                    for (let i = 0; i < repeater.count; i++) {
+                        let item = repeater.itemAt(i);
+                        if (item) {
+                            item.visualIndex = i;
+                            item.isDragging = false;
+                            item.isEditing = false;
+                        }
                     }
-                    return Theme.nestedSurface;
+                    updateLayout();
                 }
-                border.color: {
-                    if (modelData.url && eventMouseArea.containsMouse) {
-                        return Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.3);
-                    } else if (eventMouseArea.containsMouse) {
-                        return Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.15);
+                
+                function updateLayout() {
+                    let items = [];
+                    for (let i = 0; i < repeater.count; i++) {
+                        let item = repeater.itemAt(i);
+                        if (item) {
+                            items.push(item);
+                        }
                     }
-                    return Theme.outlineMedium;
-                }
-                border.width: eventMouseArea.containsMouse ? 1 : Theme.layerOutlineWidth
-
-                Rectangle {
-                    width: 3
-                    height: parent.height - 6
-                    anchors.left: parent.left
-                    anchors.leftMargin: 3
-                    anchors.verticalCenter: parent.verticalCenter
-                    radius: Theme.cornerRadius
-                    color: modelData.id.startsWith("task_") ? (modelData.title.startsWith("✓") ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.4) : Theme.primary) : Theme.primary
-                    opacity: 0.8
-                }
-
-                Column {
-                    id: eventContent
-
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.verticalCenter: parent.verticalCenter
-                    anchors.leftMargin: Theme.spacingS + 6
-                    anchors.rightMargin: modelData.id.startsWith("task_") ? 88 : Theme.spacingXS
-                    spacing: 2
-
-                    StyledText {
-                        width: parent.width
-                        text: modelData.title
-                        font.pixelSize: Theme.fontSizeSmall
-                        color: modelData.id.startsWith("task_") && modelData.title.startsWith("✓") ? Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.5) : Theme.surfaceText
-                        font.weight: Font.Medium
-                        elide: Text.ElideRight
-                        maximumLineCount: 1
+                    items.sort((a, b) => a.visualIndex - b.visualIndex);
+                    
+                    let currentY = 0;
+                    for (let i = 0; i < items.length; i++) {
+                        let item = items[i];
+                        if (item && !item.isDragging) {
+                            item.y = currentY;
+                        }
+                        if (item) {
+                            currentY += item.height + Theme.spacingXS;
+                        }
                     }
+                    listViewContainer.height = Math.max(0, currentY - Theme.spacingXS);
+                }
 
-                    StyledText {
-                        width: parent.width
-                        text: {
-                            if (!modelData || modelData.allDay) {
-                                return I18n.tr("All day");
-                            } else if (modelData.start && modelData.end) {
-                                const timeFormat = SettingsData.use24HourClock ? "HH:mm" : "h:mm AP";
-                                const startTime = Qt.formatTime(modelData.start, timeFormat);
-                                if (modelData.start.toDateString() !== modelData.end.toDateString() || modelData.start.getTime() !== modelData.end.getTime()) {
-                                    return startTime + " – " + Qt.formatTime(modelData.end, timeFormat);
+                function checkAndReorder(dragged) {
+                    let items = [];
+                    for (let i = 0; i < repeater.count; i++) {
+                        let item = repeater.itemAt(i);
+                        if (item) {
+                            items.push(item);
+                        }
+                    }
+                    items.sort((a, b) => a.visualIndex - b.visualIndex);
+                    
+                    let draggedIdx = items.indexOf(dragged);
+                    if (draggedIdx === -1) return;
+                    
+                    // Helper to get target Y position without animation offsets
+                    function getTargetY(index) {
+                        let y = 0;
+                        for (let i = 0; i < index; i++) {
+                            y += items[i].height + Theme.spacingXS;
+                        }
+                        return y;
+                    }
+                    
+                    // Check item above
+                    if (draggedIdx > 0) {
+                        let above = items[draggedIdx - 1];
+                        let targetYAbove = getTargetY(draggedIdx - 1);
+                        if (above && dragged.y < (targetYAbove + above.height / 2)) {
+                            // Swap visualIndex
+                            let temp = dragged.visualIndex;
+                            dragged.visualIndex = above.visualIndex;
+                            above.visualIndex = temp;
+                            listViewContainer.orderChanged = true;
+                            updateLayout();
+                            return;
+                        }
+                    }
+                    
+                    // Check item below
+                    if (draggedIdx < items.length - 1) {
+                        let below = items[draggedIdx + 1];
+                        let targetYBelow = getTargetY(draggedIdx + 1);
+                        if (below && (dragged.y + dragged.height) > (targetYBelow + below.height / 2)) {
+                            // Swap visualIndex
+                            let temp = dragged.visualIndex;
+                            dragged.visualIndex = below.visualIndex;
+                            below.visualIndex = temp;
+                            listViewContainer.orderChanged = true;
+                            updateLayout();
+                            return;
+                        }
+                    }
+                }
+                
+                function saveNewOrder() {
+                    if (!orderChanged) return;
+                    
+                    let items = [];
+                    for (let i = 0; i < repeater.count; i++) {
+                        let item = repeater.itemAt(i);
+                        if (item) {
+                            items.push(item);
+                        }
+                    }
+                    items.sort((a, b) => a.visualIndex - b.visualIndex);
+                    
+                    let orderedIds = [];
+                    for (let i = 0; i < items.length; i++) {
+                        let tid = items[i].taskId;
+                        if (tid && tid.startsWith("task_")) {
+                            orderedIds.push(tid.replace("task_", ""));
+                        }
+                    }
+                    if (orderedIds.length > 0) {
+                        CalendarService.reorderTasksForDate(root.selectedDate, orderedIds);
+                    }
+                    orderChanged = false;
+                }
+
+                Repeater {
+                    id: repeater
+                    model: selectedDateEvents
+                    
+                    onModelChanged: {
+                        Qt.callLater(listViewContainer.resetAndLayout);
+                    }
+                    
+                    delegate: Rectangle {
+                        id: taskItem
+                        width: parent ? parent.width : 0
+                        height: isEditing ? 34 : (eventContent.implicitHeight + Theme.spacingS)
+                        radius: Theme.cornerRadius
+                        
+                        property int visualIndex: index
+                        property string taskId: modelData ? modelData.id : ""
+                        property bool isDragging: false
+                        property bool isEditing: false
+                        property real dragMouseOffsetY: 0
+                        
+                        color: isDragging ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.15) : (eventMouseArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.06) : Theme.nestedSurface)
+                        border.color: isDragging ? Theme.primary : (eventMouseArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.15) : Theme.outlineMedium)
+                        border.width: (isDragging || eventMouseArea.containsMouse) ? 1 : Theme.layerOutlineWidth
+                        
+                        scale: isDragging ? 1.02 : 1.0
+                        z: isDragging ? 100 : visualIndex
+                        
+                        Behavior on scale { NumberAnimation { duration: 100 } }
+                        
+                        Behavior on y {
+                            id: yBehavior
+                            enabled: !taskItem.isDragging
+                            NumberAnimation {
+                                duration: 150
+                                easing.type: Easing.OutQuad
+                            }
+                        }
+                        
+                        Component.onCompleted: {
+                            visualIndex = index;
+                            listViewContainer.updateLayout();
+                        }
+                        
+                        onHeightChanged: {
+                            listViewContainer.updateLayout();
+                        }
+                        
+                        onIsEditingChanged: {
+                            if (isEditing) {
+                                editInput.forceActiveFocus();
+                                editInput.selectAll();
+                            }
+                        }
+
+                        Rectangle {
+                            width: 3
+                            height: parent.height - 6
+                            anchors.left: parent.left
+                            anchors.leftMargin: 3
+                            anchors.verticalCenter: parent.verticalCenter
+                            radius: Theme.cornerRadius
+                            color: modelData.id.startsWith("task_") ? (modelData.title.startsWith("✓") ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.4) : Theme.primary) : Theme.primary
+                            opacity: 0.8
+                        }
+
+                        // Drag Handle
+                        Rectangle {
+                            id: dragHandle
+                            width: 24
+                            height: 24
+                            anchors.left: parent.left
+                            anchors.leftMargin: 8
+                            anchors.verticalCenter: parent.verticalCenter
+                            radius: Theme.cornerRadius
+                            color: "transparent"
+                            visible: modelData.id.startsWith("task_") && !taskItem.isEditing
+
+                            DankIcon {
+                                anchors.centerIn: parent
+                                name: "drag_indicator"
+                                size: 14
+                                color: dragMouseArea.containsMouse ? Theme.primary : Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.3)
+                            }
+
+                            MouseArea {
+                                id: dragMouseArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.SizeAllCursor
+                                
+                                onPressed: mouse => {
+                                    taskItem.isDragging = true;
+                                    listViewContainer.orderChanged = false;
+                                    let containerPos = taskItem.parent.mapFromItem(dragHandle, mouse.x, mouse.y);
+                                    taskItem.dragMouseOffsetY = containerPos.y - taskItem.y;
+                                    listViewContainer.draggedItem = taskItem;
+                                    mouse.accepted = true;
                                 }
-                                return startTime;
-                            }
-                            return "";
-                        }
-                        font.pixelSize: Theme.fontSizeSmall
-                        color: Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.7)
-                        font.weight: Font.Normal
-                        visible: text !== "" && !modelData.id.startsWith("task_")
-                    }
-                }
-
-                // Main body MouseArea (declared before the delete button so delete sits on top)
-                MouseArea {
-                    id: eventMouseArea
-
-                    anchors.fill: parent
-                    anchors.rightMargin: modelData.id.startsWith("task_") ? 88 : 0
-                    hoverEnabled: true
-                    cursorShape: (modelData.url || modelData.id.startsWith("task_")) ? Qt.PointingHandCursor : Qt.ArrowCursor
-                    enabled: modelData.url !== "" || modelData.id.startsWith("task_")
-                    onClicked: {
-                        if (modelData.id.startsWith("task_")) {
-                            CalendarService.toggleTask(modelData.id);
-                        } else if (modelData.url && modelData.url !== "") {
-                            if (Qt.openUrlExternally(modelData.url) === false) {
-                                log.warn("Failed to open URL: " + modelData.url);
-                            } else {
-                                root.closeDash();
+                                
+                                onPositionChanged: mouse => {
+                                    if (taskItem.isDragging) {
+                                        let containerPos = taskItem.parent.mapFromItem(dragHandle, mouse.x, mouse.y);
+                                        let newY = containerPos.y - taskItem.dragMouseOffsetY;
+                                        
+                                        let minY = 0;
+                                        let maxY = taskItem.parent.height - taskItem.height;
+                                        taskItem.y = Math.max(minY, Math.min(maxY, newY));
+                                        
+                                        listViewContainer.checkAndReorder(taskItem);
+                                        mouse.accepted = true;
+                                    }
+                                }
+                                
+                                onReleased: mouse => {
+                                    if (taskItem.isDragging) {
+                                        taskItem.isDragging = false;
+                                        listViewContainer.draggedItem = null;
+                                        if (listViewContainer.orderChanged) {
+                                            listViewContainer.saveNewOrder();
+                                        }
+                                    }
+                                    mouse.accepted = true;
+                                }
                             }
                         }
-                    }
-                }
 
-                // Up Button
-                Rectangle {
-                    id: upButton
-                    width: 24
-                    height: 24
-                    anchors.right: downButton.left
-                    anchors.rightMargin: Theme.spacingXS
-                    anchors.verticalCenter: parent.verticalCenter
-                    radius: Theme.cornerRadius
-                    color: upMouseArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12) : "transparent"
-                    visible: modelData.id.startsWith("task_")
+                        Column {
+                            id: eventContent
 
-                    DankIcon {
-                        anchors.centerIn: parent
-                        name: "arrow_upward"
-                        size: 14
-                        color: upMouseArea.containsMouse ? Theme.primary : Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.4)
-                    }
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.leftMargin: modelData.id.startsWith("task_") ? 36 : (Theme.spacingS + 6)
+                            anchors.rightMargin: modelData.id.startsWith("task_") ? 64 : Theme.spacingXS
+                            spacing: 2
+                            visible: !taskItem.isEditing
 
-                    MouseArea {
-                        id: upMouseArea
-                        anchors.fill: parent
-                        hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
-                        onClicked: {
-                            CalendarService.moveTask(modelData.id, -1);
+                            StyledText {
+                                width: parent.width
+                                text: modelData.title
+                                font.pixelSize: Theme.fontSizeSmall
+                                color: modelData.id.startsWith("task_") && modelData.title.startsWith("✓") ? Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.5) : Theme.surfaceText
+                                font.weight: Font.Medium
+                                elide: Text.ElideRight
+                                maximumLineCount: 1
+                            }
+
+                            StyledText {
+                                width: parent.width
+                                text: {
+                                    if (!modelData || modelData.allDay) {
+                                        return I18n.tr("All day");
+                                    } else if (modelData.start && modelData.end) {
+                                        const timeFormat = SettingsData.use24HourClock ? "HH:mm" : "h:mm AP";
+                                        const startTime = Qt.formatTime(modelData.start, timeFormat);
+                                        if (modelData.start.toDateString() !== modelData.end.toDateString() || modelData.start.getTime() !== modelData.end.getTime()) {
+                                            return startTime + " – " + Qt.formatTime(modelData.end, timeFormat);
+                                        }
+                                        return startTime;
+                                    }
+                                    return "";
+                                }
+                                font.pixelSize: Theme.fontSizeSmall
+                                color: Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.7)
+                                font.weight: Font.Normal
+                                visible: text !== "" && !modelData.id.startsWith("task_")
+                            }
                         }
-                    }
-                }
 
-                // Down Button
-                Rectangle {
-                    id: downButton
-                    width: 24
-                    height: 24
-                    anchors.right: deleteButton.left
-                    anchors.rightMargin: Theme.spacingXS
-                    anchors.verticalCenter: parent.verticalCenter
-                    radius: Theme.cornerRadius
-                    color: downMouseArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12) : "transparent"
-                    visible: modelData.id.startsWith("task_")
+                        // Inline Edit Input Box
+                        Rectangle {
+                            id: editInputContainer
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.leftMargin: 36
+                            anchors.rightMargin: 64
+                            anchors.verticalCenter: parent.verticalCenter
+                            height: 28
+                            visible: taskItem.isEditing
+                            color: "transparent"
 
-                    DankIcon {
-                        anchors.centerIn: parent
-                        name: "arrow_downward"
-                        size: 14
-                        color: downMouseArea.containsMouse ? Theme.primary : Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.4)
-                    }
-
-                    MouseArea {
-                        id: downMouseArea
-                        anchors.fill: parent
-                        hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
-                        onClicked: {
-                            CalendarService.moveTask(modelData.id, 1);
+                            TextInput {
+                                id: editInput
+                                anchors.fill: parent
+                                verticalAlignment: TextInput.AlignVCenter
+                                color: Theme.surfaceText
+                                font.pixelSize: Theme.fontSizeSmall
+                                selectByMouse: true
+                                clip: true
+                                
+                                text: {
+                                    if (!modelData) return "";
+                                    let title = modelData.title;
+                                    if (title.startsWith("✓ ") || title.startsWith("☐ ")) {
+                                        return title.substring(2);
+                                    }
+                                    return title;
+                                }
+                                
+                                onAccepted: {
+                                    let txt = text.trim();
+                                    if (txt !== "") {
+                                        CalendarService.editTask(modelData.id, txt);
+                                    }
+                                    taskItem.isEditing = false;
+                                }
+                                
+                                Keys.onEscapePressed: {
+                                    taskItem.isEditing = false;
+                                }
+                            }
                         }
-                    }
-                }
 
-                // Delete Button (declared after eventMouseArea to ensure it is rendered on top and captures clicks)
-                Rectangle {
-                    id: deleteButton
-                    width: 24
-                    height: 24
-                    anchors.right: parent.right
-                    anchors.rightMargin: Theme.spacingS
-                    anchors.verticalCenter: parent.verticalCenter
-                    radius: Theme.cornerRadius
-                    color: deleteMouseArea.containsMouse ? Qt.rgba(0.9, 0.2, 0.2, 0.15) : "transparent"
-                    visible: modelData.id.startsWith("task_")
+                        // Main body MouseArea (declared before the delete/edit buttons so they sit on top)
+                        MouseArea {
+                            id: eventMouseArea
 
-                    DankIcon {
-                        anchors.centerIn: parent
-                        name: "delete"
-                        size: 14
-                        color: deleteMouseArea.containsMouse ? Qt.rgba(0.9, 0.2, 0.2, 1.0) : Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.4)
-                    }
+                            anchors.fill: parent
+                            anchors.leftMargin: modelData.id.startsWith("task_") ? 36 : 6
+                            anchors.rightMargin: modelData.id.startsWith("task_") ? 64 : 0
+                            hoverEnabled: true
+                            cursorShape: (modelData.url || modelData.id.startsWith("task_")) ? Qt.PointingHandCursor : Qt.ArrowCursor
+                            enabled: (modelData.url !== "" || modelData.id.startsWith("task_")) && !taskItem.isEditing
+                            onClicked: {
+                                if (modelData.id.startsWith("task_")) {
+                                    CalendarService.toggleTask(modelData.id);
+                                } else if (modelData.url && modelData.url !== "") {
+                                    if (Qt.openUrlExternally(modelData.url) === false) {
+                                        log.warn("Failed to open URL: " + modelData.url);
+                                    } else {
+                                        root.closeDash();
+                                    }
+                                }
+                            }
+                        }
 
-                    MouseArea {
-                        id: deleteMouseArea
-                        anchors.fill: parent
-                        hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
-                        onClicked: {
-                            CalendarService.removeTask(modelData.id);
+                        // Delete / Cancel Button
+                        Rectangle {
+                            id: deleteButton
+                            width: 24
+                            height: 24
+                            anchors.right: parent.right
+                            anchors.rightMargin: Theme.spacingS
+                            anchors.verticalCenter: parent.verticalCenter
+                            radius: Theme.cornerRadius
+                            color: deleteMouseArea.containsMouse ? (taskItem.isEditing ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12) : Qt.rgba(0.9, 0.2, 0.2, 0.15)) : "transparent"
+                            visible: modelData.id.startsWith("task_")
+
+                            DankIcon {
+                                anchors.centerIn: parent
+                                name: taskItem.isEditing ? "close" : "delete"
+                                size: 14
+                                color: deleteMouseArea.containsMouse ? (taskItem.isEditing ? Theme.primary : Qt.rgba(0.9, 0.2, 0.2, 1.0)) : Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.4)
+                            }
+
+                            MouseArea {
+                                id: deleteMouseArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: {
+                                    if (taskItem.isEditing) {
+                                        taskItem.isEditing = false;
+                                    } else {
+                                        CalendarService.removeTask(modelData.id);
+                                    }
+                                }
+                            }
+                        }
+
+                        // Edit / Save Button
+                        Rectangle {
+                            id: editButton
+                            width: 24
+                            height: 24
+                            anchors.right: deleteButton.left
+                            anchors.rightMargin: Theme.spacingXS
+                            anchors.verticalCenter: parent.verticalCenter
+                            radius: Theme.cornerRadius
+                            color: editMouseArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12) : "transparent"
+                            visible: modelData.id.startsWith("task_")
+
+                            DankIcon {
+                                anchors.centerIn: parent
+                                name: taskItem.isEditing ? "check" : "edit"
+                                size: 14
+                                color: editMouseArea.containsMouse ? Theme.primary : Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.4)
+                            }
+
+                            MouseArea {
+                                id: editMouseArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: {
+                                    if (taskItem.isEditing) {
+                                        let txt = editInput.text.trim();
+                                        if (txt !== "") {
+                                            CalendarService.editTask(modelData.id, txt);
+                                        }
+                                        taskItem.isEditing = false;
+                                    } else {
+                                        taskItem.isEditing = true;
+                                    }
+                                }
                         }
                     }
                 }

--- a/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
+++ b/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
@@ -602,51 +602,51 @@ Rectangle {
                         width: parent ? parent.width : 0
                         height: isEditing ? 34 : (eventContent.implicitHeight + Theme.spacingS)
                         radius: Theme.cornerRadius
-                        
+
                         property int modelIndex: index
                         property int visualIndex: index
-                        property string taskId: modelData ? modelData.id : ""
+                        property string taskId: (modelData && modelData.id) ? modelData.id : ""
                         property bool isDragging: false
                         property bool isEditing: false
                         property real dragMouseOffsetY: 0
-                        
+
                         onModelIndexChanged: {
                             visualIndex = modelIndex;
                         }
-                        
+
                         onYChanged: {
                             if (isDragging) {
                                 listViewContainer.checkAndReorder(taskItem);
                             }
                         }
-                        
+
                         color: isDragging ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.15) : (eventMouseArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.06) : Theme.nestedSurface)
                         border.color: isDragging ? Theme.primary : (eventMouseArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.15) : Theme.outlineMedium)
                         border.width: (isDragging || eventMouseArea.containsMouse) ? 1 : Theme.layerOutlineWidth
-                        
+
                         scale: isDragging ? 1.02 : 1.0
                         z: isDragging ? 100 : visualIndex
-                        
+
                         Behavior on scale { NumberAnimation { duration: 100 } }
-                        
+
                         Behavior on y {
                             id: yBehavior
-                            enabled: !taskItem.isDragging && listViewContainer.draggedItem === null
+                            enabled: !taskItem.isDragging
                             NumberAnimation {
                                 duration: 150
                                 easing.type: Easing.OutQuad
                             }
                         }
-                        
+
                         Component.onCompleted: {
                             visualIndex = index;
                             listViewContainer.updateLayout();
                         }
-                        
+
                         onHeightChanged: {
                             listViewContainer.updateLayout();
                         }
-                        
+
                         onIsEditingChanged: {
                             if (isEditing) {
                                 editInput.forceActiveFocus();
@@ -661,7 +661,7 @@ Rectangle {
                             anchors.leftMargin: 3
                             anchors.verticalCenter: parent.verticalCenter
                             radius: Theme.cornerRadius
-                            color: modelData.id.startsWith("task_") ? (modelData.title.startsWith("✓") ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.4) : Theme.primary) : Theme.primary
+                            color: (modelData && modelData.id && modelData.id.startsWith("task_")) ? (modelData.completed ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.4) : Theme.primary) : Theme.primary
                             opacity: 0.8
                         }
 
@@ -675,7 +675,7 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                             radius: Theme.cornerRadius
                             color: "transparent"
-                            visible: modelData.id.startsWith("task_") && !taskItem.isEditing
+                            visible: modelData && modelData.id && modelData.id.startsWith("task_") && !taskItem.isEditing
 
                             DankIcon {
                                 anchors.centerIn: parent
@@ -690,22 +690,22 @@ Rectangle {
                                  hoverEnabled: true
                                  cursorShape: Qt.SizeAllCursor
                                  preventStealing: true
-                                 
+
                                  drag.target: taskItem
                                  drag.axis: Drag.YAxis
                                  drag.minimumY: 0
                                  drag.maximumY: listViewContainer.height - taskItem.height
-                                 
+
                                  onPressed: {
                                      taskItem.isDragging = true;
                                      listViewContainer.orderChanged = false;
                                      listViewContainer.draggedItem = taskItem;
                                  }
-                                 
+
                                  onPositionChanged: {
                                      // Handled natively by MouseArea.drag
                                  }
-                                 
+
                                  onReleased: {
                                      taskItem.isDragging = false;
                                      listViewContainer.draggedItem = null;
@@ -724,22 +724,42 @@ Rectangle {
                              }
                         }
 
+                        // Checkbox status icon
+                        Rectangle {
+                            id: checkboxContainer
+                            width: 24
+                            height: 24
+                            anchors.left: parent.left
+                            anchors.leftMargin: (modelData && modelData.id && modelData.id.startsWith("task_")) ? (taskItem.isEditing ? 8 : 32) : 8
+                            anchors.verticalCenter: parent.verticalCenter
+                            radius: Theme.cornerRadius
+                            color: "transparent"
+                            visible: modelData && modelData.id && modelData.id.startsWith("task_")
+
+                            DankIcon {
+                                anchors.centerIn: parent
+                                name: (modelData && modelData.completed) ? "check_box" : "check_box_outline_blank"
+                                size: 16
+                                color: (modelData && modelData.completed) ? Theme.primary : Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.4)
+                            }
+                        }
+
                         Column {
                             id: eventContent
 
                             anchors.left: parent.left
                             anchors.right: parent.right
                             anchors.verticalCenter: parent.verticalCenter
-                            anchors.leftMargin: modelData.id.startsWith("task_") ? 36 : (Theme.spacingS + 6)
-                            anchors.rightMargin: modelData.id.startsWith("task_") ? 64 : Theme.spacingXS
+                            anchors.leftMargin: (modelData && modelData.id && modelData.id.startsWith("task_")) ? 60 : (Theme.spacingS + 6)
+                            anchors.rightMargin: (modelData && modelData.id && modelData.id.startsWith("task_")) ? 64 : Theme.spacingXS
                             spacing: 2
                             visible: !taskItem.isEditing
 
                             StyledText {
                                 width: parent.width
-                                text: modelData.title
+                                text: modelData ? modelData.title : ""
                                 font.pixelSize: Theme.fontSizeSmall
-                                color: modelData.id.startsWith("task_") && modelData.title.startsWith("✓") ? Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.5) : Theme.surfaceText
+                                color: (modelData && modelData.id && modelData.id.startsWith("task_") && modelData.completed) ? Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.5) : Theme.surfaceText
                                 font.weight: Font.Medium
                                 elide: Text.ElideRight
                                 maximumLineCount: 1
@@ -763,7 +783,7 @@ Rectangle {
                                 font.pixelSize: Theme.fontSizeSmall
                                 color: Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.7)
                                 font.weight: Font.Normal
-                                visible: text !== "" && !modelData.id.startsWith("task_")
+                                visible: text !== "" && modelData && modelData.id && !modelData.id.startsWith("task_")
                             }
                         }
 
@@ -787,24 +807,17 @@ Rectangle {
                                 font.pixelSize: Theme.fontSizeSmall
                                 selectByMouse: true
                                 clip: true
-                                
-                                text: {
-                                    if (!modelData) return "";
-                                    let title = modelData.title;
-                                    if (title.startsWith("✓ ") || title.startsWith("☐ ")) {
-                                        return title.substring(2);
-                                    }
-                                    return title;
-                                }
-                                
+
+                                text: modelData ? modelData.title : ""
+
                                 onAccepted: {
                                     let txt = text.trim();
-                                    if (txt !== "") {
+                                    if (txt !== "" && modelData && modelData.id) {
                                         CalendarService.editTask(modelData.id, txt);
                                     }
                                     taskItem.isEditing = false;
                                 }
-                                
+
                                 Keys.onEscapePressed: {
                                     taskItem.isEditing = false;
                                 }
@@ -816,15 +829,15 @@ Rectangle {
                             id: eventMouseArea
 
                             anchors.fill: parent
-                            anchors.leftMargin: modelData.id.startsWith("task_") ? 36 : 6
-                            anchors.rightMargin: modelData.id.startsWith("task_") ? 64 : 0
+                            anchors.leftMargin: (modelData && modelData.id && modelData.id.startsWith("task_")) ? 32 : 6
+                            anchors.rightMargin: (modelData && modelData.id && modelData.id.startsWith("task_")) ? 64 : 0
                             hoverEnabled: true
-                            cursorShape: (modelData.url || modelData.id.startsWith("task_")) ? Qt.PointingHandCursor : Qt.ArrowCursor
-                            enabled: (modelData.url !== "" || modelData.id.startsWith("task_")) && !taskItem.isEditing
+                            cursorShape: (modelData && (modelData.url || (modelData.id && modelData.id.startsWith("task_")))) ? Qt.PointingHandCursor : Qt.ArrowCursor
+                            enabled: modelData && (modelData.url !== "" || (modelData.id && modelData.id.startsWith("task_"))) && !taskItem.isEditing
                             onClicked: {
-                                if (modelData.id.startsWith("task_")) {
+                                if (modelData && modelData.id && modelData.id.startsWith("task_")) {
                                     CalendarService.toggleTask(modelData.id);
-                                } else if (modelData.url && modelData.url !== "") {
+                                } else if (modelData && modelData.url && modelData.url !== "") {
                                     if (Qt.openUrlExternally(modelData.url) === false) {
                                         log.warn("Failed to open URL: " + modelData.url);
                                     } else {
@@ -844,7 +857,7 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                             radius: Theme.cornerRadius
                             color: deleteMouseArea.containsMouse ? (taskItem.isEditing ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12) : Qt.rgba(0.9, 0.2, 0.2, 0.15)) : "transparent"
-                            visible: modelData.id.startsWith("task_")
+                            visible: modelData && modelData.id && modelData.id.startsWith("task_")
 
                             DankIcon {
                                 anchors.centerIn: parent
@@ -861,7 +874,7 @@ Rectangle {
                                 onClicked: {
                                     if (taskItem.isEditing) {
                                         taskItem.isEditing = false;
-                                    } else {
+                                    } else if (modelData && modelData.id) {
                                         CalendarService.removeTask(modelData.id);
                                     }
                                 }
@@ -878,7 +891,7 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                             radius: Theme.cornerRadius
                             color: editMouseArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12) : "transparent"
-                            visible: modelData.id.startsWith("task_")
+                            visible: modelData && modelData.id && modelData.id.startsWith("task_")
 
                             DankIcon {
                                 anchors.centerIn: parent
@@ -895,7 +908,7 @@ Rectangle {
                                 onClicked: {
                                     if (taskItem.isEditing) {
                                         let txt = editInput.text.trim();
-                                        if (txt !== "") {
+                                        if (txt !== "" && modelData && modelData.id) {
                                             CalendarService.editTask(modelData.id, txt);
                                         }
                                         taskItem.isEditing = false;
@@ -903,6 +916,7 @@ Rectangle {
                                         taskItem.isEditing = true;
                                     }
                                 }
+                            }
                         }
                     }
                 }

--- a/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
+++ b/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
@@ -442,6 +442,7 @@ Rectangle {
             clip: true
             contentWidth: width
             contentHeight: listViewContainer.height
+            interactive: listViewContainer.draggedItem === null
 
             Item {
                 id: listViewContainer
@@ -496,8 +497,7 @@ Rectangle {
                     }
                     items.sort((a, b) => a.visualIndex - b.visualIndex);
                     
-                    let draggedIdx = items.indexOf(dragged);
-                    if (draggedIdx === -1) return;
+                    let swapped = false;
                     
                     // Helper to get target Y position without animation offsets
                     function getTargetY(index) {
@@ -508,34 +508,62 @@ Rectangle {
                         return y;
                     }
                     
-                    // Check item above
-                    if (draggedIdx > 0) {
-                        let above = items[draggedIdx - 1];
-                        let targetYAbove = getTargetY(draggedIdx - 1);
-                        if (above && dragged.y < (targetYAbove + above.height / 2)) {
-                            // Swap visualIndex
-                            let temp = dragged.visualIndex;
-                            dragged.visualIndex = above.visualIndex;
-                            above.visualIndex = temp;
-                            listViewContainer.orderChanged = true;
-                            updateLayout();
-                            return;
+                    while (true) {
+                        let draggedIdx = items.indexOf(dragged);
+                        if (draggedIdx === -1) break;
+                        
+                        let didSwap = false;
+                        let draggedCenterY = dragged.y + dragged.height / 2;
+                        
+                        // Check item above
+                        if (draggedIdx > 0) {
+                            let above = items[draggedIdx - 1];
+                            let targetYAbove = getTargetY(draggedIdx - 1);
+                            let aboveCenterY = targetYAbove + above.height / 2;
+                            if (above && draggedCenterY < aboveCenterY) {
+                                // Swap visualIndex
+                                let temp = dragged.visualIndex;
+                                dragged.visualIndex = above.visualIndex;
+                                above.visualIndex = temp;
+                                
+                                // Swap in local array
+                                items[draggedIdx] = above;
+                                items[draggedIdx - 1] = dragged;
+                                
+                                listViewContainer.orderChanged = true;
+                                swapped = true;
+                                didSwap = true;
+                            }
+                        }
+                        
+                        // Check item below
+                        if (!didSwap && draggedIdx < items.length - 1) {
+                            let below = items[draggedIdx + 1];
+                            let targetYBelow = getTargetY(draggedIdx + 1);
+                            let belowCenterY = targetYBelow + below.height / 2;
+                            if (below && draggedCenterY > belowCenterY) {
+                                // Swap visualIndex
+                                let temp = dragged.visualIndex;
+                                dragged.visualIndex = below.visualIndex;
+                                below.visualIndex = temp;
+                                
+                                // Swap in local array
+                                items[draggedIdx] = below;
+                                items[draggedIdx + 1] = dragged;
+                                
+                                listViewContainer.orderChanged = true;
+                                swapped = true;
+                                didSwap = true;
+                            }
+                        }
+                        
+                        if (!didSwap) {
+                            break;
                         }
                     }
                     
-                    // Check item below
-                    if (draggedIdx < items.length - 1) {
-                        let below = items[draggedIdx + 1];
-                        let targetYBelow = getTargetY(draggedIdx + 1);
-                        if (below && (dragged.y + dragged.height) > (targetYBelow + below.height / 2)) {
-                            // Swap visualIndex
-                            let temp = dragged.visualIndex;
-                            dragged.visualIndex = below.visualIndex;
-                            below.visualIndex = temp;
-                            listViewContainer.orderChanged = true;
-                            updateLayout();
-                            return;
-                        }
+                    if (swapped) {
+                        updateLayout();
                     }
                 }
                 
@@ -595,7 +623,7 @@ Rectangle {
                         
                         Behavior on y {
                             id: yBehavior
-                            enabled: !taskItem.isDragging
+                            enabled: !taskItem.isDragging && listViewContainer.draggedItem === null
                             NumberAnimation {
                                 duration: 150
                                 easing.type: Easing.OutQuad
@@ -653,23 +681,24 @@ Rectangle {
                                 anchors.fill: parent
                                 hoverEnabled: true
                                 cursorShape: Qt.SizeAllCursor
+                                preventStealing: true
                                 
                                 onPressed: mouse => {
                                     taskItem.isDragging = true;
                                     listViewContainer.orderChanged = false;
-                                    let containerPos = taskItem.parent.mapFromItem(dragHandle, mouse.x, mouse.y);
-                                    taskItem.dragMouseOffsetY = containerPos.y - taskItem.y;
+                                    let pressYInContainer = listViewContainer.mapFromItem(null, mouse.sceneX, mouse.sceneY).y;
+                                    taskItem.dragMouseOffsetY = pressYInContainer - taskItem.y;
                                     listViewContainer.draggedItem = taskItem;
                                     mouse.accepted = true;
                                 }
                                 
                                 onPositionChanged: mouse => {
                                     if (taskItem.isDragging) {
-                                        let containerPos = taskItem.parent.mapFromItem(dragHandle, mouse.x, mouse.y);
-                                        let newY = containerPos.y - taskItem.dragMouseOffsetY;
+                                        let currentYInContainer = listViewContainer.mapFromItem(null, mouse.sceneX, mouse.sceneY).y;
+                                        let newY = currentYInContainer - taskItem.dragMouseOffsetY;
                                         
                                         let minY = 0;
-                                        let maxY = taskItem.parent.height - taskItem.height;
+                                        let maxY = listViewContainer.height - taskItem.height;
                                         taskItem.y = Math.max(minY, Math.min(maxY, newY));
                                         
                                         listViewContainer.checkAndReorder(taskItem);
@@ -686,6 +715,14 @@ Rectangle {
                                         }
                                     }
                                     mouse.accepted = true;
+                                }
+
+                                onCanceled: {
+                                    if (taskItem.isDragging) {
+                                        taskItem.isDragging = false;
+                                        listViewContainer.draggedItem = null;
+                                        listViewContainer.resetAndLayout();
+                                    }
                                 }
                             }
                         }

--- a/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
+++ b/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
@@ -513,14 +513,12 @@ Rectangle {
                         if (draggedIdx === -1) break;
                         
                         let didSwap = false;
-                        let draggedCenterY = dragged.y + dragged.height / 2;
                         
                         // Check item above
                         if (draggedIdx > 0) {
                             let above = items[draggedIdx - 1];
                             let targetYAbove = getTargetY(draggedIdx - 1);
-                            let aboveCenterY = targetYAbove + above.height / 2;
-                            if (above && draggedCenterY < aboveCenterY) {
+                            if (above && dragged.y < (targetYAbove + above.height / 2)) {
                                 // Swap visualIndex
                                 let temp = dragged.visualIndex;
                                 dragged.visualIndex = above.visualIndex;
@@ -540,8 +538,7 @@ Rectangle {
                         if (!didSwap && draggedIdx < items.length - 1) {
                             let below = items[draggedIdx + 1];
                             let targetYBelow = getTargetY(draggedIdx + 1);
-                            let belowCenterY = targetYBelow + below.height / 2;
-                            if (below && draggedCenterY > belowCenterY) {
+                            if (below && (dragged.y + dragged.height) > (targetYBelow + below.height / 2)) {
                                 // Swap visualIndex
                                 let temp = dragged.visualIndex;
                                 dragged.visualIndex = below.visualIndex;
@@ -606,11 +603,22 @@ Rectangle {
                         height: isEditing ? 34 : (eventContent.implicitHeight + Theme.spacingS)
                         radius: Theme.cornerRadius
                         
+                        property int modelIndex: index
                         property int visualIndex: index
                         property string taskId: modelData ? modelData.id : ""
                         property bool isDragging: false
                         property bool isEditing: false
                         property real dragMouseOffsetY: 0
+                        
+                        onModelIndexChanged: {
+                            visualIndex = modelIndex;
+                        }
+                        
+                        onYChanged: {
+                            if (isDragging) {
+                                listViewContainer.checkAndReorder(taskItem);
+                            }
+                        }
                         
                         color: isDragging ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.15) : (eventMouseArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.06) : Theme.nestedSurface)
                         border.color: isDragging ? Theme.primary : (eventMouseArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.15) : Theme.outlineMedium)
@@ -677,54 +685,43 @@ Rectangle {
                             }
 
                             MouseArea {
-                                id: dragMouseArea
-                                anchors.fill: parent
-                                hoverEnabled: true
-                                cursorShape: Qt.SizeAllCursor
-                                preventStealing: true
-                                
-                                onPressed: mouse => {
-                                    taskItem.isDragging = true;
-                                    listViewContainer.orderChanged = false;
-                                    let pressYInContainer = listViewContainer.mapFromItem(null, mouse.sceneX, mouse.sceneY).y;
-                                    taskItem.dragMouseOffsetY = pressYInContainer - taskItem.y;
-                                    listViewContainer.draggedItem = taskItem;
-                                    mouse.accepted = true;
-                                }
-                                
-                                onPositionChanged: mouse => {
-                                    if (taskItem.isDragging) {
-                                        let currentYInContainer = listViewContainer.mapFromItem(null, mouse.sceneX, mouse.sceneY).y;
-                                        let newY = currentYInContainer - taskItem.dragMouseOffsetY;
-                                        
-                                        let minY = 0;
-                                        let maxY = listViewContainer.height - taskItem.height;
-                                        taskItem.y = Math.max(minY, Math.min(maxY, newY));
-                                        
-                                        listViewContainer.checkAndReorder(taskItem);
-                                        mouse.accepted = true;
-                                    }
-                                }
-                                
-                                onReleased: mouse => {
-                                    if (taskItem.isDragging) {
-                                        taskItem.isDragging = false;
-                                        listViewContainer.draggedItem = null;
-                                        if (listViewContainer.orderChanged) {
-                                            listViewContainer.saveNewOrder();
-                                        }
-                                    }
-                                    mouse.accepted = true;
-                                }
+                                 id: dragMouseArea
+                                 anchors.fill: parent
+                                 hoverEnabled: true
+                                 cursorShape: Qt.SizeAllCursor
+                                 preventStealing: true
+                                 
+                                 drag.target: taskItem
+                                 drag.axis: Drag.YAxis
+                                 drag.minimumY: 0
+                                 drag.maximumY: listViewContainer.height - taskItem.height
+                                 
+                                 onPressed: {
+                                     taskItem.isDragging = true;
+                                     listViewContainer.orderChanged = false;
+                                     listViewContainer.draggedItem = taskItem;
+                                 }
+                                 
+                                 onPositionChanged: {
+                                     // Handled natively by MouseArea.drag
+                                 }
+                                 
+                                 onReleased: {
+                                     taskItem.isDragging = false;
+                                     listViewContainer.draggedItem = null;
+                                     if (listViewContainer.orderChanged) {
+                                         listViewContainer.saveNewOrder();
+                                     } else {
+                                         listViewContainer.updateLayout();
+                                     }
+                                 }
 
-                                onCanceled: {
-                                    if (taskItem.isDragging) {
-                                        taskItem.isDragging = false;
-                                        listViewContainer.draggedItem = null;
-                                        listViewContainer.resetAndLayout();
-                                    }
-                                }
-                            }
+                                 onCanceled: {
+                                     taskItem.isDragging = false;
+                                     listViewContainer.draggedItem = null;
+                                     listViewContainer.resetAndLayout();
+                                 }
+                             }
                         }
 
                         Column {

--- a/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
+++ b/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
@@ -105,6 +105,13 @@ Rectangle {
     }
 
     onSelectedDateChanged: updateSelectedDateEvents()
+
+    onShowEventDetailsChanged: {
+        if (showEventDetails) {
+            taskInput.forceActiveFocus();
+        }
+    }
+
     Component.onCompleted: {
         loadEventsForMonth();
         updateSelectedDateEvents();
@@ -475,7 +482,7 @@ Rectangle {
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.leftMargin: Theme.spacingS + 6
-                    anchors.rightMargin: modelData.id.startsWith("task_") ? 32 : Theme.spacingXS
+                    anchors.rightMargin: modelData.id.startsWith("task_") ? 88 : Theme.spacingXS
                     spacing: 2
 
                     StyledText {
@@ -515,7 +522,7 @@ Rectangle {
                     id: eventMouseArea
 
                     anchors.fill: parent
-                    anchors.rightMargin: modelData.id.startsWith("task_") ? 32 : 0
+                    anchors.rightMargin: modelData.id.startsWith("task_") ? 88 : 0
                     hoverEnabled: true
                     cursorShape: (modelData.url || modelData.id.startsWith("task_")) ? Qt.PointingHandCursor : Qt.ArrowCursor
                     enabled: modelData.url !== "" || modelData.id.startsWith("task_")
@@ -528,6 +535,66 @@ Rectangle {
                             } else {
                                 root.closeDash();
                             }
+                        }
+                    }
+                }
+
+                // Up Button
+                Rectangle {
+                    id: upButton
+                    width: 24
+                    height: 24
+                    anchors.right: downButton.left
+                    anchors.rightMargin: Theme.spacingXS
+                    anchors.verticalCenter: parent.verticalCenter
+                    radius: Theme.cornerRadius
+                    color: upMouseArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12) : "transparent"
+                    visible: modelData.id.startsWith("task_")
+
+                    DankIcon {
+                        anchors.centerIn: parent
+                        name: "arrow_upward"
+                        size: 14
+                        color: upMouseArea.containsMouse ? Theme.primary : Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.4)
+                    }
+
+                    MouseArea {
+                        id: upMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            CalendarService.moveTask(modelData.id, -1);
+                        }
+                    }
+                }
+
+                // Down Button
+                Rectangle {
+                    id: downButton
+                    width: 24
+                    height: 24
+                    anchors.right: deleteButton.left
+                    anchors.rightMargin: Theme.spacingXS
+                    anchors.verticalCenter: parent.verticalCenter
+                    radius: Theme.cornerRadius
+                    color: downMouseArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12) : "transparent"
+                    visible: modelData.id.startsWith("task_")
+
+                    DankIcon {
+                        anchors.centerIn: parent
+                        name: "arrow_downward"
+                        size: 14
+                        color: downMouseArea.containsMouse ? Theme.primary : Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.4)
+                    }
+
+                    MouseArea {
+                        id: downMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            CalendarService.moveTask(modelData.id, 1);
                         }
                     }
                 }
@@ -599,7 +666,6 @@ Rectangle {
                     if (txt !== "") {
                         CalendarService.addTaskForDate(root.selectedDate, txt);
                         text = "";
-                        taskInput.focus = false;
                     }
                 }
             }

--- a/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
+++ b/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
@@ -448,10 +448,10 @@ Rectangle {
                 id: listViewContainer
                 width: parent.width
                 height: 100
-                
+
                 property var draggedItem: null
                 property bool orderChanged: false
-                
+
                 function resetAndLayout() {
                     for (let i = 0; i < repeater.count; i++) {
                         let item = repeater.itemAt(i);
@@ -463,7 +463,7 @@ Rectangle {
                     }
                     updateLayout();
                 }
-                
+
                 function updateLayout() {
                     let items = [];
                     for (let i = 0; i < repeater.count; i++) {
@@ -473,7 +473,7 @@ Rectangle {
                         }
                     }
                     items.sort((a, b) => a.visualIndex - b.visualIndex);
-                    
+
                     let currentY = 0;
                     for (let i = 0; i < items.length; i++) {
                         let item = items[i];
@@ -496,9 +496,9 @@ Rectangle {
                         }
                     }
                     items.sort((a, b) => a.visualIndex - b.visualIndex);
-                    
+
                     let swapped = false;
-                    
+
                     // Helper to get target Y position without animation offsets
                     function getTargetY(index) {
                         let y = 0;
@@ -507,13 +507,14 @@ Rectangle {
                         }
                         return y;
                     }
-                    
+
                     while (true) {
                         let draggedIdx = items.indexOf(dragged);
-                        if (draggedIdx === -1) break;
-                        
+                        if (draggedIdx === -1)
+                            break;
+
                         let didSwap = false;
-                        
+
                         // Check item above
                         if (draggedIdx > 0) {
                             let above = items[draggedIdx - 1];
@@ -523,17 +524,17 @@ Rectangle {
                                 let temp = dragged.visualIndex;
                                 dragged.visualIndex = above.visualIndex;
                                 above.visualIndex = temp;
-                                
+
                                 // Swap in local array
                                 items[draggedIdx] = above;
                                 items[draggedIdx - 1] = dragged;
-                                
+
                                 listViewContainer.orderChanged = true;
                                 swapped = true;
                                 didSwap = true;
                             }
                         }
-                        
+
                         // Check item below
                         if (!didSwap && draggedIdx < items.length - 1) {
                             let below = items[draggedIdx + 1];
@@ -543,30 +544,31 @@ Rectangle {
                                 let temp = dragged.visualIndex;
                                 dragged.visualIndex = below.visualIndex;
                                 below.visualIndex = temp;
-                                
+
                                 // Swap in local array
                                 items[draggedIdx] = below;
                                 items[draggedIdx + 1] = dragged;
-                                
+
                                 listViewContainer.orderChanged = true;
                                 swapped = true;
                                 didSwap = true;
                             }
                         }
-                        
+
                         if (!didSwap) {
                             break;
                         }
                     }
-                    
+
                     if (swapped) {
                         updateLayout();
                     }
                 }
-                
+
                 function saveNewOrder() {
-                    if (!orderChanged) return;
-                    
+                    if (!orderChanged)
+                        return;
+
                     let items = [];
                     for (let i = 0; i < repeater.count; i++) {
                         let item = repeater.itemAt(i);
@@ -575,7 +577,7 @@ Rectangle {
                         }
                     }
                     items.sort((a, b) => a.visualIndex - b.visualIndex);
-                    
+
                     let orderedIds = [];
                     for (let i = 0; i < items.length; i++) {
                         let tid = items[i].taskId;
@@ -592,11 +594,11 @@ Rectangle {
                 Repeater {
                     id: repeater
                     model: selectedDateEvents
-                    
+
                     onModelChanged: {
                         Qt.callLater(listViewContainer.resetAndLayout);
                     }
-                    
+
                     delegate: Rectangle {
                         id: taskItem
                         width: parent ? parent.width : 0
@@ -627,7 +629,11 @@ Rectangle {
                         scale: isDragging ? 1.02 : 1.0
                         z: isDragging ? 100 : visualIndex
 
-                        Behavior on scale { NumberAnimation { duration: 100 } }
+                        Behavior on scale {
+                            NumberAnimation {
+                                duration: 100
+                            }
+                        }
 
                         Behavior on y {
                             id: yBehavior
@@ -685,43 +691,43 @@ Rectangle {
                             }
 
                             MouseArea {
-                                 id: dragMouseArea
-                                 anchors.fill: parent
-                                 hoverEnabled: true
-                                 cursorShape: Qt.SizeAllCursor
-                                 preventStealing: true
+                                id: dragMouseArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.SizeAllCursor
+                                preventStealing: true
 
-                                 drag.target: taskItem
-                                 drag.axis: Drag.YAxis
-                                 drag.minimumY: 0
-                                 drag.maximumY: listViewContainer.height - taskItem.height
+                                drag.target: taskItem
+                                drag.axis: Drag.YAxis
+                                drag.minimumY: 0
+                                drag.maximumY: listViewContainer.height - taskItem.height
 
-                                 onPressed: {
-                                     taskItem.isDragging = true;
-                                     listViewContainer.orderChanged = false;
-                                     listViewContainer.draggedItem = taskItem;
-                                 }
+                                onPressed: {
+                                    taskItem.isDragging = true;
+                                    listViewContainer.orderChanged = false;
+                                    listViewContainer.draggedItem = taskItem;
+                                }
 
-                                 onPositionChanged: {
-                                     // Handled natively by MouseArea.drag
-                                 }
+                                onPositionChanged: {
+                                    // Handled natively by MouseArea.drag
+                                }
 
-                                 onReleased: {
-                                     taskItem.isDragging = false;
-                                     listViewContainer.draggedItem = null;
-                                     if (listViewContainer.orderChanged) {
-                                         listViewContainer.saveNewOrder();
-                                     } else {
-                                         listViewContainer.updateLayout();
-                                     }
-                                 }
+                                onReleased: {
+                                    taskItem.isDragging = false;
+                                    listViewContainer.draggedItem = null;
+                                    if (listViewContainer.orderChanged) {
+                                        listViewContainer.saveNewOrder();
+                                    } else {
+                                        listViewContainer.updateLayout();
+                                    }
+                                }
 
-                                 onCanceled: {
-                                     taskItem.isDragging = false;
-                                     listViewContainer.draggedItem = null;
-                                     listViewContainer.resetAndLayout();
-                                 }
-                             }
+                                onCanceled: {
+                                    taskItem.isDragging = false;
+                                    listViewContainer.draggedItem = null;
+                                    listViewContainer.resetAndLayout();
+                                }
+                            }
                         }
 
                         // Checkbox status icon

--- a/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
+++ b/quickshell/Modules/DankDash/Overview/CalendarOverviewCard.qml
@@ -176,7 +176,7 @@ Rectangle {
                 text: {
                     const dateStr = Qt.formatDate(selectedDate, "MMM d");
                     if (selectedDateEvents && selectedDateEvents.length > 0) {
-                        const eventCount = selectedDateEvents.length === 1 ? I18n.tr("1 event") : selectedDateEvents.length + " " + I18n.tr("events");
+                        const eventCount = selectedDateEvents.length === 1 ? I18n.tr("1 task") : selectedDateEvents.length + " " + I18n.tr("tasks");
                         return dateStr + " • " + eventCount;
                     }
                     return dateStr;
@@ -416,10 +416,8 @@ Rectangle {
                                 hoverEnabled: true
                                 cursorShape: Qt.PointingHandCursor
                                 onClicked: {
-                                    if (CalendarService && CalendarService.khalAvailable && CalendarService.hasEventsForDate(dayDate)) {
-                                        root.selectedDate = dayDate;
-                                        root.showEventDetails = true;
-                                    }
+                                    root.selectedDate = dayDate;
+                                    root.showEventDetails = true;
                                 }
                             }
                         }
@@ -430,7 +428,7 @@ Rectangle {
 
         DankListView {
             width: parent.width - Theme.spacingS * 2
-            height: parent.height - (showEventDetails ? 40 : 28 + 18) - Theme.spacingS
+            height: parent.height - (showEventDetails ? 40 + 42 : 28 + 18) - Theme.spacingS
             anchors.horizontalCenter: parent.horizontalCenter
             model: selectedDateEvents
             visible: showEventDetails
@@ -466,7 +464,7 @@ Rectangle {
                     anchors.leftMargin: 3
                     anchors.verticalCenter: parent.verticalCenter
                     radius: Theme.cornerRadius
-                    color: Theme.primary
+                    color: modelData.id.startsWith("task_") ? (modelData.title.startsWith("✓") ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.4) : Theme.primary) : Theme.primary
                     opacity: 0.8
                 }
 
@@ -477,14 +475,14 @@ Rectangle {
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.leftMargin: Theme.spacingS + 6
-                    anchors.rightMargin: Theme.spacingXS
+                    anchors.rightMargin: modelData.id.startsWith("task_") ? 32 : Theme.spacingXS
                     spacing: 2
 
                     StyledText {
                         width: parent.width
                         text: modelData.title
                         font.pixelSize: Theme.fontSizeSmall
-                        color: Theme.surfaceText
+                        color: modelData.id.startsWith("task_") && modelData.title.startsWith("✓") ? Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.5) : Theme.surfaceText
                         font.weight: Font.Medium
                         elide: Text.ElideRight
                         maximumLineCount: 1
@@ -508,25 +506,100 @@ Rectangle {
                         font.pixelSize: Theme.fontSizeSmall
                         color: Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.7)
                         font.weight: Font.Normal
-                        visible: text !== ""
+                        visible: text !== "" && !modelData.id.startsWith("task_")
                     }
                 }
 
+                // Main body MouseArea (declared before the delete button so delete sits on top)
                 MouseArea {
                     id: eventMouseArea
 
                     anchors.fill: parent
+                    anchors.rightMargin: modelData.id.startsWith("task_") ? 32 : 0
                     hoverEnabled: true
-                    cursorShape: modelData.url ? Qt.PointingHandCursor : Qt.ArrowCursor
-                    enabled: modelData.url !== ""
+                    cursorShape: (modelData.url || modelData.id.startsWith("task_")) ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    enabled: modelData.url !== "" || modelData.id.startsWith("task_")
                     onClicked: {
-                        if (modelData.url && modelData.url !== "") {
+                        if (modelData.id.startsWith("task_")) {
+                            CalendarService.toggleTask(modelData.id);
+                        } else if (modelData.url && modelData.url !== "") {
                             if (Qt.openUrlExternally(modelData.url) === false) {
                                 log.warn("Failed to open URL: " + modelData.url);
                             } else {
                                 root.closeDash();
                             }
                         }
+                    }
+                }
+
+                // Delete Button (declared after eventMouseArea to ensure it is rendered on top and captures clicks)
+                Rectangle {
+                    id: deleteButton
+                    width: 24
+                    height: 24
+                    anchors.right: parent.right
+                    anchors.rightMargin: Theme.spacingS
+                    anchors.verticalCenter: parent.verticalCenter
+                    radius: Theme.cornerRadius
+                    color: deleteMouseArea.containsMouse ? Qt.rgba(0.9, 0.2, 0.2, 0.15) : "transparent"
+                    visible: modelData.id.startsWith("task_")
+
+                    DankIcon {
+                        anchors.centerIn: parent
+                        name: "delete"
+                        size: 14
+                        color: deleteMouseArea.containsMouse ? Qt.rgba(0.9, 0.2, 0.2, 1.0) : Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.4)
+                    }
+
+                    MouseArea {
+                        id: deleteMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            CalendarService.removeTask(modelData.id);
+                        }
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            width: parent.width - Theme.spacingS * 2
+            height: 34
+            anchors.horizontalCenter: parent.horizontalCenter
+            radius: Theme.cornerRadius
+            color: Theme.nestedSurface
+            border.color: Theme.outlineMedium
+            border.width: 1
+            visible: showEventDetails
+
+            TextInput {
+                id: taskInput
+                anchors.fill: parent
+                anchors.leftMargin: Theme.spacingS
+                anchors.rightMargin: Theme.spacingS
+                verticalAlignment: TextInput.AlignVCenter
+                color: Theme.surfaceText
+                font.pixelSize: Theme.fontSizeSmall
+                selectByMouse: true
+                clip: true
+
+                // Hint placeholder text
+                Text {
+                    text: I18n.tr("Add a task...")
+                    color: Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.4)
+                    visible: !taskInput.text && !taskInput.activeFocus
+                    font.pixelSize: Theme.fontSizeSmall
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                onAccepted: {
+                    let txt = text.trim();
+                    if (txt !== "") {
+                        CalendarService.addTaskForDate(root.selectedDate, txt);
+                        text = "";
+                        taskInput.focus = false;
                     }
                 }
             }

--- a/quickshell/Services/CalendarService.qml
+++ b/quickshell/Services/CalendarService.qml
@@ -5,9 +5,11 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import qs.Common
+import qs.Services
 
 Singleton {
     id: root
+    readonly property var log: Log.scoped("CalendarService")
 
     property bool khalAvailable: true // Always true to enable DMS calendar card UI
     property bool khalInstalled: false // Tracks if khal is actually on the system
@@ -97,7 +99,7 @@ Singleton {
             root.localTasks = JSON.parse(text);
             updateTaskEvents();
         } catch (error) {
-            console.warn("Failed to parse local tasks JSON: " + error.toString());
+            log.warn("Failed to parse local tasks JSON: " + error.toString());
         }
     }
 

--- a/quickshell/Services/CalendarService.qml
+++ b/quickshell/Services/CalendarService.qml
@@ -129,7 +129,8 @@ Singleton {
                     "description": "Task from your Planner",
                     "url": "",
                     "calendar": "Todo Planner",
-                    "color": "#10B981", // Pastel Green
+                    "color": "#10B981" // Pastel Green
+                    ,
                     "allDay": true,
                     "isMultiDay": false
                 });
@@ -168,7 +169,8 @@ Singleton {
                     break;
                 }
             }
-            if (updated) break;
+            if (updated)
+                break;
         }
         if (updated) {
             root.localTasks = tasks;
@@ -240,7 +242,8 @@ Singleton {
                     break;
                 }
             }
-            if (updated) break;
+            if (updated)
+                break;
         }
         if (updated) {
             root.localTasks = tasks;
@@ -277,7 +280,8 @@ Singleton {
             }
             list.sort((a, b) => {
                 let diff = a.start.getTime() - b.start.getTime();
-                if (diff !== 0) return diff;
+                if (diff !== 0)
+                    return diff;
                 return a._origIdx - b._origIdx;
             });
         }

--- a/quickshell/Services/CalendarService.qml
+++ b/quickshell/Services/CalendarService.qml
@@ -118,14 +118,24 @@ Singleton {
         removeTaskProcess.running = true;
     }
 
-    function moveTask(taskId, direction) {
-        let cleanId = taskId.replace("task_", "");
-        moveTaskProcess.command = [
+    function reorderTasksForDate(date, orderedIds) {
+        let dateKey = Qt.formatDate(date, "yyyy-MM-dd")
+        reorderTasksProcess.command = [
             "python", "-c",
-            "import json, sys, os; path = os.path.expanduser('~/.config/niri-calendar-todo/tasks.json'); data = json.load(open(path)) if os.path.exists(path) else {}; tid = sys.argv[1]; direction = int(sys.argv[2]); swapped = False\nfor k, v in data.items():\n    for i, item in enumerate(v):\n        if item['id'] == tid:\n            new_idx = i + direction\n            if 0 <= new_idx < len(v):\n                v[i], v[new_idx] = v[new_idx], v[i]\n                swapped = True\n            break\n    if swapped: break\nif swapped: json.dump(data, open(path, 'w'), indent=2)",
-            cleanId, direction.toString()
-        ];
-        moveTaskProcess.running = true;
+            "import json, sys, os; path = os.path.expanduser('~/.config/niri-calendar-todo/tasks.json'); data = json.load(open(path)) if os.path.exists(path) else {}; date = sys.argv[1]; ordered_ids = sys.argv[2].split(',') if sys.argv[2] else []; v = data.get(date, []); id_to_item = {item['id']: item for item in v}; new_v = [id_to_item[tid] for tid in ordered_ids if tid in id_to_item] + [item for item in v if item['id'] not in id_to_item]; data[date] = new_v; json.dump(data, open(path, 'w'), indent=2)",
+            dateKey, orderedIds.join(",")
+        ]
+        reorderTasksProcess.running = true
+    }
+
+    function editTask(taskId, newText) {
+        let cleanId = taskId.replace("task_", "")
+        editTaskProcess.command = [
+            "python", "-c",
+            "import json, sys, os; path = os.path.expanduser('~/.config/niri-calendar-todo/tasks.json'); data = json.load(open(path)) if os.path.exists(path) else {}; tid = sys.argv[1].replace('task_', ''); [item.update({'text': sys.argv[2]}) for v in data.values() for item in v if item['id'] == tid]; json.dump(data, open(path, 'w'), indent=2)",
+            cleanId, newText
+        ]
+        editTaskProcess.running = true
     }
 
     // Initialize on component completion
@@ -166,9 +176,20 @@ Singleton {
         }
     }
 
-    // Process for moving tasks
+    // Process for reordering tasks
     Process {
-        id: moveTaskProcess
+        id: reorderTasksProcess
+        running: false
+        onExited: exitCode => {
+            if (!localTasksProcess.running) {
+                localTasksProcess.running = true;
+            }
+        }
+    }
+
+    // Process for editing tasks
+    Process {
+        id: editTaskProcess
         running: false
         onExited: exitCode => {
             if (!localTasksProcess.running) {

--- a/quickshell/Services/CalendarService.qml
+++ b/quickshell/Services/CalendarService.qml
@@ -12,11 +12,17 @@ Singleton {
     property bool khalAvailable: true // Always true to enable DMS calendar card UI
     property bool khalInstalled: false // Tracks if khal is actually on the system
     property var eventsByDate: ({})
+    property var khalEventsByDate: ({})
+    property var taskEventsByDate: ({})
+    property var localTasks: ({})
     property bool isLoading: false
     property string lastError: ""
     property date lastStartDate
     property date lastEndDate
     property string khalDateFormat: "MM/dd/yyyy"
+
+    onKhalEventsByDateChanged: mergeEvents()
+    onTaskEventsByDateChanged: mergeEvents()
 
     function checkKhalAvailability() {
         if (!khalCheckProcess.running)
@@ -51,14 +57,7 @@ Singleton {
     }
 
     function loadEvents(startDate, endDate) {
-        // Read local tasks from niri-calendar-todo
-        if (!localTasksProcess.running) {
-            localTasksProcess.running = true;
-        }
-
         if (!root.khalInstalled) {
-            // If khal isn't installed, trigger change notification for local tasks
-            root.eventsByDateChanged();
             return;
         }
         if (eventsProcess.running) {
@@ -87,55 +86,201 @@ Singleton {
         return events.length > 0;
     }
 
-    // Task editing methods using clean, single-line Python scripts (no indentation or external helper file needed!)
+    // In-memory Task CRUD methods
+    function loadTasks(text) {
+        if (!text || text.trim() === "") {
+            root.localTasks = {};
+            root.taskEventsByDate = {};
+            return;
+        }
+        try {
+            root.localTasks = JSON.parse(text);
+            updateTaskEvents();
+        } catch (error) {
+            console.warn("Failed to parse local tasks JSON: " + error.toString());
+        }
+    }
+
+    function saveTasks() {
+        let dir = Quickshell.env("HOME") + "/.config/niri-calendar-todo";
+        Quickshell.execDetached(["mkdir", "-p", dir]);
+        tasksFileView.setText(JSON.stringify(root.localTasks, null, 2));
+    }
+
+    function updateTaskEvents() {
+        let newTaskEvents = {};
+        for (let dateKey in root.localTasks) {
+            let taskList = root.localTasks[dateKey] || [];
+            newTaskEvents[dateKey] = [];
+            for (let task of taskList) {
+                let eventId = "task_" + task.id;
+                let parts = dateKey.split("-");
+                let taskDate = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]));
+
+                newTaskEvents[dateKey].push({
+                    "id": eventId,
+                    "title": task.text,
+                    "completed": !!task.completed,
+                    "start": taskDate,
+                    "end": taskDate,
+                    "location": "",
+                    "description": "Task from your Planner",
+                    "url": "",
+                    "calendar": "Todo Planner",
+                    "color": "#10B981", // Pastel Green
+                    "allDay": true,
+                    "isMultiDay": false
+                });
+            }
+        }
+        root.taskEventsByDate = newTaskEvents;
+    }
+
     function addTaskForDate(date, text) {
         let dateKey = Qt.formatDate(date, "yyyy-MM-dd");
-        addTaskProcess.command = [
-            "python", "-c",
-            "import json, sys, time, os; path = os.path.expanduser('~/.config/niri-calendar-todo/tasks.json'); os.makedirs(os.path.dirname(path), exist_ok=True); data = json.load(open(path)) if os.path.exists(path) else {}; date, text = sys.argv[1], sys.argv[2]; item = {'id': str(int(time.time()*1000)) + '-dms', 'text': text, 'completed': False}; data.setdefault(date, []).append(item); json.dump(data, open(path, 'w'), indent=2)",
-            dateKey, text
-        ];
-        addTaskProcess.running = true;
+        let tasks = Object.assign({}, root.localTasks);
+        if (!tasks[dateKey]) {
+            tasks[dateKey] = [];
+        }
+        let taskId = (new Date().getTime()) + "-dms";
+        tasks[dateKey].push({
+            "id": taskId,
+            "text": text,
+            "completed": false
+        });
+        root.localTasks = tasks;
+        updateTaskEvents();
+        saveTasks();
     }
 
     function toggleTask(taskId) {
         let cleanId = taskId.replace("task_", "");
-        toggleTaskProcess.command = [
-            "python", "-c",
-            "import json, sys, os; path = os.path.expanduser('~/.config/niri-calendar-todo/tasks.json'); data = json.load(open(path)) if os.path.exists(path) else {}; tid = sys.argv[1].replace('task_', ''); [item.update({'completed': not item['completed']}) for v in data.values() for item in v if item['id'] == tid]; json.dump(data, open(path, 'w'), indent=2)",
-            cleanId
-        ];
-        toggleTaskProcess.running = true;
+        let tasks = Object.assign({}, root.localTasks);
+        let updated = false;
+        for (let dateKey in tasks) {
+            let list = tasks[dateKey];
+            for (let item of list) {
+                if (item.id === cleanId) {
+                    item.completed = !item.completed;
+                    updated = true;
+                    break;
+                }
+            }
+            if (updated) break;
+        }
+        if (updated) {
+            root.localTasks = tasks;
+            updateTaskEvents();
+            saveTasks();
+        }
     }
 
     function removeTask(taskId) {
         let cleanId = taskId.replace("task_", "");
-        removeTaskProcess.command = [
-            "python", "-c",
-            "import json, sys, os; path = os.path.expanduser('~/.config/niri-calendar-todo/tasks.json'); data = json.load(open(path)) if os.path.exists(path) else {}; tid = sys.argv[1].replace('task_', ''); data = {k: [i for i in v if i['id'] != tid] for k, v in data.items()}; data = {k: v for k, v in data.items() if len(v) > 0}; json.dump(data, open(path, 'w'), indent=2)",
-            cleanId
-        ];
-        removeTaskProcess.running = true;
+        let tasks = Object.assign({}, root.localTasks);
+        let updated = false;
+        for (let dateKey in tasks) {
+            let list = tasks[dateKey];
+            let filtered = list.filter(item => item.id !== cleanId);
+            if (filtered.length !== list.length) {
+                if (filtered.length === 0) {
+                    delete tasks[dateKey];
+                } else {
+                    tasks[dateKey] = filtered;
+                }
+                updated = true;
+                break;
+            }
+        }
+        if (updated) {
+            root.localTasks = tasks;
+            updateTaskEvents();
+            saveTasks();
+        }
     }
 
     function reorderTasksForDate(date, orderedIds) {
-        let dateKey = Qt.formatDate(date, "yyyy-MM-dd")
-        reorderTasksProcess.command = [
-            "python", "-c",
-            "import json, sys, os; path = os.path.expanduser('~/.config/niri-calendar-todo/tasks.json'); data = json.load(open(path)) if os.path.exists(path) else {}; date = sys.argv[1]; ordered_ids = sys.argv[2].split(',') if sys.argv[2] else []; v = data.get(date, []); id_to_item = {item['id']: item for item in v}; new_v = [id_to_item[tid] for tid in ordered_ids if tid in id_to_item] + [item for item in v if item['id'] not in id_to_item]; data[date] = new_v; json.dump(data, open(path, 'w'), indent=2)",
-            dateKey, orderedIds.join(",")
-        ]
-        reorderTasksProcess.running = true
+        let dateKey = Qt.formatDate(date, "yyyy-MM-dd");
+        let tasks = Object.assign({}, root.localTasks);
+        let v = tasks[dateKey] || [];
+        let idToItem = {};
+        for (let item of v) {
+            idToItem[item.id] = item;
+        }
+        let newV = [];
+        for (let tid of orderedIds) {
+            if (idToItem[tid]) {
+                newV.push(idToItem[tid]);
+            }
+        }
+        let orderedSet = new Set(orderedIds);
+        for (let item of v) {
+            if (!orderedSet.has(item.id)) {
+                newV.push(item);
+            }
+        }
+        tasks[dateKey] = newV;
+        root.localTasks = tasks;
+        updateTaskEvents();
+        saveTasks();
     }
 
     function editTask(taskId, newText) {
-        let cleanId = taskId.replace("task_", "")
-        editTaskProcess.command = [
-            "python", "-c",
-            "import json, sys, os; path = os.path.expanduser('~/.config/niri-calendar-todo/tasks.json'); data = json.load(open(path)) if os.path.exists(path) else {}; tid = sys.argv[1].replace('task_', ''); [item.update({'text': sys.argv[2]}) for v in data.values() for item in v if item['id'] == tid]; json.dump(data, open(path, 'w'), indent=2)",
-            cleanId, newText
-        ]
-        editTaskProcess.running = true
+        let cleanId = taskId.replace("task_", "");
+        let tasks = Object.assign({}, root.localTasks);
+        let updated = false;
+        for (let dateKey in tasks) {
+            let list = tasks[dateKey];
+            for (let item of list) {
+                if (item.id === cleanId) {
+                    item.text = newText;
+                    updated = true;
+                    break;
+                }
+            }
+            if (updated) break;
+        }
+        if (updated) {
+            root.localTasks = tasks;
+            updateTaskEvents();
+            saveTasks();
+        }
+    }
+
+    function mergeEvents() {
+        let merged = {};
+
+        // Merge khal events
+        for (let dateKey in root.khalEventsByDate) {
+            merged[dateKey] = [].concat(root.khalEventsByDate[dateKey]);
+        }
+
+        // Merge task events
+        for (let dateKey in root.taskEventsByDate) {
+            if (!merged[dateKey]) {
+                merged[dateKey] = [];
+            }
+            for (let event of root.taskEventsByDate[dateKey]) {
+                if (!merged[dateKey].some(e => e.id === event.id)) {
+                    merged[dateKey].push(event);
+                }
+            }
+        }
+
+        // Sort events within each date
+        for (let dateKey in merged) {
+            let list = merged[dateKey];
+            for (let idx = 0; idx < list.length; idx++) {
+                list[idx]._origIdx = idx;
+            }
+            list.sort((a, b) => {
+                let diff = a.start.getTime() - b.start.getTime();
+                if (diff !== 0) return diff;
+                return a._origIdx - b._origIdx;
+            });
+        }
+
+        root.eventsByDate = merged;
     }
 
     // Initialize on component completion
@@ -143,138 +288,23 @@ Singleton {
         detectKhalDateFormat();
     }
 
-    // Process for inserting tasks
-    Process {
-        id: addTaskProcess
-        running: false
-        onExited: exitCode => {
-            if (!localTasksProcess.running) {
-                localTasksProcess.running = true;
-            }
+    // Atomic file view for tasks
+    FileView {
+        id: tasksFileView
+        path: Quickshell.env("HOME") + "/.config/niri-calendar-todo/tasks.json"
+        blockLoading: false
+        blockWrites: false
+        atomicWrites: true
+        watchChanges: true
+        printErrors: false
+
+        onLoaded: {
+            loadTasks(tasksFileView.text());
         }
-    }
 
-    // Process for toggling task state
-    Process {
-        id: toggleTaskProcess
-        running: false
-        onExited: exitCode => {
-            if (!localTasksProcess.running) {
-                localTasksProcess.running = true;
-            }
-        }
-    }
-
-    // Process for deleting tasks
-    Process {
-        id: removeTaskProcess
-        running: false
-        onExited: exitCode => {
-            if (!localTasksProcess.running) {
-                localTasksProcess.running = true;
-            }
-        }
-    }
-
-    // Process for reordering tasks
-    Process {
-        id: reorderTasksProcess
-        running: false
-        onExited: exitCode => {
-            if (!localTasksProcess.running) {
-                localTasksProcess.running = true;
-            }
-        }
-    }
-
-    // Process for editing tasks
-    Process {
-        id: editTaskProcess
-        running: false
-        onExited: exitCode => {
-            if (!localTasksProcess.running) {
-                localTasksProcess.running = true;
-            }
-        }
-    }
-
-    // Process for detecting local tasks
-    Process {
-        id: localTasksProcess
-        command: ["cat", Quickshell.env("HOME") + "/.config/niri-calendar-todo/tasks.json"]
-        running: false
-        
-        stdout: StdioCollector {
-            onStreamFinished: {
-                let text = this.text.trim();
-                if (!text || text === "") {
-                    // Clear task events if file is empty
-                    let newEventsByDate = Object.assign({}, root.eventsByDate);
-                    for (let dateKey in newEventsByDate) {
-                        newEventsByDate[dateKey] = newEventsByDate[dateKey].filter(e => !e.id.startsWith("task_"));
-                    }
-                    root.eventsByDate = newEventsByDate;
-                    return;
-                }
-                try {
-                    let parsed = JSON.parse(text);
-                    let newEventsByDate = Object.assign({}, root.eventsByDate);
-                    
-                    // Clear any existing task events to prevent duplicates
-                    for (let dateKey in newEventsByDate) {
-                        newEventsByDate[dateKey] = newEventsByDate[dateKey].filter(e => !e.id.startsWith("task_"));
-                    }
-
-                    for (let dateKey in parsed) {
-                        let taskList = parsed[dateKey];
-                        if (!newEventsByDate[dateKey]) {
-                            newEventsByDate[dateKey] = [];
-                        }
-                        
-                        for (let task of taskList) {
-                            let eventId = "task_" + task.id;
-                            if (newEventsByDate[dateKey].some(e => e.id === eventId)) {
-                                continue;
-                            }
-                            
-                            let parts = dateKey.split("-");
-                            let taskDate = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]));
-                            
-                            let eventObj = {
-                                "id": eventId,
-                                "title": (task.completed ? "✓ " : "☐ ") + task.text,
-                                "start": taskDate,
-                                "end": taskDate,
-                                "location": "",
-                                "description": "Task from your Planner",
-                                "url": "",
-                                "calendar": "Todo Planner",
-                                "color": "#10B981", // Pastel Green
-                                "allDay": true,
-                                "isMultiDay": false
-                            };
-                            newEventsByDate[dateKey].push(eventObj);
-                        }
-                    }
-                    
-                    // Re-sort within each date
-                    for (let dateKey in newEventsByDate) {
-                        let list = newEventsByDate[dateKey];
-                        for (let idx = 0; idx < list.length; idx++) {
-                            list[idx]._origIdx = idx;
-                        }
-                        list.sort((a, b) => {
-                            let diff = a.start.getTime() - b.start.getTime();
-                            if (diff !== 0) return diff;
-                            return a._origIdx - b._origIdx;
-                        });
-                    }
-                    
-                    root.eventsByDate = newEventsByDate;
-                } catch (error) {
-                    console.warn("Failed to parse local tasks JSON: " + error.toString());
-                }
-            }
+        onLoadFailed: {
+            root.localTasks = {};
+            root.taskEventsByDate = {};
         }
     }
 
@@ -317,7 +347,6 @@ Singleton {
             if (root.khalInstalled) {
                 loadCurrentMonth();
             } else {
-                // If not installed, load local tasks anyway
                 loadEvents(root.lastStartDate || new Date(), root.lastEndDate || new Date());
             }
         }
@@ -481,23 +510,11 @@ Singleton {
                         }
                     }
                 }
-                // Sort events by start time within each date
-                for (let dateKey in newEventsByDate) {
-                    let list = newEventsByDate[dateKey];
-                    for (let idx = 0; idx < list.length; idx++) {
-                        list[idx]._origIdx = idx;
-                    }
-                    list.sort((a, b) => {
-                        let diff = a.start.getTime() - b.start.getTime();
-                        if (diff !== 0) return diff;
-                        return a._origIdx - b._origIdx;
-                    });
-                }
-                root.eventsByDate = newEventsByDate;
+                root.khalEventsByDate = newEventsByDate;
                 root.lastError = "";
             } catch (error) {
                 root.lastError = "Failed to parse events JSON: " + error.toString();
-                root.eventsByDate = {};
+                root.khalEventsByDate = {};
             }
             // Reset for next run
             eventsProcess.rawOutput = "";

--- a/quickshell/Services/CalendarService.qml
+++ b/quickshell/Services/CalendarService.qml
@@ -118,6 +118,16 @@ Singleton {
         removeTaskProcess.running = true;
     }
 
+    function moveTask(taskId, direction) {
+        let cleanId = taskId.replace("task_", "");
+        moveTaskProcess.command = [
+            "python", "-c",
+            "import json, sys, os; path = os.path.expanduser('~/.config/niri-calendar-todo/tasks.json'); data = json.load(open(path)) if os.path.exists(path) else {}; tid = sys.argv[1]; direction = int(sys.argv[2]); swapped = False\nfor k, v in data.items():\n    for i, item in enumerate(v):\n        if item['id'] == tid:\n            new_idx = i + direction\n            if 0 <= new_idx < len(v):\n                v[i], v[new_idx] = v[new_idx], v[i]\n                swapped = True\n            break\n    if swapped: break\nif swapped: json.dump(data, open(path, 'w'), indent=2)",
+            cleanId, direction.toString()
+        ];
+        moveTaskProcess.running = true;
+    }
+
     // Initialize on component completion
     Component.onCompleted: {
         detectKhalDateFormat();
@@ -148,6 +158,17 @@ Singleton {
     // Process for deleting tasks
     Process {
         id: removeTaskProcess
+        running: false
+        onExited: exitCode => {
+            if (!localTasksProcess.running) {
+                localTasksProcess.running = true;
+            }
+        }
+    }
+
+    // Process for moving tasks
+    Process {
+        id: moveTaskProcess
         running: false
         onExited: exitCode => {
             if (!localTasksProcess.running) {

--- a/quickshell/Services/CalendarService.qml
+++ b/quickshell/Services/CalendarService.qml
@@ -259,8 +259,14 @@ Singleton {
                     
                     // Re-sort within each date
                     for (let dateKey in newEventsByDate) {
-                        newEventsByDate[dateKey].sort((a, b) => {
-                            return a.start.getTime() - b.start.getTime();
+                        let list = newEventsByDate[dateKey];
+                        for (let idx = 0; idx < list.length; idx++) {
+                            list[idx]._origIdx = idx;
+                        }
+                        list.sort((a, b) => {
+                            let diff = a.start.getTime() - b.start.getTime();
+                            if (diff !== 0) return diff;
+                            return a._origIdx - b._origIdx;
                         });
                     }
                     
@@ -477,8 +483,14 @@ Singleton {
                 }
                 // Sort events by start time within each date
                 for (let dateKey in newEventsByDate) {
-                    newEventsByDate[dateKey].sort((a, b) => {
-                        return a.start.getTime() - b.start.getTime();
+                    let list = newEventsByDate[dateKey];
+                    for (let idx = 0; idx < list.length; idx++) {
+                        list[idx]._origIdx = idx;
+                    }
+                    list.sort((a, b) => {
+                        let diff = a.start.getTime() - b.start.getTime();
+                        if (diff !== 0) return diff;
+                        return a._origIdx - b._origIdx;
                     });
                 }
                 root.eventsByDate = newEventsByDate;

--- a/quickshell/Services/CalendarService.qml
+++ b/quickshell/Services/CalendarService.qml
@@ -9,7 +9,8 @@ import qs.Common
 Singleton {
     id: root
 
-    property bool khalAvailable: false
+    property bool khalAvailable: true // Always true to enable DMS calendar card UI
+    property bool khalInstalled: false // Tracks if khal is actually on the system
     property var eventsByDate: ({})
     property bool isLoading: false
     property string lastError: ""
@@ -50,7 +51,14 @@ Singleton {
     }
 
     function loadEvents(startDate, endDate) {
-        if (!root.khalAvailable) {
+        // Read local tasks from niri-calendar-todo
+        if (!localTasksProcess.running) {
+            localTasksProcess.running = true;
+        }
+
+        if (!root.khalInstalled) {
+            // If khal isn't installed, trigger change notification for local tasks
+            root.eventsByDateChanged();
             return;
         }
         if (eventsProcess.running) {
@@ -79,9 +87,147 @@ Singleton {
         return events.length > 0;
     }
 
+    // Task editing methods using clean, single-line Python scripts (no indentation or external helper file needed!)
+    function addTaskForDate(date, text) {
+        let dateKey = Qt.formatDate(date, "yyyy-MM-dd");
+        addTaskProcess.command = [
+            "python", "-c",
+            "import json, sys, time, os; path = os.path.expanduser('~/.config/niri-calendar-todo/tasks.json'); os.makedirs(os.path.dirname(path), exist_ok=True); data = json.load(open(path)) if os.path.exists(path) else {}; date, text = sys.argv[1], sys.argv[2]; item = {'id': str(int(time.time()*1000)) + '-dms', 'text': text, 'completed': False}; data.setdefault(date, []).append(item); json.dump(data, open(path, 'w'), indent=2)",
+            dateKey, text
+        ];
+        addTaskProcess.running = true;
+    }
+
+    function toggleTask(taskId) {
+        let cleanId = taskId.replace("task_", "");
+        toggleTaskProcess.command = [
+            "python", "-c",
+            "import json, sys, os; path = os.path.expanduser('~/.config/niri-calendar-todo/tasks.json'); data = json.load(open(path)) if os.path.exists(path) else {}; tid = sys.argv[1].replace('task_', ''); [item.update({'completed': not item['completed']}) for v in data.values() for item in v if item['id'] == tid]; json.dump(data, open(path, 'w'), indent=2)",
+            cleanId
+        ];
+        toggleTaskProcess.running = true;
+    }
+
+    function removeTask(taskId) {
+        let cleanId = taskId.replace("task_", "");
+        removeTaskProcess.command = [
+            "python", "-c",
+            "import json, sys, os; path = os.path.expanduser('~/.config/niri-calendar-todo/tasks.json'); data = json.load(open(path)) if os.path.exists(path) else {}; tid = sys.argv[1].replace('task_', ''); data = {k: [i for i in v if i['id'] != tid] for k, v in data.items()}; data = {k: v for k, v in data.items() if len(v) > 0}; json.dump(data, open(path, 'w'), indent=2)",
+            cleanId
+        ];
+        removeTaskProcess.running = true;
+    }
+
     // Initialize on component completion
     Component.onCompleted: {
         detectKhalDateFormat();
+    }
+
+    // Process for inserting tasks
+    Process {
+        id: addTaskProcess
+        running: false
+        onExited: exitCode => {
+            if (!localTasksProcess.running) {
+                localTasksProcess.running = true;
+            }
+        }
+    }
+
+    // Process for toggling task state
+    Process {
+        id: toggleTaskProcess
+        running: false
+        onExited: exitCode => {
+            if (!localTasksProcess.running) {
+                localTasksProcess.running = true;
+            }
+        }
+    }
+
+    // Process for deleting tasks
+    Process {
+        id: removeTaskProcess
+        running: false
+        onExited: exitCode => {
+            if (!localTasksProcess.running) {
+                localTasksProcess.running = true;
+            }
+        }
+    }
+
+    // Process for detecting local tasks
+    Process {
+        id: localTasksProcess
+        command: ["cat", Quickshell.env("HOME") + "/.config/niri-calendar-todo/tasks.json"]
+        running: false
+        
+        stdout: StdioCollector {
+            onStreamFinished: {
+                let text = this.text.trim();
+                if (!text || text === "") {
+                    // Clear task events if file is empty
+                    let newEventsByDate = Object.assign({}, root.eventsByDate);
+                    for (let dateKey in newEventsByDate) {
+                        newEventsByDate[dateKey] = newEventsByDate[dateKey].filter(e => !e.id.startsWith("task_"));
+                    }
+                    root.eventsByDate = newEventsByDate;
+                    return;
+                }
+                try {
+                    let parsed = JSON.parse(text);
+                    let newEventsByDate = Object.assign({}, root.eventsByDate);
+                    
+                    // Clear any existing task events to prevent duplicates
+                    for (let dateKey in newEventsByDate) {
+                        newEventsByDate[dateKey] = newEventsByDate[dateKey].filter(e => !e.id.startsWith("task_"));
+                    }
+
+                    for (let dateKey in parsed) {
+                        let taskList = parsed[dateKey];
+                        if (!newEventsByDate[dateKey]) {
+                            newEventsByDate[dateKey] = [];
+                        }
+                        
+                        for (let task of taskList) {
+                            let eventId = "task_" + task.id;
+                            if (newEventsByDate[dateKey].some(e => e.id === eventId)) {
+                                continue;
+                            }
+                            
+                            let parts = dateKey.split("-");
+                            let taskDate = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]));
+                            
+                            let eventObj = {
+                                "id": eventId,
+                                "title": (task.completed ? "✓ " : "☐ ") + task.text,
+                                "start": taskDate,
+                                "end": taskDate,
+                                "location": "",
+                                "description": "Task from your Planner",
+                                "url": "",
+                                "calendar": "Todo Planner",
+                                "color": "#10B981", // Pastel Green
+                                "allDay": true,
+                                "isMultiDay": false
+                            };
+                            newEventsByDate[dateKey].push(eventObj);
+                        }
+                    }
+                    
+                    // Re-sort within each date
+                    for (let dateKey in newEventsByDate) {
+                        newEventsByDate[dateKey].sort((a, b) => {
+                            return a.start.getTime() - b.start.getTime();
+                        });
+                    }
+                    
+                    root.eventsByDate = newEventsByDate;
+                } catch (error) {
+                    console.warn("Failed to parse local tasks JSON: " + error.toString());
+                }
+            }
+        }
     }
 
     // Process for detecting khal date format
@@ -119,9 +265,12 @@ Singleton {
         command: ["khal", "list", "today"]
         running: false
         onExited: exitCode => {
-            root.khalAvailable = (exitCode === 0);
-            if (exitCode === 0) {
+            root.khalInstalled = (exitCode === 0);
+            if (root.khalInstalled) {
                 loadCurrentMonth();
+            } else {
+                // If not installed, load local tasks anyway
+                loadEvents(root.lastStartDate || new Date(), root.lastEndDate || new Date());
             }
         }
     }


### PR DESCRIPTION
 # Description

    <!-- What does this PR do and why? -->
    This PR integrates a local task planner / to-do list feature directly
  into the Calendar card in the Quickshell overview tab. It allows users to
  click on any calendar day to add, toggle, and delete daily tasks locally.
  If `khal` is installed, these local planner tasks are displayed alongside
  calendar events; if `khal` is not installed, the Calendar card remains
  fully functional as a standalone local to-do planner rather than
  displaying as empty.

    ## Type of change

    <!-- Check all that apply. -->

    - [ ] Bug fix (non-breaking change that fixes an issue)
    - [x] New feature (non-breaking change that adds functionality)
    - [ ] Breaking change (fix or feature that changes existing behavior)
    - [ ] Refactor / internal cleanup
    - [ ] Documentation
    - [ ] Other

    ## Related issues

    <!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

    ## Screenshots / video

   



https://github.com/user-attachments/assets/0a7bfdf4-5c31-4da1-8b03-b1a385a2c9a2







    ## Checklist

    - [x] My code follows the conventions in CONTRIBUTING.md
    - [x] I have tested my changes locally
    - [x] New user-facing strings are wrapped in `I18n.tr()` with translator
  context, reusing existing terms where possible
    - [ ] Go changes: ran `make fmt`, added/updated tests, `make test`
  passes, and `go mod tidy` is clean
    - [x] My QML changes: ran `make lint-qml` with no new warnings
    - [ ] I have opened a corresponding pull request in dlx-docs to document
  any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs