### PR TITLE
launcher: add ctrl+H/L navigation in grid mode

### DIFF
--- a/quickshell/Modals/DankLauncherV2/LauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/LauncherContent.qml
@@ -219,6 +219,24 @@ FocusScope {
             }
             event.accepted = false;
             return;
+        case Qt.Key_L:
+            if (hasCtrl) {
+                if (controller.getCurrentSectionViewMode() !== "list") {
+                    controller.selectRight();
+                }
+                return;
+            }
+            event.accepted = false;
+            return;
+        case Qt.Key_H:
+            if (hasCtrl) {
+                if (controller.getCurrentSectionViewMode() !== "list") {
+                    controller.selectLeft();
+                }
+                return;
+            }
+            event.accepted = false;
+            return;
         case Qt.Key_N:
             if (hasCtrl) {
                 controller.selectNextSection();


### PR DESCRIPTION
## Description

Add missing ctrl + h/l navigation for launcher grid mode

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [ ] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
