### PR TITLE
feat(bar): add visual indication for connected bluetooth

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/ControlCenterButton.qml
+++ b/quickshell/Modules/DankBar/Widgets/ControlCenterButton.qml
@@ -513,7 +513,7 @@ BasePill {
                                 case "vpn":
                                     return "vpn_lock";
                                 case "bluetooth":
-                                    return "bluetooth";
+                                    return BluetoothService.connected ? "bluetooth_connected" : "bluetooth";
                                 case "battery":
                                     return Theme.getBatteryIcon(BatteryService.batteryLevel, BatteryService.isCharging, BatteryService.batteryAvailable);
                                 case "printer":
@@ -698,7 +698,7 @@ BasePill {
                                 case "vpn":
                                     return "vpn_lock";
                                 case "bluetooth":
-                                    return "bluetooth";
+                                    return BluetoothService.connected ? "bluetooth_connected" : "bluetooth";
                                 case "battery":
                                     return Theme.getBatteryIcon(BatteryService.batteryLevel, BatteryService.isCharging, BatteryService.batteryAvailable);
                                 case "printer":


### PR DESCRIPTION
## Description

Add a visual indicator to conctrol center widget  when a bluetooth device is connected



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->


## Screenshots / video

<img width="119" height="97" alt="image" src="https://github.com/user-attachments/assets/642bf625-0d1d-4acc-8369-d1b1c5bf5709" />


## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
