### PR TITLE
fix(bar): clear blur region when the bar is hidden (auto-hide)

### DIFF
--- a/quickshell/Modules/DankBar/DankBarWindow.qml
+++ b/quickshell/Modules/DankBar/DankBarWindow.qml
@@ -150,6 +150,9 @@ PanelWindow {
         function onUsesFrameBarChromeChanged() {
             _blurRebuildTimer.restart();
         }
+        function onBarRevealedChanged() {
+            _blurRebuildTimer.restart();
+        }
     }
 
     Component {
@@ -175,6 +178,13 @@ PanelWindow {
         function rebuild() {
             teardown();
             if (!BlurService.enabled || !BlurService.available)
+                return;
+            // When the bar is hidden (auto-hide, or config not visible) keep the blur
+            // region empty rather than sliding it off-surface. Some compositors (Hyprland)
+            // gate blur on a non-empty region and then blur the whole surface box when the
+            // clip degenerates to empty, leaving the bar strip blurred while the bar is
+            // hidden (issue #2656). A null region disables the effect cleanly.
+            if (!barWindow.barRevealed)
                 return;
             // In frame mode, FrameWindow owns the blur region for the entire screen edge
             // (including the bar area). The bar must not set its own competing blur region


### PR DESCRIPTION
## Summary

Fixes #2656.

When a bar with background transparency + blur uses **auto-hide**, the blur effect stays applied to the bar's strip even while the bar is hidden, on Hyprland (with `ext-background-effect-v1`).

## Root cause

On auto-hide the bar's `ext-background-effect-v1` blur region was only slid off-surface via the reveal `Translate` (`topBarSlide.x/y` added to the region geometry), but the `Region` object itself stayed **non-empty**.

Hyprland gates layer-surface blur on `!m_blurRegion.empty()` (`shouldBlur` in `Renderer.cpp`), so a non-empty region keeps blur enabled. The renderer then intersects the region with the surface box (`OpenGL.cpp`); for an off-surface region that intersection degenerates to an **empty** clip, and an empty clip region is treated as *unclipped* — so the blurred background is drawn over the **entire bar surface box**, i.e. exactly "the area where the bar would be".

niri clips correctly, so the bug never reproduced there — this is why it's Hyprland-specific.

## Fix

Gate the published blur region on `barRevealed`: in `barBlur.rebuild()`, tear the region down (set it to `null`) whenever the bar is not currently shown, and rebuild on `barRevealedChanged`. A genuinely empty/`null` region makes the compositor disable the effect cleanly instead of relying on pushing a non-empty region out of bounds. This also covers bars with `visible: false`.

## Trade-off (intentional)

The region is cleared as soon as the bar *starts* hiding rather than after the slide-out animation finishes. Keeping a non-empty region alive during the off-surface slide is precisely what triggers the Hyprland whole-surface blur, so clearing immediately is deliberate. On clipping-correct compositors this means a translucent bar loses its backdrop blur for the ~150–300 ms slide-out; the reveal/slide-in direction is unaffected and blur tracks the bar in.

## Testing

Reproduced and verified on a Hyprland VM running `hyprland-git` (so `ext-background-effect-v1` is available, matching the reporter), with blur enabled, bar transparency 45 %, and auto-hide on:

![before/after](https://github.com/Rocho-EL-Locho/DankMaterialShell/raw/assets/2656-blur-when-hidden.png)

- **Before**, bar hidden → blurred strip where the bar would be (the bug).
- **After**, bar hidden → strip is crisp, no blur.
- Bar shown → bar + backdrop blur, correct both before and after (no regression).
