### PR TITLE
feat(clipboard): add type filters to clipboard history

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -108,6 +108,8 @@ Singleton {
     }
 
     property bool clipboardEnterToPaste: false
+    property bool clipboardRememberTypeFilter: false
+    property string clipboardTypeFilter: "all"
     property var clipboardVisibleEntryActions: ["pin", "edit", "delete"]
 
     property var launcherPluginVisibility: ({})

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -591,6 +591,8 @@ var SPEC = {
 
     builtInPluginSettings: { def: {} },
     clipboardEnterToPaste: { def: false },
+    clipboardRememberTypeFilter: { def: false },
+    clipboardTypeFilter: { def: "all" },
     clipboardVisibleEntryActions: { def: ["pin", "edit", "delete"] },
 
     launcherPluginVisibility: { def: {} },

--- a/quickshell/Modals/Clipboard/ClipboardContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContent.qml
@@ -30,6 +30,8 @@ Item {
             showKeyboardHints: modal.showKeyboardHints
             activeTab: modal.activeTab
             pinnedCount: modal.pinnedCount
+            activeFilter: modal.activeFilter
+            onFilterChanged: filter => modal.activeFilter = filter
             onKeyboardHintsToggled: modal.showKeyboardHints = !modal.showKeyboardHints
             onTabChanged: tabName => modal.activeTab = tabName
             onClearAllClicked: modal.confirmClearAll()

--- a/quickshell/Modals/Clipboard/ClipboardContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContent.qml
@@ -11,6 +11,14 @@ Item {
     property alias searchField: searchField
     property alias clipboardListView: clipboardListView
 
+    readonly property var filterOptions: [I18n.tr("All"), I18n.tr("Text"), I18n.tr("Long Text"), I18n.tr("Image")]
+    readonly property var filterValues: ["all", "text", "long_text", "image"]
+
+    function closeFilterMenu() {
+        filterMenuLoader.active = false;
+        filterMenuLoader.active = true;
+    }
+
     anchors.fill: parent
 
     Column {
@@ -30,60 +38,22 @@ Item {
             showKeyboardHints: modal.showKeyboardHints
             activeTab: modal.activeTab
             pinnedCount: modal.pinnedCount
-            activeFilter: modal.activeFilter
-            onFilterChanged: filter => modal.activeFilter = filter
             onKeyboardHintsToggled: modal.showKeyboardHints = !modal.showKeyboardHints
             onTabChanged: tabName => modal.activeTab = tabName
             onClearAllClicked: modal.confirmClearAll()
             onCloseClicked: modal.hide()
         }
 
-         Row {
+        Item {
+            id: searchRow
             width: parent.width
-            spacing: Theme.spacingS
-
-            DankDropdown {
-                id: filterDropdown
-                width: 120
-
-                text: ""
-                currentValue: {
-                    switch (modal.activeFilter) {
-                        case "text":
-                            return I18n.tr("Text");
-                        case "long_text":
-                            return I18n.tr("Long Text");
-                        case "image":
-                            return I18n.tr("Image");
-                        default:
-                            return I18n.tr("All");
-                    }
-                }
-
-                options: [I18n.tr("All"), I18n.tr("Text"), I18n.tr("Long Text"), I18n.tr("Image")]
-
-                onValueChanged: value => {
-                    switch (value) {
-                        case I18n.tr("Text"):
-                            modal.activeFilter = "text";
-                            break;
-                        case I18n.tr("Long Text"):
-                            modal.activeFilter = "long_text";
-                            break;
-                        case I18n.tr("Image"):
-                            modal.activeFilter = "image";
-                            break;
-                        default:
-                            modal.activeFilter = "all";
-                    }
-                }
-            }
+            implicitHeight: searchField.height
 
             DankTextField {
                 id: searchField
 
-                width: parent.width - 120 - parent.spacing
-
+                width: parent.width
+                rightAccessoryWidth: filterButton.width + Theme.spacingS
                 placeholderText: ""
                 leftIconName: "search"
                 showClearButton: true
@@ -105,6 +75,49 @@ Item {
                     Qt.callLater(function () {
                         forceActiveFocus();
                     });
+                }
+            }
+
+            DankActionButton {
+                id: filterButton
+
+                anchors.right: parent.right
+                anchors.rightMargin: Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+                iconName: "filter_list"
+                iconColor: modal.activeFilter !== "all" ? Theme.primary : Theme.surfaceText
+                backgroundColor: modal.activeFilter !== "all" ? Theme.primarySelected : "transparent"
+                tooltipText: I18n.tr("Filter by type", "Clipboard history type filter button tooltip")
+                onClicked: filterMenuLoader.item?.openDropdownMenu()
+            }
+
+            Loader {
+                id: filterMenuLoader
+
+                active: true
+                sourceComponent: filterMenuComponent
+            }
+
+            Component {
+                id: filterMenuComponent
+
+                DankDropdown {
+                    showTrigger: false
+                    popupAnchorItem: filterButton
+                    popupWidth: 180
+                    alignPopupRight: true
+                    options: clipboardContent.filterOptions
+                    currentValue: {
+                        const idx = clipboardContent.filterValues.indexOf(clipboardContent.modal.activeFilter);
+                        return idx >= 0 ? clipboardContent.filterOptions[idx] : clipboardContent.filterOptions[0];
+                    }
+
+                    onValueChanged: value => {
+                        const idx = clipboardContent.filterOptions.indexOf(value);
+                        if (idx >= 0) {
+                            clipboardContent.modal.activeFilter = clipboardContent.filterValues[idx];
+                        }
+                    }
                 }
             }
         }

--- a/quickshell/Modals/Clipboard/ClipboardContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContent.qml
@@ -38,27 +38,74 @@ Item {
             onCloseClicked: modal.hide()
         }
 
-        DankTextField {
-            id: searchField
+         Row {
             width: parent.width
-            placeholderText: ""
-            leftIconName: "search"
-            showClearButton: true
-            focus: true
-            ignoreTabKeys: true
-            keyForwardTargets: [modal.modalFocusScope]
-            onTextChanged: {
-                modal.searchText = text;
-                modal.updateFilteredModel();
+            spacing: Theme.spacingS
+
+            DankDropdown {
+                id: filterDropdown
+                width: 120
+
+                text: ""
+                currentValue: {
+                    switch (modal.activeFilter) {
+                        case "text":
+                            return I18n.tr("Text");
+                        case "long_text":
+                            return I18n.tr("Long Text");
+                        case "image":
+                            return I18n.tr("Image");
+                        default:
+                            return I18n.tr("All");
+                    }
+                }
+
+                options: [I18n.tr("All"), I18n.tr("Text"), I18n.tr("Long Text"), I18n.tr("Image")]
+
+                onValueChanged: value => {
+                    switch (value) {
+                        case I18n.tr("Text"):
+                            modal.activeFilter = "text";
+                            break;
+                        case I18n.tr("Long Text"):
+                            modal.activeFilter = "long_text";
+                            break;
+                        case I18n.tr("Image"):
+                            modal.activeFilter = "image";
+                            break;
+                        default:
+                            modal.activeFilter = "all";
+                    }
+                }
             }
-            Keys.onEscapePressed: function (event) {
-                modal.hide();
-                event.accepted = true;
-            }
-            Component.onCompleted: {
-                Qt.callLater(function () {
-                    forceActiveFocus();
-                });
+
+            DankTextField {
+                id: searchField
+
+                width: parent.width - 120 - parent.spacing
+
+                placeholderText: ""
+                leftIconName: "search"
+                showClearButton: true
+                focus: true
+                ignoreTabKeys: true
+                keyForwardTargets: [modal.modalFocusScope]
+
+                onTextChanged: {
+                    modal.searchText = text;
+                    modal.updateFilteredModel();
+                }
+
+                Keys.onEscapePressed: function (event) {
+                    modal.hide();
+                    event.accepted = true;
+                }
+
+                Component.onCompleted: {
+                    Qt.callLater(function () {
+                        forceActiveFocus();
+                    });
+                }
             }
         }
     }

--- a/quickshell/Modals/Clipboard/ClipboardHeader.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHeader.qml
@@ -11,13 +11,11 @@ Item {
     property bool showKeyboardHints: false
     property string activeTab: "recents"
     property int pinnedCount: 0
-    property string activeFilter: "all"
 
     signal keyboardHintsToggled
     signal clearAllClicked
     signal closeClicked
     signal tabChanged(string tabName)
-    signal filterChanged(string filter)
 
     height: ClipboardConstants.headerHeight
 

--- a/quickshell/Modals/Clipboard/ClipboardHeader.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHeader.qml
@@ -11,11 +11,13 @@ Item {
     property bool showKeyboardHints: false
     property string activeTab: "recents"
     property int pinnedCount: 0
+    property string activeFilter: "all"
 
     signal keyboardHintsToggled
     signal clearAllClicked
     signal closeClicked
     signal tabChanged(string tabName)
+    signal filterChanged(string filter)
 
     height: ClipboardConstants.headerHeight
 
@@ -37,6 +39,42 @@ Item {
             color: Theme.surfaceText
             font.weight: Font.Medium
             anchors.verticalCenter: parent.verticalCenter
+        }
+
+        DankDropdown {
+            width: 140
+
+            text: ""
+            currentValue: {
+                switch (header.activeFilter) {
+                    case "text":
+                        return I18n.tr("Text");
+                    case "long_text":
+                        return I18n.tr("Long Text");
+                    case "image":
+                        return I18n.tr("Image");
+                    default:
+                        return I18n.tr("All");
+                }
+            }
+
+            options: [I18n.tr("All"), I18n.tr("Text"), I18n.tr("Long Text"), I18n.tr("Image")]
+
+            onValueChanged: value => {
+                switch (value) {
+                    case I18n.tr("Text"):
+                        filterChanged("text");
+                        break;
+                    case I18n.tr("Long Text"):
+                        filterChanged("long_text");
+                        break;
+                    case I18n.tr("Image"):
+                        filterChanged("image");
+                        break;
+                    default:
+                        filterChanged("all");
+                }
+            }
         }
     }
 

--- a/quickshell/Modals/Clipboard/ClipboardHeader.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHeader.qml
@@ -41,41 +41,6 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
         }
 
-        DankDropdown {
-            width: 140
-
-            text: ""
-            currentValue: {
-                switch (header.activeFilter) {
-                    case "text":
-                        return I18n.tr("Text");
-                    case "long_text":
-                        return I18n.tr("Long Text");
-                    case "image":
-                        return I18n.tr("Image");
-                    default:
-                        return I18n.tr("All");
-                }
-            }
-
-            options: [I18n.tr("All"), I18n.tr("Text"), I18n.tr("Long Text"), I18n.tr("Image")]
-
-            onValueChanged: value => {
-                switch (value) {
-                    case I18n.tr("Text"):
-                        filterChanged("text");
-                        break;
-                    case I18n.tr("Long Text"):
-                        filterChanged("long_text");
-                        break;
-                    case I18n.tr("Image"):
-                        filterChanged("image");
-                        break;
-                    default:
-                        filterChanged("all");
-                }
-            }
-        }
     }
 
     Row {

--- a/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
@@ -16,6 +16,7 @@ FocusScope {
 
     property string mode: "history"
     property string searchText: ClipboardService.searchText
+    property string activeFilter: ClipboardService.activeFilter
 
     readonly property bool clipboardAvailable: ClipboardService.clipboardAvailable
     readonly property bool wtypeAvailable: ClipboardService.wtypeAvailable
@@ -49,6 +50,11 @@ FocusScope {
         }
     }
     onSearchTextChanged: ClipboardService.searchText = searchText
+
+    onActiveFilterChanged: {
+        ClipboardService.activeFilter = activeFilter;
+        ClipboardService.updateFilteredModel();
+    }
 
     function hide() {
         closeRequested();

--- a/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
@@ -16,7 +16,7 @@ FocusScope {
 
     property string mode: "history"
     property string searchText: ClipboardService.searchText
-    property string activeFilter: ClipboardService.activeFilter
+    property string activeFilter: SettingsData.clipboardRememberTypeFilter ? SettingsData.clipboardTypeFilter : "all"
 
     readonly property bool clipboardAvailable: ClipboardService.clipboardAvailable
     readonly property bool wtypeAvailable: ClipboardService.wtypeAvailable
@@ -53,7 +53,12 @@ FocusScope {
 
     onActiveFilterChanged: {
         ClipboardService.activeFilter = activeFilter;
+        ClipboardService.selectedIndex = 0;
+        ClipboardService.keyboardNavigationActive = false;
         ClipboardService.updateFilteredModel();
+        if (SettingsData.clipboardRememberTypeFilter) {
+            SettingsData.set("clipboardTypeFilter", activeFilter);
+        }
     }
 
     function hide() {
@@ -124,6 +129,8 @@ FocusScope {
     function resetState() {
         activeImageLoads = 0;
         mode = "history";
+        historyContent.closeFilterMenu();
+        activeFilter = SettingsData.clipboardRememberTypeFilter ? SettingsData.clipboardTypeFilter : "all";
         ClipboardService.reset();
         keyboardController.reset();
     }

--- a/quickshell/Modules/Settings/ClipboardTab.qml
+++ b/quickshell/Modules/Settings/ClipboardTab.qml
@@ -464,6 +464,16 @@ Item {
                     onToggled: checked => SettingsData.set("clipboardEnterToPaste", checked)
                 }
 
+                SettingsToggleRow {
+                    tab: "clipboard"
+                    tags: ["clipboard", "filter", "type", "remember", "behavior"]
+                    settingKey: "clipboardRememberTypeFilter"
+                    text: I18n.tr("Remember Type Filter", "Clipboard behavior setting title")
+                    description: I18n.tr("Keep the clipboard type filter when reopening history", "Clipboard behavior setting description")
+                    checked: SettingsData.clipboardRememberTypeFilter
+                    onToggled: checked => SettingsData.set("clipboardRememberTypeFilter", checked)
+                }
+
                 SettingsButtonGroupRow {
                     tab: "clipboard"
                     tags: ["clipboard", "actions", "buttons", "hide", "density", "pin", "edit", "delete"]

--- a/quickshell/Services/ClipboardService.qml
+++ b/quickshell/Services/ClipboardService.qml
@@ -23,6 +23,7 @@ Singleton {
     property int pinnedCount: 0
     property int totalCount: 0
     property string searchText: ""
+    property string activeFilter: "all"
     property int selectedIndex: 0
     property bool keyboardNavigationActive: false
     property int refCount: 0

--- a/quickshell/Services/ClipboardService.qml
+++ b/quickshell/Services/ClipboardService.qml
@@ -51,46 +51,46 @@ Singleton {
     }
 
     function updateFilteredModel() {
-    let filtered = internalEntries;
+        let filtered = internalEntries;
 
-    if (activeFilter !== "all") {
-        filtered = filtered.filter(entry =>
-            getEntryType(entry) === activeFilter
-        );
+        if (activeFilter !== "all") {
+            filtered = filtered.filter(entry =>
+                getEntryType(entry) === activeFilter
+            );
+        }
+
+        const query = searchText.trim();
+
+        if (query.length > 0) {
+            const lowerQuery = query.toLowerCase();
+            filtered = filtered.filter(entry =>
+                entry.preview.toLowerCase().includes(lowerQuery)
+            );
+        }
+
+        filtered.sort((a, b) => {
+            if (a.pinned !== b.pinned)
+                return b.pinned ? 1 : -1;
+            return b.id - a.id;
+        });
+
+        clipboardEntries = filtered;
+        unpinnedEntries = filtered.filter(e => !e.pinned);
+        pinnedEntries = filtered.filter(e => e.pinned);
+        totalCount = clipboardEntries.length;
+
+        const activeCount = Math.max(unpinnedEntries.length, pinnedEntries.length);
+
+        if (activeCount === 0) {
+            keyboardNavigationActive = false;
+            selectedIndex = 0;
+            return;
+        }
+
+        if (selectedIndex >= activeCount) {
+            selectedIndex = activeCount - 1;
+        }
     }
-
-    const query = searchText.trim();
-
-    if (query.length > 0) {
-        const lowerQuery = query.toLowerCase();
-        filtered = filtered.filter(entry =>
-            entry.preview.toLowerCase().includes(lowerQuery)
-        );
-    }
-
-    filtered.sort((a, b) => {
-        if (a.pinned !== b.pinned)
-            return b.pinned ? 1 : -1;
-        return b.id - a.id;
-    });
-
-    clipboardEntries = filtered;
-    unpinnedEntries = filtered.filter(e => !e.pinned);
-    pinnedEntries = filtered.filter(e => e.pinned);
-    totalCount = clipboardEntries.length;
-
-    const activeCount = Math.max(unpinnedEntries.length, pinnedEntries.length);
-
-    if (activeCount === 0) {
-        keyboardNavigationActive = false;
-        selectedIndex = 0;
-        return;
-    }
-
-    if (selectedIndex >= activeCount) {
-        selectedIndex = activeCount - 1;
-    }
-}
 
     function refresh() {
         if (!clipboardAvailable) {

--- a/quickshell/Services/ClipboardService.qml
+++ b/quickshell/Services/ClipboardService.qml
@@ -51,37 +51,46 @@ Singleton {
     }
 
     function updateFilteredModel() {
-        const query = searchText.trim();
-        let filtered = [];
+    let filtered = internalEntries;
 
-        if (query.length === 0) {
-            filtered = internalEntries;
-        } else {
-            const lowerQuery = query.toLowerCase();
-            filtered = internalEntries.filter(entry => entry.preview.toLowerCase().includes(lowerQuery));
-        }
-
-        filtered.sort((a, b) => {
-            if (a.pinned !== b.pinned)
-                return b.pinned ? 1 : -1;
-            return b.id - a.id;
-        });
-
-        clipboardEntries = filtered;
-        unpinnedEntries = filtered.filter(e => !e.pinned);
-        pinnedEntries = filtered.filter(e => e.pinned);
-        totalCount = clipboardEntries.length;
-
-        const activeCount = Math.max(unpinnedEntries.length, pinnedEntries.length);
-        if (activeCount === 0) {
-            keyboardNavigationActive = false;
-            selectedIndex = 0;
-            return;
-        }
-        if (selectedIndex >= activeCount) {
-            selectedIndex = activeCount - 1;
-        }
+    if (activeFilter !== "all") {
+        filtered = filtered.filter(entry =>
+            getEntryType(entry) === activeFilter
+        );
     }
+
+    const query = searchText.trim();
+
+    if (query.length > 0) {
+        const lowerQuery = query.toLowerCase();
+        filtered = filtered.filter(entry =>
+            entry.preview.toLowerCase().includes(lowerQuery)
+        );
+    }
+
+    filtered.sort((a, b) => {
+        if (a.pinned !== b.pinned)
+            return b.pinned ? 1 : -1;
+        return b.id - a.id;
+    });
+
+    clipboardEntries = filtered;
+    unpinnedEntries = filtered.filter(e => !e.pinned);
+    pinnedEntries = filtered.filter(e => e.pinned);
+    totalCount = clipboardEntries.length;
+
+    const activeCount = Math.max(unpinnedEntries.length, pinnedEntries.length);
+
+    if (activeCount === 0) {
+        keyboardNavigationActive = false;
+        selectedIndex = 0;
+        return;
+    }
+
+    if (selectedIndex >= activeCount) {
+        selectedIndex = activeCount - 1;
+    }
+}
 
     function refresh() {
         if (!clipboardAvailable) {

--- a/quickshell/Widgets/DankDropdown.qml
+++ b/quickshell/Widgets/DankDropdown.qml
@@ -49,38 +49,57 @@ Item {
     property bool alignPopupRight: false
     property int dropdownWidth: 200
     property bool compactMode: text === "" && description === ""
+    property bool showTrigger: true
+    property Item popupAnchorItem: null
     property bool addHorizontalPadding: false
     property string emptyText: ""
     property bool usePopupTransparency: !checkParentDisablesTransparency()
 
     signal valueChanged(string value)
 
+    property bool menuOpen: false
+
     function closeDropdownMenu() {
+        if (!root.menuOpen && !dropdownMenu.opened && !dropdownMenu.visible)
+            return;
+        root.menuOpen = false;
         dropdownMenu.close();
     }
 
-    function openDropdownMenu() {
-        if (dropdownMenu.visible) {
-            dropdownMenu.close();
-            return;
-        }
-        if (root.options.length === 0)
-            return;
-
-        dropdownMenu.open();
-
+    function positionDropdownMenu() {
         let currentIndex = root.options.indexOf(root.currentValue);
         listView.positionViewAtIndex(currentIndex >= 0 ? currentIndex : 0, ListView.Beginning);
 
-        const pos = dropdown.mapToItem(Overlay.overlay, 0, 0);
+        const anchorItem = root.popupAnchorItem || dropdown;
+        const pos = anchorItem.mapToItem(Overlay.overlay, 0, 0);
         const popupW = dropdownMenu.width;
         const popupH = dropdownMenu.height;
         const overlayH = Overlay.overlay.height;
-        const goUp = root.openUpwards || pos.y + dropdown.height + popupH + 4 > overlayH;
-        dropdownMenu.x = root.alignPopupRight ? pos.x + dropdown.width - popupW : pos.x - (root.popupWidthOffset / 2);
-        dropdownMenu.y = goUp ? pos.y - popupH - 4 : pos.y + dropdown.height + 4;
+        const goUp = root.openUpwards || pos.y + anchorItem.height + popupH + 4 > overlayH;
+        dropdownMenu.x = root.alignPopupRight ? pos.x + anchorItem.width - popupW : pos.x - (root.popupWidthOffset / 2);
+        dropdownMenu.y = goUp ? pos.y - popupH - 4 : pos.y + anchorItem.height + 4;
+    }
+
+    function showDropdownMenu() {
+        if (root.options.length === 0)
+            return;
+        if (root.menuOpen)
+            return;
+
+        root.menuOpen = true;
+        dropdownMenu.open();
+        positionDropdownMenu();
+
         if (root.enableFuzzySearch)
             searchField.forceActiveFocus();
+    }
+
+    function openDropdownMenu() {
+        if (root.menuOpen) {
+            closeDropdownMenu();
+            return;
+        }
+        showDropdownMenu();
     }
 
     function resetSearch() {
@@ -90,11 +109,11 @@ Item {
         dropdownMenu.selectedIndex = -1;
     }
 
-    width: compactMode ? dropdownWidth : parent.width
-    implicitHeight: compactMode ? 40 : Math.max(60, labelColumn.implicitHeight + Theme.spacingM)
+    width: !showTrigger ? 0 : (compactMode ? dropdownWidth : parent.width)
+    implicitHeight: !showTrigger ? 0 : (compactMode ? 40 : Math.max(60, labelColumn.implicitHeight + Theme.spacingM))
 
     Component.onDestruction: {
-        if (dropdownMenu.visible)
+        if (root.menuOpen || dropdownMenu.opened || dropdownMenu.visible)
             dropdownMenu.close();
     }
 
@@ -107,7 +126,7 @@ Item {
         anchors.leftMargin: root.addHorizontalPadding ? Theme.spacingM : 0
         anchors.rightMargin: Theme.spacingL
         spacing: Theme.spacingXS
-        visible: !root.compactMode
+        visible: !root.compactMode && root.showTrigger
 
         StyledText {
             text: root.text
@@ -132,6 +151,7 @@ Item {
     Rectangle {
         id: dropdown
 
+        visible: root.showTrigger
         width: root.compactMode ? parent.width : (root.popupWidth === -1 ? undefined : (root.popupWidth > 0 ? root.popupWidth : root.dropdownWidth))
         height: 40
         anchors.right: parent.right
@@ -259,6 +279,7 @@ Item {
         }
 
         onOpened: {
+            root.menuOpen = true;
             selectedIndex = -1;
             if (searchField.text.length > 0) {
                 initFinder();
@@ -268,6 +289,8 @@ Item {
                 searchQuery = "";
             }
         }
+
+        onClosed: root.menuOpen = false
 
         parent: Overlay.overlay
         width: root.popupWidth === -1 ? undefined : (root.popupWidth > 0 ? root.popupWidth : (dropdown.width + root.popupWidthOffset))

--- a/quickshell/Widgets/DankTextField.qml
+++ b/quickshell/Widgets/DankTextField.qml
@@ -35,6 +35,7 @@ StyledRect {
     property color leftIconFocusedColor: Theme.primary
     property bool showClearButton: false
     property bool showPasswordToggle: false
+    property real rightAccessoryWidth: 0
     property bool passwordVisible: false
     property bool usePopupTransparency: !checkParentDisablesTransparency()
     property color backgroundColor: usePopupTransparency ? Theme.withAlpha(Theme.surfaceContainerHigh, Theme.popupTransparency) : Theme.surfaceContainerHigh
@@ -46,7 +47,7 @@ StyledRect {
     property real cornerRadius: Theme.cornerRadius
     readonly property real leftPadding: Theme.spacingM + (leftIconName ? leftIconSize + Theme.spacingM : 0)
     readonly property real rightPadding: {
-        let p = Theme.spacingS;
+        let p = Theme.spacingS + rightAccessoryWidth;
         if (showPasswordToggle)
             p += 20 + Theme.spacingXS;
         if (showClearButton && text.length > 0)


### PR DESCRIPTION
## Description

This PR introduces the ability to filter clipboard history by entry type (Text, Long Text, and Image), exposing the existing `getEntryType()` backend classification to the frontend UI.

Currently, users with large clipboard histories must scroll extensively or rely purely on text search, which is inefficient for finding specific media like images or long text blocks. 

**Key Changes:**
* **State Management:** Added an `activeFilter` property to `ClipboardService.qml`.
* **Filtering Logic:** Modified `updateFilteredModel()` to apply the entry type filter before the search text filter and sorting logic.
* **UI Integration:** Added a `DankDropdown` to `ClipboardHeader.qml` with options for "All", "Text", "Long Text", and "Image".
* **Localization:** All new user-facing strings in the dropdown are wrapped in `I18n.tr()` with appropriate context, using array indices to ensure safe selection regardless of the active language.
* **Data Flow:** Connected the state through `ClipboardContent` and `ClipboardHistoryContent` to keep the UI perfectly synchronized with the singleton service.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

 Closes #2639

## Screenshots / video


https://github.com/user-attachments/assets/02e89b00-9418-4d25-96f1-694daf522568



## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
