### PR TITLE
fix(clipboard): exit saved filter when pinned entries are empty

### DIFF
--- a/quickshell/Modals/Clipboard/ClipboardHeader.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHeader.qml
@@ -50,7 +50,7 @@ Item {
             iconSize: Theme.iconSize - 4
             iconColor: header.activeTab === "saved" ? Theme.primary : Theme.surfaceText
             backgroundColor: header.activeTab === "saved" ? Theme.primarySelected : "transparent"
-            visible: header.pinnedCount > 0
+            visible: header.pinnedCount > 0 || header.activeTab === "saved"
             tooltipText: header.activeTab === "saved" ? I18n.tr("Recent") : I18n.tr("Saved")
             onClicked: tabChanged(header.activeTab === "saved" ? "recents" : "saved")
         }

--- a/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
@@ -36,8 +36,17 @@ FocusScope {
     signal instantCloseRequested
 
     onActiveTabChanged: {
+        if (activeTab === "saved" && pinnedCount === 0) {
+            activeTab = "recents";
+            return;
+        }
         ClipboardService.selectedIndex = 0;
         ClipboardService.keyboardNavigationActive = false;
+    }
+    onPinnedCountChanged: {
+        if (activeTab === "saved" && pinnedCount === 0) {
+            activeTab = "recents";
+        }
     }
     onSearchTextChanged: ClipboardService.searchText = searchText
 


### PR DESCRIPTION
## Description

Fixes the clipboard saved filter getting stuck after the last pinned entry is unpinned. When no pinned entries remain, the lipboard history now returns to recents and keeps the filter toggle recoverable while saved is active.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
