### PR TITLE
fix(keybinds): record numpad keys as KP_* keysyms

### DIFF
--- a/quickshell/Common/KeyUtils.js
+++ b/quickshell/Common/KeyUtils.js
@@ -126,7 +126,40 @@ const KEY_MAP = {
     161: "exclamdown"
 };
 
-function xkbKeyFromQtKey(qk) {
+// Numpad (keypad) keys. Qt reuses the same Qt::Key_* values for the numpad and
+// the main rows/nav cluster; only Qt.KeypadModifier distinguishes them. niri and
+// the other compositors bind against the xkb KP_* keysym names, so we must emit
+// those instead of the collapsed twin. With NumLock off the numpad sends the
+// navigation keysyms (KP_Home, KP_End, ...); with NumLock on it sends KP_0..KP_9
+// (handled by the digit range in xkbKeyFromQtKey). Operators/Enter are the same
+// in both states.
+const KP_MAP = {
+    16777232: "KP_Home",
+    16777235: "KP_Up",
+    16777238: "KP_Prior",
+    16777234: "KP_Left",
+    16777227: "KP_Begin",
+    16777236: "KP_Right",
+    16777233: "KP_End",
+    16777237: "KP_Down",
+    16777239: "KP_Next",
+    16777222: "KP_Insert",
+    16777223: "KP_Delete",
+    16777221: "KP_Enter",
+    43: "KP_Add",
+    45: "KP_Subtract",
+    42: "KP_Multiply",
+    47: "KP_Divide",
+    46: "KP_Decimal"
+};
+
+function xkbKeyFromQtKey(qk, isKeypad) {
+    if (isKeypad) {
+        if (qk >= 48 && qk <= 57)
+            return "KP_" + (qk - 48);
+        if (KP_MAP[qk])
+            return KP_MAP[qk];
+    }
     if (qk >= 65 && qk <= 90)
         return String.fromCharCode(qk);
     if (qk >= 97 && qk <= 122)

--- a/quickshell/Widgets/KeybindItem.qml
+++ b/quickshell/Widgets/KeybindItem.qml
@@ -698,6 +698,12 @@ Item {
                             case Qt.Key_Shift:
                             case Qt.Key_Alt:
                             case Qt.Key_Meta:
+                            // Lock keys are toggles, not useful bind targets; ignore
+                            // them so toggling NumLock to pick the numpad keysym
+                            // (KP_7 vs KP_Home) doesn't get captured as the bind.
+                            case Qt.Key_NumLock:
+                            case Qt.Key_CapsLock:
+                            case Qt.Key_ScrollLock:
                                 return;
                             }
 

--- a/quickshell/Widgets/KeybindItem.qml
+++ b/quickshell/Widgets/KeybindItem.qml
@@ -720,7 +720,7 @@ Item {
                                     mods.push("Shift");
                             }
 
-                            const key = KeyUtils.xkbKeyFromQtKey(qtKey);
+                            const key = KeyUtils.xkbKeyFromQtKey(qtKey, !!(event.modifiers & Qt.KeypadModifier));
                             if (!key) {
                                 log.warn("Unknown key:", event.key, "mods:", event.modifiers);
                                 return;


### PR DESCRIPTION
## Description

The keyboard-shortcut recorder captured numpad keys as their main-row / navigation twins, so numpad binds never matched the physical key in niri (and the other providers).

`captureScope`'s `Keys.onPressed` (`Widgets/KeybindItem.qml`) passed only `event.key` to `KeyUtils.xkbKeyFromQtKey`, discarding `Qt.KeypadModifier`. Qt reuses the same `Qt::Key_*` values for the numpad and the main row / nav cluster, so without the keypad bit the recorder could not tell them apart:

- numpad-7 → `7` (NumLock on) or `Home` (NumLock off) instead of `KP_7` / `KP_Home`
- numpad-`+` → `Equal`, numpad-`*` → `8`, numpad Enter → `Return`
- numpad-5 with NumLock off (`Qt.Key_Clear`) was missing from the map entirely, so the capture was silently dropped (journal WARN only, no UI feedback)

The compositors bind against the xkb `KP_*` keysym names, so these tokens never matched the physical key — exactly the report in #2636.

**Commit 1** threads the keypad flag through to `xkbKeyFromQtKey` and maps keypad presses to the `KP_*` keysyms: `KP_0`..`KP_9` for the NumLock-on digit codes, the navigation names (`KP_Home`, `KP_End`, `KP_Up`, …) for the NumLock-off codes, plus the operators and `KP_Enter`. Main-row keys are untouched because they never carry the keypad modifier.

**Commit 2** ignores the lock keys (NumLock/CapsLock/ScrollLock) during capture, like the other pure modifier keys already are — pressing NumLock to switch the numpad between its digit and navigation keysyms was otherwise captured as the bind itself (`Super+Num_Lock`).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes #2636

## Screenshots / video

n/a — the change only affects which keysym string the recorder produces; there is no visual change.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally on niri: numpad-7 → `KP_Home` (NumLock off) / `KP_7` (NumLock on), numpad-`+` → `KP_Add`, numpad-`*` → `KP_Multiply`, numpad Enter → `KP_Enter`, numpad-5 → `KP_Begin`; `Super+KP_7` (NumLock on) binds and fires; main-row keys unchanged; NumLock no longer captured as a bind
- [ ] QML changes: ran `make lint-qml` — could not generate the `.qmlls.ini` tooling VFS without launching a second shell instance on the live session. Instead verified the patched files load in the running shell with no QML errors and unit-checked the `xkbKeyFromQtKey` mapping. Happy to attach a `make lint-qml` run if a maintainer prefers.
- [x] No new user-facing strings (no `I18n.tr()` needed)
- [x] No Go changes
