### PR TITLE
fix(lock): bypass IME for password input

### DIFF
--- a/core/internal/qmlchecks/lockscreen_input_test.go
+++ b/core/internal/qmlchecks/lockscreen_input_test.go
@@ -1,0 +1,25 @@
+package qmlchecks
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestLockScreenPasswordFieldBypassesTextInputIME(t *testing.T) {
+	data, err := os.ReadFile("../../../quickshell/Modules/Lock/LockScreenContent.qml")
+	if err != nil {
+		t.Fatalf("read lock screen QML: %v", err)
+	}
+
+	content := string(data)
+	textInputPasswordField := regexp.MustCompile(`(?s)TextInput\s*\{[^{}]*id:\s*passwordField`)
+	if textInputPasswordField.MatchString(content) {
+		t.Fatalf("passwordField must not be a TextInput because TextInput can route physical keyboard input through IME")
+	}
+
+	if !strings.Contains(content, "Keys.onPressed") || !strings.Contains(content, "event.text") {
+		t.Fatalf("passwordField should handle physical key text manually instead of relying on a text input control")
+	}
+}

--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -753,8 +753,45 @@ Item {
                         }
                     }
 
-                    TextInput {
+                    FocusScope {
                         id: passwordField
+
+                        property string text: root.passwordBuffer
+                        property int cursorPosition: text.length
+
+                        signal accepted()
+
+                        function clampCursorPosition() {
+                            cursorPosition = Math.max(0, Math.min(cursorPosition, text.length));
+                        }
+
+                        function clear() {
+                            text = "";
+                            cursorPosition = 0;
+                        }
+
+                        function insertText(value) {
+                            if (value.length === 0)
+                                return;
+                            clampCursorPosition();
+                            text = text.slice(0, cursorPosition) + value + text.slice(cursorPosition);
+                            cursorPosition += value.length;
+                        }
+
+                        function backspace() {
+                            clampCursorPosition();
+                            if (cursorPosition === 0)
+                                return;
+                            text = text.slice(0, cursorPosition - 1) + text.slice(cursorPosition);
+                            cursorPosition -= 1;
+                        }
+
+                        function isPrintableText(value) {
+                            if (value.length === 0)
+                                return false;
+                            const code = value.charCodeAt(0);
+                            return code >= 0x20 && code !== 0x7f;
+                        }
 
                         anchors.fill: parent
                         anchors.leftMargin: lockIconContainer.width + Theme.spacingM * 2
@@ -781,7 +818,6 @@ Item {
                         focus: true
                         enabled: !demoMode
                         activeFocusOnTab: !demoMode
-                        echoMode: parent.showPassword ? TextInput.Normal : TextInput.Password
                         onTextChanged: {
                             if (!demoMode) {
                                 root.passwordBuffer = text;
@@ -809,12 +845,31 @@ Item {
                                     return;
                                 }
                                 clear();
+                                event.accepted = true;
+                                return;
                             }
 
                             if (pam.passwd.active) {
                                 log.debug("PAM is active, ignoring input");
                                 event.accepted = true;
                                 return;
+                            }
+
+                            if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                                accepted();
+                                event.accepted = true;
+                                return;
+                            }
+
+                            if (event.key === Qt.Key_Backspace) {
+                                backspace();
+                                event.accepted = true;
+                                return;
+                            }
+
+                            if (isPrintableText(event.text)) {
+                                insertText(event.text);
+                                event.accepted = true;
                             }
                         }
 
@@ -847,6 +902,17 @@ Item {
                                         passwordField.forceActiveFocus();
                                     }
                                 });
+                            }
+                        }
+
+                        Connections {
+                            target: root
+
+                            function onPasswordBufferChanged() {
+                                if (passwordField.text === root.passwordBuffer)
+                                    return;
+                                passwordField.text = root.passwordBuffer;
+                                passwordField.cursorPosition = passwordField.text.length;
                             }
                         }
                     }


### PR DESCRIPTION
## Description
Replaces the lock screen password `TextInput` with a focusable non-text `FocusScope` that handles physical key events manually. This avoids routing lock screen password entry through Qt text input / IME paths, which can break password entry when an IME such as fcitx-rime is active but its candidate UI cannot appear on the locked session.
The existing `passwordField` API is preserved for PAM flow and the built-in virtual keyboard, and a regression test guards against changing the lock password field back to `TextInput`.
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other
## Related issues
## Screenshots / video
Not included; behavior is input handling rather than a visual UI change.
## Checklist
- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
