### PR TITLE
Fix/clipboard confirmation keyboard safety

### DIFF
--- a/quickshell/Modals/Clipboard/ClipboardContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContent.qml
@@ -7,7 +7,6 @@ Item {
     id: clipboardContent
 
     required property var modal
-    required property var clearConfirmDialog
 
     property alias searchField: searchField
     property alias clipboardListView: clipboardListView
@@ -33,14 +32,7 @@ Item {
             pinnedCount: modal.pinnedCount
             onKeyboardHintsToggled: modal.showKeyboardHints = !modal.showKeyboardHints
             onTabChanged: tabName => modal.activeTab = tabName
-            onClearAllClicked: {
-                const hasPinned = modal.pinnedCount > 0;
-                const message = hasPinned ? I18n.tr("This will delete all unpinned entries. %1 pinned entries will be kept.").arg(modal.pinnedCount) : I18n.tr("This will permanently delete all clipboard history.");
-                clearConfirmDialog.show(I18n.tr("Clear History?"), message, function () {
-                    modal.clearAll();
-                    modal.hide();
-                }, function () {});
-            }
+            onClearAllClicked: modal.confirmClearAll()
             onCloseClicked: modal.hide()
         }
 

--- a/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
@@ -82,6 +82,15 @@ FocusScope {
         ClipboardService.clearAll();
     }
 
+    function confirmClearAll() {
+        const hasPinned = pinnedCount > 0;
+        const message = hasPinned ? I18n.tr("This will delete all unpinned entries. %1 pinned entries will be kept.").arg(pinnedCount) : I18n.tr("This will permanently delete all clipboard history.");
+        clearConfirmDialog.show(I18n.tr("Clear History?"), message, function () {
+            clearAll();
+            hide();
+        }, function () {});
+    }
+
     function getEntryPreview(entry) {
         return ClipboardService.getEntryPreview(entry);
     }
@@ -135,7 +144,6 @@ FocusScope {
             id: historyContent
             anchors.fill: parent
             modal: root
-            clearConfirmDialog: root.clearConfirmDialog
         }
     }
 

--- a/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
@@ -82,21 +82,34 @@ DankModal {
         id: clearConfirmDialog
         confirmButtonText: I18n.tr("Clear All")
         confirmButtonColor: Theme.primary
-        onVisibleChanged: {
-            if (visible) {
+        onShouldBeVisibleChanged: {
+            if (shouldBeVisible) {
                 clipboardHistoryModal.shouldHaveFocus = false;
+                selectedButton = 0;
+                keyboardNavigation = true;
                 return;
             }
             Qt.callLater(function () {
                 if (!clipboardHistoryModal.shouldBeVisible) {
                     return;
                 }
-                clipboardHistoryModal.shouldHaveFocus = true;
+                clipboardHistoryModal.shouldHaveFocus = Qt.binding(() => clipboardHistoryModal.shouldBeVisible);
                 clipboardHistoryModal.modalFocusScope.forceActiveFocus();
                 if (clipboardHistoryModal.contentLoader.item?.searchField) {
                     clipboardHistoryModal.contentLoader.item.searchField.forceActiveFocus();
                 }
             });
+        }
+        Connections {
+            target: clearConfirmDialog.modalFocusScope.Keys
+            function onPressed(event) {
+                if (!clearConfirmDialog.shouldBeVisible || event.key !== Qt.Key_Backtab) {
+                    return;
+                }
+                clearConfirmDialog.selectedButton = clearConfirmDialog.selectedButton === -1 ? 1 : (clearConfirmDialog.selectedButton - 1 + 2) % 2;
+                clearConfirmDialog.keyboardNavigation = true;
+                event.accepted = true;
+            }
         }
     }
 

--- a/quickshell/Modals/Clipboard/ClipboardHistoryPopout.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryPopout.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import Quickshell.Wayland
 import qs.Common
 import qs.Modals.Clipboard
 import qs.Modals.Common
@@ -95,6 +96,35 @@ DankPopout {
         id: clearConfirmDialog
         confirmButtonText: I18n.tr("Clear All")
         confirmButtonColor: Theme.primary
+        onShouldBeVisibleChanged: {
+            if (shouldBeVisible) {
+                root.customKeyboardFocus = WlrKeyboardFocus.None;
+                selectedButton = 0;
+                keyboardNavigation = true;
+                return;
+            }
+            root.customKeyboardFocus = null;
+            Qt.callLater(function () {
+                if (!root.shouldBeVisible || !root.contentLoader.item) {
+                    return;
+                }
+                root.contentLoader.item.forceActiveFocus();
+                if (root.contentLoader.item.searchField) {
+                    root.contentLoader.item.searchField.forceActiveFocus();
+                }
+            });
+        }
+        Connections {
+            target: clearConfirmDialog.modalFocusScope.Keys
+            function onPressed(event) {
+                if (!clearConfirmDialog.shouldBeVisible || event.key !== Qt.Key_Backtab) {
+                    return;
+                }
+                clearConfirmDialog.selectedButton = clearConfirmDialog.selectedButton === -1 ? 1 : (clearConfirmDialog.selectedButton - 1 + 2) % 2;
+                clearConfirmDialog.keyboardNavigation = true;
+                event.accepted = true;
+            }
+        }
     }
 
     content: Component {

--- a/quickshell/Modals/Clipboard/ClipboardKeyboardController.qml
+++ b/quickshell/Modals/Clipboard/ClipboardKeyboardController.qml
@@ -184,8 +184,7 @@ QtObject {
         if (event.modifiers & Qt.ShiftModifier) {
             switch (event.key) {
             case Qt.Key_Delete:
-                modal.clearAll();
-                modal.hide();
+                modal.confirmClearAll();
                 event.accepted = true;
                 return;
             case Qt.Key_Return:


### PR DESCRIPTION
## Description

This PR improves keyboard safety around the clipboard clear-history confirmation flow.

The clear-history confirmation dialog now defaults keyboard selection to Cancel instead of the destructive Clear All action. This makes keyboard interaction safer for a destructive operation and keeps the behavior consistent with pressing the final-line selection, where the user is not pushed directly into confirming a destructive action.

This also makes the Shift+Delete clear-all shortcut use the same confirmation flow as the Clear All button. Previously, the button asked for confirmation, but the shortcut cleared clipboard history immediately. Both entry points now share the same confirmation behavior: confirming clears the relevant history and closes the clipboard, while canceling leaves it unchanged.

The confirmation dialog also handles Tab and Shift+Tab keyboard navigation correctly while open.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
