### PR TITLE
fix(ui): use primaryText instead of primary for text and icons displayed on primaryContainer background in the launcher

### DIFF
--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -449,7 +449,6 @@ Singleton {
                 "primary": getMatugenColor("primary", "#42a5f5"),
                 "primaryText": getMatugenColor("on_primary", "#ffffff"),
                 "primaryContainer": getMatugenColor("primary_container", "#1976d2"),
-                "onPrimaryContainer": getMatugenColor("on_primary_container", "#cfe5ff"),
                 "secondary": getMatugenColor("secondary", "#8ab4f8"),
                 "secondaryContainer": getMatugenColor("secondary_container", getMatugenColor("surface_container_high", "#292b2f")),
                 "tertiary": getMatugenColor("tertiary", "#efb8c8"),
@@ -524,7 +523,6 @@ Singleton {
 
     property color primary: currentThemeData.primary
     property color primaryText: currentThemeData.primaryText
-    property color onPrimaryContainer: currentThemeData.onPrimaryContainer || primaryText
     property color secondary: currentThemeData.secondary
     property color tertiary: currentThemeData.tertiary || currentThemeData.secondary
     property color surface: currentThemeData.surface

--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -449,6 +449,7 @@ Singleton {
                 "primary": getMatugenColor("primary", "#42a5f5"),
                 "primaryText": getMatugenColor("on_primary", "#ffffff"),
                 "primaryContainer": getMatugenColor("primary_container", "#1976d2"),
+                "onPrimaryContainer": getMatugenColor("on_primary_container", "#cfe5ff"),
                 "secondary": getMatugenColor("secondary", "#8ab4f8"),
                 "secondaryContainer": getMatugenColor("secondary_container", getMatugenColor("surface_container_high", "#292b2f")),
                 "tertiary": getMatugenColor("tertiary", "#efb8c8"),
@@ -523,6 +524,7 @@ Singleton {
 
     property color primary: currentThemeData.primary
     property color primaryText: currentThemeData.primaryText
+    property color onPrimaryContainer: currentThemeData.onPrimaryContainer || primaryText
     property color secondary: currentThemeData.secondary
     property color tertiary: currentThemeData.tertiary || currentThemeData.secondary
     property color surface: currentThemeData.surface

--- a/quickshell/Modals/DankLauncherV2/LauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/LauncherContent.qml
@@ -374,14 +374,14 @@ FocusScope {
                                 anchors.verticalCenter: parent.verticalCenter
                                 name: modelData.icon
                                 size: 14
-                                color: controller.searchMode === modelData.id ? Theme.primaryText : Theme.surfaceVariantText
+                                color: controller.searchMode === modelData.id ? Theme.onPrimaryContainer : Theme.surfaceVariantText
                             }
 
                             StyledText {
                                 anchors.verticalCenter: parent.verticalCenter
                                 text: modelData.label
                                 font.pixelSize: Theme.fontSizeSmall
-                                color: controller.searchMode === modelData.id ? Theme.primaryText : Theme.surfaceText
+                                color: controller.searchMode === modelData.id ? Theme.onPrimaryContainer : Theme.surfaceText
                             }
                         }
 
@@ -647,14 +647,14 @@ FocusScope {
                                         anchors.verticalCenter: parent.verticalCenter
                                         name: modelData.icon
                                         size: 14
-                                        color: controller.fileSearchType === modelData.id ? Theme.primaryText : Theme.surfaceVariantText
+                                        color: controller.fileSearchType === modelData.id ? Theme.onPrimaryContainer : Theme.surfaceVariantText
                                     }
 
                                     StyledText {
                                         anchors.verticalCenter: parent.verticalCenter
                                         text: modelData.label
                                         font.pixelSize: Theme.fontSizeSmall
-                                        color: controller.fileSearchType === modelData.id ? Theme.primaryText : Theme.surfaceVariantText
+                                        color: controller.fileSearchType === modelData.id ? Theme.onPrimaryContainer : Theme.surfaceVariantText
                                     }
                                 }
 

--- a/quickshell/Modals/DankLauncherV2/LauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/LauncherContent.qml
@@ -363,7 +363,7 @@ FocusScope {
                         width: buttonContent.width + Theme.spacingM * 2
                         height: 28
                         radius: Theme.cornerRadius
-                        color: controller.searchMode === modelData.id || modeArea.containsMouse ? Theme.primaryContainer : "transparent"
+                        color: controller.searchMode === modelData.id ? Theme.primaryContainer : modeArea.containsMouse ? Theme.surfaceContainerHighest : "transparent"
 
                         Row {
                             id: buttonContent
@@ -374,14 +374,14 @@ FocusScope {
                                 anchors.verticalCenter: parent.verticalCenter
                                 name: modelData.icon
                                 size: 14
-                                color: controller.searchMode === modelData.id ? Theme.primary : Theme.surfaceVariantText
+                                color: controller.searchMode === modelData.id ? Theme.primaryText : Theme.surfaceVariantText
                             }
 
                             StyledText {
                                 anchors.verticalCenter: parent.verticalCenter
                                 text: modelData.label
                                 font.pixelSize: Theme.fontSizeSmall
-                                color: controller.searchMode === modelData.id ? Theme.primary : Theme.surfaceText
+                                color: controller.searchMode === modelData.id ? Theme.primaryText : Theme.surfaceText
                             }
                         }
 
@@ -636,7 +636,7 @@ FocusScope {
                                 width: chipContent.width + Theme.spacingM * 2
                                 height: sortDropdown.height
                                 radius: Theme.cornerRadius
-                                color: controller.fileSearchType === modelData.id || chipArea.containsMouse ? Theme.primaryContainer : "transparent"
+                                color: controller.fileSearchType === modelData.id ? Theme.primaryContainer : chipArea.containsMouse ? Theme.surfaceContainerHighest : "transparent"
 
                                 Row {
                                     id: chipContent
@@ -647,14 +647,14 @@ FocusScope {
                                         anchors.verticalCenter: parent.verticalCenter
                                         name: modelData.icon
                                         size: 14
-                                        color: controller.fileSearchType === modelData.id ? Theme.primary : Theme.surfaceVariantText
+                                        color: controller.fileSearchType === modelData.id ? Theme.primaryText : Theme.surfaceVariantText
                                     }
 
                                     StyledText {
                                         anchors.verticalCenter: parent.verticalCenter
                                         text: modelData.label
                                         font.pixelSize: Theme.fontSizeSmall
-                                        color: controller.fileSearchType === modelData.id ? Theme.primary : Theme.surfaceText
+                                        color: controller.fileSearchType === modelData.id ? Theme.primaryText : Theme.surfaceVariantText
                                     }
                                 }
 

--- a/quickshell/Modals/DankLauncherV2/LauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/LauncherContent.qml
@@ -363,7 +363,7 @@ FocusScope {
                         width: buttonContent.width + Theme.spacingM * 2
                         height: 28
                         radius: Theme.cornerRadius
-                        color: controller.searchMode === modelData.id ? Theme.primaryContainer : modeArea.containsMouse ? Theme.surfaceContainerHighest : "transparent"
+                        color: controller.searchMode === modelData.id ? Theme.buttonBg : modeArea.containsMouse ? Theme.surfaceContainerHighest : "transparent"
 
                         Row {
                             id: buttonContent
@@ -374,14 +374,14 @@ FocusScope {
                                 anchors.verticalCenter: parent.verticalCenter
                                 name: modelData.icon
                                 size: 14
-                                color: controller.searchMode === modelData.id ? Theme.onPrimaryContainer : Theme.surfaceVariantText
+                                color: controller.searchMode === modelData.id ? Theme.buttonText : Theme.surfaceVariantText
                             }
 
                             StyledText {
                                 anchors.verticalCenter: parent.verticalCenter
                                 text: modelData.label
                                 font.pixelSize: Theme.fontSizeSmall
-                                color: controller.searchMode === modelData.id ? Theme.onPrimaryContainer : Theme.surfaceText
+                                color: controller.searchMode === modelData.id ? Theme.buttonText : Theme.surfaceText
                             }
                         }
 
@@ -636,7 +636,7 @@ FocusScope {
                                 width: chipContent.width + Theme.spacingM * 2
                                 height: sortDropdown.height
                                 radius: Theme.cornerRadius
-                                color: controller.fileSearchType === modelData.id ? Theme.primaryContainer : chipArea.containsMouse ? Theme.surfaceContainerHighest : "transparent"
+                                color: controller.fileSearchType === modelData.id ? Theme.buttonBg : chipArea.containsMouse ? Theme.surfaceContainerHighest : "transparent"
 
                                 Row {
                                     id: chipContent
@@ -647,14 +647,14 @@ FocusScope {
                                         anchors.verticalCenter: parent.verticalCenter
                                         name: modelData.icon
                                         size: 14
-                                        color: controller.fileSearchType === modelData.id ? Theme.onPrimaryContainer : Theme.surfaceVariantText
+                                        color: controller.fileSearchType === modelData.id ? Theme.buttonText : Theme.surfaceVariantText
                                     }
 
                                     StyledText {
                                         anchors.verticalCenter: parent.verticalCenter
                                         text: modelData.label
                                         font.pixelSize: Theme.fontSizeSmall
-                                        color: controller.fileSearchType === modelData.id ? Theme.onPrimaryContainer : Theme.surfaceVariantText
+                                        color: controller.fileSearchType === modelData.id ? Theme.buttonText : Theme.surfaceVariantText
                                     }
                                 }
 

--- a/quickshell/Widgets/DankIcon.qml
+++ b/quickshell/Widgets/DankIcon.qml
@@ -37,13 +37,6 @@ Item {
         horizontalAlignment: Text.AlignHCenter
         renderType: root.smoothTransform ? Text.QtRendering : Text.NativeRendering
 
-        Behavior on color {
-            enabled: Theme.currentAnimationSpeed !== SettingsData.AnimationSpeed.None
-            DankColorAnim {
-                duration: Theme.shorterDuration
-                easing.bezierCurve: Theme.expressiveCurves.standard
-            }
-        }
         font.variableAxes: {
             "FILL": root.fill.toFixed(1),
             "GRAD": root.grade,


### PR DESCRIPTION
## Description

With my current background, the theme generated makes the selected mode button unreadable in the DMS launcher. I changed a few colors to solve this.

This could be a matter of taste and still not work for all generated themes, I just thought that it made more sense to have `primaryText` rather than `primary` on top of `primaryContainer`.

There are other places in the code where `primary` is used on `primaryContainer`, but I could not find the corresponding elements in the DMS UI so I made no change I could not test.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [x] Other

## Screenshots / video

https://github.com/user-attachments/assets/6b6f323e-ac09-49d4-8694-e3ab2bce1c12

https://github.com/user-attachments/assets/975bc04d-160e-41f0-866e-762aa50132e7

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [N/A] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [N/A] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [N/A] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
