### PR TITLE
Fix/clipboard pinned recents dedupe

### DIFF
--- a/core/internal/server/clipboard/manager.go
+++ b/core/internal/server/clipboard/manager.go
@@ -935,7 +935,7 @@ func (m *Manager) CreateHistoryEntryFromPinned(pinnedEntry *Entry) error {
 		Pinned:    false,
 	}
 
-	if err := m.storeEntryWithoutDedup(newEntry); err != nil {
+	if err := m.storeEntry(newEntry); err != nil {
 		return err
 	}
 
@@ -943,36 +943,6 @@ func (m *Manager) CreateHistoryEntryFromPinned(pinnedEntry *Entry) error {
 	m.notifySubscribers()
 
 	return nil
-}
-
-func (m *Manager) storeEntryWithoutDedup(entry Entry) error {
-	if m.db == nil {
-		return fmt.Errorf("database not available")
-	}
-
-	entry.Hash = computeHash(entry.Data)
-
-	return m.db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("clipboard"))
-
-		id, err := b.NextSequence()
-		if err != nil {
-			return err
-		}
-
-		entry.ID = id
-
-		encoded, err := encodeEntry(entry)
-		if err != nil {
-			return err
-		}
-
-		if err := b.Put(itob(id), encoded); err != nil {
-			return err
-		}
-
-		return m.trimLengthInTx(b)
-	})
 }
 
 func (m *Manager) ClearHistory() {
@@ -1651,6 +1621,37 @@ func (m *Manager) UnpinEntry(id uint64) error {
 		entry, err := decodeEntry(v)
 		if err != nil {
 			return err
+		}
+
+		if entry.Pinned {
+			currentKey := itob(id)
+			var keepKey []byte
+			var deleteKeys [][]byte
+
+			c := b.Cursor()
+			for k, v := c.Last(); k != nil; k, v = c.Prev() {
+				if bytes.Equal(k, currentKey) || extractHash(v) != entry.Hash {
+					continue
+				}
+				duplicate, err := decodeEntryMeta(v)
+				if err == nil && !duplicate.Pinned {
+					key := append([]byte(nil), k...)
+					if keepKey == nil {
+						keepKey = key
+					} else {
+						deleteKeys = append(deleteKeys, key)
+					}
+				}
+			}
+
+			if keepKey != nil {
+				for _, key := range deleteKeys {
+					if err := b.Delete(key); err != nil {
+						return err
+					}
+				}
+				return b.Delete(currentKey)
+			}
 		}
 
 		entry.Pinned = false

--- a/core/internal/server/clipboard/manager_test.go
+++ b/core/internal/server/clipboard/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
 
 	mocks_wlcontext "github.com/AvengeMedia/DankMaterialShell/core/internal/mocks/wlcontext"
 )
@@ -271,6 +272,110 @@ func TestHandleGetEntry_MissingIDReturnsNullResult(t *testing.T) {
 	require.NoError(t, json.NewDecoder(conn.writeBuf).Decode(&resp))
 	assert.Empty(t, resp.Error)
 	assert.Nil(t, resp.Result)
+}
+
+func TestUnpinEntry_KeepsTopUnpinnedDuplicate(t *testing.T) {
+	m := newTestManagerWithDB(t)
+
+	require.NoError(t, m.storeEntry(Entry{
+		Data:      []byte("saved content"),
+		MimeType:  "text/plain;charset=utf-8",
+		Preview:   "saved content",
+		Size:      len("saved content"),
+		Timestamp: time.Now().Add(-time.Minute).Truncate(time.Second),
+		IsImage:   false,
+	}))
+
+	history := m.GetHistory()
+	require.Len(t, history, 1)
+	pinnedID := history[0].ID
+	require.NoError(t, m.PinEntry(pinnedID))
+
+	pinnedEntry, err := m.GetEntry(pinnedID)
+	require.NoError(t, err)
+	require.True(t, pinnedEntry.Pinned)
+
+	// Bypass storeEntry to simulate legacy duplicate ordinary history entries.
+	insertLegacyUnpinnedDuplicate := func(timestamp time.Time) Entry {
+		duplicate := Entry{
+			Data:      pinnedEntry.Data,
+			MimeType:  pinnedEntry.MimeType,
+			Preview:   pinnedEntry.Preview,
+			Size:      pinnedEntry.Size,
+			Timestamp: timestamp,
+			IsImage:   pinnedEntry.IsImage,
+			Pinned:    false,
+		}
+		duplicate.Hash = computeHash(duplicate.Data)
+
+		require.NoError(t, m.db.Update(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte("clipboard"))
+			id, err := b.NextSequence()
+			if err != nil {
+				return err
+			}
+			duplicate.ID = id
+
+			encoded, err := encodeEntry(duplicate)
+			if err != nil {
+				return err
+			}
+			return b.Put(itob(id), encoded)
+		}))
+
+		return duplicate
+	}
+
+	olderHistoryDuplicate := insertLegacyUnpinnedDuplicate(time.Now().Add(time.Hour))
+	topHistoryDuplicate := insertLegacyUnpinnedDuplicate(time.Now().Add(-time.Hour))
+	require.Greater(t, topHistoryDuplicate.ID, olderHistoryDuplicate.ID)
+	require.True(t, olderHistoryDuplicate.Timestamp.After(topHistoryDuplicate.Timestamp))
+
+	history = m.GetHistory()
+	require.Len(t, history, 3)
+	require.Equal(t, topHistoryDuplicate.ID, history[0].ID)
+	require.NoError(t, m.UnpinEntry(pinnedID))
+
+	history = m.GetHistory()
+	require.Len(t, history, 1)
+	assert.False(t, history[0].Pinned)
+	assert.Equal(t, pinnedEntry.Hash, history[0].Hash)
+	assert.Equal(t, topHistoryDuplicate.ID, history[0].ID)
+}
+
+func TestCreateHistoryEntryFromPinned_KeepsLatestUnpinnedDuplicate(t *testing.T) {
+	m := newTestManagerWithDB(t)
+
+	require.NoError(t, m.storeEntry(Entry{
+		Data:      []byte("saved content"),
+		MimeType:  "text/plain;charset=utf-8",
+		Preview:   "saved content",
+		Size:      len("saved content"),
+		Timestamp: time.Now().Add(-time.Minute).Truncate(time.Second),
+		IsImage:   false,
+	}))
+
+	history := m.GetHistory()
+	require.Len(t, history, 1)
+	pinnedID := history[0].ID
+	require.NoError(t, m.PinEntry(pinnedID))
+
+	pinnedEntry, err := m.GetEntry(pinnedID)
+	require.NoError(t, err)
+	require.True(t, pinnedEntry.Pinned)
+	require.NoError(t, m.CreateHistoryEntryFromPinned(pinnedEntry))
+	firstDuplicate := m.GetHistory()[0]
+	require.NotEqual(t, pinnedID, firstDuplicate.ID)
+	require.NoError(t, m.CreateHistoryEntryFromPinned(pinnedEntry))
+	latestDuplicate := m.GetHistory()[0]
+
+	history = m.GetHistory()
+	require.Len(t, history, 2)
+	assert.Equal(t, latestDuplicate.ID, history[0].ID)
+	assert.False(t, history[0].Pinned)
+	assert.Equal(t, pinnedID, history[1].ID)
+	assert.True(t, history[1].Pinned)
+	assert.NotEqual(t, firstDuplicate.ID, latestDuplicate.ID)
 }
 
 func TestManager_ConcurrentSubscriberAccess(t *testing.T) {

--- a/quickshell/Modals/Clipboard/ClipboardContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContent.qml
@@ -149,8 +149,8 @@ Item {
                 listView: clipboardListView
                 onCopyRequested: clipboardContent.modal.copyEntry(modelData)
                 onDeleteRequested: clipboardContent.modal.deleteEntry(modelData)
-                onPinRequested: clipboardContent.modal.pinEntry(modelData)
-                onUnpinRequested: clipboardContent.modal.unpinEntry(modelData)
+                onPinRequested: targetEntry => clipboardContent.modal.pinEntry(targetEntry)
+                onUnpinRequested: targetEntry => clipboardContent.modal.unpinEntry(targetEntry)
                 onEditRequested: clipboardContent.modal.editEntry(modelData)
             }
         }
@@ -223,8 +223,8 @@ Item {
                 listView: savedListView
                 onCopyRequested: clipboardContent.modal.copyEntry(modelData)
                 onDeleteRequested: clipboardContent.modal.deletePinnedEntry(modelData)
-                onPinRequested: clipboardContent.modal.pinEntry(modelData)
-                onUnpinRequested: clipboardContent.modal.unpinEntry(modelData)
+                onPinRequested: targetEntry => clipboardContent.modal.pinEntry(targetEntry)
+                onUnpinRequested: targetEntry => clipboardContent.modal.unpinEntry(targetEntry)
                 onEditRequested: clipboardContent.modal.editEntry(modelData)
             }
         }

--- a/quickshell/Modals/Clipboard/ClipboardEntry.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEntry.qml
@@ -15,13 +15,14 @@ Rectangle {
 
     signal copyRequested
     signal deleteRequested
-    signal pinRequested
-    signal unpinRequested
+    signal pinRequested(var targetEntry)
+    signal unpinRequested(var targetEntry)
     signal editRequested
 
     readonly property string entryType: modal ? modal.getEntryType(entry) : "text"
     readonly property string entryPreview: modal ? modal.getEntryPreview(entry) : ""
-    readonly property bool hasPinnedDuplicate: !entry.pinned && ClipboardService.hashedPinnedEntry(entry.hash)
+    readonly property var pinnedDuplicateEntry: !entry.pinned ? ClipboardService.getPinnedEntryByHash(entry.hash) : null
+    readonly property bool effectivePinned: entry.pinned || pinnedDuplicateEntry !== null
 
     radius: Theme.cornerRadius
     color: {
@@ -66,9 +67,19 @@ Rectangle {
         DankActionButton {
             iconName: "push_pin"
             iconSize: Theme.iconSize - 6
-            iconColor: (entry.pinned || hasPinnedDuplicate) ? Theme.primary : Theme.surfaceText
-            backgroundColor: (entry.pinned || hasPinnedDuplicate) ? Theme.primarySelected : "transparent"
-            onClicked: entry.pinned ? unpinRequested() : pinRequested()
+            iconColor: effectivePinned ? Theme.primary : Theme.surfaceText
+            backgroundColor: effectivePinned ? Theme.primarySelected : "transparent"
+            onClicked: {
+                if (entry.pinned) {
+                    unpinRequested(entry);
+                    return;
+                }
+                if (pinnedDuplicateEntry) {
+                    unpinRequested(pinnedDuplicateEntry);
+                    return;
+                }
+                pinRequested(entry);
+            }
         }
 
         DankActionButton {

--- a/quickshell/Modals/Clipboard/ClipboardKeyboardController.qml
+++ b/quickshell/Modals/Clipboard/ClipboardKeyboardController.qml
@@ -59,8 +59,13 @@ QtObject {
             return;
         }
         const selectedEntry = entries[ClipboardService.selectedIndex];
-        if (modal.activeTab === "saved") {
+        if (selectedEntry.pinned) {
             modal.unpinEntry(selectedEntry);
+            return;
+        }
+        const pinnedDuplicate = ClipboardService.getPinnedEntryByHash(selectedEntry.hash);
+        if (pinnedDuplicate) {
+            modal.unpinEntry(pinnedDuplicate);
         } else {
             modal.pinEntry(selectedEntry);
         }

--- a/quickshell/Services/ClipboardService.qml
+++ b/quickshell/Services/ClipboardService.qml
@@ -388,11 +388,15 @@ Singleton {
         return "text";
     }
 
-    function hashedPinnedEntry(entryHash) {
+    function getPinnedEntryByHash(entryHash) {
         if (!entryHash) {
-            return false;
+            return null;
         }
-        return pinnedEntries.some(pinnedEntry => pinnedEntry.hash === entryHash);
+        return internalEntries.find(entry => entry.pinned && entry.hash === entryHash) || null;
+    }
+
+    function hashedPinnedEntry(entryHash) {
+        return getPinnedEntryByHash(entryHash) !== null;
     }
 
     onClipboardAvailableChanged: {


### PR DESCRIPTION
## Description

Fixes inconsistent clipboard state when pinned entries and regular history entries contain the same content.

Previously, a regular history entry with the same content as a pinned entry could appear pinned but could not be unpinned directly. Also, copying or using a pinned entry bypassed the regular history dedupe path, causing repeated duplicate entries to accumulate in regular clipboard history.

This PR updates duplicate pinned-entry handling so regular history duplicates operate on the corresponding pinned entry. It also routes pinned-entry usage through the normal history dedupe logic, and when unpinning, merges back into regular history while keeping only the latest matching regular history entry.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
