### PR TITLE
fix(clipboard): paste selected history entry

### DIFF
--- a/quickshell/Modals/Clipboard/ClipboardEditor.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEditor.qml
@@ -15,6 +15,12 @@ Item {
     property var entry: null
     property string editorText: ""
 
+    function releaseTextInputFocus() {
+        if (editField) {
+            editField.focus = false;
+        }
+    }
+
     function decodeEntryData(data) {
         if (!data) {
             return "";

--- a/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
@@ -61,16 +61,46 @@ FocusScope {
         }
     }
 
+    function releaseTextInputFocus() {
+        // Drop text-input focus before hiding the Wayland surface.
+        if (searchField) {
+            searchField.setFocus(false);
+        }
+        if (editorView) {
+            editorView.releaseTextInputFocus();
+        }
+        root.forceActiveFocus();
+    }
+
+    function requestClose(instant) {
+        releaseTextInputFocus();
+        if (instant) {
+            root.instantCloseRequested();
+        } else {
+            root.closeRequested();
+        }
+    }
+
     function hide() {
-        closeRequested();
+        requestClose(false);
     }
 
     function pasteSelected() {
-        ClipboardService.pasteSelected(() => root.instantCloseRequested());
+        const entry = selectedEntry();
+        if (!entry)
+            return;
+        ClipboardService.pasteEntry(entry, () => root.requestClose(true));
     }
 
     function copyEntry(entry) {
-        ClipboardService.copyEntry(entry, () => root.closeRequested());
+        ClipboardService.copyEntry(entry, () => root.requestClose(false));
+    }
+
+    function selectedEntry() {
+        const entries = activeTab === "saved" ? pinnedEntries : unpinnedEntries;
+        if (!entries || entries.length === 0 || selectedIndex < 0 || selectedIndex >= entries.length)
+            return null;
+        return entries[selectedIndex];
     }
 
     function deleteEntry(entry) {

--- a/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
@@ -45,8 +45,22 @@ DankModal {
         });
     }
 
+    function releaseTextInputFocus() {
+        contentLoader.item?.releaseTextInputFocus();
+    }
+
     function hide() {
-        close();
+        releaseTextInputFocus();
+        Qt.callLater(function () {
+            clipboardHistoryModal.close();
+        });
+    }
+
+    function instantHide() {
+        releaseTextInputFocus();
+        Qt.callLater(function () {
+            clipboardHistoryModal.instantClose();
+        });
     }
 
     onDialogClosed: {
@@ -68,6 +82,11 @@ DankModal {
     enableShadow: true
     closeOnEscapeKey: (contentLoader.item?.mode ?? "history") !== "editor"
     onBackgroundClicked: hide()
+    onShouldBeVisibleChanged: {
+        if (!shouldBeVisible) {
+            releaseTextInputFocus();
+        }
+    }
 
     Ref {
         service: ClipboardService
@@ -112,7 +131,7 @@ DankModal {
         ClipboardHistoryContent {
             clearConfirmDialog: clearConfirmDialog
             onCloseRequested: clipboardHistoryModal.hide()
-            onInstantCloseRequested: clipboardHistoryModal.instantClose()
+            onInstantCloseRequested: clipboardHistoryModal.instantHide()
         }
     }
 }

--- a/quickshell/Modals/Clipboard/ClipboardHistoryPopout.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryPopout.qml
@@ -37,8 +37,15 @@ DankPopout {
         });
     }
 
+    function releaseTextInputFocus() {
+        contentLoader.item?.releaseTextInputFocus();
+    }
+
     function hide() {
-        close();
+        releaseTextInputFocus();
+        Qt.callLater(function () {
+            root.close();
+        });
     }
 
     function clearAll() {
@@ -57,6 +64,7 @@ DankPopout {
 
     onShouldBeVisibleChanged: {
         if (!shouldBeVisible) {
+            releaseTextInputFocus();
             return;
         }
         if (clipboardAvailable) {
@@ -134,7 +142,7 @@ DankPopout {
 
             clearConfirmDialog: clearConfirmDialog
             onCloseRequested: root.hide()
-            onInstantCloseRequested: root.close()
+            onInstantCloseRequested: root.hide()
 
             Component.onCompleted: {
                 activeTab = root.activeTab;

--- a/quickshell/Services/ClipboardService.qml
+++ b/quickshell/Services/ClipboardService.qml
@@ -39,6 +39,9 @@ Singleton {
 
     Process {
         id: wtypeProcess
+        // TODO: This is only a paste shortcut fallback. It assumes the target
+        // application accepts Ctrl+V, which is false for many terminals.
+        // Replace with a more reliable target-aware paste strategy.
         command: ["wtype", "-M", "ctrl", "-P", "v", "-p", "v", "-m", "ctrl"]
         running: false
     }

--- a/quickshell/Services/PopoutService.qml
+++ b/quickshell/Services/PopoutService.qml
@@ -480,7 +480,7 @@ Singleton {
     }
 
     function closeClipboardHistory() {
-        clipboardHistoryModal?.close();
+        clipboardHistoryModal?.hide();
     }
 
     function unloadClipboardHistoryPopout() {


### PR DESCRIPTION
## Description

Fixes an issue where pasting from clipboard history with Enter/Shift+Enter could always paste the first history entry. The paste action now uses the actually selected item in the active tab.

Also releases text input focus before closing the clipboard modal/popout to avoid Wayland text-input warning logs.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

fix #2474

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
