### PR TITLE
feat(Notifications): add option to disable popup background fill

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -839,6 +839,7 @@ Singleton {
 
     property bool notificationOverlayEnabled: false
     property bool notificationPopupShadowEnabled: true
+    property bool notificationPopupBgDisabled: false
     property bool notificationPopupPrivacyMode: false
     property int overviewRows: 2
     property int overviewColumns: 5

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -426,6 +426,7 @@ var SPEC = {
 
     notificationOverlayEnabled: { def: false },
     notificationPopupShadowEnabled: { def: true },
+    notificationPopupBgDisabled: { def: false },
     notificationPopupPrivacyMode: { def: false },
     overviewRows: { def: 2, persist: false },
     overviewColumns: { def: 5, persist: false },

--- a/quickshell/Modules/Notifications/Popup/NotificationPopup.qml
+++ b/quickshell/Modules/Notifications/Popup/NotificationPopup.qml
@@ -647,7 +647,9 @@ PanelWindow {
             sourceWidth: Math.max(0, content.width - (content.cardInset * 2))
             sourceHeight: Math.max(0, content.height - (content.cardInset * 2))
             targetRadius: win.connectedFrameMode ? Theme.connectedSurfaceRadius : Theme.cornerRadius
-            targetColor: win.connectedFrameMode ? Theme.floatingSurface : Theme.readableSurface
+            targetColor: (win.connectedFrameMode && SettingsData.notificationPopupBgDisabled)
+                ? "transparent"
+                : (win.connectedFrameMode ? Theme.floatingSurface : Theme.readableSurface)
             borderColor: win.notificationData && win.notificationData.urgency === NotificationUrgency.Critical ? Theme.withAlpha(Theme.primary, 0.3) : Theme.withAlpha(Theme.outline, 0.08)
             borderWidth: win.notificationData && win.notificationData.urgency === NotificationUrgency.Critical ? 2 : 0
         }

--- a/quickshell/Modules/Settings/NotificationsTab.qml
+++ b/quickshell/Modules/Settings/NotificationsTab.qml
@@ -331,6 +331,16 @@ Item {
                 }
 
                 SettingsToggleRow {
+                    settingKey: "notificationPopupBgDisabled"
+                    visible: SettingsData.connectedFrameModeActive
+                    tags: ["notification", "popup", "background", "color", "fill", "transparent", "blur"]
+                    text: I18n.tr("Disable Background Fill")
+                    description: I18n.tr("Render notification popups with no fill color, letting blur and border show through.")
+                    checked: SettingsData.notificationPopupBgDisabled
+                    onToggled: checked => SettingsData.set("notificationPopupBgDisabled", checked)
+                }
+
+                SettingsToggleRow {
                     settingKey: "notificationPopupPrivacyMode"
                     tags: ["notification", "popup", "privacy", "body", "content", "hide"]
                     text: I18n.tr("Privacy Mode")


### PR DESCRIPTION
- New "Disable Background Fill" toggle in Settings > Notifications
- Adds notificationPopupBgDisabled setting (default off)
- Popup renders transparent fill in connected frame mode, keeping blur/border
- Toggle only visible when Connected Frame Mode is active

## Description
Add a "Disable Background Fill" toggle (**Connected** Frame Mode only) that makes notification popups render with a transparent fill for a more seamless, glass-like integration with the shell.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video
<img width="660" height="445" alt="image" src="https://github.com/user-attachments/assets/f5dafff0-1716-496e-9d25-cff22a98ff54" />
<img width="660" height="445" alt="image" src="https://github.com/user-attachments/assets/3d966742-fd6f-457c-b17c-580d30992c8a" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a14ed0da-7722-41df-bff5-6150c973f8af" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a6edf470-a567-432d-a5cd-97bbf289295b" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
