### PR TITLE
fix(lock): dismiss fade-to-lock overlay when using a custom lock command

### DIFF
--- a/quickshell/DMSShell.qml
+++ b/quickshell/DMSShell.qml
@@ -116,6 +116,12 @@ Item {
                         fadeWindowLoader.item.cancelFade();
                     }
                 }
+
+                function onDismissFadeToLock() {
+                    if (fadeWindowLoader.item) {
+                        fadeWindowLoader.item.dismiss();
+                    }
+                }
             }
         }
     }

--- a/quickshell/Modules/Lock/Lock.qml
+++ b/quickshell/Modules/Lock/Lock.qml
@@ -60,6 +60,10 @@ Scope {
     function lock() {
         if (SettingsData.customPowerActionLock?.length > 0) {
             Quickshell.execDetached(["sh", "-c", SettingsData.customPowerActionLock]);
+            // The custom locker manages its own surface; DMS never engages
+            // WlSessionLock here, so isShellLocked stays false and the fade
+            // overlay would never be dismissed. Hand off by dismissing it now.
+            IdleService.dismissFadeToLock();
             return;
         }
         if (shouldLock || pendingLock)

--- a/quickshell/Services/IdleService.qml
+++ b/quickshell/Services/IdleService.qml
@@ -53,6 +53,7 @@ Singleton {
     signal lockRequested
     signal fadeToLockRequested
     signal cancelFadeToLock
+    signal dismissFadeToLock
     signal fadeToDpmsRequested
     signal cancelFadeToDpms
     signal requestMonitorOff


### PR DESCRIPTION
## Summary

Fixes #2595.

With a **custom lock command** configured (e.g. `hyprlock`, or `/bin/true`) **and** fade-to-lock enabled, the auto-lock fade animates to full black but the `FadeToLockWindow` is never dismissed. The screen stays completely black and the desktop is unusable after re-login; only a `dms` restart or the next fade cycle clears it. `dms ipc lock unlock` / `forceReset` don't dismiss it either.

## Root cause

Regression from b8f4c35, which added the `_completed` guard (making `cancelFade()` a no-op once the fade has completed) and tied the overlay's dismissal **solely** to `IdleService.isShellLocked` transitioning `true → false` (`FadeToLockWindow.qml`):

```qml
Connections {
    target: IdleService
    function onIsShellLockedChanged() {
        if (!IdleService.isShellLocked && root._completed)
            root.dismiss();
    }
}
```

But `Lock.lock()` returns early in the custom-lock-command branch, **before** it ever sets `shouldLock = true`:

```qml
function lock() {
    if (SettingsData.customPowerActionLock?.length > 0) {
        Quickshell.execDetached(["sh", "-c", SettingsData.customPowerActionLock]);
        return;
    }
    ...
    shouldLock = true;
}
```

`isShellLocked` is only ever written from `shouldLock`, so with a custom locker it never becomes `true`, the `true → false` transition never happens, and the completed black overlay is never torn down.

## Fix

In the custom-command branch DMS hands lock responsibility off to the external locker, so it must also tear down its own fade overlay there. Add a dedicated `dismissFadeToLock` signal — mirroring the existing `fadeToLockRequested` / `cancelFadeToLock` wiring — that the custom-lock branch emits after launching the locker:

- `IdleService.qml`: new `signal dismissFadeToLock`
- `Lock.qml`: emit it in the custom-command branch after `execDetached`
- `DMSShell.qml`: `onDismissFadeToLock` → `fadeWindowLoader.item.dismiss()`

The built-in `WlSessionLock` path is unchanged and still dismisses the overlay on unlock via `isShellLocked`.

## Testing

Reproduced and verified on niri (3 outputs) with `/bin/true` as the custom lock command and a short lock timeout. Traced the full chain end to end: idle → `startFade` → fade completes → custom command fires → `dismissFadeToLock` → `dismiss()`. The overlay is now torn down (desktop returns) instead of staying black. The `dismiss()` step is exactly what never ran before. Built-in lock path re-checked and unaffected.

## Notes / accepted trade-offs

- There may be a brief flash before an external locker (e.g. hyprlock) maps its own surface. This is inherent to handing off to an external locker — DMS has no handle on the locker's surface — and is not a regression; it's strictly better than the previous permanent black screen. A timer delay would not reliably help without an IPC handshake to the locker.
- A no-op locker such as `/bin/true` leaves the session unlocked after the overlay is dismissed. That is the user's configuration (it never locked anything); the fix turns a stuck black screen into a usable desktop.
- `FadeToDpmsWindow` has no analogous `dismiss()`, but it has no analogous bug: there is no custom-command branch in the DPMS path and the DPMS fade is always released by `requestMonitorOn`.
