### PR TITLE
feat: add option to hide package source badges in launcher

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -464,6 +464,7 @@ Singleton {
     onAppDrawerSectionViewModesChanged: saveSettings()
     property bool niriOverviewOverlayEnabled: true
     property string dankLauncherV2Size: "compact"
+    property bool dankLauncherV2ShowSourceBadges: true
     property bool dankLauncherV2BorderEnabled: false
     property int dankLauncherV2BorderThickness: 2
     property string dankLauncherV2BorderColor: "primary"

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -227,6 +227,7 @@ var SPEC = {
     appDrawerSectionViewModes: { def: {} },
     niriOverviewOverlayEnabled: { def: true },
     dankLauncherV2Size: { def: "compact" },
+    dankLauncherV2ShowSourceBadges: { def: true },
     dankLauncherV2BorderEnabled: { def: false },
     dankLauncherV2BorderThickness: { def: 2 },
     dankLauncherV2BorderColor: { def: "primary" },

--- a/quickshell/Modals/DankLauncherV2/SourceBadge.qml
+++ b/quickshell/Modals/DankLauncherV2/SourceBadge.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import Quickshell.Widgets
+import qs.Common
 
 Item {
     id: root
@@ -16,7 +17,7 @@ Item {
 
     readonly property string assetPath: sourceAsset[source] || ""
 
-    visible: assetPath.length > 0
+    visible: SettingsData.dankLauncherV2ShowSourceBadges && assetPath.length > 0
     implicitWidth: glyphSize
     implicitHeight: glyphSize
 

--- a/quickshell/Modules/Settings/LauncherTab.qml
+++ b/quickshell/Modules/Settings/LauncherTab.qml
@@ -671,6 +671,15 @@ Item {
                     onToggled: checked => SettingsData.set("dankLauncherV2UnloadOnClose", checked)
                 }
 
+                 SettingsToggleRow {
+                    settingKey: "dankLauncherV2ShowSourceBadges"
+                    tags: ["launcher", "appearance", "badge", "source", "flatpak"]
+                    text: I18n.tr("Show Package Source Badges")
+                    description: I18n.tr("Show Flatpak, Snap, AppImage, or Nix badge icons on launcher items.")
+                    checked: SettingsData.dankLauncherV2ShowSourceBadges
+                    onToggled: checked => SettingsData.set("dankLauncherV2ShowSourceBadges", checked)
+                }
+
                 SettingsToggleRow {
                     settingKey: "dankLauncherV2BorderEnabled"
                     tags: ["launcher", "border", "outline"]

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -2680,6 +2680,34 @@
     "description": "Show All, Apps, Files, and Plugins chips beside the Spotlight Bar input."
   },
   {
+    "section": "dankLauncherV2ShowSourceBadges",
+    "label": "Show Package Source Badges",
+    "tabIndex": 9,
+    "category": "Launcher",
+    "keywords": [
+      "app drawer",
+      "app menu",
+      "appearance",
+      "appimage",
+      "applications",
+      "badge",
+      "badges",
+      "drawer",
+      "flatpak",
+      "icons",
+      "items",
+      "launcher",
+      "menu",
+      "package",
+      "show",
+      "snap",
+      "source",
+      "start",
+      "start menu"
+    ],
+    "description": "Show Flatpak, Snap, AppImage, or Nix badge icons on launcher items."
+  },
+  {
     "section": "launcherLogoSizeOffset",
     "label": "Size Offset",
     "tabIndex": 9,


### PR DESCRIPTION
## Description

This PR introduces an appearance toggle setting to show/hide package source badges (Flatpak, Snap, AppImage, Nix) at the top right of launcher panels. This addresses request for visual noise reduction in launcher grids.

Key changes:
- Defined `dankLauncherV2ShowSourceBadges` settings schema in `SettingsSpec.js` with default `true`.
- Declared QML binding property `dankLauncherV2ShowSourceBadges` in `SettingsData.qml`.
- Added a "Show Package Source Badges" toggle switch in the "Appearance" card in `LauncherTab.qml`.
- Updated `SourceBadge.qml` to conditionalize visibility on `SettingsData.dankLauncherV2ShowSourceBadges` and added `import qs.Common` to resolve the `SettingsData` namespace.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

Closes #2473

## Screenshots / video

<img width="1695" height="890" alt="1782000793525129642" src="https://github.com/user-attachments/assets/9fc98bbc-7fa6-4f9f-91dc-67371f933c3a" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
