### PR TITLE
fix(popouts): keep Hyprland focus during close

### DIFF
--- a/quickshell/Widgets/DankPopout.qml
+++ b/quickshell/Widgets/DankPopout.qml
@@ -63,7 +63,7 @@ Item {
                 list.push(root.backgroundWindow);
             return list.concat(KeyboardFocus.barWindows);
         }
-        active: KeyboardFocus.wantsGrab(root.shouldBeVisible, root.customKeyboardFocus)
+        active: KeyboardFocus.wantsGrab(root.shouldBeVisible || root.isClosing, root.customKeyboardFocus)
     }
 
     Loader {

--- a/quickshell/Widgets/DankPopoutConnected.qml
+++ b/quickshell/Widgets/DankPopoutConnected.qml
@@ -493,8 +493,8 @@ Item {
         interval: Theme.variantCloseInterval(animationDuration)
         onTriggered: {
             if (!shouldBeVisible) {
-                isClosing = false;
                 contentWindow.visible = false;
+                isClosing = false;
                 PopoutManager.hidePopout(popoutHandle);
                 popoutClosed();
             }
@@ -782,7 +782,7 @@ Item {
         WlrLayershell.namespace: root.layerNamespace
         WlrLayershell.layer: root.effectivePopoutLayer
         WlrLayershell.exclusiveZone: -1
-        WlrLayershell.keyboardFocus: KeyboardFocus.keyboardFocus(shouldBeVisible, customKeyboardFocus)
+        WlrLayershell.keyboardFocus: KeyboardFocus.keyboardFocus(shouldBeVisible || isClosing, customKeyboardFocus)
 
         readonly property bool _fullHeight: root.fullHeightSurface
         anchors {

--- a/quickshell/Widgets/DankPopoutStandalone.qml
+++ b/quickshell/Widgets/DankPopoutStandalone.qml
@@ -376,9 +376,9 @@ Item {
         interval: Theme.variantCloseInterval(animationDuration)
         onTriggered: {
             if (!shouldBeVisible) {
-                isClosing = false;
                 contentWindow.visible = false;
                 backgroundWindow.visible = false;
+                isClosing = false;
                 PopoutManager.hidePopout(popoutHandle);
                 popoutClosed();
             }
@@ -607,7 +607,7 @@ Item {
         WlrLayershell.namespace: root.layerNamespace
         WlrLayershell.layer: root.effectivePopoutLayer
         WlrLayershell.exclusiveZone: -1
-        WlrLayershell.keyboardFocus: KeyboardFocus.keyboardFocus(shouldBeVisible, customKeyboardFocus)
+        WlrLayershell.keyboardFocus: KeyboardFocus.keyboardFocus(shouldBeVisible || isClosing, customKeyboardFocus)
 
         anchors {
             left: true


### PR DESCRIPTION
## Description

Fixes a Hyprland focus regression when closing popouts such as Control Center with Escape. The popout layer surface was dropping `OnDemand` keyboard focus and the Hyprland focus grab as soon as `shouldBeVisible` became false, while the surface stayed mapped for its close animation. Hyprland could then report the previous client as active, but keyboard input would not be delivered to it until another real window focus transition occurred.

This keeps the popout keyboard focus/grab active through the close animation and releases it only after the popout surface is unmapped.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues


## Screenshots / video

N/A, no visual change.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs

Notes:

- No user-facing strings were added.
- No Go files were changed.
- No documentation PR is needed because this fixes existing focus behavior without adding user-facing behavior.

Local validation:

- `git diff --check origin/master..HEAD`
- `make lint-qml`
- Reproduced and verified on Hyprland with a local DMS instance: opened a temporary kitty, toggled Control Center via `dms ipc call control-center toggle`, sent Escape with `wtype`, waited for close, then verified typed input reached the original kitty.
