### PR TITLE
add lexical-binding to emacs theme

### DIFF
--- a/quickshell/matugen/templates/dank-emacs.el
+++ b/quickshell/matugen/templates/dank-emacs.el
@@ -1,4 +1,4 @@
-;;; dank-emacs-theme.el --- Enhanced theme using Matugen SCSS variables with dank16 colors
+;;; dank-emacs-theme.el --- Enhanced theme using Matugen SCSS variables with dank16 colors -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2025
 


### PR DESCRIPTION
## Description

Adds lexical-binding to Emacs theme to stop Emacs compiler from complaining about lexical-binding not being present.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [x] Other

## Related issues

## Screenshots / video

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [x] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
