### PR TITLE
feat(DankBar): add configurable middle-click action on empty bar space

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -997,6 +997,7 @@ Singleton {
             "scrollEnabled": true,
             "scrollXBehavior": "column",
             "scrollYBehavior": "workspace",
+            "middleClickAction": "none",
             "shadowIntensity": 0,
             "shadowOpacity": 60,
             "shadowColorMode": "default",

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -565,6 +565,7 @@ var SPEC = {
             scrollEnabled: true,
             scrollXBehavior: "column",
             scrollYBehavior: "workspace",
+            middleClickAction: "none",
             shadowIntensity: 0,
             shadowOpacity: 60,
             shadowColorMode: "default",

--- a/quickshell/Modules/DankBar/DankBarWindow.qml
+++ b/quickshell/Modules/DankBar/DankBarWindow.qml
@@ -979,7 +979,26 @@ PanelWindow {
                         anchors.fill: parent
                         z: -2
                         acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
-                        onClicked: {
+                        onClicked: mouse => {
+                            if (mouse.button === Qt.MiddleButton) {
+                                const action = barConfig?.middleClickAction ?? "none"
+                                switch (action) {
+                                case "control-center":
+                                    barWindow.triggerControlCenter();
+                                    return;
+                                case "spotlight":
+                                    PopoutService.toggleDankLauncherV2();
+                                    return;
+                                case "close-window":
+                                    const active = ToplevelManager.activeToplevel;
+                                    if (active && typeof active.close === "function")
+                                        active.close();
+                                    return;
+                                case "settings":
+                                    PopoutService.toggleSettings();
+                                    return;
+                                }
+                            }
                             const screenName = barWindow.screen?.name;
                             if (!screenName)
                                 return;

--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -171,6 +171,7 @@ Item {
             scrollEnabled: defaultBar.scrollEnabled ?? true,
             scrollXBehavior: defaultBar.scrollXBehavior ?? "column",
             scrollYBehavior: defaultBar.scrollYBehavior ?? "workspace",
+            middleClickAction: defaultBar.middleClickAction ?? "none",
             hoverPopouts: defaultBar.hoverPopouts ?? false,
             hoverPopoutDelay: defaultBar.hoverPopoutDelay ?? 150,
             shadowIntensity: defaultBar.shadowIntensity ?? 0,
@@ -1933,6 +1934,52 @@ Item {
                         SettingsData.updateBarConfig(selectedBarId, {
                             scrollXBehavior: behavior
                         });
+                    }
+                }
+            }
+
+            SettingsCard {
+                iconName: "mouse"
+                title: I18n.tr("Mouse Click Action")
+                settingKey: "barMouseClickAction"
+                visible: !dankBarTab.appearanceOnly && selectedBarConfig?.enabled
+
+                SettingsDropdownRow {
+                    text: I18n.tr("Middle Click")
+                    description: I18n.tr("Choose what middle-clicking empty bar space does")
+                    settingKey: "barMiddleClickAction"
+                    options: [
+                        I18n.tr("None", "bar middle click action"),
+                        I18n.tr("Toggle Control Center", "bar middle click action"),
+                        I18n.tr("Toggle Launcher", "bar middle click action"),
+                        I18n.tr("Close Active Window", "bar middle click action"),
+                        I18n.tr("Toggle Settings", "bar middle click action")
+                    ]
+                    currentValue: {
+                        switch (selectedBarConfig?.middleClickAction ?? "none") {
+                        case "control-center":
+                            return I18n.tr("Toggle Control Center", "bar middle click action");
+                        case "spotlight":
+                            return I18n.tr("Toggle Launcher", "bar middle click action");
+                        case "close-window":
+                            return I18n.tr("Close Active Window", "bar middle click action");
+                        case "settings":
+                            return I18n.tr("Toggle Settings", "bar middle click action");
+                        default:
+                            return I18n.tr("None", "bar middle click action");
+                        }
+                    }
+                    onValueChanged: value => {
+                        if (value === I18n.tr("Toggle Control Center", "bar middle click action"))
+                            SettingsData.updateBarConfig(selectedBarId, { middleClickAction: "control-center" });
+                        else if (value === I18n.tr("Toggle Launcher", "bar middle click action"))
+                            SettingsData.updateBarConfig(selectedBarId, { middleClickAction: "spotlight" });
+                        else if (value === I18n.tr("Close Active Window", "bar middle click action"))
+                            SettingsData.updateBarConfig(selectedBarId, { middleClickAction: "close-window" });
+                        else if (value === I18n.tr("Toggle Settings", "bar middle click action"))
+                            SettingsData.updateBarConfig(selectedBarId, { middleClickAction: "settings" });
+                        else
+                            SettingsData.updateBarConfig(selectedBarId, { middleClickAction: "none" });
                     }
                 }
             }


### PR DESCRIPTION
- New per-bar "Middle Click" setting in DankBar Settings (SettingsDropdownRow)
- Options: None / Toggle Control Center / Toggle Launcher / Close Active Window / Toggle Settings
- Stores middleClickAction in barConfigs (default "none", zero regression)
- BarCanvas MouseArea branches on middle button and dispatches the configured action
- Left/right click behavior unchanged (still dismisses popouts/menus)

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
