### PR TITLE
fix(shell): don't treat DPMS off/on as a screen-reconnect recovery storm

### DIFF
--- a/quickshell/DMSShell.qml
+++ b/quickshell/DMSShell.qml
@@ -323,6 +323,9 @@ Item {
 
     property bool hadRealScreen: true
     property var previousRealScreenNames: []
+    // Guards for the screen-reconnect recovery path (see scheduleScreenReconnectRecovery).
+    property bool _screenRecoveryCooldown: false
+    property bool _screenRecoveryPending: false
 
     function _getRealScreenNames() {
         const names = [];
@@ -365,12 +368,57 @@ Item {
             const partialReconnect = root.previousRealScreenNames.length > 0
                 && currentNames.some(name => !root.previousRealScreenNames.includes(name));
             if (fullReconnect || partialReconnect) {
-                log.info("Screen reconnect detected, triggering surface recovery",
+                log.info("Screen reconnect detected, scheduling surface recovery",
                          "full:", fullReconnect, "partial:", partialReconnect);
-                root.triggerSurfaceRecovery("screen-reconnect");
+                root.scheduleScreenReconnectRecovery();
             }
             root.hadRealScreen = hasReal;
             root.previousRealScreenNames = currentNames;
+        }
+    }
+
+    // A DPMS off/on cycle removes an output from the screen list and re-adds it,
+    // which is indistinguishable here from a hotplug. Recovering immediately on
+    // every such event lets a flapping monitor (or a recovery that itself perturbs
+    // the output) drive an endless recovery storm that power-cycles the display
+    // (#2642). Debounce a burst of changes into a single pass, then hold a cooldown
+    // so repeated flaps trigger at most one recovery per window. Recovery still runs
+    // once per resume, so a partial DPMS resume keeps redrawing its surfaces (#2579).
+    function scheduleScreenReconnectRecovery() {
+        if (root._screenRecoveryCooldown) {
+            root._screenRecoveryPending = true;
+            return;
+        }
+        screenReconnectDebounce.restart();
+    }
+
+    Timer {
+        id: screenReconnectDebounce
+        // Wide enough to collapse the output-remove + output-re-add pair that one
+        // DPMS off/on cycle emits as two near-simultaneous events into one recovery.
+        interval: 450
+        repeat: false
+        onTriggered: {
+            root._screenRecoveryCooldown = true;
+            root._screenRecoveryPending = false;
+            screenReconnectCooldown.restart();
+            root.triggerSurfaceRecovery("screen-reconnect");
+        }
+    }
+
+    Timer {
+        id: screenReconnectCooldown
+        // Must exceed the full two-pass surfaceResumeRecoveryTimer sequence
+        // (800 + 2000 ms) so the cooldown still covers an in-flight recovery;
+        // raise this if those passes are lengthened.
+        interval: 4000
+        repeat: false
+        onTriggered: {
+            root._screenRecoveryCooldown = false;
+            if (root._screenRecoveryPending) {
+                root._screenRecoveryPending = false;
+                screenReconnectDebounce.restart();
+            }
         }
     }
 
@@ -1002,6 +1050,14 @@ Item {
             root.pendingOsdResumeReloads = 2;
             osdResumeRecreateTimer.interval = 400;
             osdResumeRecreateTimer.restart();
+
+            // This path runs its own recovery directly, so drop any queued or
+            // in-flight screen-reconnect recovery to avoid a redundant pass once
+            // its cooldown expires.
+            screenReconnectDebounce.stop();
+            screenReconnectCooldown.stop();
+            root._screenRecoveryCooldown = false;
+            root._screenRecoveryPending = false;
 
             root.triggerSurfaceRecovery("sessionResumed");
         }


### PR DESCRIPTION
## Problem

On Hyprland, a DPMS off/on cycle removes an output from `Quickshell.screens` and immediately re-adds it. `DMSShell`'s `onScreensChanged` cannot distinguish that from a real hotplug, so the `partialReconnect`/`fullReconnect` branch fires `triggerSurfaceRecovery("screen-reconnect")` on **every** such event.

On hardware where recreating layer-shell surfaces re-wakes the just-powered-down output, that emits another output-remove/re-add, which triggers another recovery — a self-reinforcing loop that visibly power-cycles the monitor. Reported in #2642 (logs there show the `Screens changed → reconnect → recovery pass 1/2` block repeating).

## Root cause

`quickshell/DMSShell.qml` → `onScreensChanged` called recovery synchronously and unthrottled. A single DPMS cycle already emits the output-remove and output-re-add as two near-simultaneous events, and a flapping/looping output emits many more.

## Fix

Route the screen-reconnect path through `scheduleScreenReconnectRecovery()`:

- a **450 ms debounce** collapses the remove + re-add pair (and any burst) from one cycle into a single recovery;
- a **4 s cooldown** (longer than the full two-pass `surfaceResumeRecoveryTimer` sequence, 800 + 2000 ms) caps repeated flaps at **at most one recovery per window**; a pending flag fires exactly one follow-up if a flap arrived during the cooldown.

`triggerSurfaceRecovery()` and the 2-pass timer are unchanged.

### Preserves #2579

The `partialReconnect` detection was added in #2579 so a partial DPMS resume still recovers the external monitor. This change keeps firing recovery **once per resume** — it only coalesces/rate-limits, it never skips. The `onSessionResumed` path still runs its own recovery directly and now clears any queued screen-reconnect recovery so it can't fire a redundant follow-up after the cooldown.

## Verification

Reproduced on Hyprland by flapping an output (`hyprctl output remove`/`create`), which produces the same `Screens changed → reconnect → recovery` sequence as the report:

- **Single flap:** still exactly 1 recovery (1 schedule → 1 trigger → 2 passes) — #2579 behavior intact.
- **Identical 5-flap storm:** 4 recoveries before → 2 after; under sub-second real flaps all fall in one cooldown window → effectively 1.

QML reloads cleanly (no errors).

## Trade-offs

- The intervals (450 ms / 4 s) are heuristics; both are commented inline, and the 4 s lower bound is tied to the recovery sequence length.
- A genuinely *distinct* second reconnect (e.g. a real hotplug arriving within 4 s of a DPMS resume) is coalesced into the same window — it still recovers, just batched rather than as a separate immediate pass. This seemed the right bias given the storm it prevents.