### PR TITLE
fix(dropdown): respect Animation Duration setting for DankDropdown popups

### DIFF
--- a/quickshell/Widgets/DankDropdown.qml
+++ b/quickshell/Widgets/DankDropdown.qml
@@ -289,6 +289,40 @@ Item {
         dim: false
         closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
+        enter: Transition {
+            NumberAnimation {
+                property: "scale"
+                from: 0.9
+                to: 1
+                duration: Theme.shortDuration
+                easing.type: Theme.emphasizedEasing
+            }
+            NumberAnimation {
+                property: "opacity"
+                from: 0
+                to: 1
+                duration: Theme.shortDuration
+                easing.type: Theme.standardEasing
+            }
+        }
+
+        exit: Transition {
+            NumberAnimation {
+                property: "scale"
+                from: 1
+                to: 0.9
+                duration: Theme.shortDuration
+                easing.type: Theme.emphasizedEasing
+            }
+            NumberAnimation {
+                property: "opacity"
+                from: 1
+                to: 0
+                duration: Theme.shortDuration
+                easing.type: Theme.standardEasing
+            }
+        }
+
         background: Rectangle {
             color: "transparent"
         }


### PR DESCRIPTION
DankDropdown popups opened and closed at a fixed speed regardless of the configured Animation Duration (Settings → Typography & Motion).

### Cause
`shell.qml` sets `QT_QUICK_CONTROLS_STYLE=Material`, so the dropdown's `Popup` inherited Qt Material's default `enter`/`exit` transitions, whose durations are hardcoded (~220 ms scale / 150 ms opacity) and never reference `Theme.shortDuration`.

### Fix
Override `enter`/`exit` with theme-driven transitions that keep the Material grow/fade look (scale + opacity) but read their duration from `Theme.shortDuration`. This applies to every `DankDropdown` instance across the shell.

Easing follows the existing house pattern for scale+fade transitions (e.g. `Modals/Clipboard/ClipboardHistoryContent.qml`): scale → `emphasizedEasing`, opacity → `standardEasing`. Enter/exit durations are kept symmetric, matching the default Material variant used by `DankPopoutStandalone`/`DankModalStandalone`.

Fixes #2659
