### PR TITLE
feat(media-control): support scroll and right-click on audio output devices in media popout

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -396,6 +396,7 @@ Singleton {
     property bool audioVisualizerEnabled: true
     property string audioScrollMode: "volume"
     property int audioWheelScrollAmount: 5
+    property bool audioDeviceScrollVolumeEnabled: false
     property bool clockCompactMode: false
     property int focusedWindowSize: 1
     property bool focusedWindowCompactMode: false

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -156,6 +156,7 @@ var SPEC = {
     audioVisualizerEnabled: { def: true },
     audioScrollMode: { def: "volume" },
     audioWheelScrollAmount: { def: 5 },
+    audioDeviceScrollVolumeEnabled: { def: false },
     clockCompactMode: { def: false },
     focusedWindowCompactMode: { def: false },
     focusedWindowSize: { def: 1 },

--- a/quickshell/Modules/DankDash/DankDashPopout.qml
+++ b/quickshell/Modules/DankDash/DankDashPopout.qml
@@ -108,9 +108,6 @@ DankPopout {
                 MprisController.setActivePlayer(player);
                 root.__hideDropdowns();
             }
-            onDeviceSelected: device => {
-                root.__hideDropdowns();
-            }
         }
     }
 

--- a/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
+++ b/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
@@ -383,7 +383,23 @@ Item {
                                 anchors.fill: parent
                                 hoverEnabled: true
                                 cursorShape: Qt.PointingHandCursor
-                                onClicked: {
+                                acceptedButtons: Qt.LeftButton | Qt.RightButton
+                                onPressed: mouse => {
+                                    if (mouse.button === Qt.RightButton) {
+                                        mouse.accepted = true;
+                                    }
+                                }
+                                onWheel: wheelEvent => {
+                                    AudioService.handleNodeVolumeWheel(modelData, wheelEvent);
+                                }
+                                onClicked: mouse => {
+                                    if (mouse.button === Qt.RightButton) {
+                                        if (modelData && modelData.audio) {
+                                            SessionData.suppressOSDTemporarily();
+                                            modelData.audio.muted = !modelData.audio.muted;
+                                        }
+                                        return;
+                                    }
                                     if (modelData && modelData.name) {
                                         AudioService.setDefaultSinkByName(modelData.name);
                                         root.deviceSelected(modelData);

--- a/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
+++ b/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
@@ -390,7 +390,11 @@ Item {
                                     }
                                 }
                                 onWheel: wheelEvent => {
-                                    AudioService.handleNodeVolumeWheel(modelData, wheelEvent);
+                                    if (SettingsData.audioDeviceScrollVolumeEnabled && wheelEvent.x >= deviceMouseArea.width / 2) {
+                                        AudioService.handleNodeVolumeWheel(modelData, wheelEvent);
+                                    } else {
+                                        wheelEvent.accepted = false;
+                                    }
                                 }
                                 onClicked: mouse => {
                                     if (mouse.button === Qt.RightButton) {

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -873,7 +873,11 @@ Item {
                 }
             }
             onWheel: wheelEvent => {
-                AudioService.handleNodeVolumeWheel(AudioService.sink, wheelEvent);
+                const delta = wheelEvent.angleDelta.y;
+                if (delta !== 0) {
+                    AudioService.cycleAudioOutputDirection(delta < 0);
+                    wheelEvent.accepted = true;
+                }
             }
             onClicked: mouse => {
                 if (mouse.button === Qt.RightButton) {

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -866,7 +866,23 @@ Item {
             anchors.fill: parent
             hoverEnabled: true
             cursorShape: Qt.PointingHandCursor
-            onClicked: {
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onPressed: mouse => {
+                if (mouse.button === Qt.RightButton) {
+                    mouse.accepted = true;
+                }
+            }
+            onWheel: wheelEvent => {
+                AudioService.handleNodeVolumeWheel(AudioService.sink, wheelEvent);
+            }
+            onClicked: mouse => {
+                if (mouse.button === Qt.RightButton) {
+                    if (AudioService.sink?.audio) {
+                        SessionData.suppressOSDTemporarily();
+                        AudioService.sink.audio.muted = !AudioService.sink.audio.muted;
+                    }
+                    return;
+                }
                 if (devicesExpanded) {
                     const sinks = AudioService.getAvailableSinks();
                     if (sinks && sinks.length > 1) {

--- a/quickshell/Modules/Settings/MediaPlayerTab.qml
+++ b/quickshell/Modules/Settings/MediaPlayerTab.qml
@@ -113,6 +113,13 @@ Item {
                         }
                     }
                 }
+
+                SettingsToggleRow {
+                    text: I18n.tr("Device list scroll volume")
+                    description: I18n.tr("Allow adjusting device volume by scrolling on the right half of items in the device list")
+                    checked: SettingsData.audioDeviceScrollVolumeEnabled
+                    onToggled: checked => SettingsData.set("audioDeviceScrollVolumeEnabled", checked)
+                }
             }
         }
     }

--- a/quickshell/Services/AudioService.qml
+++ b/quickshell/Services/AudioService.qml
@@ -58,6 +58,8 @@ Singleton {
         return SessionData.deviceMaxVolumes[name] ?? 100;
     }
 
+    readonly property int wheelVolumeStep: 5
+
     signal micMuteChanged
     signal audioOutputCycled(string deviceName, string deviceIcon)
     signal deviceAliasChanged(string nodeName, string newAlias)
@@ -831,6 +833,28 @@ EOFCONFIG
 
         root.sink.audio.muted = !root.sink.audio.muted;
         return root.sink.audio.muted ? "Audio muted" : "Audio unmuted";
+    }
+
+    function handleNodeVolumeWheel(node, wheelEvent) {
+        if (!node?.audio)
+            return;
+
+        SessionData.suppressOSDTemporarily();
+        const delta = wheelEvent.angleDelta.y;
+        if (delta === 0)
+            return;
+
+        const current = Math.round(node.audio.volume * 100);
+        const maxVol = getMaxVolumePercent(node);
+        const newVolume = delta > 0 ? Math.min(maxVol, current + root.wheelVolumeStep) : Math.max(0, current - root.wheelVolumeStep);
+
+        node.audio.muted = false;
+        node.audio.volume = newVolume / 100;
+
+        if (node === sink) {
+            playVolumeChangeSoundIfEnabled();
+        }
+        wheelEvent.accepted = true;
     }
 
     function setMicVolume(percentage) {

--- a/quickshell/Services/AudioService.qml
+++ b/quickshell/Services/AudioService.qml
@@ -58,7 +58,7 @@ Singleton {
         return SessionData.deviceMaxVolumes[name] ?? 100;
     }
 
-    readonly property int wheelVolumeStep: 5
+    readonly property int wheelVolumeStep: SettingsData.audioWheelScrollAmount
 
     signal micMuteChanged
     signal audioOutputCycled(string deviceName, string deviceIcon)
@@ -158,19 +158,28 @@ Singleton {
         return false;
     }
 
-    function cycleAudioOutput() {
+    function cycleAudioOutputDirection(forward) {
         const sinks = getAvailableSinks();
         if (sinks.length < 2)
             return null;
 
         const currentName = root.sink?.name ?? "";
         const currentIndex = sinks.findIndex(s => s.name === currentName);
-        const nextIndex = (currentIndex + 1) % sinks.length;
+        let nextIndex;
+        if (forward) {
+            nextIndex = (currentIndex + 1) % sinks.length;
+        } else {
+            nextIndex = (currentIndex - 1 + sinks.length) % sinks.length;
+        }
         const nextSink = sinks[nextIndex];
         setDefaultSinkByName(nextSink.name);
         const name = displayName(nextSink);
         audioOutputCycled(name, sinkIcon(nextSink));
         return name;
+    }
+
+    function cycleAudioOutput() {
+        return cycleAudioOutputDirection(true);
     }
 
     function getDeviceAlias(nodeName) {


### PR DESCRIPTION
### What
Supports scroll wheel volume adjustment and right-click mute toggling for audio output devices in the media control popout:
1. Scrolling on the Audio Output Device icon or a specific device in the dropdown list adjusts its volume (step size 5%).
2. Right-clicking the Audio Output Device icon or a specific device in the dropdown list toggles its muted state without closing the popout.
3. Left-clicking a device in the dropdown list no longer closes the dropdown list.

### Why
Improves user experience by providing quick volume controls for secondary or main output devices directly within the media controls popout.

### How tested
Tested locally on quickshell. Verifying that:
- Scrolling adjusts volume and unmutes properly.
- Right click toggles mute/unmute and does not dismiss the popout.
- Left click switches default sink device without dismissing the dropdown.