### PR TITLE
fix(processlist): clean up system monitor on compositor close

### DIFF
--- a/quickshell/Modals/ProcessListModal.qml
+++ b/quickshell/Modals/ProcessListModal.qml
@@ -60,6 +60,9 @@ FloatingWindow {
                 toplevel.activate();
                 return;
             }
+            hide();
+            show();
+            return;
         }
         show();
     }
@@ -94,6 +97,8 @@ FloatingWindow {
         if (visible && currentTab === 0 && searchField.visible)
             searchField.forceActiveFocus();
     }
+
+    onClosed: hide()
 
     onVisibleChanged: {
         if (!visible) {


### PR DESCRIPTION
## Summary

- Handle Quickshell `closed()` on `ProcessListModal` so compositor `close-window` (Win+Q) runs the same cleanup as Escape, the close button, and IPC `close`
- Recover stale state in `focusOrToggle()` when the modal is logically open but its toplevel no longer exists

Fixes the bug where closing System Monitor with Win+Q left `visible` true, prevented reopening via Win+M, and kept `DgopService` polling until `dms ipc call processlist close` or a DMS restart.

## Test plan

- [ ] Open System Monitor with Win+M
- [ ] Close with Win+Q; confirm window closes
- [ ] Press Win+M again; confirm System Monitor reopens
- [ ] After Win+Q close, confirm `dgop` is not left polling (`pgrep -a dgop`)
- [ ] Close with Escape, then reopen with Win+M
- [ ] Close with the X button, then reopen with Win+M
- [ ] Open, run `dms ipc call processlist close`, then reopen with Win+M
- [ ] Switch tabs, close with Win+Q, confirm cleanup still runs


Made with [Cursor](https://cursor.com)