### PR TITLE
feat(launcher): make dms color picker entry toggleable

### DIFF
--- a/quickshell/Modules/Settings/LauncherTab.qml
+++ b/quickshell/Modules/Settings/LauncherTab.qml
@@ -769,7 +769,7 @@ Item {
                     spacing: Theme.spacingS
 
                     Repeater {
-                        model: ["dms_settings", "dms_notepad", "dms_sysmon", "dms_settings_search", "dms_clipboard_search"]
+                        model: ["dms_settings", "dms_notepad", "dms_sysmon", "dms_settings_search", "dms_clipboard_search", "dms_colorpicker"]
 
                         delegate: Rectangle {
                             id: pluginDelegate


### PR DESCRIPTION
## Description

Currently, the launcher settings do not expose a toggle for the color picker visibility. All other DMS built-in plugins (settings, notepad, system monitor, settings search, clipboard) do so. This PR simply adds the missing plugin to the list.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

N/A

## Screenshots / video

<img width="994" height="644" alt="1781768340201776187" src="https://github.com/user-attachments/assets/e17cc4d3-166b-4518-b8a6-6aafe3f8a6e8" />


## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
