### PR TITLE
Fix stuck OSD after external exclusive-input surface releases

### DIFF
--- a/quickshell/Widgets/DankOSD.qml
+++ b/quickshell/Widgets/DankOSD.qml
@@ -28,6 +28,15 @@ PanelWindow {
     function show() {
         if (SessionData.suppressOSD)
             return;
+        // Hyprlock or any external exclusive-input surface can leave shouldBeVisible=true
+        // while the underlying layer surface has already gone, so every subsequent show()
+        // silently early-returns and the OSD never appears again. Reset and re-show when
+        // the flag and the actual visibility have desynced.
+        if (shouldBeVisible && !visible) {
+            shouldBeVisible = false;
+            hideTimer.stop();
+            closeTimer.stop();
+        }
         if (shouldBeVisible) {
             hideTimer.restart();
             return;
@@ -46,6 +55,15 @@ PanelWindow {
     }
 
     function resetHideTimer() {
+        // Hyprlock or any external exclusive-input surface can leave shouldBeVisible=true
+        // while the underlying layer surface has already gone, so every subsequent show()
+        // silently early-returns and the OSD never appears again. Reset and re-show when
+        // the flag and the actual visibility have desynced.
+        if (shouldBeVisible && !visible) {
+            shouldBeVisible = false;
+            hideTimer.stop();
+            closeTimer.stop();
+        }
         if (shouldBeVisible) {
             hideTimer.restart();
         }


### PR DESCRIPTION
The volume/brightness/etc OSDs silently stop appearing after a hyprlock cycle (or any custom lock command, or anything else that takes an exclusive Wayland input grab over DMS's layer surfaces). Volume still changes, the bar widgets still update, only the popup never renders. `systemctl --user restart dms.service` clears it.

## Root cause

`DankOSD.show()` early-returns when `shouldBeVisible` is true:

```qml
function show() {
    if (SessionData.suppressOSD) return
    if (shouldBeVisible) {
        hideTimer.restart()
        return
    }
    OSDManager.showOSD(root)
    ...
}
```

When hyprlock (or any session-lock surface) takes the exclusive grab while an OSD is mid-show, the underlying layer surface gets cleared, but `shouldBeVisible` stays true. After unlock, every subsequent `show()` hits that guard and silently does nothing. `hideTimer` keeps getting restarted but never fires the actual `hide()` either, because `mouseArea.containsMouse` can latch true while focus was held by the lock surface (Volume OSD has `enableMouseInteraction: true`).

Net effect: a state flag stuck `true` with no real surface backing it, no path back to a clean state without process restart.

## Fix

Detect the desync at the top of `show()`. If `shouldBeVisible` is set but `visible` is not, the OSD is in the stuck state, so reset both timers and the flag before falling through to the normal show path.

One block of code, no API changes, no behavioural change in the happy path: `shouldBeVisible && !visible` only evaluates true when something already pulled the surface out from under us.

## Status

Static analysis only at the time of filing. The patched QML had not yet been loaded by a live DMS process. I'll edit this section with a real repro result once verified.

## Impact

8-line addition inside `show()`, no other files touched, no settings or signals added.

### Note

Comment in the patch describes the failure mode in terms of "external exclusive-input surface", since this isn't hyprlock-specific. Same shape will happen with any layer-shell client that takes the grab while an OSD is open.