### PR TITLE
feat(tray): add IPC action to open tray menus

### DIFF
--- a/quickshell/Common/TrayMenuManager.qml
+++ b/quickshell/Common/TrayMenuManager.qml
@@ -8,8 +8,29 @@ Singleton {
     id: root
 
     property var activeTrayMenus: ({})
+    property var _pendingMenuRequest: null
 
-    signal openTrayMenuRequested(string itemId)
+    signal openTrayMenuRequested
+
+    function requestOpenMenu(itemId, screenName) {
+        _pendingMenuRequest = {
+            "itemId": itemId,
+            "screenName": screenName
+        };
+        openTrayMenuRequested();
+    }
+
+    // Every SystemTrayBar instance receives the signal; the claim ensures
+    // exactly one opens the menu, preferring the requested screen
+    function claimMenuRequest(instanceScreenName) {
+        if (!_pendingMenuRequest)
+            return null;
+        if (_pendingMenuRequest.screenName && _pendingMenuRequest.screenName !== instanceScreenName)
+            return null;
+        const request = _pendingMenuRequest;
+        _pendingMenuRequest = null;
+        return request;
+    }
 
     function findTrayItem(itemId: string): var {
         if (!itemId)
@@ -24,27 +45,30 @@ Singleton {
     }
 
     function registerMenu(screenName, menu) {
-        if (!screenName || !menu) return
-        const newMenus = Object.assign({}, activeTrayMenus)
-        newMenus[screenName] = menu
-        activeTrayMenus = newMenus
+        if (!screenName || !menu)
+            return;
+        const newMenus = Object.assign({}, activeTrayMenus);
+        newMenus[screenName] = menu;
+        activeTrayMenus = newMenus;
     }
 
     function unregisterMenu(screenName) {
-        if (!screenName) return
-        const newMenus = Object.assign({}, activeTrayMenus)
-        delete newMenus[screenName]
-        activeTrayMenus = newMenus
+        if (!screenName)
+            return;
+        const newMenus = Object.assign({}, activeTrayMenus);
+        delete newMenus[screenName];
+        activeTrayMenus = newMenus;
     }
 
     function closeAllMenus() {
         for (const screenName in activeTrayMenus) {
-            const menu = activeTrayMenus[screenName]
-            if (!menu) continue
+            const menu = activeTrayMenus[screenName];
+            if (!menu)
+                continue;
             if (typeof menu.close === "function") {
-                menu.close()
+                menu.close();
             } else if (menu.showMenu !== undefined) {
-                menu.showMenu = false
+                menu.showMenu = false;
             }
         }
     }

--- a/quickshell/Common/TrayMenuManager.qml
+++ b/quickshell/Common/TrayMenuManager.qml
@@ -1,12 +1,27 @@
 pragma Singleton
 
 import Quickshell
+import Quickshell.Services.SystemTray
 import QtQuick
 
 Singleton {
     id: root
 
     property var activeTrayMenus: ({})
+
+    signal openTrayMenuRequested(string itemId)
+
+    function findTrayItem(itemId: string): var {
+        if (!itemId)
+            return null;
+
+        return SystemTray.items.values.find(item => {
+            const id = item?.id || "";
+            const title = item?.tooltipTitle || "";
+            const fullKey = title ? `${id}::${title}` : id;
+            return fullKey === itemId || id === itemId;
+        });
+    }
 
     function registerMenu(screenName, menu) {
         if (!screenName || !menu) return

--- a/quickshell/DMSShellIPC.qml
+++ b/quickshell/DMSShellIPC.qml
@@ -2054,7 +2054,7 @@ Item {
             if (!item.hasMenu)
                 return `ERROR: Tray item has no menu: ${itemId}`;
 
-            TrayMenuManager.openTrayMenuRequested(itemId);
+            TrayMenuManager.requestOpenMenu(itemId, BarWidgetService.getFocusedScreenName());
             return `SUCCESS: Requested menu ${itemId}`;
         }
 

--- a/quickshell/DMSShellIPC.qml
+++ b/quickshell/DMSShellIPC.qml
@@ -2023,18 +2023,6 @@ Item {
     }
 
     IpcHandler {
-        function findTrayItem(itemId: string): var {
-            if (!itemId)
-                return null;
-
-            return SystemTray.items.values.find(item => {
-                const id = item?.id || "";
-                const title = item?.tooltipTitle || "";
-                const fullKey = title ? `${id}::${title}` : id;
-                return fullKey === itemId || id === itemId;
-            });
-        }
-
         function list(): string {
             const items = SystemTray.items.values;
             if (items.length === 0)
@@ -2050,7 +2038,7 @@ Item {
         }
 
         function activate(itemId: string): string {
-            const item = findTrayItem(itemId);
+            const item = TrayMenuManager.findTrayItem(itemId);
             if (!item)
                 return `ERROR: Tray item not found: ${itemId}`;
 
@@ -2058,8 +2046,20 @@ Item {
             return `SUCCESS: Activated ${itemId}`;
         }
 
+        function menu(itemId: string): string {
+            const item = TrayMenuManager.findTrayItem(itemId);
+            if (!item)
+                return `ERROR: Tray item not found: ${itemId}`;
+
+            if (!item.hasMenu)
+                return `ERROR: Tray item has no menu: ${itemId}`;
+
+            TrayMenuManager.openTrayMenuRequested(itemId);
+            return `SUCCESS: Requested menu ${itemId}`;
+        }
+
         function status(itemId: string): string {
-            const item = findTrayItem(itemId);
+            const item = TrayMenuManager.findTrayItem(itemId);
             if (!item)
                 return `ERROR: Tray item not found: ${itemId}`;
 

--- a/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
+++ b/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
@@ -86,9 +86,12 @@ BasePill {
     Connections {
         target: TrayMenuManager
 
-        function onOpenTrayMenuRequested(itemId) {
-            const item = TrayMenuManager.findTrayItem(itemId);
+        function onOpenTrayMenuRequested() {
+            const request = TrayMenuManager.claimMenuRequest(root.parentScreen?.name);
+            if (!request)
+                return;
 
+            const item = TrayMenuManager.findTrayItem(request.itemId);
             if (!item || !item.hasMenu)
                 return;
 

--- a/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
+++ b/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
@@ -83,6 +83,19 @@ BasePill {
         root.showForTrayItem(trayItem, anchorItem, parentScreen, root.isAtBottom, root.isVerticalOrientation, root.axis);
     }
 
+    Connections {
+        target: TrayMenuManager
+
+        function onOpenTrayMenuRequested(itemId) {
+            const item = TrayMenuManager.findTrayItem(itemId);
+
+            if (!item || !item.hasMenu)
+                return;
+
+            root.showForTrayItem(item, root, parentScreen, root.isAtBottom, root.isVerticalOrientation, root.axis);
+        }
+    }
+
     function openInlineTrayContextMenu(trayItem, areaItem, mouse, anchorItem) {
         if (!trayItem) {
             return;


### PR DESCRIPTION
## Summary

This adds a new tray IPC action:

```bash
dms ipc call tray menu <id>
```

The new action opens the menu for a system tray item using the same item lookup behavior as the existing tray IPC actions.

## Implementation

* Adds an `openTrayMenuRequested` signal to `TrayMenuManager`.
* Adds a `menu(itemId)` function to the tray IPC handler.
* Handles the actual menu opening in `SystemTrayBar` by reusing the existing `showForTrayItem()` path.

The IPC layer only requests the menu to be opened. It does not attempt to render or display tray menus directly.

## Motivation

This makes it possible to open tray item menus from compositor keybindings, for example from niri shortcuts, without manually clicking the tray item in the bar.

## Tested

Built and launched the current source tree with:

```bash
make run
```

Verified the tray IPC actions using the locally built binary:

```bash
./core/bin/dms ipc call tray list
./core/bin/dms ipc call tray status "Fcitx"
./core/bin/dms ipc call tray activate "Fcitx"
./core/bin/dms ipc call tray menu "Fcitx"
./core/bin/dms ipc call tray menu "nm-applet"
./core/bin/dms ipc call tray menu "definitely-not-existing"
```

Confirmed that valid tray menus open correctly, existing tray IPC actions continue to work, and missing tray items return the expected error.

