### PR TITLE
fix(network): show WiFi connection progress

### DIFF
--- a/quickshell/Modules/ControlCenter/Details/NetworkDetail.qml
+++ b/quickshell/Modules/ControlCenter/Details/NetworkDetail.qml
@@ -565,6 +565,7 @@ Rectangle {
             required property int index
 
             readonly property bool isConnected: modelData.ssid === NetworkService.currentWifiSSID
+            readonly property bool isConnecting: NetworkService.isWifiConnecting && NetworkService.connectingSSID === modelData.ssid
             readonly property bool isPinned: root.getPinnedNetworks().includes(modelData.ssid)
             readonly property string networkName: modelData.ssid || I18n.tr("Unknown Network")
             readonly property int signalStrength: modelData.signal || 0
@@ -583,7 +584,17 @@ Rectangle {
                 anchors.leftMargin: Theme.spacingM
                 spacing: Theme.spacingS
 
+                DankSpinner {
+                    size: Theme.iconSize - 4
+                    strokeWidth: 2
+                    color: Theme.warning
+                    running: wifiDelegate.isConnecting
+                    visible: wifiDelegate.isConnecting
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
                 DankIcon {
+                    visible: !wifiDelegate.isConnecting
                     name: {
                         if (wifiDelegate.signalStrength >= 50)
                             return "wifi";
@@ -603,7 +614,7 @@ Rectangle {
                     StyledText {
                         text: wifiDelegate.networkName
                         font.pixelSize: Theme.fontSizeMedium
-                        color: Theme.surfaceText
+                        color: wifiDelegate.isConnected ? Theme.primary : Theme.surfaceText
                         font.weight: wifiDelegate.isConnected ? Font.Medium : Font.Normal
                         elide: Text.ElideRight
                         width: parent.width
@@ -613,9 +624,9 @@ Rectangle {
                         spacing: Theme.spacingXS
 
                         StyledText {
-                            text: wifiDelegate.isConnected ? I18n.tr("Connected") + " \u2022" : (modelData.secured ? I18n.tr("Secured") + " \u2022" : I18n.tr("Open") + " \u2022")
+                            text: wifiDelegate.isConnecting ? I18n.tr("Connecting...") + " \u2022" : (wifiDelegate.isConnected ? I18n.tr("Connected") + " \u2022" : (modelData.secured ? I18n.tr("Secured") + " \u2022" : I18n.tr("Open") + " \u2022"))
                             font.pixelSize: Theme.fontSizeSmall
-                            color: Theme.surfaceVariantText
+                            color: wifiDelegate.isConnecting ? Theme.warning : Theme.surfaceVariantText
                         }
 
                         StyledText {
@@ -651,6 +662,7 @@ Rectangle {
                     networkContextMenu.currentSecured = modelData.secured;
                     networkContextMenu.currentEnterprise = modelData.enterprise;
                     networkContextMenu.currentConnected = wifiDelegate.isConnected;
+                    networkContextMenu.currentConnecting = wifiDelegate.isConnecting;
                     networkContextMenu.currentSaved = modelData.saved;
                     networkContextMenu.currentSignal = modelData.signal;
                     networkContextMenu.currentAutoconnect = modelData.autoconnect || false;
@@ -743,7 +755,8 @@ Rectangle {
                 anchors.fill: parent
                 anchors.rightMargin: optionsButton.width + pinWifiRow.width + (qrCodeButton.visible ? qrCodeButton.width : 0) + Theme.spacingS * 5 + Theme.spacingM
                 hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
+                enabled: !NetworkService.isWifiConnecting || wifiDelegate.isConnected
+                cursorShape: enabled ? Qt.PointingHandCursor : Qt.BusyCursor
                 onPressed: mouse => wifiRipple.trigger(mouse.x, mouse.y)
                 onClicked: function (event) {
                     if (wifiDelegate.isConnected) {
@@ -768,6 +781,7 @@ Rectangle {
         property bool currentSecured: false
         property bool currentEnterprise: false
         property bool currentConnected: false
+        property bool currentConnecting: false
         property bool currentSaved: false
         property int currentSignal: 0
         property bool currentAutoconnect: false
@@ -786,13 +800,14 @@ Rectangle {
         }
 
         MenuItem {
-            text: networkContextMenu.currentConnected ? I18n.tr("Disconnect") : I18n.tr("Connect")
+            text: networkContextMenu.currentConnecting ? I18n.tr("Connecting...") : (networkContextMenu.currentConnected ? I18n.tr("Disconnect") : I18n.tr("Connect"))
             height: 32
+            enabled: !networkContextMenu.currentConnecting
 
             contentItem: StyledText {
                 text: parent.text
                 font.pixelSize: Theme.fontSizeSmall
-                color: Theme.surfaceText
+                color: parent.enabled ? Theme.surfaceText : Theme.surfaceVariantText
                 leftPadding: Theme.spacingS
                 verticalAlignment: Text.AlignVCenter
             }

--- a/quickshell/Modules/Settings/NetworkWifiTab.qml
+++ b/quickshell/Modules/Settings/NetworkWifiTab.qml
@@ -465,6 +465,7 @@ Item {
                                     required property int index
 
                                     readonly property bool isConnected: modelData.ssid === NetworkService.currentWifiSSID
+                                    readonly property bool isConnecting: NetworkService.isWifiConnecting && NetworkService.connectingSSID === modelData.ssid
                                     readonly property bool isPinned: root.getPinnedWifiNetworks().includes(modelData.ssid)
                                     readonly property bool isExpanded: root.expandedWifiSsid === modelData.ssid
 
@@ -499,7 +500,17 @@ Item {
                                                 anchors.rightMargin: Theme.spacingS
                                                 spacing: Theme.spacingS
 
+                                                DankSpinner {
+                                                    size: 20
+                                                    strokeWidth: 2
+                                                    color: Theme.warning
+                                                    running: isConnecting
+                                                    visible: isConnecting
+                                                    anchors.verticalCenter: parent.verticalCenter
+                                                }
+
                                                 DankIcon {
+                                                    visible: !isConnecting
                                                     name: {
                                                         const s = modelData.signal || 0;
                                                         if (s >= 50)
@@ -552,9 +563,9 @@ Item {
                                                         spacing: Theme.spacingXS
 
                                                         StyledText {
-                                                            text: isConnected ? I18n.tr("Connected") : (modelData.secured ? I18n.tr("Secured") : I18n.tr("Open"))
+                                                            text: isConnecting ? I18n.tr("Connecting...") : (isConnected ? I18n.tr("Connected") : (modelData.secured ? I18n.tr("Secured") : I18n.tr("Open")))
                                                             font.pixelSize: Theme.fontSizeSmall
-                                                            color: isConnected ? Theme.primary : Theme.surfaceVariantText
+                                                            color: isConnecting ? Theme.warning : (isConnected ? Theme.primary : Theme.surfaceVariantText)
                                                         }
 
                                                         StyledText {
@@ -672,7 +683,8 @@ Item {
                                                 anchors.fill: parent
                                                 anchors.rightMargin: wifiNetworkActions.width + Theme.spacingM
                                                 hoverEnabled: true
-                                                cursorShape: Qt.PointingHandCursor
+                                                enabled: !NetworkService.isWifiConnecting || isConnected
+                                                cursorShape: enabled ? Qt.PointingHandCursor : Qt.BusyCursor
                                                 onClicked: {
                                                     WifiConnectionActions.connectToNetwork(modelData, {
                                                         connected: isConnected,
@@ -859,6 +871,7 @@ Item {
                             required property int index
 
                             readonly property bool isConnected: modelData.ssid === NetworkService.currentWifiSSID
+                            readonly property bool isConnecting: NetworkService.isWifiConnecting && NetworkService.connectingSSID === modelData.ssid
                             readonly property bool isPinned: root.getPinnedWifiNetworks().includes(modelData.ssid)
                             readonly property bool isOutOfRange: modelData.outOfRange || false
                             readonly property bool isExpanded: !isOutOfRange && root.expandedSavedWifiSsid === modelData.ssid
@@ -894,7 +907,17 @@ Item {
                                         anchors.rightMargin: Theme.spacingS
                                         spacing: Theme.spacingS
 
+                                        DankSpinner {
+                                            size: 20
+                                            strokeWidth: 2
+                                            color: Theme.warning
+                                            running: isConnecting
+                                            visible: isConnecting
+                                            anchors.verticalCenter: parent.verticalCenter
+                                        }
+
                                         DankIcon {
+                                            visible: !isConnecting
                                             name: {
                                                 if (isOutOfRange)
                                                     return "wifi_off";
@@ -941,6 +964,8 @@ Item {
 
                                             StyledText {
                                                 text: {
+                                                    if (isConnecting)
+                                                        return I18n.tr("Connecting...");
                                                     const parts = [isConnected ? I18n.tr("Connected") : (modelData.secured ? I18n.tr("Secured") : I18n.tr("Open"))];
                                                     parts.push(isOutOfRange ? I18n.tr("Unavailable") : (modelData.signal || 0) + "%");
                                                     if (modelData.hidden || false)
@@ -948,7 +973,7 @@ Item {
                                                     return parts.join(" • ");
                                                 }
                                                 font.pixelSize: Theme.fontSizeSmall
-                                                color: isConnected ? Theme.primary : Theme.surfaceVariantText
+                                                color: isConnecting ? Theme.warning : (isConnected ? Theme.primary : Theme.surfaceVariantText)
                                                 width: parent.width
                                                 elide: Text.ElideRight
                                             }
@@ -1028,7 +1053,8 @@ Item {
                                         anchors.fill: parent
                                         anchors.rightMargin: savedWifiActions.width + Theme.spacingM
                                         hoverEnabled: true
-                                        cursorShape: isOutOfRange ? Qt.ArrowCursor : Qt.PointingHandCursor
+                                        enabled: !NetworkService.isWifiConnecting || isConnected
+                                        cursorShape: isOutOfRange ? Qt.ArrowCursor : (enabled ? Qt.PointingHandCursor : Qt.BusyCursor)
                                         onClicked: {
                                             if (isOutOfRange)
                                                 return;
@@ -1162,14 +1188,15 @@ Item {
                                 }
 
                                 MenuItem {
-                                    text: isConnected ? I18n.tr("Disconnect") : I18n.tr("Connect")
+                                    text: isConnecting ? I18n.tr("Connecting...") : (isConnected ? I18n.tr("Disconnect") : I18n.tr("Connect"))
                                     height: isOutOfRange ? 0 : 32
                                     visible: !isOutOfRange
+                                    enabled: !isConnecting
 
                                     contentItem: StyledText {
                                         text: parent.text
                                         font.pixelSize: Theme.fontSizeSmall
-                                        color: Theme.surfaceText
+                                        color: parent.enabled ? Theme.surfaceText : Theme.surfaceVariantText
                                         leftPadding: Theme.spacingS
                                         verticalAlignment: Text.AlignVCenter
                                     }

--- a/quickshell/Services/DMSNetworkService.qml
+++ b/quickshell/Services/DMSNetworkService.qml
@@ -467,6 +467,8 @@ Singleton {
             return;
         pendingConnectionSSID = ssid;
         pendingConnectionStartTime = Date.now();
+        isConnecting = true;
+        connectingSSID = ssid;
         connectionError = "";
         connectionStatus = "connecting";
         credentialsRequested = false;
@@ -510,6 +512,8 @@ Singleton {
                 connectionError = response.error;
                 lastConnectionError = response.error;
                 pendingConnectionSSID = "";
+                isConnecting = false;
+                connectingSSID = "";
                 connectionStatus = "failed";
                 ToastService.showError(I18n.tr("Failed to start connection to %1").arg(ssid));
             }


### PR DESCRIPTION
## Description

When starting a WiFi connection through the DMS network backend, the UI did not immediately show which network was being connected. This made slow or failed connection attempts look like the network list had stopped responding, especially when switching from the current network to a saved network with outdated credentials.

This updates the DMS network service to expose `isConnecting` and `connectingSSID` as soon as a WiFi connection request starts. The Control Center network detail and Settings WiFi lists now show a row-level `Connecting...` state with a spinner, disable duplicate connection attempts while another WiFi connection is in progress, and keep the connected network visually distinct from the network being attempted.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

None

## Screenshots / video

<img width="821" height="496" alt="wifi-connecting-detail-5s" src="https://github.com/user-attachments/assets/cbf94dfb-4cbe-48c2-8201-b7b5cc43ae21" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
