### PR TITLE
feat(Settings): add Settings window opacity option

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -165,6 +165,7 @@ Singleton {
     property bool runUserMatugenTemplates: true
     property string matugenTargetMonitor: ""
     property real popupTransparency: 1.0
+    property real settingsModalOpacity: 1.0
     property real dockTransparency: 1
     property string widgetBackgroundColor: "sch"
     property string widgetBackgroundCustomColor: "#6750A4"

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -16,6 +16,7 @@ var SPEC = {
     matugenTargetMonitor: { def: "", onChange: "regenSystemThemes" },
 
     popupTransparency: { def: 1.0, coerce: percentToUnit },
+    settingsModalOpacity: { def: 1.0, coerce: percentToUnit },
     dockTransparency: { def: 1.0, coerce: percentToUnit },
 
     widgetBackgroundColor: { def: "sch" },

--- a/quickshell/Modals/Settings/SettingsModal.qml
+++ b/quickshell/Modals/Settings/SettingsModal.qml
@@ -90,7 +90,7 @@ FloatingWindow {
     minimumSize: Qt.size(500, 400)
     implicitWidth: 900
     implicitHeight: screen ? Math.min(940, screen.height - 100) : 940
-    color: Theme.surfaceContainer
+    color: "transparent"
     visible: false
 
     onIsCompactModeChanged: {
@@ -170,6 +170,11 @@ FloatingWindow {
         }
     }
 
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.withAlpha(Theme.surfaceContainer, SettingsData.settingsModalOpacity)
+    }
+
     FocusScope {
         id: contentFocusScope
 
@@ -192,12 +197,6 @@ FloatingWindow {
                     anchors.fill: parent
                     onPressed: windowControls.tryStartMove()
                     onDoubleClicked: windowControls.tryToggleMaximize()
-                }
-
-                Rectangle {
-                    anchors.fill: parent
-                    color: Theme.surfaceContainer
-                    opacity: 0.5
                 }
 
                 Row {

--- a/quickshell/Modals/Settings/SettingsSidebar.qml
+++ b/quickshell/Modals/Settings/SettingsSidebar.qml
@@ -631,7 +631,7 @@ Rectangle {
     implicitWidth: __calculatedWidth
     width: __calculatedWidth
     height: parent.height
-    color: Theme.surfaceContainer
+    color: "transparent"
     radius: Theme.cornerRadius
 
     Component.onCompleted: {

--- a/quickshell/Modules/Settings/ThemeColorsTab.qml
+++ b/quickshell/Modules/Settings/ThemeColorsTab.qml
@@ -2033,6 +2033,20 @@ Item {
                     checked: SettingsData.modalDarkenBackground
                     onToggled: checked => SettingsData.set("modalDarkenBackground", checked)
                 }
+
+                SettingsSliderRow {
+                    tab: "theme"
+                    tags: ["modal", "settings", "transparency", "opacity", "background"]
+                    settingKey: "settingsModalOpacity"
+                    text: I18n.tr("Settings Window Opacity")
+                    description: I18n.tr("Controls opacity of the Settings window background")
+                    value: Math.round(SettingsData.settingsModalOpacity * 100)
+                    minimum: 0
+                    maximum: 100
+                    unit: "%"
+                    defaultValue: 100
+                    onSliderValueChanged: newValue => SettingsData.set("settingsModalOpacity", newValue / 100)
+                }
             }
 
             SettingsCard {


### PR DESCRIPTION
- New "Settings Window Opacity" slider in Theme & Colors > Modal Background
- Adds settingsModalOpacity setting (default 100%, 0-100% range)
- Settings modal background honors the opacity value
- Make sidebar transparent so window opacity shows through
- Remove redundant title bar Rectangle that caused opacity desync

## Description
Add a "Settings Window Opacity" slider (0–100%) in Theme & Colors that makes the Settings window see through to the desktop with a surface-color tint.

For niri users: disable `shadow.draw-behind-window` of settings modal to avoid unexpected dark background.
```kdl
window-rule {
    match app-id="^com.danklinux.dms$" title="Settings|设置"
    open-floating true
    shadow {
        draw-behind-window false
    }
}
```

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video
- 100% Opacity
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/95400b89-f168-4002-876c-592b8f62af04" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c953cfa7-eb79-4266-9825-f441ec876332" />

- 60% Opacity
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c767f4ff-ef03-4e43-b370-2e5044bc81e1" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/aa18f513-84ad-4900-9b12-a584464c4aec" />

- 0% Opacity (Not recommended)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/46b2f26d-1533-4c10-9a99-a5564012b2d6" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/08ab2613-05f3-4c43-82e5-3907ae81a552" />

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
