### PR TITLE
fix(clipboard): hide pin action while keeping saved indicator

### DIFF
--- a/quickshell/Modals/Clipboard/ClipboardEntry.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEntry.qml
@@ -28,7 +28,7 @@ Rectangle {
     readonly property bool showPinAction: visibleEntryActions.includes("pin")
     readonly property bool showEditAction: visibleEntryActions.includes("edit")
     readonly property bool showDeleteAction: visibleEntryActions.includes("delete")
-    readonly property bool showPinnedIndicator: !showPinAction && effectivePinned
+    readonly property bool showPinnedIndicator: hasPinnedDuplicate && !showPinAction
     readonly property bool showAnyAction: showPinAction || showEditAction || showDeleteAction || showPinnedIndicator
 
     radius: Theme.cornerRadius
@@ -72,20 +72,17 @@ Rectangle {
         spacing: Theme.spacingXS
         visible: root.showAnyAction
 
-        DankActionButton {
-            iconName: "push_pin"
-            iconSize: Theme.iconSize - 6
-            iconColor: Theme.primary
-            backgroundColor: Theme.primarySelected
+        Item {
+            width: 40
+            height: 40
             visible: root.showPinnedIndicator
-            onClicked: {
-                if (entry.pinned) {
-                    unpinRequested(entry);
-                    return;
-                }
-                if (pinnedDuplicateEntry) {
-                    unpinRequested(pinnedDuplicateEntry);
-                }
+
+            // Status indicator only; the Pin action remains hidden.
+            DankIcon {
+                anchors.centerIn: parent
+                name: "push_pin"
+                size: Theme.iconSize - 6
+                color: Theme.primary
             }
         }
 


### PR DESCRIPTION
## Description

Follow-up to #2621.

When the Pin action is hidden, saved duplicate entries in Recents now show only a non-interactive pinned status indicator. This keeps the saved state visible while ensuring the Pin action itself remains hidden.

Saved entries no longer get a special clickable pin/unpin indicator when the Pin action is hidden.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
