### PR TITLE
feat(battery): add options to toggle percentage and remaining time

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -605,6 +605,10 @@ Singleton {
     property bool batteryNotifyLow: false
     property int batteryNotificationType: 0
     property bool batteryAutoPowerSaver: false
+    property bool showBatteryPercent: true
+    property bool showBatteryPercentOnlyOnBattery: false
+    property bool showBatteryTime: false
+    property bool showBatteryTimeOnlyOnBattery: false
     property bool lockBeforeSuspend: false
     property bool loginctlLockIntegration: true
     property bool fadeToLockEnabled: true

--- a/quickshell/Common/settings/Lists.qml
+++ b/quickshell/Common/settings/Lists.qml
@@ -28,6 +28,10 @@ Singleton {
             showMicIcon: false,
             showMicPercent: true,
             showBatteryIcon: false,
+            showBatteryPercent: true,
+            showBatteryPercentOnlyOnBattery: false,
+            showBatteryTime: false,
+            showBatteryTimeOnlyOnBattery: false,
             showPrinterIcon: false,
             showScreenSharingIcon: true
         };
@@ -83,6 +87,14 @@ Singleton {
                 item.showMicPercent = order[i].showMicPercent;
             if (isObj && order[i].showBatteryIcon !== undefined)
                 item.showBatteryIcon = order[i].showBatteryIcon;
+            if (isObj && order[i].showBatteryPercent !== undefined)
+                item.showBatteryPercent = order[i].showBatteryPercent;
+            if (isObj && order[i].showBatteryPercentOnlyOnBattery !== undefined)
+                item.showBatteryPercentOnlyOnBattery = order[i].showBatteryPercentOnlyOnBattery;
+            if (isObj && order[i].showBatteryTime !== undefined)
+                item.showBatteryTime = order[i].showBatteryTime;
+            if (isObj && order[i].showBatteryTimeOnlyOnBattery !== undefined)
+                item.showBatteryTimeOnlyOnBattery = order[i].showBatteryTimeOnlyOnBattery;
             if (isObj && order[i].showPrinterIcon !== undefined)
                 item.showPrinterIcon = order[i].showPrinterIcon;
             if (isObj && order[i].showScreenSharingIcon !== undefined)

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -94,6 +94,10 @@ var SPEC = {
     showClock: { def: true },
     showNotificationButton: { def: true },
     showBattery: { def: true },
+    showBatteryPercent: { def: true },
+    showBatteryPercentOnlyOnBattery: { def: false },
+    showBatteryTime: { def: false },
+    showBatteryTimeOnlyOnBattery: { def: false },
     showControlCenterButton: { def: true },
     showCapsLockIndicator: { def: true },
 

--- a/quickshell/Modules/DankBar/Widgets/Battery.qml
+++ b/quickshell/Modules/DankBar/Widgets/Battery.qml
@@ -42,6 +42,9 @@ BasePill {
     }
 
     readonly property string verticalDisplayText: {
+        if (showPercent && showTime && batteryTimeText) {
+            return `${BatteryService.batteryLevel}% (${batteryTimeText})`;
+        }
         if (showPercent) {
             return BatteryService.batteryLevel.toString();
         }

--- a/quickshell/Modules/DankBar/Widgets/Battery.qml
+++ b/quickshell/Modules/DankBar/Widgets/Battery.qml
@@ -28,6 +28,29 @@ BasePill {
         return time !== "Unknown" ? time : "";
     }
 
+    readonly property string verticalBatteryTimeText: {
+        if (!batteryTimeText) return "";
+
+        // Parse batteryTimeText, e.g., "2h 41m" or "41m"
+        let hours = 0;
+        let minutes = 0;
+
+        const hourMatch = batteryTimeText.match(/(\d+)h/);
+        const minMatch = batteryTimeText.match(/(\d+)m/);
+
+        if (hourMatch) {
+            hours = parseInt(hourMatch[1], 10);
+        }
+        if (minMatch) {
+            minutes = parseInt(minMatch[1], 10);
+        }
+
+        const hoursStr = hours < 10 ? "0" + hours : hours.toString();
+        const minutesStr = minutes < 10 ? "0" + minutes : minutes.toString();
+
+        return `${hoursStr}\n${minutesStr}`;
+    }
+
     readonly property string horizontalDisplayText: {
         if (showPercent && showTime && batteryTimeText) {
             return `${BatteryService.batteryLevel}% (${batteryTimeText})`;
@@ -43,13 +66,13 @@ BasePill {
 
     readonly property string verticalDisplayText: {
         if (showPercent && showTime && batteryTimeText) {
-            return `${BatteryService.batteryLevel}% (${batteryTimeText})`;
+            return `${BatteryService.batteryLevel}%\n${verticalBatteryTimeText}`;
         }
         if (showPercent) {
             return BatteryService.batteryLevel.toString();
         }
         if (showTime && batteryTimeText) {
-            return batteryTimeText;
+            return verticalBatteryTimeText;
         }
         return "";
     }
@@ -111,6 +134,7 @@ BasePill {
                     text: battery.verticalDisplayText
                     font.pixelSize: Theme.barTextSize(battery.barThickness, battery.barConfig?.fontScale, battery.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
+                    horizontalAlignment: Text.AlignHCenter
                     anchors.horizontalCenter: parent.horizontalCenter
                     visible: BatteryService.batteryAvailable && battery.verticalDisplayText !== ""
                 }

--- a/quickshell/Modules/DankBar/Widgets/Battery.qml
+++ b/quickshell/Modules/DankBar/Widgets/Battery.qml
@@ -11,6 +11,45 @@ BasePill {
 
     property bool batteryPopupVisible: false
     property var popoutTarget: null
+    property var widgetData: null
+    readonly property bool showPercentOnlyOnBattery: widgetData?.showBatteryPercentOnlyOnBattery !== undefined ? widgetData.showBatteryPercentOnlyOnBattery : SettingsData.showBatteryPercentOnlyOnBattery
+    readonly property bool showPercent: {
+        const base = widgetData?.showBatteryPercent !== undefined ? widgetData.showBatteryPercent : SettingsData.showBatteryPercent;
+        return base && !(showPercentOnlyOnBattery && BatteryService.isPluggedIn);
+    }
+    readonly property bool showTime: widgetData?.showBatteryTime !== undefined ? widgetData.showBatteryTime : SettingsData.showBatteryTime
+    readonly property bool showTimeOnlyOnBattery: widgetData?.showBatteryTimeOnlyOnBattery !== undefined ? widgetData.showBatteryTimeOnlyOnBattery : SettingsData.showBatteryTimeOnlyOnBattery
+
+    readonly property string batteryTimeText: {
+        if (showTimeOnlyOnBattery && BatteryService.isPluggedIn) {
+            return "";
+        }
+        const time = BatteryService.formatTimeRemaining();
+        return time !== "Unknown" ? time : "";
+    }
+
+    readonly property string horizontalDisplayText: {
+        if (showPercent && showTime && batteryTimeText) {
+            return `${BatteryService.batteryLevel}% (${batteryTimeText})`;
+        }
+        if (showPercent) {
+            return `${BatteryService.batteryLevel}%`;
+        }
+        if (showTime && batteryTimeText) {
+            return batteryTimeText;
+        }
+        return "";
+    }
+
+    readonly property string verticalDisplayText: {
+        if (showPercent) {
+            return BatteryService.batteryLevel.toString();
+        }
+        if (showTime && batteryTimeText) {
+            return batteryTimeText;
+        }
+        return "";
+    }
 
     property real touchpadAccumulator: 0
 
@@ -66,11 +105,11 @@ BasePill {
                 }
 
                 StyledText {
-                    text: BatteryService.batteryLevel.toString()
+                    text: battery.verticalDisplayText
                     font.pixelSize: Theme.barTextSize(battery.barThickness, battery.barConfig?.fontScale, battery.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
                     anchors.horizontalCenter: parent.horizontalCenter
-                    visible: BatteryService.batteryAvailable
+                    visible: BatteryService.batteryAvailable && battery.verticalDisplayText !== ""
                 }
             }
 
@@ -102,11 +141,11 @@ BasePill {
                 }
 
                 StyledText {
-                    text: `${BatteryService.batteryLevel}%`
+                    text: battery.horizontalDisplayText
                     font.pixelSize: Theme.barTextSize(battery.barThickness, battery.barConfig?.fontScale, battery.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
                     anchors.verticalCenter: parent.verticalCenter
-                    visible: BatteryService.batteryAvailable
+                    visible: BatteryService.batteryAvailable && battery.horizontalDisplayText !== ""
                 }
             }
         }

--- a/quickshell/Modules/DankBar/Widgets/Battery.qml
+++ b/quickshell/Modules/DankBar/Widgets/Battery.qml
@@ -66,7 +66,7 @@ BasePill {
 
     readonly property string verticalDisplayText: {
         if (showPercent && showTime && batteryTimeText) {
-            return `${BatteryService.batteryLevel}%\n${verticalBatteryTimeText}`;
+            return `${BatteryService.batteryLevel}\n${verticalBatteryTimeText}`;
         }
         if (showPercent) {
             return BatteryService.batteryLevel.toString();

--- a/quickshell/Modules/Settings/WidgetsTab.qml
+++ b/quickshell/Modules/Settings/WidgetsTab.qml
@@ -422,6 +422,12 @@ Item {
             widgetObj.showDoNotDisturbIcon = SettingsData.controlCenterShowDoNotDisturbIcon;
             widgetObj.controlCenterGroupOrder = ["network", "vpn", "bluetooth", "audio", "microphone", "brightness", "battery", "printer", "screenSharing", "idleInhibitor", "doNotDisturb"];
         }
+        if (widgetId === "battery") {
+            widgetObj.showBatteryPercent = SettingsData.showBatteryPercent;
+            widgetObj.showBatteryPercentOnlyOnBattery = SettingsData.showBatteryPercentOnlyOnBattery;
+            widgetObj.showBatteryTime = SettingsData.showBatteryTime;
+            widgetObj.showBatteryTimeOnlyOnBattery = SettingsData.showBatteryTimeOnlyOnBattery;
+        }
         if (widgetId === "runningApps") {
             widgetObj.runningAppsCompactMode = SettingsData.runningAppsCompactMode;
             widgetObj.runningAppsGroupByApp = SettingsData.runningAppsGroupByApp;
@@ -460,7 +466,7 @@ Item {
             "id": widget.id,
             "enabled": widget.enabled
         };
-        var keys = ["size", "selectedGpuIndex", "pciId", "mountPath", "diskUsageMode", "minimumWidth", "showSwap", "showInGb", "mediaSize", "clockCompactMode", "focusedWindowSize", "focusedWindowCompactMode", "runningAppsCompactMode", "keyboardLayoutNameCompactMode", "keyboardLayoutNameShowIcon", "runningAppsGroupByApp", "runningAppsCurrentWorkspace", "runningAppsCurrentMonitor", "showNetworkIcon", "showBluetoothIcon", "showAudioIcon", "showAudioPercent", "showVpnIcon", "showBrightnessIcon", "showBrightnessPercent", "showMicIcon", "showMicPercent", "showBatteryIcon", "showPrinterIcon", "showScreenSharingIcon", "showIdleInhibitorIcon", "showDoNotDisturbIcon", "controlCenterGroupOrder", "barMaxVisibleApps", "barMaxVisibleRunningApps", "barShowOverflowBadge", "trayUseInlineExpansion", "trayPopupSingleLine", "trayAutoOverflow", "trayMaxVisibleItems", "hideWhenIdle"];
+        var keys = ["size", "selectedGpuIndex", "pciId", "mountPath", "diskUsageMode", "minimumWidth", "showSwap", "showInGb", "mediaSize", "clockCompactMode", "focusedWindowSize", "focusedWindowCompactMode", "runningAppsCompactMode", "keyboardLayoutNameCompactMode", "keyboardLayoutNameShowIcon", "runningAppsGroupByApp", "runningAppsCurrentWorkspace", "runningAppsCurrentMonitor", "showNetworkIcon", "showBluetoothIcon", "showAudioIcon", "showAudioPercent", "showVpnIcon", "showBrightnessIcon", "showBrightnessPercent", "showMicIcon", "showMicPercent", "showBatteryIcon", "showBatteryPercent", "showBatteryPercentOnlyOnBattery", "showBatteryTime", "showBatteryTimeOnlyOnBattery", "showPrinterIcon", "showScreenSharingIcon", "showIdleInhibitorIcon", "showDoNotDisturbIcon", "controlCenterGroupOrder", "barMaxVisibleApps", "barMaxVisibleRunningApps", "barShowOverflowBadge", "trayUseInlineExpansion", "trayPopupSingleLine", "trayAutoOverflow", "trayMaxVisibleItems", "hideWhenIdle"];
         for (var i = 0; i < keys.length; i++) {
             if (widget[keys[i]] !== undefined)
                 result[keys[i]] = widget[keys[i]];
@@ -759,6 +765,14 @@ Item {
                     item.showMicPercent = widget.showMicPercent;
                 if (widget.showBatteryIcon !== undefined)
                     item.showBatteryIcon = widget.showBatteryIcon;
+                if (widget.showBatteryPercent !== undefined)
+                    item.showBatteryPercent = widget.showBatteryPercent;
+                if (widget.showBatteryPercentOnlyOnBattery !== undefined)
+                    item.showBatteryPercentOnlyOnBattery = widget.showBatteryPercentOnlyOnBattery;
+                if (widget.showBatteryTime !== undefined)
+                    item.showBatteryTime = widget.showBatteryTime;
+                if (widget.showBatteryTimeOnlyOnBattery !== undefined)
+                    item.showBatteryTimeOnlyOnBattery = widget.showBatteryTimeOnlyOnBattery;
                 if (widget.showPrinterIcon !== undefined)
                     item.showPrinterIcon = widget.showPrinterIcon;
                 if (widget.showScreenSharingIcon !== undefined)

--- a/quickshell/Modules/Settings/WidgetsTabSection.qml
+++ b/quickshell/Modules/Settings/WidgetsTabSection.qml
@@ -43,7 +43,7 @@ Column {
             "id": widget.id,
             "enabled": widget.enabled
         };
-        var keys = ["size", "selectedGpuIndex", "pciId", "mountPath", "diskUsageMode", "minimumWidth", "showSwap", "showInGb", "mediaSize", "clockCompactMode", "focusedWindowSize", "focusedWindowCompactMode", "runningAppsCompactMode", "keyboardLayoutNameCompactMode", "keyboardLayoutNameShowIcon", "runningAppsGroupByApp", "runningAppsCurrentWorkspace", "runningAppsCurrentMonitor", "showNetworkIcon", "showBluetoothIcon", "showAudioIcon", "showAudioPercent", "showVpnIcon", "showBrightnessIcon", "showBrightnessPercent", "showMicIcon", "showMicPercent", "showBatteryIcon", "showPrinterIcon", "showScreenSharingIcon", "showIdleInhibitorIcon", "showDoNotDisturbIcon", "controlCenterGroupOrder", "barMaxVisibleApps", "barMaxVisibleRunningApps", "barShowOverflowBadge", "trayUseInlineExpansion", "trayPopupSingleLine", "trayAutoOverflow", "trayMaxVisibleItems"];
+        var keys = ["size", "selectedGpuIndex", "pciId", "mountPath", "diskUsageMode", "minimumWidth", "showSwap", "showInGb", "mediaSize", "clockCompactMode", "focusedWindowSize", "focusedWindowCompactMode", "runningAppsCompactMode", "keyboardLayoutNameCompactMode", "keyboardLayoutNameShowIcon", "runningAppsGroupByApp", "runningAppsCurrentWorkspace", "runningAppsCurrentMonitor", "showNetworkIcon", "showBluetoothIcon", "showAudioIcon", "showAudioPercent", "showVpnIcon", "showBrightnessIcon", "showBrightnessPercent", "showMicIcon", "showMicPercent", "showBatteryIcon", "showBatteryPercent", "showBatteryPercentOnlyOnBattery", "showBatteryTime", "showBatteryTimeOnlyOnBattery", "showPrinterIcon", "showScreenSharingIcon", "showIdleInhibitorIcon", "showDoNotDisturbIcon", "controlCenterGroupOrder", "barMaxVisibleApps", "barMaxVisibleRunningApps", "barShowOverflowBadge", "trayUseInlineExpansion", "trayPopupSingleLine", "trayAutoOverflow", "trayMaxVisibleItems"];
         for (var i = 0; i < keys.length; i++) {
             if (widget[keys[i]] !== undefined)
                 result[keys[i]] = widget[keys[i]];
@@ -490,6 +490,39 @@ Column {
                                 runningAppsContextMenu.x = xPos;
                                 runningAppsContextMenu.y = yPos;
                                 runningAppsContextMenu.open();
+                            }
+                        }
+
+                        DankActionButton {
+                            id: batteryMenuButton
+                            visible: modelData.id === "battery"
+                            buttonSize: 32
+                            iconName: "more_vert"
+                            iconSize: 18
+                            iconColor: Theme.outline
+                            onClicked: {
+                                batteryContextMenu.widgetData = modelData;
+                                batteryContextMenu.sectionId = root.sectionId;
+                                batteryContextMenu.widgetIndex = index;
+
+                                var buttonPos = batteryMenuButton.mapToItem(root, 0, 0);
+                                var popupWidth = batteryContextMenu.width;
+                                var popupHeight = batteryContextMenu.height;
+
+                                var xPos = buttonPos.x - popupWidth - Theme.spacingS;
+                                if (xPos < 0)
+                                    xPos = buttonPos.x + batteryMenuButton.width + Theme.spacingS;
+
+                                var yPos = buttonPos.y - popupHeight / 2 + batteryMenuButton.height / 2;
+                                if (yPos < 0) {
+                                    yPos = Theme.spacingS;
+                                } else if (yPos + popupHeight > root.height) {
+                                    yPos = root.height - popupHeight - Theme.spacingS;
+                                }
+
+                                batteryContextMenu.x = xPos;
+                                batteryContextMenu.y = yPos;
+                                batteryContextMenu.open();
                             }
                         }
 
@@ -2555,6 +2588,256 @@ Column {
                                 root.gpuSelectionChanged(gpuContextMenu.sectionId, gpuContextMenu.widgetIndex, index);
                                 gpuContextMenu.close();
                             }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Popup {
+        id: batteryContextMenu
+
+        property var widgetData: null
+        property string sectionId: ""
+        property int widgetIndex: -1
+        readonly property var currentWidgetData: (widgetIndex >= 0 && widgetIndex < root.items.length) ? root.items[widgetIndex] : widgetData
+
+        width: 270
+        height: batteryMenuColumn.implicitHeight + Theme.spacingS * 2
+        padding: 0
+        modal: true
+        focus: true
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+        background: Rectangle {
+            color: Theme.surfaceContainer
+            radius: Theme.cornerRadius
+            border.color: Qt.rgba(Theme.outline.r, Theme.outline.g, Theme.outline.b, 0.08)
+            border.width: 0
+        }
+
+        contentItem: Item {
+            Column {
+                id: batteryMenuColumn
+                anchors.fill: parent
+                anchors.margins: Theme.spacingS
+                spacing: 2
+
+                Rectangle {
+                    width: parent.width
+                    height: Math.max(18, Theme.fontSizeSmall) + Theme.spacingM * 2
+                    radius: Theme.cornerRadius
+                    color: batteryPercentArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12) : "transparent"
+
+                    Row {
+                        anchors.left: parent.left
+                        anchors.leftMargin: Theme.spacingS
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Theme.spacingS
+
+                        DankIcon {
+                            name: "percent"
+                            size: 18
+                            color: Theme.outline
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+
+                        StyledText {
+                            text: I18n.tr("Show Percentage")
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            font.weight: Font.Normal
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+
+                    DankToggle {
+                        id: batteryPercentToggle
+                        anchors.right: parent.right
+                        anchors.rightMargin: Theme.spacingS
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 40
+                        height: 20
+                        checked: batteryContextMenu.currentWidgetData?.showBatteryPercent ?? SettingsData.showBatteryPercent
+                        onToggled: {
+                            root.overflowSettingChanged(batteryContextMenu.sectionId, batteryContextMenu.widgetIndex, "showBatteryPercent", toggled);
+                        }
+                    }
+
+                    MouseArea {
+                        id: batteryPercentArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onPressed: {
+                            batteryPercentToggle.checked = !batteryPercentToggle.checked;
+                            root.overflowSettingChanged(batteryContextMenu.sectionId, batteryContextMenu.widgetIndex, "showBatteryPercent", batteryPercentToggle.checked);
+                        }
+                    }
+                }
+
+                Rectangle {
+                    width: parent.width
+                    height: Math.max(18, Theme.fontSizeSmall) + Theme.spacingM * 2
+                    radius: Theme.cornerRadius
+                    color: batteryPercentOnlyOnBatteryArea.containsMouse && batteryPercentToggle.checked ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12) : "transparent"
+                    opacity: batteryPercentToggle.checked ? 1.0 : 0.5
+
+                    Row {
+                        anchors.left: parent.left
+                        anchors.leftMargin: Theme.spacingS + 18
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Theme.spacingS
+
+                        DankIcon {
+                            name: "battery_charging_full"
+                            size: 18
+                            color: Theme.outline
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+
+                        StyledText {
+                            text: I18n.tr("Only on Battery")
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            font.weight: Font.Normal
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+
+                    DankToggle {
+                        id: batteryPercentOnlyOnBatteryToggle
+                        anchors.right: parent.right
+                        anchors.rightMargin: Theme.spacingS
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 40
+                        height: 20
+                        enabled: batteryPercentToggle.checked
+                        checked: batteryContextMenu.currentWidgetData?.showBatteryPercentOnlyOnBattery ?? SettingsData.showBatteryPercentOnlyOnBattery
+                        onToggled: {
+                            root.overflowSettingChanged(batteryContextMenu.sectionId, batteryContextMenu.widgetIndex, "showBatteryPercentOnlyOnBattery", toggled);
+                        }
+                    }
+
+                    MouseArea {
+                        id: batteryPercentOnlyOnBatteryArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        enabled: batteryPercentToggle.checked
+                        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                        onPressed: {
+                            batteryPercentOnlyOnBatteryToggle.checked = !batteryPercentOnlyOnBatteryToggle.checked;
+                            root.overflowSettingChanged(batteryContextMenu.sectionId, batteryContextMenu.widgetIndex, "showBatteryPercentOnlyOnBattery", batteryPercentOnlyOnBatteryToggle.checked);
+                        }
+                    }
+                }
+
+                Rectangle {
+                    width: parent.width
+                    height: Math.max(18, Theme.fontSizeSmall) + Theme.spacingM * 2
+                    radius: Theme.cornerRadius
+                    color: batteryTimeArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12) : "transparent"
+
+                    Row {
+                        anchors.left: parent.left
+                        anchors.leftMargin: Theme.spacingS
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Theme.spacingS
+
+                        DankIcon {
+                            name: "schedule"
+                            size: 18
+                            color: Theme.outline
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+
+                        StyledText {
+                            text: I18n.tr("Show Remaining Time")
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            font.weight: Font.Normal
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+
+                    DankToggle {
+                        id: batteryTimeToggle
+                        anchors.right: parent.right
+                        anchors.rightMargin: Theme.spacingS
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 40
+                        height: 20
+                        checked: batteryContextMenu.currentWidgetData?.showBatteryTime ?? SettingsData.showBatteryTime
+                        onToggled: {
+                            root.overflowSettingChanged(batteryContextMenu.sectionId, batteryContextMenu.widgetIndex, "showBatteryTime", toggled);
+                        }
+                    }
+
+                    MouseArea {
+                        id: batteryTimeArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onPressed: {
+                            batteryTimeToggle.checked = !batteryTimeToggle.checked;
+                            root.overflowSettingChanged(batteryContextMenu.sectionId, batteryContextMenu.widgetIndex, "showBatteryTime", batteryTimeToggle.checked);
+                        }
+                    }
+                }
+
+                Rectangle {
+                    width: parent.width
+                    height: Math.max(18, Theme.fontSizeSmall) + Theme.spacingM * 2
+                    radius: Theme.cornerRadius
+                    color: batteryTimeOnlyOnBatteryArea.containsMouse && batteryTimeToggle.checked ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.12) : "transparent"
+                    opacity: batteryTimeToggle.checked ? 1.0 : 0.5
+
+                    Row {
+                        anchors.left: parent.left
+                        anchors.leftMargin: Theme.spacingS + 18
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Theme.spacingS
+
+                        DankIcon {
+                            name: "battery_charging_full"
+                            size: 18
+                            color: Theme.outline
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+
+                        StyledText {
+                            text: I18n.tr("Only on Battery")
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            font.weight: Font.Normal
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+
+                    DankToggle {
+                        id: batteryTimeOnlyOnBatteryToggle
+                        anchors.right: parent.right
+                        anchors.rightMargin: Theme.spacingS
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 40
+                        height: 20
+                        enabled: batteryTimeToggle.checked
+                        checked: batteryContextMenu.currentWidgetData?.showBatteryTimeOnlyOnBattery ?? SettingsData.showBatteryTimeOnlyOnBattery
+                        onToggled: {
+                            root.overflowSettingChanged(batteryContextMenu.sectionId, batteryContextMenu.widgetIndex, "showBatteryTimeOnlyOnBattery", toggled);
+                        }
+                    }
+
+                    MouseArea {
+                        id: batteryTimeOnlyOnBatteryArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        enabled: batteryTimeToggle.checked
+                        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                        onPressed: {
+                            batteryTimeOnlyOnBatteryToggle.checked = !batteryTimeOnlyOnBatteryToggle.checked;
+                            root.overflowSettingChanged(batteryContextMenu.sectionId, batteryContextMenu.widgetIndex, "showBatteryTimeOnlyOnBattery", batteryTimeOnlyOnBatteryToggle.checked);
                         }
                     }
                 }


### PR DESCRIPTION
## Description

This PR implements customization options for the battery widget on the Dank Bar:
- Adds two toggle options to the battery widget's 3-dot context menu under Dank Bar settings:
  - **Show Percentage**: Toggles the display of battery percentage (e.g., `95%`) on the bar pill.
    - **Only on Battery** (Sub-toggle): Only visible and active when "Show Percentage" is enabled. When active, it hides the percentage text when the laptop is plugged in / charging (only displaying it when discharging on battery).
  - **Show Remaining Time**: Toggles the display of remaining time (e.g., `3h 15m` / `45m`) on the bar pill.
    - **Only on Battery** (Sub-toggle): Only visible and active when "Show Remaining Time" is enabled. When active, it hides the remaining time text when the laptop is plugged in / charging (only displaying it when discharging on battery).
  - If both are enabled (and visible), the pill displays them combined as `95% (3h 15m)`.
- Adjusts the context menu width to `270` to prevent translation cut-offs (such as "Show Percentage" cutting off in narrow configurations).

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

Closes #1853

## Screenshots / video

<img width="1390" height="686" alt="image" src="https://github.com/user-attachments/assets/29544c3c-b65a-4770-88d7-b4f33387de91" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
