### PR TITLE
feat(network): captive portal detection and sign-in popup

### DIFF
--- a/core/internal/server/network/captive_portal.go
+++ b/core/internal/server/network/captive_portal.go
@@ -1,0 +1,185 @@
+package network
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/AvengeMedia/DankMaterialShell/core/internal/log"
+)
+
+const (
+	portalProbeURL       = "http://nmcheck.gnome.org/check_network_status.txt"
+	portalProbeExpect    = "NetworkManager is online"
+	portalProbeTimeout   = 5 * time.Second
+	portalProbeInterval  = 30 * time.Second
+	portalProbeMaxBody   = 4096
+	portalFullProbeTicks = 10 // re-probe a healthy connection every ~5min, not every tick
+)
+
+// portalProbe checks a known endpoint to spot a captive portal: a redirect or an
+// unexpected 200 body means traffic is being intercepted.
+type portalProbe struct {
+	mgr       *Manager
+	client    *http.Client
+	url       string
+	trigger   chan struct{}
+	stopChan  chan struct{}
+	wg        sync.WaitGroup
+	lastKey   string
+	fullTicks int
+}
+
+func newPortalProbe(m *Manager) *portalProbe {
+	probeURL := portalProbeURL
+	if v := os.Getenv("DMS_CAPTIVE_PROBE_URL"); v != "" {
+		probeURL = v
+	}
+	return &portalProbe{
+		mgr:      m,
+		url:      probeURL,
+		trigger:  make(chan struct{}, 1),
+		stopChan: make(chan struct{}),
+		client: &http.Client{
+			Timeout: portalProbeTimeout,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+func (p *portalProbe) start() {
+	p.wg.Add(1)
+	go p.run()
+	p.kick()
+}
+
+func (p *portalProbe) stop() {
+	close(p.stopChan)
+	p.wg.Wait()
+}
+
+func (p *portalProbe) kick() {
+	select {
+	case p.trigger <- struct{}{}:
+	default:
+	}
+}
+
+func (p *portalProbe) run() {
+	defer p.wg.Done()
+	ticker := time.NewTicker(portalProbeInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.stopChan:
+			return
+		case <-p.trigger:
+			p.probe(false)
+		case <-ticker.C:
+			p.probe(true)
+		}
+	}
+}
+
+func (p *portalProbe) probe(periodic bool) {
+	m := p.mgr
+	m.stateMutex.RLock()
+	connected := m.state.WiFiConnected || m.state.EthernetConnected
+	curConn := m.state.Connectivity
+	key := fmt.Sprintf("%v|%s|%s", connected, m.state.WiFiSSID, m.state.EthernetIP)
+	m.stateMutex.RUnlock()
+
+	if !connected {
+		p.lastKey = key
+		p.set(ConnectivityNone, "")
+		return
+	}
+
+	if periodic {
+		if curConn == ConnectivityFull {
+			p.fullTicks++
+			if p.fullTicks < portalFullProbeTicks {
+				return
+			}
+			p.fullTicks = 0
+		}
+	} else if key == p.lastKey {
+		return
+	}
+	p.lastKey = key
+
+	conn, loc := p.check()
+	p.set(conn, loc)
+}
+
+func (p *portalProbe) check() (Connectivity, string) {
+	req, err := http.NewRequest(http.MethodGet, p.url, nil)
+	if err != nil {
+		return ConnectivityUnknown, ""
+	}
+	req.Header.Set("User-Agent", "DankMaterialShell/captive-portal-check")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return ConnectivityNone, ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return ConnectivityPortal, p.resolveLocation(resp.Header.Get("Location"))
+	}
+	if resp.StatusCode == http.StatusNoContent {
+		return ConnectivityFull, ""
+	}
+	// server/infra errors are not a portal
+	if resp.StatusCode >= 400 {
+		return ConnectivityUnknown, ""
+	}
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, portalProbeMaxBody))
+	if resp.StatusCode == http.StatusOK && strings.Contains(string(body), portalProbeExpect) {
+		return ConnectivityFull, ""
+	}
+
+	return ConnectivityPortal, p.url
+}
+
+// resolveLocation turns a possibly-relative redirect target into an absolute url.
+func (p *portalProbe) resolveLocation(loc string) string {
+	if loc == "" {
+		return p.url
+	}
+	base, err := url.Parse(p.url)
+	if err != nil {
+		return loc
+	}
+	ref, err := url.Parse(loc)
+	if err != nil {
+		return loc
+	}
+	return base.ResolveReference(ref).String()
+}
+
+func (p *portalProbe) set(conn Connectivity, loc string) {
+	m := p.mgr
+	m.stateMutex.Lock()
+	changed := m.state.Connectivity != conn || m.state.PortalURL != loc
+	m.state.Connectivity = conn
+	m.state.PortalURL = loc
+	m.stateMutex.Unlock()
+
+	if !changed {
+		return
+	}
+	if conn == ConnectivityPortal {
+		log.Infof("[captive-portal] portal detected, login url: %s", loc)
+	}
+	m.notifySubscribers()
+}

--- a/core/internal/server/network/captive_portal_test.go
+++ b/core/internal/server/network/captive_portal_test.go
@@ -1,0 +1,99 @@
+package network
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPortalProbeCheck(t *testing.T) {
+	tests := []struct {
+		name     string
+		handler  http.HandlerFunc
+		wantConn Connectivity
+		wantURL  func(srv string) string
+	}{
+		{
+			name: "online when expected body returned",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(portalProbeExpect + "\n"))
+			},
+			wantConn: ConnectivityFull,
+			wantURL:  func(string) string { return "" },
+		},
+		{
+			name: "portal on redirect, url from location",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, "http://portal.example/login", http.StatusFound)
+			},
+			wantConn: ConnectivityPortal,
+			wantURL:  func(string) string { return "http://portal.example/login" },
+		},
+		{
+			name: "portal on unexpected 200 body",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("<html>please sign in</html>"))
+			},
+			wantConn: ConnectivityPortal,
+			wantURL:  func(srv string) string { return srv },
+		},
+		{
+			name: "relative redirect location resolved to absolute",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Location", "/login")
+				w.WriteHeader(http.StatusFound)
+			},
+			wantConn: ConnectivityPortal,
+			wantURL:  func(srv string) string { return srv + "/login" },
+		},
+		{
+			name: "204 no content means online",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			},
+			wantConn: ConnectivityFull,
+			wantURL:  func(string) string { return "" },
+		},
+		{
+			name: "server error is not a portal",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			},
+			wantConn: ConnectivityUnknown,
+			wantURL:  func(string) string { return "" },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+
+			p := newPortalProbe(nil)
+			p.url = srv.URL
+
+			conn, url := p.check()
+			if conn != tt.wantConn {
+				t.Errorf("connectivity = %q, want %q", conn, tt.wantConn)
+			}
+			if want := tt.wantURL(srv.URL); url != want {
+				t.Errorf("url = %q, want %q", url, want)
+			}
+		})
+	}
+}
+
+func TestPortalProbeCheckUnreachable(t *testing.T) {
+	p := newPortalProbe(nil)
+	p.url = "http://127.0.0.1:1"
+
+	conn, url := p.check()
+	if conn != ConnectivityNone {
+		t.Errorf("connectivity = %q, want %q", conn, ConnectivityNone)
+	}
+	if url != "" {
+		t.Errorf("url = %q, want empty", url)
+	}
+}

--- a/core/internal/server/network/manager.go
+++ b/core/internal/server/network/manager.go
@@ -65,6 +65,7 @@ func NewManager() (*Manager, error) {
 		backend: backend,
 		state: &NetworkState{
 			NetworkStatus:     StatusDisconnected,
+			Connectivity:      ConnectivityUnknown,
 			Preference:        PreferenceAuto,
 			WiFiNetworks:      []WiFiNetwork{},
 			SavedWiFiNetworks: []WiFiNetwork{},
@@ -95,6 +96,9 @@ func NewManager() (*Manager, error) {
 		m.Close()
 		return nil, fmt.Errorf("failed to start monitoring: %w", err)
 	}
+
+	m.portalProbe = newPortalProbe(m)
+	m.portalProbe.start()
 
 	return m, nil
 }
@@ -139,6 +143,9 @@ func (m *Manager) onBackendStateChange() {
 	if err := m.syncStateFromBackend(); err != nil {
 		log.Errorf("failed to sync state from backend: %v", err)
 	}
+	if m.portalProbe != nil {
+		m.portalProbe.kick()
+	}
 	m.notifySubscribers()
 }
 
@@ -169,6 +176,12 @@ func (m *Manager) snapshotState() NetworkState {
 
 func stateChangedMeaningfully(old, new *NetworkState) bool {
 	if old.NetworkStatus != new.NetworkStatus {
+		return true
+	}
+	if old.Connectivity != new.Connectivity {
+		return true
+	}
+	if old.PortalURL != new.PortalURL {
 		return true
 	}
 	if old.Preference != new.Preference {
@@ -420,6 +433,10 @@ func (m *Manager) GetPromptBroker() PromptBroker {
 }
 
 func (m *Manager) Close() {
+	if m.portalProbe != nil {
+		m.portalProbe.stop()
+	}
+
 	close(m.stopChan)
 	m.notifierWg.Wait()
 

--- a/core/internal/server/network/types.go
+++ b/core/internal/server/network/types.go
@@ -24,6 +24,16 @@ const (
 	PreferenceEthernet ConnectionPreference = "ethernet"
 )
 
+type Connectivity string
+
+const (
+	ConnectivityUnknown Connectivity = "unknown"
+	ConnectivityNone    Connectivity = "none"
+	ConnectivityPortal  Connectivity = "portal"
+	ConnectivityLimited Connectivity = "limited"
+	ConnectivityFull    Connectivity = "full"
+)
+
 type WiFiNetwork struct {
 	SSID        string `json:"ssid"`
 	BSSID       string `json:"bssid"`
@@ -98,6 +108,8 @@ type VPNState struct {
 type NetworkState struct {
 	Backend                string               `json:"backend"`
 	NetworkStatus          NetworkStatus        `json:"networkStatus"`
+	Connectivity           Connectivity         `json:"connectivity"`
+	PortalURL              string               `json:"portalURL"`
 	Preference             ConnectionPreference `json:"preference"`
 	EthernetIP             string               `json:"ethernetIP"`
 	EthernetDevice         string               `json:"ethernetDevice"`
@@ -162,6 +174,7 @@ type Manager struct {
 	notifierWg            sync.WaitGroup
 	lastNotifiedState     *NetworkState
 	credentialSubscribers syncmap.Map[string, chan CredentialPrompt]
+	portalProbe           *portalProbe
 }
 
 type EventType string

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -506,6 +506,7 @@ Singleton {
     property bool weatherEnabled: true
 
     property string networkPreference: "auto"
+    property bool captivePortalAutoOpen: true
 
     property string iconThemeDark: "System Default"
     property string iconThemeLight: "System Default"

--- a/quickshell/DMSShell.qml
+++ b/quickshell/DMSShell.qml
@@ -1454,4 +1454,50 @@ Item {
             }
         }
     }
+
+    Loader {
+        id: captivePortalLoader
+        active: false
+        property string dismissedKey: ""
+
+        function connKey() {
+            return NetworkService.currentWifiSSID !== "" ? "wifi:" + NetworkService.currentWifiSSID : "net:" + NetworkService.networkStatus;
+        }
+
+        sourceComponent: CaptivePortalModal {
+            onDialogClosed: {
+                captivePortalLoader.dismissedKey = captivePortalLoader.connKey();
+                Qt.callLater(() => captivePortalLoader.active = false);
+            }
+            Component.onCompleted: Qt.callLater(() => open())
+        }
+
+        function evaluate() {
+            if (NetworkService.connectivity === "full")
+                dismissedKey = "";
+            const wantPortal = NetworkService.connectivity === "portal" && SettingsData.captivePortalAutoOpen && connKey() !== dismissedKey;
+            if (wantPortal) {
+                if (!active)
+                    active = true;
+                else if (item)
+                    item.open();
+            } else if (active && item) {
+                item.close();
+            }
+        }
+
+        Connections {
+            target: NetworkService
+            function onConnectivityChanged() {
+                captivePortalLoader.evaluate();
+            }
+        }
+
+        Connections {
+            target: SettingsData
+            function onCaptivePortalAutoOpenChanged() {
+                captivePortalLoader.evaluate();
+            }
+        }
+    }
 }

--- a/quickshell/Modals/CaptivePortalModal.qml
+++ b/quickshell/Modals/CaptivePortalModal.qml
@@ -1,0 +1,175 @@
+import QtQuick
+import qs.Common
+import qs.Modals.Common
+import qs.Services
+import qs.Widgets
+
+DankModal {
+    id: root
+
+    readonly property string fallbackURL: "http://nmcheck.gnome.org/check_network_status.txt"
+    readonly property string ssid: NetworkService.currentWifiSSID
+
+    function openPortal() {
+        const url = NetworkService.portalURL && NetworkService.portalURL.length > 0 ? NetworkService.portalURL : root.fallbackURL;
+        Qt.openUrlExternally(url);
+        root.close();
+    }
+
+    shouldBeVisible: false
+    allowStacking: true
+    useOverlayLayer: true
+    modalWidth: 420
+    modalHeight: contentLoader.item ? contentLoader.item.implicitHeight + Theme.spacingM * 2 : 220
+
+    onBackgroundClicked: root.close()
+
+    content: Component {
+        FocusScope {
+            id: portalContent
+
+            anchors.fill: parent
+            focus: true
+            implicitHeight: mainColumn.implicitHeight
+
+            Keys.onEscapePressed: event => {
+                root.close();
+                event.accepted = true;
+            }
+
+            Keys.onReturnPressed: event => {
+                root.openPortal();
+                event.accepted = true;
+            }
+
+            Column {
+                id: mainColumn
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.leftMargin: Theme.spacingM
+                anchors.rightMargin: Theme.spacingM
+                anchors.topMargin: Theme.spacingM
+                spacing: Theme.spacingM
+
+                Row {
+                    width: parent.width
+                    spacing: Theme.spacingM
+
+                    DankIcon {
+                        anchors.verticalCenter: parent.verticalCenter
+                        name: "wifi_lock"
+                        size: Theme.iconSizeLarge
+                        color: Theme.primary
+                    }
+
+                    StyledText {
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: parent.width - Theme.iconSizeLarge - Theme.spacingM
+                        text: I18n.tr("Sign in to network")
+                        font.pixelSize: Theme.fontSizeLarge
+                        color: Theme.surfaceText
+                        font.weight: Font.Medium
+                        wrapMode: Text.WordWrap
+                    }
+                }
+
+                StyledText {
+                    width: parent.width
+                    text: root.ssid.length > 0 ? I18n.tr("The network \"%1\" requires sign-in before you can reach the internet.").arg(root.ssid) : I18n.tr("This network requires sign-in before you can reach the internet.")
+                    font.pixelSize: Theme.fontSizeMedium
+                    color: Theme.surfaceVariantText
+                    wrapMode: Text.WordWrap
+                }
+
+                StyledText {
+                    width: parent.width
+                    visible: NetworkService.vpnConnected
+                    text: I18n.tr("A VPN is active. You may need to disconnect it to reach the login page.")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.warning
+                    wrapMode: Text.WordWrap
+                }
+
+                Item {
+                    width: parent.width
+                    height: 36
+
+                    Row {
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Theme.spacingS
+
+                        Rectangle {
+                            width: Math.max(80, dismissText.contentWidth + Theme.spacingM * 2)
+                            height: 36
+                            radius: Theme.cornerRadius
+                            color: dismissArea.containsMouse ? Theme.surfaceTextHover : "transparent"
+                            border.color: Theme.surfaceVariantAlpha
+                            border.width: 1
+
+                            StyledText {
+                                id: dismissText
+                                anchors.centerIn: parent
+                                text: I18n.tr("Dismiss")
+                                font.pixelSize: Theme.fontSizeMedium
+                                color: Theme.surfaceText
+                                font.weight: Font.Medium
+                            }
+
+                            MouseArea {
+                                id: dismissArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.close()
+                            }
+                        }
+
+                        Rectangle {
+                            width: Math.max(120, openText.contentWidth + Theme.spacingM * 2)
+                            height: 36
+                            radius: Theme.cornerRadius
+                            color: openArea.containsMouse ? Qt.darker(Theme.primary, 1.1) : Theme.primary
+
+                            StyledText {
+                                id: openText
+                                anchors.centerIn: parent
+                                text: I18n.tr("Open login page")
+                                font.pixelSize: Theme.fontSizeMedium
+                                color: Theme.background
+                                font.weight: Font.Medium
+                            }
+
+                            MouseArea {
+                                id: openArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.openPortal()
+                            }
+
+                            Behavior on color {
+                                ColorAnimation {
+                                    duration: Theme.shortDuration
+                                    easing.type: Theme.standardEasing
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            DankActionButton {
+                anchors.top: parent.top
+                anchors.right: parent.right
+                anchors.topMargin: Theme.spacingM
+                anchors.rightMargin: Theme.spacingM
+                iconName: "close"
+                iconSize: Theme.iconSize - 4
+                iconColor: Theme.surfaceText
+                onClicked: root.close()
+            }
+        }
+    }
+}

--- a/quickshell/Modules/Settings/NetworkStatusTab.qml
+++ b/quickshell/Modules/Settings/NetworkStatusTab.qml
@@ -197,6 +197,70 @@ Item {
                     }
                 }
             }
+
+            SettingsCard {
+                title: I18n.tr("Captive Portal")
+                iconName: "wifi_lock"
+                settingKey: "captivePortal"
+                tags: ["captive", "portal", "hotspot", "sign in", "login", "public wifi"]
+
+                width: parent.width
+
+                Column {
+                    width: parent.width
+                    spacing: Theme.spacingM
+
+                    SettingsToggleRow {
+                        width: parent.width
+                        settingKey: "captivePortalAutoOpen"
+                        text: I18n.tr("Open sign-in page automatically")
+                        description: I18n.tr("Show a popup to sign in when a network requires it before reaching the internet.")
+                        checked: SettingsData.captivePortalAutoOpen
+                        onToggled: checked => SettingsData.set("captivePortalAutoOpen", checked)
+                    }
+
+                    Row {
+                        width: parent.width
+                        spacing: Theme.spacingM
+                        visible: NetworkService.connectivity === "portal"
+
+                        StyledText {
+                            text: I18n.tr("Sign-in required for this network")
+                            font.pixelSize: Theme.fontSizeMedium
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: parent.width - openPortalButton.width - Theme.spacingM
+                            wrapMode: Text.WordWrap
+                        }
+
+                        Rectangle {
+                            id: openPortalButton
+                            width: Math.max(120, openPortalLabel.contentWidth + Theme.spacingM * 2)
+                            height: 36
+                            radius: Theme.cornerRadius
+                            anchors.verticalCenter: parent.verticalCenter
+                            color: openPortalArea.containsMouse ? Qt.darker(Theme.primary, 1.1) : Theme.primary
+
+                            StyledText {
+                                id: openPortalLabel
+                                anchors.centerIn: parent
+                                text: I18n.tr("Open sign-in page")
+                                font.pixelSize: Theme.fontSizeMedium
+                                color: Theme.background
+                                font.weight: Font.Medium
+                            }
+
+                            MouseArea {
+                                id: openPortalArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: Qt.openUrlExternally(NetworkService.portalURL && NetworkService.portalURL.length > 0 ? NetworkService.portalURL : "http://nmcheck.gnome.org/check_network_status.txt")
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/quickshell/Services/DMSNetworkService.qml
+++ b/quickshell/Services/DMSNetworkService.qml
@@ -14,6 +14,8 @@ Singleton {
     property string backend: ""
 
     property string networkStatus: "disconnected"
+    property string connectivity: "unknown"
+    property string portalURL: ""
     property string primaryConnection: ""
 
     property string ethernetIP: ""
@@ -285,6 +287,8 @@ Singleton {
         backend = state.backend || "";
         vpnAvailable = networkAvailable && backend === "networkmanager";
         networkStatus = state.networkStatus || "disconnected";
+        connectivity = state.connectivity || "unknown";
+        portalURL = state.portalURL || "";
         primaryConnection = state.primaryConnection || "";
 
         ethernetIP = state.ethernetIP || "";

--- a/quickshell/Services/NetworkService.qml
+++ b/quickshell/Services/NetworkService.qml
@@ -12,6 +12,8 @@ Singleton {
     property bool networkAvailable: activeService !== null
     property string backend: activeService?.backend ?? ""
     property string networkStatus: activeService?.networkStatus ?? "disconnected"
+    property string connectivity: activeService?.connectivity ?? "unknown"
+    property string portalURL: activeService?.portalURL ?? ""
     property string primaryConnection: activeService?.primaryConnection ?? ""
 
     property string ethernetIP: activeService?.ethernetIP ?? ""

--- a/quickshell/translations/en.json
+++ b/quickshell/translations/en.json
@@ -624,6 +624,12 @@
     "comment": ""
   },
   {
+    "term": "A VPN is active. You may need to disconnect it to reach the login page.",
+    "context": "A VPN is active. You may need to disconnect it to reach the login page.",
+    "reference": "Modals/CaptivePortalModal.qml:88",
+    "comment": ""
+  },
+  {
     "term": "A file with this name already exists. Do you want to overwrite it?",
     "context": "A file with this name already exists. Do you want to overwrite it?",
     "reference": "Modals/FileBrowser/FileBrowserOverwriteDialog.qml:61",
@@ -2541,6 +2547,12 @@
     "term": "Caps Lock is on",
     "context": "Caps Lock is on",
     "reference": "Modules/Lock/LockScreenContent.qml:1200",
+    "comment": ""
+  },
+  {
+    "term": "Captive Portal",
+    "context": "Captive Portal",
+    "reference": "Modules/Settings/NetworkStatusTab.qml:202",
     "comment": ""
   },
   {
@@ -4724,7 +4736,7 @@
   {
     "term": "Dismiss",
     "context": "Dismiss",
-    "reference": "Modules/Notifications/Popup/NotificationPopup.qml:95, Modules/Notifications/Popup/NotificationPopup.qml:1452, Modules/Notifications/Center/NotificationCard.qml:835, Modules/Notifications/Center/NotificationCard.qml:975, Modules/Notifications/Center/NotificationCard.qml:1125",
+    "reference": "Modules/Notifications/Popup/NotificationPopup.qml:95, Modules/Notifications/Popup/NotificationPopup.qml:1452, Modules/Notifications/Center/NotificationCard.qml:835, Modules/Notifications/Center/NotificationCard.qml:975, Modules/Notifications/Center/NotificationCard.qml:1125, Modals/CaptivePortalModal.qml:114",
     "comment": ""
   },
   {
@@ -10740,9 +10752,27 @@
     "comment": ""
   },
   {
+    "term": "Open login page",
+    "context": "Open login page",
+    "reference": "Modals/CaptivePortalModal.qml:138",
+    "comment": ""
+  },
+  {
     "term": "Open search bar to find text",
     "context": "Open search bar to find text",
     "reference": "Modules/Notepad/NotepadSettings.qml:223",
+    "comment": ""
+  },
+  {
+    "term": "Open sign-in page",
+    "context": "Open sign-in page",
+    "reference": "Modules/Settings/NetworkStatusTab.qml:247",
+    "comment": ""
+  },
+  {
+    "term": "Open sign-in page automatically",
+    "context": "Open sign-in page automatically",
+    "reference": "Modules/Settings/NetworkStatusTab.qml:212",
     "comment": ""
   },
   {
@@ -13968,6 +13998,12 @@
     "comment": ""
   },
   {
+    "term": "Show a popup to sign in when a network requires it before reaching the internet.",
+    "context": "Show a popup to sign in when a network requires it before reaching the internet.",
+    "reference": "Modules/Settings/NetworkStatusTab.qml:213",
+    "comment": ""
+  },
+  {
     "term": "Show all 9 tags instead of only occupied tags",
     "context": "Show all 9 tags instead of only occupied tags",
     "reference": "Modules/Settings/WorkspacesTab.qml:194",
@@ -14223,6 +14259,18 @@
     "term": "Shutdown",
     "context": "Shutdown",
     "reference": "Services/CupsService.qml:817",
+    "comment": ""
+  },
+  {
+    "term": "Sign in to network",
+    "context": "Sign in to network",
+    "reference": "Modals/CaptivePortalModal.qml:69",
+    "comment": ""
+  },
+  {
+    "term": "Sign-in required for this network",
+    "context": "Sign-in required for this network",
+    "reference": "Modules/Settings/NetworkStatusTab.qml:228",
     "comment": ""
   },
   {
@@ -15012,6 +15060,12 @@
     "comment": ""
   },
   {
+    "term": "The network \"%1\" requires sign-in before you can reach the internet.",
+    "context": "The network \"%1\" requires sign-in before you can reach the internet.",
+    "reference": "Modals/CaptivePortalModal.qml:79",
+    "comment": ""
+  },
+  {
     "term": "The rule applies to any window matching one of these.",
     "context": "The rule applies to any window matching one of these.",
     "reference": "Modals/WindowRuleModal.qml:757",
@@ -15130,6 +15184,12 @@
     "context": "This may take a few seconds",
     "reference": "Modules/Settings/AudioTab.qml:513",
     "comment": "Loading overlay subtitle"
+  },
+  {
+    "term": "This network requires sign-in before you can reach the internet.",
+    "context": "This network requires sign-in before you can reach the internet.",
+    "reference": "Modals/CaptivePortalModal.qml:79",
+    "comment": ""
   },
   {
     "term": "This output is disabled in the current profile",

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -2105,6 +2105,37 @@
     "description": "Show an outline ring around the focused workspace indicator"
   },
   {
+    "section": "captivePortal",
+    "label": "Captive Portal",
+    "tabIndex": 7,
+    "category": "Network",
+    "keywords": [
+      "before",
+      "captive",
+      "connection",
+      "connectivity",
+      "ethernet",
+      "hotspot",
+      "internet",
+      "login",
+      "network",
+      "online",
+      "popup",
+      "portal",
+      "public wifi",
+      "reaching",
+      "requires",
+      "show",
+      "sign",
+      "sign in",
+      "wi-fi",
+      "wifi",
+      "wireless"
+    ],
+    "icon": "wifi_lock",
+    "description": "Show a popup to sign in when a network requires it before reaching the internet."
+  },
+  {
     "section": "_tab_7",
     "label": "Network",
     "tabIndex": 7,
@@ -2141,6 +2172,33 @@
       "wireless"
     ],
     "icon": "lan"
+  },
+  {
+    "section": "captivePortalAutoOpen",
+    "label": "Open sign-in page automatically",
+    "tabIndex": 7,
+    "category": "Network",
+    "keywords": [
+      "automatically",
+      "before",
+      "connection",
+      "connectivity",
+      "ethernet",
+      "internet",
+      "network",
+      "online",
+      "open",
+      "page",
+      "popup",
+      "reaching",
+      "requires",
+      "show",
+      "sign",
+      "wi-fi",
+      "wifi",
+      "wireless"
+    ],
+    "description": "Show a popup to sign in when a network requires it before reaching the internet."
   },
   {
     "section": "_tab_8",


### PR DESCRIPTION
## Description

Adds captive portal detection and a sign-in popup, similar to mainstream desktop and mobile OSes: when you join a network that requires sign-in before reaching the internet, DMS surfaces a popup and opens the login page in your default browser.

How it works:
- A backend-agnostic connectivity probe in the network manager requests a known endpoint with redirects disabled. A redirect (or an unexpected response body) means traffic is being intercepted by a portal; a `204`/expected body means full connectivity. The result is exposed as two new `NetworkState` fields, `connectivity` (`unknown`/`none`/`portal`/`limited`/`full`) and `portalURL`, which flow over the socket to the QML services.
- `CaptivePortalModal` auto-opens when a portal is detected (gated by a setting) and closes automatically once the user signs in (the periodic re-probe flips the state to `full`).
- A settings toggle under **Network Status → Captive Portal** enables/disables the popup, and a manual "Open sign-in page" entry is shown there while a portal is active.

Notes / design decisions (open to feedback):
- The probe lives in the `Manager` rather than the NetworkManager backend, so it works across all backends (NetworkManager, iwd, networkd) and does not depend on NM's connectivity checking being enabled.
- The probe endpoint defaults to `http://nmcheck.gnome.org/check_network_status.txt` (the same default NetworkManager uses) and is overridable via `DMS_CAPTIVE_PROBE_URL`. Once a connection is healthy, it is re-checked only every ~5 minutes to keep background traffic low.
- The modal reports the SSID and warns when a VPN is active (it may need to be disconnected to reach the portal).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Fixes #2632

## Screenshots / video

The popup ("Sign in to network") shows the network name with **Open login page** and **Dismiss** actions. I can attach a screenshot/recording with demo data on request.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally (against a real captive portal and a local simulation)
- [x] New user-facing strings are wrapped in `I18n.tr()` and registered in `en.json`, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: `make lint-qml` was not run locally — generating the tooling VFS requires a newer Quickshell than the packaged 0.3.0 here. QML was verified with `qmllint` syntax checks and a live runtime load; happy to address anything CI flags.
- [ ] I have opened a corresponding pull request in DankLinux-Docs — glad to do so if you'd like docs for this.
