### PR TITLE
feat(settings): add clipboard entry action visibility controls

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -108,6 +108,7 @@ Singleton {
     }
 
     property bool clipboardEnterToPaste: false
+    property var clipboardVisibleEntryActions: ["pin", "edit", "delete"]
 
     property var launcherPluginVisibility: ({})
 

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -572,6 +572,7 @@ var SPEC = {
 
     builtInPluginSettings: { def: {} },
     clipboardEnterToPaste: { def: false },
+    clipboardVisibleEntryActions: { def: ["pin", "edit", "delete"] },
 
     launcherPluginVisibility: { def: {} },
     launcherPluginOrder: { def: [] },

--- a/quickshell/Modals/Clipboard/ClipboardEntry.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEntry.qml
@@ -22,7 +22,14 @@ Rectangle {
     readonly property string entryType: modal ? modal.getEntryType(entry) : "text"
     readonly property string entryPreview: modal ? modal.getEntryPreview(entry) : ""
     readonly property var pinnedDuplicateEntry: !entry.pinned ? ClipboardService.getPinnedEntryByHash(entry.hash) : null
-    readonly property bool effectivePinned: entry.pinned || pinnedDuplicateEntry !== null
+    readonly property bool hasPinnedDuplicate: pinnedDuplicateEntry !== null
+    readonly property bool effectivePinned: entry.pinned || hasPinnedDuplicate
+    readonly property var visibleEntryActions: SettingsData.clipboardVisibleEntryActions || ["pin", "edit", "delete"]
+    readonly property bool showPinAction: visibleEntryActions.includes("pin")
+    readonly property bool showEditAction: visibleEntryActions.includes("edit")
+    readonly property bool showDeleteAction: visibleEntryActions.includes("delete")
+    readonly property bool showPinnedIndicator: hasPinnedDuplicate && !showPinAction
+    readonly property bool showAnyAction: showPinAction || showEditAction || showDeleteAction || showPinnedIndicator
 
     radius: Theme.cornerRadius
     color: {
@@ -63,12 +70,23 @@ Rectangle {
         anchors.rightMargin: Theme.spacingS
         anchors.verticalCenter: parent.verticalCenter
         spacing: Theme.spacingXS
+        visible: root.showAnyAction
 
         DankActionButton {
             iconName: "push_pin"
             iconSize: Theme.iconSize - 6
-            iconColor: effectivePinned ? Theme.primary : Theme.surfaceText
-            backgroundColor: effectivePinned ? Theme.primarySelected : "transparent"
+            iconColor: Theme.primary
+            backgroundColor: Theme.primarySelected
+            visible: root.showPinnedIndicator
+            onClicked: unpinRequested(pinnedDuplicateEntry)
+        }
+
+        DankActionButton {
+            iconName: "push_pin"
+            iconSize: Theme.iconSize - 6
+            iconColor: (entry.pinned || hasPinnedDuplicate) ? Theme.primary : Theme.surfaceText
+            backgroundColor: (entry.pinned || hasPinnedDuplicate) ? Theme.primarySelected : "transparent"
+            visible: root.showPinAction
             onClicked: {
                 if (entry.pinned) {
                     unpinRequested(entry);
@@ -86,6 +104,7 @@ Rectangle {
             iconName: "edit"
             iconSize: Theme.iconSize - 6
             iconColor: Theme.surfaceText
+            visible: root.showEditAction
 
             onClicked: {
                 if (entryType === "image") {
@@ -99,6 +118,7 @@ Rectangle {
             iconName: "close"
             iconSize: Theme.iconSize - 6
             iconColor: Theme.surfaceText
+            visible: root.showDeleteAction
             onClicked: deleteRequested()
         }
     }
@@ -106,8 +126,8 @@ Rectangle {
     Item {
         anchors.left: indexBadge.right
         anchors.leftMargin: Theme.spacingM
-        anchors.right: actionButtons.left
-        anchors.rightMargin: Theme.spacingM
+        anchors.right: root.showAnyAction ? actionButtons.left : parent.right
+        anchors.rightMargin: root.showAnyAction ? Theme.spacingM : Theme.spacingS
         anchors.verticalCenter: parent.verticalCenter
         // height: contentColumn.implicitHeight
         height: ClipboardConstants.itemHeight
@@ -168,8 +188,8 @@ Rectangle {
     MouseArea {
         id: mouseArea
         anchors.left: parent.left
-        anchors.right: actionButtons.left
-        anchors.rightMargin: Theme.spacingS
+        anchors.right: root.showAnyAction ? actionButtons.left : parent.right
+        anchors.rightMargin: root.showAnyAction ? Theme.spacingS : 0
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         hoverEnabled: true

--- a/quickshell/Modals/Clipboard/ClipboardEntry.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEntry.qml
@@ -28,7 +28,7 @@ Rectangle {
     readonly property bool showPinAction: visibleEntryActions.includes("pin")
     readonly property bool showEditAction: visibleEntryActions.includes("edit")
     readonly property bool showDeleteAction: visibleEntryActions.includes("delete")
-    readonly property bool showPinnedIndicator: hasPinnedDuplicate && !showPinAction
+    readonly property bool showPinnedIndicator: !showPinAction && effectivePinned
     readonly property bool showAnyAction: showPinAction || showEditAction || showDeleteAction || showPinnedIndicator
 
     radius: Theme.cornerRadius
@@ -78,7 +78,15 @@ Rectangle {
             iconColor: Theme.primary
             backgroundColor: Theme.primarySelected
             visible: root.showPinnedIndicator
-            onClicked: unpinRequested(pinnedDuplicateEntry)
+            onClicked: {
+                if (entry.pinned) {
+                    unpinRequested(entry);
+                    return;
+                }
+                if (pinnedDuplicateEntry) {
+                    unpinRequested(pinnedDuplicateEntry);
+                }
+            }
         }
 
         DankActionButton {

--- a/quickshell/Modules/Settings/ClipboardTab.qml
+++ b/quickshell/Modules/Settings/ClipboardTab.qml
@@ -152,6 +152,9 @@ Item {
         }
     ]
 
+    readonly property var entryActionKeys: ["pin", "edit", "delete"]
+    readonly property var entryActionLabels: [I18n.tr("Pin"), I18n.tr("Edit"), I18n.tr("Delete")]
+
     function getMaxHistoryText(value) {
         if (value <= 0)
             return "∞";
@@ -185,6 +188,29 @@ Item {
                 return opt.text;
         }
         return value.toString();
+    }
+
+    function visibleEntryActionKeys() {
+        return SettingsData.clipboardVisibleEntryActions || ["pin", "edit", "delete"];
+    }
+
+    function visibleEntryActionLabels() {
+        const visibleKeys = visibleEntryActionKeys();
+        return entryActionKeys.map((key, index) => visibleKeys.includes(key) ? entryActionLabels[index] : null).filter(label => label !== null);
+    }
+
+    function setVisibleEntryAction(index, selected) {
+        const actionKey = entryActionKeys[index];
+        if (!actionKey)
+            return;
+
+        let actions = visibleEntryActionKeys().slice();
+        if (selected && !actions.includes(actionKey)) {
+            actions.push(actionKey);
+        } else if (!selected && actions.includes(actionKey)) {
+            actions = actions.filter(action => action !== actionKey);
+        }
+        SettingsData.set("clipboardVisibleEntryActions", actions);
     }
 
     function loadConfig() {
@@ -436,6 +462,24 @@ Item {
                     description: I18n.tr("Press Enter to paste, Shift+Enter to copy", "Clipboard behavior setting description")
                     checked: SettingsData.clipboardEnterToPaste
                     onToggled: checked => SettingsData.set("clipboardEnterToPaste", checked)
+                }
+
+                SettingsButtonGroupRow {
+                    tab: "clipboard"
+                    tags: ["clipboard", "actions", "buttons", "hide", "density", "pin", "edit", "delete"]
+                    settingKey: "clipboardVisibleEntryActions"
+                    text: I18n.tr("Visible Entry Actions")
+                    description: I18n.tr("Choose which action buttons appear on clipboard entries")
+                    selectionMode: "multi"
+                    model: root.entryActionLabels
+                    currentSelection: root.visibleEntryActionLabels()
+                    checkEnabled: false
+                    buttonHeight: 28
+                    minButtonWidth: 56
+                    buttonPadding: Theme.spacingS
+                    textSize: Theme.fontSizeSmall
+                    spacing: 1
+                    onSelectionChanged: (index, selected) => root.setVisibleEntryAction(index, selected)
                 }
             }
 

--- a/quickshell/Modules/Settings/Widgets/SettingsButtonGroupRow.qml
+++ b/quickshell/Modules/Settings/Widgets/SettingsButtonGroupRow.qml
@@ -64,6 +64,8 @@ Item {
 
     property alias model: buttonGroup.model
     property alias currentIndex: buttonGroup.currentIndex
+    property alias initialSelection: buttonGroup.initialSelection
+    property alias currentSelection: buttonGroup.currentSelection
     property alias selectionMode: buttonGroup.selectionMode
     property alias buttonHeight: buttonGroup.buttonHeight
     property alias minButtonWidth: buttonGroup.minButtonWidth


### PR DESCRIPTION
## Description

Adds configurable visibility for clipboard entry action buttons.

Users can now choose which action buttons appear on clipboard entries from Settings -> Clipboard -> Behavior: Pin, Edit, and Delete. The default configuration preserves the existing behavior with all three buttons visible. When all action buttons are hidden, the entry content area and click-to-copy area expand to the right, reducing unused space.

This adds a new `clipboardVisibleEntryActions` setting and exposes multi-selection state from `SettingsButtonGroupRow`, so it can reuse the existing `DankButtonGroup` multi-select mode.

When the Pin action is hidden, a normal clipboard entry whose content matches an already pinned entry still shows a pinned-state indicator on the right. This keeps the saved/pinned status visible even when the action button itself is hidden.

Note: because the translation-related generated changes are relatively large, this PR does not update the translation files or settings search index for now.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

- Clipboard settings section showing the new visible entry actions control.

<img width="548" height="274" alt="Screenshot from 2026-06-12 16-30-18" src="https://github.com/user-attachments/assets/c8d92b47-8ebe-4cb5-a7c5-282cf6860ad4" />

- Saved/pinned clipboard page after pinning an entry.

<img width="543" height="272" alt="Screenshot from 2026-06-12 16-34-52" src="https://github.com/user-attachments/assets/3460bed4-0fe7-46e0-ba0e-2940133011cb" />

- Recents page showing a normal clipboard entry with the same content as a pinned entry, including the pinned indicator shown when the Pin action is hidden.

<img width="543" height="272" alt="Screenshot from 2026-06-12 16-37-18" src="https://github.com/user-attachments/assets/784ccaa0-0eb2-46c5-b5e4-83ea78802bf6" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
