### PR TITLE
feat(wallpaper): support configurable background color

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -241,6 +241,24 @@ Singleton {
     property string wallpaperFillMode: "Fill"
     property bool blurredWallpaperLayer: false
     property bool blurWallpaperOnOverview: false
+    property string wallpaperBackgroundColorMode: "black"
+    property string wallpaperBackgroundCustomColor: "#000000"
+    readonly property color effectiveWallpaperBackgroundColor: {
+        switch (wallpaperBackgroundColorMode) {
+        case "black":
+            return "#000000";
+        case "white":
+            return "#ffffff";
+        case "primary":
+            return Theme.primary;
+        case "surface":
+            return Theme.surfaceContainer;
+        case "custom":
+            return wallpaperBackgroundCustomColor;
+        default:
+            return "#000000";
+        }
+    }
 
     property bool frameEnabled: false
     onFrameEnabledChanged: saveSettings()

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -74,6 +74,8 @@ var SPEC = {
     wallpaperFillMode: { def: "Fill" },
     blurredWallpaperLayer: { def: false },
     blurWallpaperOnOverview: { def: false },
+    wallpaperBackgroundColorMode: { def: "black" },
+    wallpaperBackgroundCustomColor: { def: "#000000" },
 
     showLauncherButton: { def: true },
     showWorkspaceSwitcher: { def: true },

--- a/quickshell/Modules/BlurredWallpaperBackground.qml
+++ b/quickshell/Modules/BlurredWallpaperBackground.qml
@@ -43,6 +43,11 @@ Variants {
             id: root
             anchors.fill: parent
 
+            Rectangle {
+                anchors.fill: parent
+                color: SettingsData.effectiveWallpaperBackgroundColor
+            }
+
             function encodeFileUrl(path) {
                 if (!path)
                     return "";
@@ -135,6 +140,12 @@ Variants {
             Connections {
                 target: SettingsData
                 function onWallpaperFillModeChanged() {
+                    root.invalidate();
+                }
+                function onWallpaperBackgroundColorModeChanged() {
+                    root.invalidate();
+                }
+                function onWallpaperBackgroundCustomColorChanged() {
                     root.invalidate();
                 }
             }

--- a/quickshell/Modules/Greetd/GreetdSettings.qml
+++ b/quickshell/Modules/Greetd/GreetdSettings.qml
@@ -79,6 +79,24 @@ Singleton {
     property var screenPreferences: ({})
     property int animationSpeed: 2
     property string wallpaperFillMode: "Fill"
+    property string wallpaperBackgroundColorMode: "black"
+    property string wallpaperBackgroundCustomColor: "#000000"
+    readonly property color effectiveWallpaperBackgroundColor: {
+        switch (wallpaperBackgroundColorMode) {
+        case "black":
+            return "#000000";
+        case "white":
+            return "#ffffff";
+        case "primary":
+            return (typeof Theme !== "undefined") ? Theme.primary : "#000000";
+        case "surface":
+            return (typeof Theme !== "undefined") ? Theme.surfaceContainer : "#000000";
+        case "custom":
+            return wallpaperBackgroundCustomColor;
+        default:
+            return "#000000";
+        }
+    }
 
     function parseSettings(content) {
         try {
@@ -147,6 +165,8 @@ Singleton {
             screenPreferences = settings.screenPreferences !== undefined ? settings.screenPreferences : ({});
             animationSpeed = settings.animationSpeed !== undefined ? settings.animationSpeed : 2;
             wallpaperFillMode = settings.wallpaperFillMode !== undefined ? settings.wallpaperFillMode : "Fill";
+            wallpaperBackgroundColorMode = settings.wallpaperBackgroundColorMode !== undefined ? settings.wallpaperBackgroundColorMode : "black";
+            wallpaperBackgroundCustomColor = settings.wallpaperBackgroundCustomColor !== undefined ? settings.wallpaperBackgroundCustomColor : "#000000";
 
             if (typeof Theme !== "undefined") {
                 if (currentThemeName === "custom" && customThemeFile) {

--- a/quickshell/Modules/Greetd/GreeterContent.qml
+++ b/quickshell/Modules/Greetd/GreeterContent.qml
@@ -794,6 +794,11 @@ Item {
         }
     }
 
+    Rectangle {
+        anchors.fill: parent
+        color: GreetdSettings.effectiveWallpaperBackgroundColor
+    }
+
     DankBackdrop {
         anchors.fill: parent
         screenName: root.screenName

--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -182,6 +182,11 @@ Item {
         }
     }
 
+    Rectangle {
+        anchors.fill: parent
+        color: SettingsData.effectiveWallpaperBackgroundColor
+    }
+
     Loader {
         anchors.fill: parent
         active: {

--- a/quickshell/Modules/Settings/GreeterTab.qml
+++ b/quickshell/Modules/Settings/GreeterTab.qml
@@ -689,14 +689,15 @@ Item {
                     tags: ["greeter", "wallpaper", "background", "fill"]
                     text: I18n.tr("Wallpaper fill mode")
                     description: I18n.tr("How the background image is scaled")
-                    options: root._wallpaperFillModes.map(m => I18n.tr(m, "wallpaper fill mode"))
+                    options: root._wallpaperFillModes.map(m => m === "Pad" ? I18n.tr("Center", "wallpaper fill mode") : I18n.tr(m, "wallpaper fill mode"))
                     currentValue: {
                         var mode = (SettingsData.greeterWallpaperFillMode && SettingsData.greeterWallpaperFillMode !== "") ? SettingsData.greeterWallpaperFillMode : (SettingsData.wallpaperFillMode || "Fill");
                         var idx = root._wallpaperFillModes.indexOf(mode);
-                        return idx >= 0 ? I18n.tr(root._wallpaperFillModes[idx], "wallpaper fill mode") : I18n.tr("Fill", "wallpaper fill mode");
+                        var actualMode = idx >= 0 ? root._wallpaperFillModes[idx] : "Fill";
+                        return actualMode === "Pad" ? I18n.tr("Center", "wallpaper fill mode") : I18n.tr(actualMode, "wallpaper fill mode");
                     }
                     onValueChanged: value => {
-                        var idx = root._wallpaperFillModes.map(m => I18n.tr(m, "wallpaper fill mode")).indexOf(value);
+                        var idx = root._wallpaperFillModes.map(m => m === "Pad" ? I18n.tr("Center", "wallpaper fill mode") : I18n.tr(m, "wallpaper fill mode")).indexOf(value);
                         if (idx >= 0)
                             SettingsData.set("greeterWallpaperFillMode", root._wallpaperFillModes[idx]);
                     }

--- a/quickshell/Modules/Settings/GreeterTab.qml
+++ b/quickshell/Modules/Settings/GreeterTab.qml
@@ -689,15 +689,14 @@ Item {
                     tags: ["greeter", "wallpaper", "background", "fill"]
                     text: I18n.tr("Wallpaper fill mode")
                     description: I18n.tr("How the background image is scaled")
-                    options: root._wallpaperFillModes.map(m => m === "Pad" ? I18n.tr("Center", "wallpaper fill mode") : I18n.tr(m, "wallpaper fill mode"))
+                    options: root._wallpaperFillModes.map(m => I18n.tr(m, "wallpaper fill mode"))
                     currentValue: {
                         var mode = (SettingsData.greeterWallpaperFillMode && SettingsData.greeterWallpaperFillMode !== "") ? SettingsData.greeterWallpaperFillMode : (SettingsData.wallpaperFillMode || "Fill");
                         var idx = root._wallpaperFillModes.indexOf(mode);
-                        var actualMode = idx >= 0 ? root._wallpaperFillModes[idx] : "Fill";
-                        return actualMode === "Pad" ? I18n.tr("Center", "wallpaper fill mode") : I18n.tr(actualMode, "wallpaper fill mode");
+                        return idx >= 0 ? I18n.tr(root._wallpaperFillModes[idx], "wallpaper fill mode") : I18n.tr("Fill", "wallpaper fill mode");
                     }
                     onValueChanged: value => {
-                        var idx = root._wallpaperFillModes.map(m => m === "Pad" ? I18n.tr("Center", "wallpaper fill mode") : I18n.tr(m, "wallpaper fill mode")).indexOf(value);
+                        var idx = root._wallpaperFillModes.map(m => I18n.tr(m, "wallpaper fill mode")).indexOf(value);
                         if (idx >= 0)
                             SettingsData.set("greeterWallpaperFillMode", root._wallpaperFillModes[idx]);
                     }

--- a/quickshell/Modules/Settings/WallpaperTab.qml
+++ b/quickshell/Modules/Settings/WallpaperTab.qml
@@ -309,7 +309,7 @@ Item {
                         id: fillModeGroup
                         property var internalModes: ["Stretch", "Fit", "Fill", "Tile", "TileVertically", "TileHorizontally", "Pad"]
                         anchors.horizontalCenter: parent.horizontalCenter
-                        model: [I18n.tr("Stretch", "wallpaper fill mode"), I18n.tr("Fit", "wallpaper fill mode"), I18n.tr("Fill", "wallpaper fill mode"), I18n.tr("Tile", "wallpaper fill mode"), I18n.tr("Tile V", "wallpaper fill mode"), I18n.tr("Tile H", "wallpaper fill mode"), I18n.tr("Center", "wallpaper fill mode")]
+                        model: [I18n.tr("Stretch", "wallpaper fill mode"), I18n.tr("Fit", "wallpaper fill mode"), I18n.tr("Fill", "wallpaper fill mode"), I18n.tr("Tile", "wallpaper fill mode"), I18n.tr("Tile V", "wallpaper fill mode"), I18n.tr("Tile H", "wallpaper fill mode"), I18n.tr("Pad", "wallpaper fill mode")]
                         selectionMode: "single"
                         buttonHeight: 28
                         minButtonWidth: 48
@@ -359,7 +359,7 @@ Item {
                     tags: ["background", "color", "fill", "fit", "custom"]
                     settingKey: "wallpaperBackgroundColorMode"
                     text: I18n.tr("Background Color")
-                    description: I18n.tr("Color shown for areas not covered by wallpaper (e.g. Fit or Center modes)")
+                    description: I18n.tr("Color shown for areas not covered by wallpaper (e.g. Fit or Pad modes)")
                     visible: root.currentWallpaper !== "" && !root.currentWallpaper.startsWith("#")
                     dropdownWidth: 220
                     options: [

--- a/quickshell/Modules/Settings/WallpaperTab.qml
+++ b/quickshell/Modules/Settings/WallpaperTab.qml
@@ -309,7 +309,7 @@ Item {
                         id: fillModeGroup
                         property var internalModes: ["Stretch", "Fit", "Fill", "Tile", "TileVertically", "TileHorizontally", "Pad"]
                         anchors.horizontalCenter: parent.horizontalCenter
-                        model: [I18n.tr("Stretch", "wallpaper fill mode"), I18n.tr("Fit", "wallpaper fill mode"), I18n.tr("Fill", "wallpaper fill mode"), I18n.tr("Tile", "wallpaper fill mode"), I18n.tr("Tile V", "wallpaper fill mode"), I18n.tr("Tile H", "wallpaper fill mode"), I18n.tr("Pad", "wallpaper fill mode")]
+                        model: [I18n.tr("Stretch", "wallpaper fill mode"), I18n.tr("Fit", "wallpaper fill mode"), I18n.tr("Fill", "wallpaper fill mode"), I18n.tr("Tile", "wallpaper fill mode"), I18n.tr("Tile V", "wallpaper fill mode"), I18n.tr("Tile H", "wallpaper fill mode"), I18n.tr("Center", "wallpaper fill mode")]
                         selectionMode: "single"
                         buttonHeight: 28
                         minButtonWidth: 48
@@ -352,6 +352,28 @@ Item {
                             }
                         }
                     }
+                }
+
+                ColorDropdownRow {
+                    tab: "wallpaper"
+                    tags: ["background", "color", "fill", "fit", "custom"]
+                    settingKey: "wallpaperBackgroundColorMode"
+                    text: I18n.tr("Background Color")
+                    description: I18n.tr("Color shown for areas not covered by wallpaper (e.g. Fit or Center modes)")
+                    visible: root.currentWallpaper !== "" && !root.currentWallpaper.startsWith("#")
+                    dropdownWidth: 220
+                    options: [
+                        { "value": "black", "label": I18n.tr("Black") },
+                        { "value": "white", "label": I18n.tr("White") },
+                        { "value": "primary", "label": I18n.tr("Primary Theme Color") },
+                        { "value": "surface", "label": I18n.tr("Surface Container") },
+                        { "value": "custom", "label": I18n.tr("Custom") }
+                    ]
+                    currentMode: SettingsData.wallpaperBackgroundColorMode
+                    customColor: SettingsData.wallpaperBackgroundCustomColor || "#000000"
+                    pickerTitle: I18n.tr("Wallpaper Background Color")
+                    onModeSelected: mode => SettingsData.set("wallpaperBackgroundColorMode", mode)
+                    onCustomColorSelected: selectedColor => SettingsData.set("wallpaperBackgroundCustomColor", selectedColor.toString())
                 }
 
                 Rectangle {

--- a/quickshell/Modules/WallpaperBackground.qml
+++ b/quickshell/Modules/WallpaperBackground.qml
@@ -42,6 +42,11 @@ Variants {
             id: root
             anchors.fill: parent
 
+            Rectangle {
+                anchors.fill: parent
+                color: SettingsData.effectiveWallpaperBackgroundColor
+            }
+
             function encodeFileUrl(path) {
                 if (!path)
                     return "";
@@ -129,6 +134,12 @@ Variants {
             Connections {
                 target: SettingsData
                 function onWallpaperFillModeChanged() {
+                    root.invalidate();
+                }
+                function onWallpaperBackgroundColorModeChanged() {
+                    root.invalidate();
+                }
+                function onWallpaperBackgroundCustomColorChanged() {
                     root.invalidate();
                 }
             }

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -343,28 +343,27 @@
     "category": "Personalization",
     "keywords": [
       "appearance",
+      "areas",
       "background",
       "bg",
+      "center",
+      "color",
+      "colour",
+      "covered",
       "custom",
       "customize",
-      "dark",
-      "dark mode",
-      "day",
       "desktop",
-      "different",
+      "hue",
       "image",
-      "light",
-      "light mode",
-      "mode",
-      "night",
       "personal",
       "personalization",
       "picture",
-      "wallpaper",
-      "wallpapers"
+      "shown",
+      "tint",
+      "wallpaper"
     ],
     "icon": "wallpaper",
-    "description": "Set different wallpapers for light and dark mode"
+    "description": "Color shown for areas not covered by wallpaper (e.g. Fit or Center modes)"
   },
   {
     "section": "selectedMonitor",

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -346,7 +346,6 @@
       "areas",
       "background",
       "bg",
-      "center",
       "color",
       "colour",
       "covered",
@@ -363,7 +362,7 @@
       "wallpaper"
     ],
     "icon": "wallpaper",
-    "description": "Color shown for areas not covered by wallpaper (e.g. Fit or Center modes)"
+    "description": "Color shown for areas not covered by wallpaper (e.g. Fit or Pad modes)"
   },
   {
     "section": "selectedMonitor",


### PR DESCRIPTION
## Description

This PR adds support for a configurable wallpaper background color, which is rendered behind the wallpaper across the desktop background, blurred background, lock screen, and greeter screens. This color is shown in fill modes that do not cover the whole screen (e.g. Fit or Pad).

It also adds a Settings row in the Wallpaper panel using the standard `ColorDropdownRow` component to easily select preset colors (Black, White, Primary, Surface Container) or customize with a custom color via the Color Picker.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Closes #1675

## Screenshots / video

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
