### PR TITLE
fix(lock): show the faillock lockout reason instead of "incorrect password"

### DIFF
--- a/quickshell/Modules/Lock/Pam.qml
+++ b/quickshell/Modules/Lock/Pam.qml
@@ -23,6 +23,9 @@ Scope {
     property string u2fPendingMode
     property string buffer
 
+    property var attemptInfoMessages: []
+    property bool lockoutAnnouncedThisAttempt: false
+
     signal flashMsg
     signal unlockRequested
 
@@ -118,23 +121,37 @@ Scope {
         configDirectory: (dankshellConfigWatcher.loaded || nixosMarker.loaded || root.runningFromNixStore) ? "/etc/pam.d" : Quickshell.shellDir + "/assets/pam"
 
         onMessageChanged: {
-            if (message.startsWith("The account is locked")) {
-                root.lockMessage = message;
-            } else if (root.lockMessage && message.endsWith(" left to unlock)")) {
-                root.lockMessage += "\n" + message;
-            } else if (root.lockMessage && message && message.length > 0) {
-                root.lockMessage = "";
-            }
+            // collected by position, not text, so it works in any locale
+            if (message.length > 0 && !responseRequired)
+                root.attemptInfoMessages = root.attemptInfoMessages.concat([message]);
         }
 
         onResponseRequiredChanged: {
             if (!responseRequired)
                 return;
 
+            const notice = root.attemptInfoMessages.filter(m => m !== message);
+            if (notice.length > 0) {
+                root.lockMessage = notice.join("\n");
+                root.lockoutAnnouncedThisAttempt = true;
+            }
+            root.attemptInfoMessages = [];
+
             respond(root.buffer);
         }
 
         onCompleted: res => {
+            // requisite preauth can lock without ever prompting; surface it here too
+            if (!root.lockoutAnnouncedThisAttempt) {
+                if (root.attemptInfoMessages.length > 0) {
+                    root.lockMessage = root.attemptInfoMessages.join("\n");
+                    root.lockoutAnnouncedThisAttempt = true;
+                } else {
+                    root.lockMessage = "";
+                }
+                root.attemptInfoMessages = [];
+            }
+
             if (res === PamResult.Success) {
                 if (!root.unlockInProgress) {
                     fprint.abort();
@@ -168,6 +185,8 @@ Scope {
 
         function onActiveChanged() {
             if (passwd.active) {
+                root.attemptInfoMessages = [];
+                root.lockoutAnnouncedThisAttempt = false;
                 passwdActiveTimeout.restart();
             } else {
                 passwdActiveTimeout.running = false;
@@ -393,6 +412,8 @@ Scope {
         root.u2fPending = false;
         root.u2fPendingMode = "";
         root.lockMessage = "";
+        root.attemptInfoMessages = [];
+        root.lockoutAnnouncedThisAttempt = false;
         root.resetAuthFlows();
         fprint.checkAvail();
         u2f.checkAvail();


### PR DESCRIPTION
## Problem

On distros that include `pam_faillock` in the auth stack (the default on Arch/CachyOS via `/etc/pam.d/login` → `system-auth`), a few failed attempts lock the account. While locked, the lock screen kept showing **"Incorrect password - try again"**, so a *correct* password looks rejected and it seems like only a reboot helps — the faillock tally lives in `/run/faillock` (tmpfs), which a reboot clears. Reported in #2647 (two affected users, both confirmed an actual faillock lockout in a shell; a `faillock --reset` made the same password work again).

## Cause

`Pam.qml`'s `onMessageChanged` only recognised the **English** faillock strings (`"The account is locked …"`) and then cleared that text again on the trailing `pam_unix` `"Password:"` prompt. Two failure modes:

- **English locale:** the notice was captured but immediately wiped by the prompt → generic "Incorrect password".
- **Non-English locale:** the lock screen runs under the user's locale, so `pam_faillock` emits e.g. `"Das Konto ist wegen 3 fehlgeschlagener Anmelde-Versuche gesperrt."`. The English match never fired, so the lockout was **never shown at all**.

## Fix

Detect the notice by **position instead of text**, so it is locale-independent: collect the informational PAM messages that arrive before the password prompt and surface them as `lockMessage` once the prompt arrives (or on completion if the stack short-circuits without prompting, e.g. `pam_faillock preauth` configured as `requisite`). A per-attempt flag keeps the message stable across repeated locked attempts and retires it once an attempt completes without a lockout (faillock reset / `unlock_time` elapsed).

Note: this surfaces any informational PAM message emitted before the password prompt, not only faillock. In the default stacks that is just the faillock notice; a custom module such as `pam_echo` would likewise be shown.

## Testing

Reproduced on niri / CachyOS (German locale): tripping faillock at the lock screen now shows the localized lockout reason (including the remaining time) instead of "Incorrect password". Non-locked wrong-password attempts are unchanged.

Fixes #2647
