### PR TITLE
feat(settings): add separate light and dark mode icon theme options

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -471,6 +471,9 @@ Singleton {
     property string networkPreference: "auto"
 
     property string iconTheme: "System Default"
+    property bool enableModeSpecificIcons: false
+    property string iconThemeLight: "System Default"
+    property string iconThemeDark: "System Default"
     property var availableIconThemes: ["System Default"]
     property string systemDefaultIconTheme: ""
     property bool qt5ctAvailable: false
@@ -1230,6 +1233,15 @@ Singleton {
             MangoService.generateLayoutConfig();
     }
 
+    function getActiveIconTheme() {
+        if (!enableModeSpecificIcons) {
+            return iconTheme;
+        }
+        const isLight = (typeof SessionData !== "undefined") ? SessionData.isLightMode : false;
+        const desiredTheme = isLight ? iconThemeLight : iconThemeDark;
+        return (desiredTheme === "System Default") ? iconTheme : desiredTheme;
+    }
+
     function applyStoredIconTheme() {
         updateGtkIconTheme();
         updateQtIconTheme();
@@ -1237,7 +1249,8 @@ Singleton {
     }
 
     function updateCosmicIconTheme() {
-        let cosmicThemeName = (iconTheme === "System Default") ? systemDefaultIconTheme : iconTheme;
+        const activeTheme = getActiveIconTheme();
+        let cosmicThemeName = (activeTheme === "System Default") ? systemDefaultIconTheme : activeTheme;
         if (!cosmicThemeName || cosmicThemeName === "System Default") {
             const detectScript = `if command -v gsettings >/dev/null 2>&1; then
             gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | sed "s/'//g"
@@ -1273,7 +1286,8 @@ Singleton {
     }
 
     function updateGtkIconTheme() {
-        const gtkThemeName = (iconTheme === "System Default") ? systemDefaultIconTheme : iconTheme;
+        const activeTheme = getActiveIconTheme();
+        const gtkThemeName = (activeTheme === "System Default") ? systemDefaultIconTheme : activeTheme;
         if (gtkThemeName === "System Default" || gtkThemeName === "")
             return;
         if (typeof DMSService !== "undefined" && DMSService.apiVersion >= 3 && typeof PortalService !== "undefined") {
@@ -1306,7 +1320,8 @@ Singleton {
     }
 
     function updateQtIconTheme() {
-        const qtThemeName = (iconTheme === "System Default") ? "" : iconTheme;
+        const activeTheme = getActiveIconTheme();
+        const qtThemeName = (activeTheme === "System Default") ? "" : activeTheme;
         if (!qtThemeName)
             return;
         const home = _homeUrl.replace("file://", "").replace(/'/g, "'\\''");
@@ -2407,6 +2422,36 @@ Singleton {
 
     function setIconTheme(themeName) {
         iconTheme = themeName;
+        updateGtkIconTheme();
+        updateQtIconTheme();
+        updateCosmicIconTheme();
+        saveSettings();
+        if (typeof Theme !== "undefined" && Theme.currentTheme === Theme.dynamic)
+            Theme.generateSystemThemesFromCurrentTheme();
+    }
+
+    function setEnableModeSpecificIcons(value) {
+        enableModeSpecificIcons = value;
+        updateGtkIconTheme();
+        updateQtIconTheme();
+        updateCosmicIconTheme();
+        saveSettings();
+        if (typeof Theme !== "undefined" && Theme.currentTheme === Theme.dynamic)
+            Theme.generateSystemThemesFromCurrentTheme();
+    }
+
+    function setIconThemeLight(themeName) {
+        iconThemeLight = themeName;
+        updateGtkIconTheme();
+        updateQtIconTheme();
+        updateCosmicIconTheme();
+        saveSettings();
+        if (typeof Theme !== "undefined" && Theme.currentTheme === Theme.dynamic)
+            Theme.generateSystemThemesFromCurrentTheme();
+    }
+
+    function setIconThemeDark(themeName) {
+        iconThemeDark = themeName;
         updateGtkIconTheme();
         updateQtIconTheme();
         updateCosmicIconTheme();

--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -151,7 +151,7 @@ Singleton {
             if (colorsFileLoadFailed && currentTheme === dynamic && rawWallpaperPath) {
                 log.info("Matugen now available, regenerating colors for dynamic theme");
                 const isLight = (typeof SessionData !== "undefined" && SessionData.isLightMode);
-                const iconTheme = (typeof SettingsData !== "undefined" && SettingsData.iconTheme) ? SettingsData.iconTheme : "System Default";
+                const iconTheme = (typeof SettingsData !== "undefined") ? SettingsData.getActiveIconTheme() : "System Default";
                 const selectedMatugenType = (typeof SettingsData !== "undefined" && SettingsData.matugenScheme) ? SettingsData.matugenScheme : "scheme-tonal-spot";
                 if (rawWallpaperPath.startsWith("#")) {
                     setDesiredTheme("hex", rawWallpaperPath, isLight, iconTheme, selectedMatugenType);
@@ -162,7 +162,7 @@ Singleton {
             }
 
             const isLight = (typeof SessionData !== "undefined" && SessionData.isLightMode);
-            const iconTheme = (typeof SettingsData !== "undefined" && SettingsData.iconTheme) ? SettingsData.iconTheme : "System Default";
+            const iconTheme = (typeof SettingsData !== "undefined") ? SettingsData.getActiveIconTheme() : "System Default";
 
             if (currentTheme === dynamic) {
                 if (rawWallpaperPath) {
@@ -1574,6 +1574,9 @@ Singleton {
         if (currentTheme === "custom" && customThemeFileView.path) {
             customThemeFileView.reload();
         }
+        if (typeof SettingsData !== "undefined") {
+            SettingsData.applyStoredIconTheme();
+        }
     }
 
     function setDesiredTheme(kind, value, isLight, iconTheme, matugenType, stockColors) {
@@ -1707,7 +1710,7 @@ Singleton {
         _pendingGenerateParams = null;
 
         const isLight = (typeof SessionData !== "undefined" && SessionData.isLightMode);
-        const iconTheme = (typeof SettingsData !== "undefined" && SettingsData.iconTheme) ? SettingsData.iconTheme : "System Default";
+        const iconTheme = (typeof SettingsData !== "undefined") ? SettingsData.getActiveIconTheme() : "System Default";
 
         if (currentTheme === dynamic) {
             if (!rawWallpaperPath)

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -232,6 +232,9 @@ var SPEC = {
     networkPreference: { def: "auto" },
 
     iconTheme: { def: "System Default", onChange: "applyStoredIconTheme" },
+    enableModeSpecificIcons: { def: false, onChange: "applyStoredIconTheme" },
+    iconThemeLight: { def: "System Default", onChange: "applyStoredIconTheme" },
+    iconThemeDark: { def: "System Default", onChange: "applyStoredIconTheme" },
     availableIconThemes: { def: ["System Default"], persist: false },
     systemDefaultIconTheme: { def: "", persist: false },
     qt5ctAvailable: { def: false, persist: false },

--- a/quickshell/Modules/Settings/ThemeColorsTab.qml
+++ b/quickshell/Modules/Settings/ThemeColorsTab.qml
@@ -2223,7 +2223,68 @@ Item {
                 settingKey: "iconTheme"
                 iconName: "interests"
 
+                SettingsToggleRow {
+                    tab: "theme"
+                    tags: ["icon", "theme", "system"]
+                    settingKey: "enableModeSpecificIcons"
+                    text: I18n.tr("Separate Light/Dark Icons")
+                    description: I18n.tr("Use different icon themes for light and dark modes")
+                    checked: SettingsData.enableModeSpecificIcons
+                    onToggled: checked => {
+                        SettingsData.setEnableModeSpecificIcons(checked);
+                    }
+                }
+
+                SettingsDivider {
+                    visible: SettingsData.enableModeSpecificIcons
+                }
+
                 SettingsDropdownRow {
+                    visible: SettingsData.enableModeSpecificIcons
+                    tab: "theme"
+                    tags: ["icon", "theme", "system"]
+                    settingKey: "iconThemeLight"
+                    text: I18n.tr("Light Icon Theme")
+                    description: I18n.tr("Icons used in Light Mode (requires restart)")
+                    currentValue: SettingsData.iconThemeLight
+                    enableFuzzySearch: true
+                    popupWidthOffset: 100
+                    maxPopupHeight: 236
+                    options: cachedIconThemes
+                    onValueChanged: value => {
+                        SettingsData.setIconThemeLight(value);
+                        if (Quickshell.env("QT_QPA_PLATFORMTHEME") != "gtk3" && Quickshell.env("QT_QPA_PLATFORMTHEME") != "qt6ct" && Quickshell.env("QT_QPA_PLATFORMTHEME_QT6") != "qt6ct") {
+                            ToastService.showError(I18n.tr("Missing Environment Variables", "qt theme env error title"), I18n.tr("You need to set either:\nQT_QPA_PLATFORMTHEME=gtk3 OR\nQT_QPA_PLATFORMTHEME=qt6ct\nas environment variables, and then restart the shell.\n\nqt6ct requires qt6ct-kde to be installed.", "qt theme env error body"));
+                        }
+                    }
+                }
+
+                SettingsDivider {
+                    visible: SettingsData.enableModeSpecificIcons
+                }
+
+                SettingsDropdownRow {
+                    visible: SettingsData.enableModeSpecificIcons
+                    tab: "theme"
+                    tags: ["icon", "theme", "system"]
+                    settingKey: "iconThemeDark"
+                    text: I18n.tr("Dark Icon Theme")
+                    description: I18n.tr("Icons used in Dark Mode (requires restart)")
+                    currentValue: SettingsData.iconThemeDark
+                    enableFuzzySearch: true
+                    popupWidthOffset: 100
+                    maxPopupHeight: 236
+                    options: cachedIconThemes
+                    onValueChanged: value => {
+                        SettingsData.setIconThemeDark(value);
+                        if (Quickshell.env("QT_QPA_PLATFORMTHEME") != "gtk3" && Quickshell.env("QT_QPA_PLATFORMTHEME") != "qt6ct" && Quickshell.env("QT_QPA_PLATFORMTHEME_QT6") != "qt6ct") {
+                            ToastService.showError(I18n.tr("Missing Environment Variables", "qt theme env error title"), I18n.tr("You need to set either:\nQT_QPA_PLATFORMTHEME=gtk3 OR\nQT_QPA_PLATFORMTHEME=qt6ct\nas environment variables, and then restart the shell.\n\nqt6ct requires qt6ct-kde to be installed.", "qt theme env error body"));
+                        }
+                    }
+                }
+
+                SettingsDropdownRow {
+                    visible: !SettingsData.enableModeSpecificIcons
                     tab: "theme"
                     tags: ["icon", "theme", "system"]
                     settingKey: "iconTheme"


### PR DESCRIPTION
## Description

This PR introduces the option to configure separate icon themes for dark and light modes. 
When switching theme modes, the shell now dynamically resolves and applies the designated mode-specific icon pack, preventing low-contrast visibility issues (e.g., white-on-white or dark-on-dark icons) caused by a single static icon theme.

Key changes:
- Defined `enableModeSpecificIcons`, `iconThemeLight`, and `iconThemeDark` settings schema in `SettingsSpec.js`.
- Implemented `getActiveIconTheme()` helper in `SettingsData.qml` to resolve the current active icon pack based on the mode.
- Updated GTK, Qt, and Cosmic icon appliers in `SettingsData.qml` to respect the mode-specific icon setting.
- Triggered `applyStoredIconTheme()` inside `Theme.qml`'s `onLightModeChanged` to ensure immediate application of the correct icon theme upon mode transitions.
- Added a "Separate Light/Dark Icons" toggle in `ThemeColorsTab.qml` settings UI which dynamically exposes dropdown selectors for light and dark icon packs.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

Closes #608

## Screenshots / video

<img width="520" height="535" alt="image" src="https://github.com/user-attachments/assets/a960c088-8bfd-4f9f-b215-efeb5b4c6be2" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
