### PR TITLE
fix(settings): fix text truncation in some section of settings and update icons

### DIFF
--- a/quickshell/Modules/Settings/AutoStartTab.qml
+++ b/quickshell/Modules/Settings/AutoStartTab.qml
@@ -722,7 +722,7 @@ Item {
 
             SettingsCard {
                 width: parent.width
-                iconName: "system_tray"
+                iconName: "handyman"
                 title: I18n.tr("Tray Icon Fix")
                 visible: DesktopService.isSystemd
 

--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -1754,6 +1754,9 @@ Item {
                     text: I18n.tr("Y Axis")
                     description: I18n.tr("Action performed when scrolling vertically on the bar")
                     model: CompositorService.isNiri ? [I18n.tr("None"), I18n.tr("Workspace"), I18n.tr("Column")] : [I18n.tr("None"), I18n.tr("Workspace")]
+                    buttonPadding: Theme.spacingS
+                    minButtonWidth: 44
+                    textSize: Theme.fontSizeSmall
                     currentIndex: {
                         switch (selectedBarConfig?.scrollYBehavior || "workspace") {
                         case "none":
@@ -1792,6 +1795,9 @@ Item {
                     description: I18n.tr("Action performed when scrolling horizontally on the bar")
                     visible: CompositorService.isNiri
                     model: [I18n.tr("None"), I18n.tr("Workspace"), I18n.tr("Column")]
+                    buttonPadding: Theme.spacingS
+                    minButtonWidth: 44
+                    textSize: Theme.fontSizeSmall
                     currentIndex: {
                         switch (selectedBarConfig?.scrollXBehavior || "column") {
                         case "none":

--- a/quickshell/Modules/Settings/FrameTab.qml
+++ b/quickshell/Modules/Settings/FrameTab.qml
@@ -205,6 +205,9 @@ Item {
                     tags: ["frame", "border", "color", "theme", "primary", "surface", "default"]
                     text: I18n.tr("Border Color")
                     model: [I18n.tr("Default"), I18n.tr("Primary"), I18n.tr("Surface"), I18n.tr("Custom")]
+                    buttonPadding: Theme.spacingS
+                    minButtonWidth: 44
+                    textSize: Theme.fontSizeSmall
                     currentIndex: {
                         const fc = SettingsData.frameColor;
                         if (!fc || fc === "default")

--- a/quickshell/Modules/Settings/ThemeColorsTab.qml
+++ b/quickshell/Modules/Settings/ThemeColorsTab.qml
@@ -2681,7 +2681,7 @@ Item {
                             spacing: Theme.spacingS
 
                             DankIcon {
-                                name: "folder"
+                                name: "settings"
                                 size: 16
                                 color: Theme.primary
                                 anchors.verticalCenter: parent.verticalCenter

--- a/quickshell/Modules/Settings/WallpaperTab.qml
+++ b/quickshell/Modules/Settings/WallpaperTab.qml
@@ -1271,6 +1271,7 @@ Item {
                 tags: ["blur", "layer", "niri", "compositor"]
                 title: I18n.tr("Blur Wallpaper Layer")
                 settingKey: "blurWallpaper"
+                iconName: "blur_on"
                 visible: CompositorService.isNiri
 
                 SettingsToggleRow {

--- a/quickshell/Modules/Settings/WidgetSelectionPopup.qml
+++ b/quickshell/Modules/Settings/WidgetSelectionPopup.qml
@@ -330,7 +330,7 @@ FloatingWindow {
 
                         delegate: Rectangle {
                             width: widgetList.width
-                            height: 60
+                            height: Math.max(60, textColumn.implicitHeight + 24)
                             radius: Theme.cornerRadius
                             property bool isSelected: root.keyboardNavigationActive && index === root.selectedIndex
                             color: isSelected ? Theme.withAlpha(Theme.primary, root.blurActive ? 0.22 : 0.16) : widgetArea.containsMouse ? Theme.withAlpha(Theme.primary, root.blurActive ? 0.14 : 0.08) : Theme.withAlpha(Theme.surfaceVariant, root.rowAlpha)
@@ -351,9 +351,10 @@ FloatingWindow {
                                 }
 
                                 Column {
+                                    id: textColumn
                                     anchors.verticalCenter: parent.verticalCenter
                                     spacing: 2
-                                    width: parent.width - Theme.iconSize - Theme.spacingM * 3
+                                    width: parent.width - Theme.iconSize * 2 - Theme.spacingM * 4 + 4
 
                                     StyledText {
                                         text: modelData.text
@@ -362,6 +363,7 @@ FloatingWindow {
                                         color: Theme.surfaceText
                                         elide: Text.ElideRight
                                         width: parent.width
+                                        wrapMode: Text.WordWrap
                                     }
 
                                     StyledText {

--- a/quickshell/Modules/Settings/WidgetsTabSection.qml
+++ b/quickshell/Modules/Settings/WidgetsTabSection.qml
@@ -90,7 +90,7 @@ Column {
                 property real originalY: y
 
                 width: itemsList.width
-                height: 70
+                height: Math.max(70, textColumn.implicitHeight + 32)
                 z: held ? 2 : 1
 
                 Rectangle {
@@ -123,6 +123,7 @@ Column {
                     }
 
                     Column {
+                        id: textColumn
                         anchors.left: parent.left
                         anchors.leftMargin: Theme.spacingM * 3 + 40 + Theme.iconSize
                         anchors.right: actionButtons.left
@@ -137,6 +138,7 @@ Column {
                             color: modelData.enabled ? Theme.surfaceText : Theme.outline
                             elide: Text.ElideRight
                             width: parent.width
+                            wrapMode: Text.WordWrap
                         }
 
                         StyledText {


### PR DESCRIPTION
## Description
This PR addresses layout and visual issues within the Settings modules:
- **Fixed spacing and text truncation:** Updated `WidgetSelectionPopup.qml`,  `WidgetsTabSection.qml`, `DankBarTab.qml` and `FrameTab.qml` to calculate heights dynamically based on text content.
- **Icon updates:** Added a missing icon (`blur_on` in `WallpaperTab`) and replaced two icons (`system_tray` -> `handyman` in `AutoStartTab.qml` and `folder` -> `settings` in `ThemeColorsTab.qml`).

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

### Before
<img width="536" height="223" alt="2026-06-11 15-52-43" src="https://github.com/user-attachments/assets/c3ea0003-b5fe-42e3-bf4c-c5d59f32b504" />
<img width="511" height="95" alt="2026-06-11 15-52-52" src="https://github.com/user-attachments/assets/b6e47691-477a-4857-a7de-cbef2e3cb691" />
<img width="462" height="86" alt="2026-06-11 15-53-47" src="https://github.com/user-attachments/assets/84822baf-5fad-4586-83d6-8f40dd2454d4" />
<img width="501" height="79" alt="2026-06-11 15-52-59" src="https://github.com/user-attachments/assets/367c1f4e-bec6-44c5-9b04-58d3c4c19f25" />

### After
<img width="527" height="219" alt="2026-06-11 15-54-50" src="https://github.com/user-attachments/assets/d199c82a-62cb-421c-b443-b13039133038" />
<img width="513" height="118" alt="2026-06-11 15-55-09" src="https://github.com/user-attachments/assets/20101146-fa92-4a64-9271-76ad5693a38a" />
<img width="482" height="98" alt="2026-06-11 15-55-21" src="https://github.com/user-attachments/assets/89cc5849-dc79-4242-92fe-ccb1f75c041a" />
<img width="542" height="84" alt="2026-06-11 15-55-28" src="https://github.com/user-attachments/assets/54284a18-031c-4c7f-8d95-af012c87c843" />


## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
