### PR TITLE
fix(powermenu): close control center on lock and power actions

### DIFF
--- a/quickshell/DMSShell.qml
+++ b/quickshell/DMSShell.qml
@@ -1140,6 +1140,7 @@ Item {
             id: powerMenuModal
 
             onPowerActionRequested: (action, title, message) => {
+                PopoutService.closeControlCenter();
                 switch (action) {
                 case "logout":
                     SessionService.logout();
@@ -1160,6 +1161,7 @@ Item {
             }
 
             onLockRequested: {
+                PopoutService.closeControlCenter();
                 lock.activate();
             }
 


### PR DESCRIPTION
## Description

When the power menu is opened from the Control Center, actions like lock and suspend currently leave the Control Center open after the action is triggered. This feels unintuitive and creates inconsistent UI feedback after the user has already confirmed a session or power action. This PR closes the Control Center alongside those actions so the flow behaves more cleanly and predictably.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [x] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
