### PR TITLE
fix(settings): dedupe search index tab entries

### DIFF
--- a/quickshell/translations/extract_settings_index.py
+++ b/quickshell/translations/extract_settings_index.py
@@ -452,8 +452,14 @@ def parse_tabs_from_sidebar(sidebar_file):
     return tabs
 
 
-def generate_tab_entries(sidebar_file):
+def generate_tab_entries(sidebar_file, settings_entries=None):
     tabs = parse_tabs_from_sidebar(sidebar_file)
+    settings_entries = settings_entries or []
+    highlightable_labels = {
+        (entry["tabIndex"], entry["label"])
+        for entry in settings_entries
+        if not str(entry["section"]).startswith("_tab_")
+    }
 
     label_counts = Counter([t["label"] for t in tabs])
 
@@ -465,6 +471,9 @@ def generate_tab_entries(sidebar_file):
             else tab["label"]
         )
         category = TAB_CATEGORY_MAP.get(tab["tabIndex"], "Settings")
+
+        if (tab["tabIndex"], label) in highlightable_labels:
+            continue
 
         keywords = enrich_keywords(tab["label"], None, category, [])
 
@@ -543,7 +552,7 @@ def main():
 
     print("Extracting settings search index...")
     settings_entries = extract_settings_index(root_dir)
-    tab_entries = generate_tab_entries(sidebar_file)
+    tab_entries = generate_tab_entries(sidebar_file, settings_entries)
 
     all_entries = tab_entries + settings_entries
 

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -429,6 +429,28 @@
     "description": "Automatically determine your location using your IP address"
   },
   {
+    "section": "calendarBackend",
+    "label": "Calendar Backend",
+    "tabIndex": 1,
+    "category": "Time & Weather",
+    "keywords": [
+      "backend",
+      "calendar",
+      "clock",
+      "daemon",
+      "dankcalendar",
+      "date",
+      "day",
+      "events",
+      "forecast",
+      "khal",
+      "month",
+      "time",
+      "weather",
+      "year"
+    ]
+  },
+  {
     "section": "dateFormat",
     "label": "Date Format",
     "tabIndex": 1,
@@ -1817,21 +1839,6 @@
     ],
     "icon": "rounded_corner",
     "description": "Remove corner rounding from the bar"
-  },
-  {
-    "section": "_tab_6",
-    "label": "Dank Bar",
-    "tabIndex": 6,
-    "category": "Dank Bar",
-    "keywords": [
-      "bar",
-      "dank",
-      "panel",
-      "statusbar",
-      "taskbar",
-      "topbar"
-    ],
-    "icon": "toolbar"
   },
   {
     "section": "barAppearance",
@@ -6370,25 +6377,6 @@
     "description": "Choose where on-screen displays appear on screen"
   },
   {
-    "section": "_tab_18",
-    "label": "On-screen Displays",
-    "tabIndex": 18,
-    "category": "On-screen Displays",
-    "keywords": [
-      "displays",
-      "indicator",
-      "monitor",
-      "monitors",
-      "osd",
-      "output",
-      "outputs",
-      "popup",
-      "screen",
-      "screens"
-    ],
-    "icon": "tune"
-  },
-  {
     "section": "osd",
     "label": "On-screen Displays",
     "tabIndex": 18,
@@ -6522,20 +6510,6 @@
     ],
     "icon": "tune",
     "description": "Open a terminal and run a custom command instead of the in-shell upgrade flow."
-  },
-  {
-    "section": "_tab_20",
-    "label": "System Updater",
-    "tabIndex": 20,
-    "category": "System Updater",
-    "keywords": [
-      "packages",
-      "system",
-      "updater",
-      "updates",
-      "upgrade"
-    ],
-    "icon": "refresh"
   },
   {
     "section": "systemUpdater",
@@ -7992,19 +7966,6 @@
     "description": "Reveal the arcs where surfaces meet the frame"
   },
   {
-    "section": "_tab_33",
-    "label": "Frame",
-    "tabIndex": 33,
-    "category": "Frame",
-    "keywords": [
-      "border",
-      "decoration",
-      "frame",
-      "window"
-    ],
-    "icon": "frame_source"
-  },
-  {
     "section": "frameEnabled",
     "label": "Frame",
     "tabIndex": 33,
@@ -8883,23 +8844,6 @@
     "description": "Space between windows"
   },
   {
-    "section": "_tab_38",
-    "label": "Window Rules",
-    "tabIndex": 38,
-    "category": "Applications",
-    "keywords": [
-      "applications",
-      "apps",
-      "floating",
-      "matching",
-      "programs",
-      "rules",
-      "window"
-    ],
-    "icon": "select_window",
-    "conditionKey": "windowRulesCapable"
-  },
-  {
     "section": "windowRules",
     "label": "Window Rules",
     "tabIndex": 38,
@@ -8923,19 +8867,6 @@
     "conditionKey": "windowRulesCapable"
   },
   {
-    "section": "_tab_39",
-    "label": "Ethernet",
-    "tabIndex": 39,
-    "category": "Network",
-    "keywords": [
-      "connectivity",
-      "ethernet",
-      "network",
-      "online"
-    ],
-    "icon": "settings_ethernet"
-  },
-  {
     "section": "networkEthernet",
     "label": "Ethernet",
     "tabIndex": 39,
@@ -8950,19 +8881,6 @@
       "wired"
     ],
     "icon": "settings_ethernet"
-  },
-  {
-    "section": "_tab_40",
-    "label": "WiFi",
-    "tabIndex": 40,
-    "category": "Network",
-    "keywords": [
-      "connectivity",
-      "network",
-      "online",
-      "wifi"
-    ],
-    "icon": "wifi"
   },
   {
     "section": "networkWifi",
@@ -8981,19 +8899,6 @@
       "wireless"
     ],
     "icon": "wifi"
-  },
-  {
-    "section": "_tab_41",
-    "label": "VPN",
-    "tabIndex": 41,
-    "category": "Network",
-    "keywords": [
-      "connectivity",
-      "network",
-      "online",
-      "vpn"
-    ],
-    "icon": "vpn_key"
   },
   {
     "section": "networkVpn",


### PR DESCRIPTION
## Description

Fixes duplicate entries in the settings search index.

Previously, the index generator could emit both of these for the same settings destination:

  - a sidebar tab entry, such as _tab_33 / Frame
  - a highlightable settings entry, such as frameEnabled / Frame

When both entries had the same tabIndex and label, search results showed two identical-looking items. The tab-only entry could only navigate to the tab, while the settings entry could navigate to the same tab and highlight the specific settings block, making the tab-only result redundant.

This PR updates the settings_search_index.json generation logic so sidebar tab entries are skipped when a highlightable settings entry already exists for the same tabIndex + label.

This keeps the more specific search result and removes existing redundant tab-only entries such as Frame, Dank Bar, On-screen Displays, System Updater, and Window Rules.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

before:

<img width="340" height="296" alt="Screenshot from 2026-06-15 17-25-26" src="https://github.com/user-attachments/assets/09a61bf5-455f-4993-a4f5-d5794c119285" />

after:

<img width="340" height="296" alt="Screenshot from 2026-06-15 17-26-33" src="https://github.com/user-attachments/assets/983e2ea4-6106-4e25-b046-1b286c114ecf" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
