### PR TITLE
feat(sounds): make muting sounds during media playback configurable

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -572,6 +572,7 @@ Singleton {
     property bool soundVolumeChanged: true
     property bool soundPluggedIn: true
     property bool soundLogin: false
+    property bool muteSoundsWhenMediaPlaying: true
 
     property int acMonitorTimeout: 0
     property int acLockTimeout: 0

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -282,6 +282,7 @@ var SPEC = {
     soundNewNotification: { def: true },
     soundVolumeChanged: { def: true },
     soundPluggedIn: { def: true },
+    muteSoundsWhenMediaPlaying: { def: true },
 
     acMonitorTimeout: { def: 0 },
     acLockTimeout: { def: 0 },

--- a/quickshell/Modules/Settings/SoundsTab.qml
+++ b/quickshell/Modules/Settings/SoundsTab.qml
@@ -131,6 +131,23 @@ Item {
                         checked: SettingsData.soundPluggedIn
                         onToggled: checked => SettingsData.set("soundPluggedIn", checked)
                     }
+
+                    Rectangle {
+                        width: parent.width
+                        height: 1
+                        color: Theme.outline
+                        opacity: 0.2
+                    }
+
+                    SettingsToggleRow {
+                        tab: "sounds"
+                        tags: ["sound", "media", "playback", "mute", "mpris", "music"]
+                        settingKey: "muteSoundsWhenMediaPlaying"
+                        text: I18n.tr("Mute During Playback")
+                        description: I18n.tr("Silence system sounds while media is playing")
+                        checked: SettingsData.muteSoundsWhenMediaPlaying
+                        onToggled: checked => SettingsData.set("muteSoundsWhenMediaPlaying", checked)
+                    }
                 }
             }
 

--- a/quickshell/Services/AudioService.qml
+++ b/quickshell/Services/AudioService.qml
@@ -589,38 +589,42 @@ EOFCONFIG
         return MprisController.activePlayer?.isPlaying ?? false;
     }
 
+    function shouldMuteForMedia() {
+        return SettingsData.muteSoundsWhenMediaPlaying && isMediaPlaying();
+    }
+
     function playVolumeChangeSound() {
-        if (!soundsAvailable || !volumeChangeSound || notificationsAudioMuted || isMediaPlaying())
+        if (!soundsAvailable || !volumeChangeSound || notificationsAudioMuted || shouldMuteForMedia())
             return;
         volumeChangeSound.play();
     }
 
     function playPowerPlugSound() {
-        if (!soundsAvailable || !powerPlugSound || notificationsAudioMuted || isMediaPlaying())
+        if (!soundsAvailable || !powerPlugSound || notificationsAudioMuted || shouldMuteForMedia())
             return;
         powerPlugSound.play();
     }
 
     function playPowerUnplugSound() {
-        if (!soundsAvailable || !powerUnplugSound || notificationsAudioMuted || isMediaPlaying())
+        if (!soundsAvailable || !powerUnplugSound || notificationsAudioMuted || shouldMuteForMedia())
             return;
         powerUnplugSound.play();
     }
 
     function playNormalNotificationSound() {
-        if (!soundsAvailable || !normalNotificationSound || SessionData.doNotDisturb || notificationsAudioMuted || isMediaPlaying())
+        if (!soundsAvailable || !normalNotificationSound || SessionData.doNotDisturb || notificationsAudioMuted || shouldMuteForMedia())
             return;
         normalNotificationSound.play();
     }
 
     function playCriticalNotificationSound() {
-        if (!soundsAvailable || !criticalNotificationSound || SessionData.doNotDisturb || notificationsAudioMuted || isMediaPlaying())
+        if (!soundsAvailable || !criticalNotificationSound || SessionData.doNotDisturb || notificationsAudioMuted || shouldMuteForMedia())
             return;
         criticalNotificationSound.play();
     }
 
     function playLoginSound() {
-        if (!soundsAvailable || !loginSound || notificationsAudioMuted || isMediaPlaying()) {
+        if (!soundsAvailable || !loginSound || notificationsAudioMuted || shouldMuteForMedia()) {
             return;
         }
         loginSound.play();


### PR DESCRIPTION
Closes #2616

## Problem

Commit e3dbaed ("audio: disable effects when mpris player is playing") added an `isMediaPlaying()` check to every sound function in `AudioService.qml`, so all system sounds — notifications, volume, power, login — are skipped whenever an MPRIS player is playing. There is no way to opt out.

Users who rely on notification sounds while listening to music lost them entirely, with no setting to restore the previous behaviour.

## Fix

Add a `Mute During Playback` toggle backed by `SettingsData.muteSoundsWhenMediaPlaying`:

- **Default `true`**, so the current behaviour is preserved for everyone.
- When disabled, system sounds play again even while media is playing — the behaviour requested in the issue.

The media check is wrapped in a small helper so the gate is applied consistently across all sound functions:

```qml
function shouldMuteForMedia() {
    return SettingsData.muteSoundsWhenMediaPlaying && isMediaPlaying();
}
```

Each `play*Sound()` function now calls `shouldMuteForMedia()` instead of `isMediaPlaying()` directly.

## Changes

- `Common/SettingsData.qml` — new `muteSoundsWhenMediaPlaying` property (default `true`)
- `Common/settings/SettingsSpec.js` — persistence spec entry
- `Services/AudioService.qml` — `shouldMuteForMedia()` helper, used by all sound functions
- `Modules/Settings/SoundsTab.qml` — `Mute During Playback` toggle in the System Sounds card

## Testing

Verified live on niri:

| Toggle | Media playing | Notification sound |
|--------|---------------|--------------------|
| On (default) | yes | silent |
| Off | yes | plays |

## Note

`translations/settings_search_index.json` is left untouched. It is a generated file and is already out of sync with the current sources (regenerating it on a clean checkout produces an unrelated ~50-line diff), so regenerating here would mix in churn unrelated to this change. Happy to include a regenerated index if you prefer it handled in this PR.