### PR TITLE
fix(frame): add widget end inset for edge widgets when Frame is enabled

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -263,6 +263,8 @@ Singleton {
     readonly property string frameModalEmergeSide: frameLauncherEmergeSide === "top" ? "bottom" : "top"
     property string frameMode: "connected"
     onFrameModeChanged: saveSettings()
+    property int frameBarEndInset: 0
+    onFrameBarEndInsetChanged: saveSettings()
     property var connectedFrameBarStyleBackups: ({})
     onConnectedFrameBarStyleBackupsChanged: saveSettings()
     readonly property bool connectedFrameModeActive: frameEnabled && frameMode === "connected"

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -585,7 +585,8 @@ var SPEC = {
     frameCloseGaps: { def: true },
     frameLauncherEmergeSide: { def: "bottom" },
     frameLauncherArcExtender: { def: false },
-    frameMode: { def: "connected" }
+    frameMode: { def: "connected" },
+    frameBarEndInset: { def: 0 }
 };
 
 function getValidKeys() {

--- a/quickshell/Modules/DankBar/DankBarContent.qml
+++ b/quickshell/Modules/DankBar/DankBarContent.qml
@@ -48,25 +48,26 @@ Item {
     onHasAdjacentRightBarLiveChanged: if (hasAdjacentRightBarLive)
         _hadAdjacentRightBar = true
 
+    readonly property real _frameEndInset: SettingsData.frameThickness + SettingsData.frameBarEndInset
     readonly property real _frameLeftInset: {
         if (!_hasBarWindow || !SettingsData.frameEnabled || !_usesFrameBarChrome || _barIsVertical)
             return 0;
-        return hasAdjacentLeftBarLive ? SettingsData.frameBarSize : (_hadAdjacentLeftBar ? _frameEdgeFloorInset : 0);
+        return hasAdjacentLeftBarLive ? SettingsData.frameBarSize : (_hadAdjacentLeftBar ? _frameEdgeFloorInset : _frameEndInset);
     }
     readonly property real _frameRightInset: {
         if (!_hasBarWindow || !SettingsData.frameEnabled || !_usesFrameBarChrome || _barIsVertical)
             return 0;
-        return hasAdjacentRightBarLive ? SettingsData.frameBarSize : (_hadAdjacentRightBar ? _frameEdgeFloorInset : 0);
+        return hasAdjacentRightBarLive ? SettingsData.frameBarSize : (_hadAdjacentRightBar ? _frameEdgeFloorInset : _frameEndInset);
     }
     readonly property real _frameTopInset: {
         if (!_hasBarWindow || !SettingsData.frameEnabled || !_usesFrameBarChrome || !_barIsVertical)
             return 0;
-        return hasAdjacentTopBarLive ? SettingsData.frameThickness : (_hadAdjacentTopBar ? _frameEdgeFloorInset : 0);
+        return hasAdjacentTopBarLive ? SettingsData.frameThickness : (_hadAdjacentTopBar ? _frameEdgeFloorInset : _frameEndInset);
     }
     readonly property real _frameBottomInset: {
         if (!_hasBarWindow || !SettingsData.frameEnabled || !_usesFrameBarChrome || !_barIsVertical)
             return 0;
-        return hasAdjacentBottomBarLive ? SettingsData.frameThickness : (_hadAdjacentBottomBar ? _frameEdgeFloorInset : 0);
+        return hasAdjacentBottomBarLive ? SettingsData.frameThickness : (_hadAdjacentBottomBar ? _frameEdgeFloorInset : _frameEndInset);
     }
 
     property alias hLeftSection: hLeftSection

--- a/quickshell/Modules/Settings/FrameTab.qml
+++ b/quickshell/Modules/Settings/FrameTab.qml
@@ -140,6 +140,27 @@ Item {
                 }
 
                 SettingsSliderRow {
+                    id: barEndInsetSlider
+                    settingKey: "frameBarEndInset"
+                    tags: ["frame", "bar", "end", "inset", "widget", "padding", "edge"]
+                    text: I18n.tr("Widget End Inset")
+                    description: I18n.tr("Extra space between edge widgets and the frame corners")
+                    unit: "px"
+                    minimum: 0
+                    maximum: 20
+                    step: 1
+                    defaultValue: 0
+                    value: SettingsData.frameBarEndInset
+                    onSliderDragFinished: v => SettingsData.set("frameBarEndInset", v)
+
+                    Binding {
+                        target: barEndInsetSlider
+                        property: "value"
+                        value: SettingsData.frameBarEndInset
+                    }
+                }
+
+                SettingsSliderRow {
                     id: opacitySlider
                     settingKey: "frameOpacity"
                     tags: ["frame", "border", "surface", "popup", "opacity", "transparency"]


### PR DESCRIPTION
## Description

When Frame is enabled, edge widgets on both ends of the bar had no inset from the frame corners — _frameLeftInset/_frameRightInset (horizontal bar) and _frameTopInset/_frameBottomInset (vertical bar) fell back to 0 when no adjacent bar was present, causing widgets to sit flush against the frame.
Fixed by introducing _frameEndInset = frameThickness + frameBarEndInset as the fallback value. Also added a Widget End Inset slider in Settings → Frame → Border (default 0, range 0–20px) so users can add extra padding on top of frameThickness.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->
Fixes #2597

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
