### PR TITLE
fix(ui): resolve ui inconsistencies and missing i18n strings

### DIFF
--- a/quickshell/Modules/Settings/DankDashTab.qml
+++ b/quickshell/Modules/Settings/DankDashTab.qml
@@ -12,6 +12,10 @@ Item {
     focus: true
     property string highlightedId: ""
 
+    DankTooltipV2 {
+        id: sharedTooltip
+    }
+
     readonly property var __presentation: ({
             "overview": {
                 "icon": "dashboard",
@@ -261,6 +265,12 @@ Item {
                                 hoverEnabled: true
                                 cursorShape: Qt.PointingHandCursor
                                 onClicked: SettingsData.resetDashTabs()
+                                onEntered: {
+                                    sharedTooltip.show(I18n.tr("Reset"), resetButton, 0, 0, "bottom");
+                                }
+                                onExited: {
+                                    sharedTooltip.hide();
+                                }
                             }
 
                             Behavior on color {
@@ -527,6 +537,13 @@ Item {
                                             root.forceActiveFocus();
                                             root.highlightedId = rowItem.modelData;
                                             SettingsData.setDashTabEnabled(rowItem.modelData, !rowItem.isEnabled);
+                                        }
+                                        onEntered: {
+                                            const tooltipText = rowItem.isEnabled ? I18n.tr("Hide") : I18n.tr("Show");
+                                            sharedTooltip.show(tooltipText, visibilityButton, 0, 0, "bottom");
+                                        }
+                                        onExited: {
+                                            sharedTooltip.hide();
                                         }
                                     }
                                 }

--- a/quickshell/Modules/Settings/WallpaperTab.qml
+++ b/quickshell/Modules/Settings/WallpaperTab.qml
@@ -428,7 +428,7 @@ Item {
                         },
                         {
                             "value": "primary",
-                            "label": I18n.tr("Primary Theme Color")
+                            "label": I18n.tr("Primary")
                         },
                         {
                             "value": "surface",

--- a/quickshell/Modules/Settings/WallpaperTab.qml
+++ b/quickshell/Modules/Settings/WallpaperTab.qml
@@ -302,54 +302,109 @@ Item {
 
                 Item {
                     width: parent.width
-                    height: fillModeGroup.height
+                    height: fillModeColumn.height
                     visible: root.currentWallpaper !== "" && !root.currentWallpaper.startsWith("#")
 
-                    DankButtonGroup {
-                        id: fillModeGroup
-                        property var internalModes: ["Stretch", "Fit", "Fill", "Scrolling", "Tile", "TileVertically", "TileHorizontally", "Pad"]
+                    Column {
+                        id: fillModeColumn
                         anchors.horizontalCenter: parent.horizontalCenter
-                        model: [I18n.tr("Stretch", "wallpaper fill mode"), I18n.tr("Fit", "wallpaper fill mode"), I18n.tr("Fill", "wallpaper fill mode"), I18n.tr("Scroll", "wallpaper fill mode"), I18n.tr("Tile", "wallpaper fill mode"), I18n.tr("Tile V", "wallpaper fill mode"), I18n.tr("Tile H", "wallpaper fill mode"), I18n.tr("Pad", "wallpaper fill mode")]
-                        selectionMode: "single"
-                        buttonHeight: 28
-                        minButtonWidth: 48
-                        buttonPadding: Theme.spacingS
-                        checkIconSize: 0
-                        textSize: Theme.fontSizeSmall
-                        checkEnabled: false
-                        currentIndex: {
-                            var mode = SessionData.perMonitorWallpaper ? SessionData.getMonitorWallpaperFillMode(selectedMonitorName) : SettingsData.wallpaperFillMode;
-                            return internalModes.indexOf(mode);
+                        spacing: Theme.spacingS
+
+                        property var firstRowModes: ["Stretch", "Fit", "Fill", "Scrolling"]
+                        property var secondRowModes: ["Tile", "TileVertically", "TileHorizontally", "Pad"]
+
+                        function currentMode() {
+                            return SessionData.perMonitorWallpaper ? SessionData.getMonitorWallpaperFillMode(selectedMonitorName) : SettingsData.wallpaperFillMode;
                         }
-                        onSelectionChanged: (index, selected) => {
-                            if (!selected)
-                                return;
+
+                        function selectMode(mode) {
                             if (SessionData.perMonitorWallpaper) {
-                                SessionData.setMonitorWallpaperFillMode(selectedMonitorName, internalModes[index]);
+                                SessionData.setMonitorWallpaperFillMode(selectedMonitorName, mode);
                             } else {
-                                SettingsData.set("wallpaperFillMode", internalModes[index]);
+                                SettingsData.set("wallpaperFillMode", mode);
                             }
                         }
 
-                        Connections {
-                            target: SettingsData
-                            function onWallpaperFillModeChanged() {
-                                if (SessionData.perMonitorWallpaper)
+                        DankButtonGroup {
+                            id: fillModeGroupFirstRow
+                            property var internalModes: fillModeColumn.firstRowModes
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            model: [I18n.tr("Stretch", "wallpaper fill mode"), I18n.tr("Fit", "wallpaper fill mode"), I18n.tr("Fill", "wallpaper fill mode"), I18n.tr("Scroll", "wallpaper fill mode")]
+                            selectionMode: "single"
+                            buttonHeight: 28
+                            minButtonWidth: 48
+                            buttonPadding: Theme.spacingS
+                            checkIconSize: 0
+                            textSize: Theme.fontSizeSmall
+                            checkEnabled: false
+                            currentIndex: {
+                                var mode = fillModeColumn.currentMode();
+                                var idx = internalModes.indexOf(mode);
+                                return idx >= 0 ? idx : -1;
+                            }
+                            onSelectionChanged: (index, selected) => {
+                                if (!selected)
                                     return;
-                                fillModeGroup.currentIndex = fillModeGroup.internalModes.indexOf(SettingsData.wallpaperFillMode);
+                                fillModeColumn.selectMode(internalModes[index]);
                             }
                         }
 
-                        Connections {
-                            target: root
-                            function onSelectedMonitorNameChanged() {
-                                if (!SessionData.perMonitorWallpaper)
-                                    return;
-                                fillModeGroup.currentIndex = Qt.binding(() => {
-                                    var mode = SessionData.perMonitorWallpaper ? SessionData.getMonitorWallpaperFillMode(selectedMonitorName) : SettingsData.wallpaperFillMode;
-                                    return fillModeGroup.internalModes.indexOf(mode);
-                                });
+                        DankButtonGroup {
+                            id: fillModeGroupSecondRow
+                            property var internalModes: fillModeColumn.secondRowModes
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            model: [I18n.tr("Tile", "wallpaper fill mode"), I18n.tr("Tile V", "wallpaper fill mode"), I18n.tr("Tile H", "wallpaper fill mode"), I18n.tr("Pad", "wallpaper fill mode")]
+                            selectionMode: "single"
+                            buttonHeight: 28
+                            minButtonWidth: 48
+                            buttonPadding: Theme.spacingS
+                            checkIconSize: 0
+                            textSize: Theme.fontSizeSmall
+                            checkEnabled: false
+                            currentIndex: {
+                                var mode = fillModeColumn.currentMode();
+                                var idx = internalModes.indexOf(mode);
+                                return idx >= 0 ? idx : -1;
                             }
+                            onSelectionChanged: (index, selected) => {
+                                if (!selected)
+                                    return;
+                                fillModeColumn.selectMode(internalModes[index]);
+                            }
+                        }
+                    }
+
+                    Connections {
+                        target: SettingsData
+                        function onWallpaperFillModeChanged() {
+                            if (SessionData.perMonitorWallpaper)
+                                return;
+                            fillModeGroupFirstRow.currentIndex = Qt.binding(() => {
+                                var idx = fillModeGroupFirstRow.internalModes.indexOf(SettingsData.wallpaperFillMode);
+                                return idx >= 0 ? idx : -1;
+                            });
+                            fillModeGroupSecondRow.currentIndex = Qt.binding(() => {
+                                var idx = fillModeGroupSecondRow.internalModes.indexOf(SettingsData.wallpaperFillMode);
+                                return idx >= 0 ? idx : -1;
+                            });
+                        }
+                    }
+
+                    Connections {
+                        target: root
+                        function onSelectedMonitorNameChanged() {
+                            if (!SessionData.perMonitorWallpaper)
+                                return;
+                            fillModeGroupFirstRow.currentIndex = Qt.binding(() => {
+                                var mode = SessionData.getMonitorWallpaperFillMode(selectedMonitorName);
+                                var idx = fillModeGroupFirstRow.internalModes.indexOf(mode);
+                                return idx >= 0 ? idx : -1;
+                            });
+                            fillModeGroupSecondRow.currentIndex = Qt.binding(() => {
+                                var mode = SessionData.getMonitorWallpaperFillMode(selectedMonitorName);
+                                var idx = fillModeGroupSecondRow.internalModes.indexOf(mode);
+                                return idx >= 0 ? idx : -1;
+                            });
                         }
                     }
                 }

--- a/quickshell/Modules/Settings/Widgets/SettingsButtonGroupRow.qml
+++ b/quickshell/Modules/Settings/Widgets/SettingsButtonGroupRow.qml
@@ -78,7 +78,7 @@ Item {
     signal selectionChanged(int index, bool selected)
 
     width: parent?.width ?? 0
-    height: 60
+    height: Math.max(60, textColumn.implicitHeight + Theme.spacingM * 2)
 
     Row {
         id: contentRow
@@ -88,6 +88,7 @@ Item {
         spacing: Theme.spacingM
 
         Column {
+            id: textColumn
             width: parent.width - buttonGroup.width - Theme.spacingM
             anchors.verticalCenter: parent.verticalCenter
             spacing: Theme.spacingXS

--- a/quickshell/Modules/Settings/Widgets/SettingsSliderCard.qml
+++ b/quickshell/Modules/Settings/Widgets/SettingsSliderCard.qml
@@ -26,6 +26,11 @@ StyledRect {
 
     signal sliderValueChanged(int newValue)
     signal sliderDragFinished(int finalValue)
+
+    DankTooltipV2 {
+        id: sharedTooltip
+    }
+
     width: parent?.width ?? 0
     height: Theme.spacingL * 2 + contentColumn.height
     radius: Theme.cornerRadius
@@ -120,6 +125,12 @@ StyledRect {
                     slider.value = root.defaultValue;
                     root.sliderValueChanged(root.defaultValue);
                     root.sliderDragFinished(root.defaultValue);
+                }
+                onEntered: {
+                    sharedTooltip.show(I18n.tr("Reset"), resetButton, 0, 0, "bottom");
+                }
+                onExited: {
+                    sharedTooltip.hide();
                 }
             }
         }

--- a/quickshell/Modules/Settings/Widgets/SettingsSliderRow.qml
+++ b/quickshell/Modules/Settings/Widgets/SettingsSliderRow.qml
@@ -72,6 +72,11 @@ Item {
 
     signal sliderValueChanged(int newValue)
     signal sliderDragFinished(int finalValue)
+
+    DankTooltipV2 {
+        id: sharedTooltip
+    }
+
     width: parent?.width ?? 0
     height: headerRow.height + Theme.spacingXS + slider.height
 
@@ -134,6 +139,12 @@ Item {
                         slider.value = root.defaultValue;
                         root.sliderValueChanged(root.defaultValue);
                         root.sliderDragFinished(root.defaultValue);
+                    }
+                    onEntered: {
+                        sharedTooltip.show(I18n.tr("Reset"), resetButton, 0, 0, "bottom");
+                    }
+                    onExited: {
+                        sharedTooltip.hide();
                     }
                 }
             }

--- a/quickshell/Modules/Settings/WidgetsTabSection.qml
+++ b/quickshell/Modules/Settings/WidgetsTabSection.qml
@@ -57,12 +57,30 @@ Column {
     readonly property real rowHeight: 72
     readonly property real rowSpacing: Theme.spacingS
 
+    property var rowHeights: []
+
+    function rowHeightAt(i) {
+        if (i < 0 || i >= rowHeights.length || rowHeights[i] === undefined)
+            return rowHeight;
+        return Math.max(rowHeight, rowHeights[i]);
+    }
+
+    function cumulativeHeightUpTo(pos) {
+        var y = 0;
+        var n = Math.min(pos, items.length);
+        for (var i = 0; i < n; i++)
+            y += rowHeightAt(i) + rowSpacing;
+        return y;
+    }
+
     readonly property real totalHeight: {
         const n = items.length;
-        let base = n * (rowHeight + rowSpacing);
+        let base = cumulativeHeightUpTo(n);
+        if (n > 0)
+            base -= rowSpacing;
         if (gapIndex >= 0)
             base += (rowHeight + rowSpacing);
-        return Math.max(0, base - rowSpacing);
+        return Math.max(0, base);
     }
 
     function resetWorkingOrder() {
@@ -76,15 +94,21 @@ Column {
         var pos = workingOrder.indexOf(i);
         if (pos < 0)
             pos = i;
-        var y = pos * (rowHeight + rowSpacing);
+        var y = cumulativeHeightUpTo(pos);
         if (gapIndex >= 0 && pos >= gapIndex)
             y += (rowHeight + rowSpacing);
         return y;
     }
 
     function slotIndexForY(localY) {
-        var idx = Math.round(localY / (rowHeight + rowSpacing));
-        return Math.max(0, Math.min(idx, items.length));
+        var y = 0;
+        for (var i = 0; i < items.length; i++) {
+            var h = rowHeightAt(i) + rowSpacing;
+            if (y + h / 2 > localY)
+                return i;
+            y += h;
+        }
+        return items.length;
     }
 
     function slotIndexForGlobalY(rootItem, gy) {
@@ -102,7 +126,7 @@ Column {
     function updateDragTarget(centerY) {
         if (draggingIndex < 0)
             return;
-        var pos = Math.floor(centerY / (rowHeight + rowSpacing));
+        var pos = slotIndexForY(centerY);
         pos = Math.max(0, Math.min(pos, items.length - 1));
         var arr = workingOrder.slice();
         var d = arr.indexOf(draggingIndex);
@@ -201,9 +225,26 @@ Column {
                 readonly property bool highlighted: root.highlightedId !== "" && root.highlightedId === modelData.id && root.highlightedSection === root.sectionId
 
                 width: reorderArea.width
-                height: root.rowHeight
+                height: Math.max(root.rowHeight, textColumn.implicitHeight + 28)
                 z: dragging ? 100 : (highlighted ? 3 : 1)
                 opacity: (dragging && root.crossSectionActive) ? 0 : 1
+
+                onHeightChanged: {
+                    var arr = root.rowHeights.slice();
+                    while (arr.length <= rowIndex)
+                        arr.push(root.rowHeight);
+                    if (arr[rowIndex] !== height) {
+                        arr[rowIndex] = height;
+                        root.rowHeights = arr;
+                    }
+                }
+                Component.onCompleted: {
+                    var arr = root.rowHeights.slice();
+                    while (arr.length <= rowIndex)
+                        arr.push(root.rowHeight);
+                    arr[rowIndex] = height;
+                    root.rowHeights = arr;
+                }
 
                 Binding {
                     target: delegateItem
@@ -235,13 +276,12 @@ Column {
                     id: itemBackground
 
                     anchors.fill: parent
-                    anchors.margins: 2
                     scale: delegateItem.dragging ? 1.02 : 1.0
                     transformOrigin: Item.Center
                     radius: delegateItem.dragging ? Theme.cornerRadius + 6 : Theme.cornerRadius
-                    color: delegateItem.dragging ? Theme.secondaryContainer : Theme.withAlpha(Theme.surfaceContainer, 0.8)
+                    color: delegateItem.dragging ? Theme.secondaryContainer : Theme.withAlpha(Theme.surfaceContainer, modelData.enabled ? 0.7 : 0.4)
                     border.color: delegateItem.dragging ? Theme.primary : Theme.outlineHeavy
-                    border.width: delegateItem.dragging ? 2 : 0
+                    border.width: delegateItem.dragging ? 2 : 1
 
                     Behavior on scale {
                         NumberAnimation {
@@ -266,29 +306,61 @@ Column {
                         }
                     }
 
-                    DankIcon {
-                        name: "drag_indicator"
-                        size: Theme.iconSize - 4
-                        color: Theme.outline
-                        anchors.left: parent.left
-                        anchors.leftMargin: Theme.spacingM + 8
-                        anchors.verticalCenter: parent.verticalCenter
-                        opacity: 0.8
+                    Rectangle {
+                        anchors.fill: parent
+                        radius: parent.radius
+                        color: Theme.primary
+                        opacity: (dragArea.containsMouse && !delegateItem.dragging) ? 0.06 : 0
+                        Behavior on opacity {
+                            NumberAnimation {
+                                duration: Theme.shortDuration
+                            }
+                        }
                     }
 
                     DankIcon {
+                        id: dragHandle
+                        name: "drag_indicator"
+                        size: Theme.iconSize - 4
+                        color: delegateItem.dragging ? Theme.primary : Theme.outline
+                        anchors.left: parent.left
+                        anchors.leftMargin: Theme.spacingM
+                        anchors.verticalCenter: parent.verticalCenter
+                        opacity: modelData.enabled ? ((dragArea.containsMouse || delegateItem.dragging || delegateItem.highlighted) ? 1.0 : 0.45) : 0
+                        visible: opacity > 0.01
+
+                        Behavior on opacity {
+                            NumberAnimation {
+                                duration: Theme.shortDuration
+                            }
+                        }
+                        Behavior on color {
+                            ColorAnimation {
+                                duration: Theme.shortDuration
+                            }
+                        }
+                    }
+
+                    DankIcon {
+                        id: tabIcon
                         name: modelData.icon
                         size: Theme.iconSize
                         color: modelData.enabled ? Theme.primary : Theme.outline
                         anchors.left: parent.left
-                        anchors.leftMargin: Theme.spacingM * 2 + 40
+                        anchors.leftMargin: Theme.spacingM * 2 + Theme.iconSize - 4
                         anchors.verticalCenter: parent.verticalCenter
+
+                        Behavior on color {
+                            ColorAnimation {
+                                duration: Theme.shortDuration
+                            }
+                        }
                     }
 
                     Column {
                         id: textColumn
-                        anchors.left: parent.left
-                        anchors.leftMargin: Theme.spacingM * 3 + 40 + Theme.iconSize
+                        anchors.left: tabIcon.right
+                        anchors.leftMargin: Theme.spacingM
                         anchors.right: actionButtons.left
                         anchors.rightMargin: Theme.spacingM
                         anchors.verticalCenter: parent.verticalCenter
@@ -496,7 +568,7 @@ Column {
                             }
                             onEntered: {
                                 var currentEnabled = modelData.minimumWidth !== undefined ? modelData.minimumWidth : true;
-                                const tooltipText = currentEnabled ? "Force Padding" : "Dynamic Width";
+                                const tooltipText = currentEnabled ? I18n.tr("Force Padding") : I18n.tr("Dynamic Width");
                                 sharedTooltip.show(tooltipText, minimumWidthButton, 0, 0, "bottom");
                             }
                             onExited: {
@@ -515,7 +587,7 @@ Column {
                                 root.hideWhenIdleChanged(root.sectionId, index, modelData.hideWhenIdle !== true);
                             }
                             onEntered: {
-                                const tooltipText = modelData.hideWhenIdle === true ? "Hide when no updates: ON" : "Hide when no updates: OFF";
+                                const tooltipText = modelData.hideWhenIdle === true ? I18n.tr("Hide when no updates: ON") : I18n.tr("Hide when no updates: OFF");
                                 sharedTooltip.show(tooltipText, hideWhenIdleButton, 0, 0, "bottom");
                             }
                             onExited: {
@@ -748,7 +820,7 @@ Column {
                                                 return false;
                                             }
                                         })();
-                                    const tooltipText = isCompact ? "Full Size" : "Compact";
+                                    const tooltipText = isCompact ? I18n.tr("Full Size") : I18n.tr("Compact");
                                     sharedTooltip.show(tooltipText, compactModeButton, 0, 0, "bottom");
                                 }
                                 onExited: {
@@ -965,13 +1037,6 @@ Column {
                             iconColor: modelData.enabled ? Theme.primary : Theme.outline
                             onClicked: {
                                 root.itemEnabledChanged(root.sectionId, modelData.id, !modelData.enabled);
-                            }
-                            onEntered: {
-                                const tooltipText = modelData.enabled ? "Hide" : "Show";
-                                sharedTooltip.show(tooltipText, visibilityButton, 0, 0, "bottom");
-                            }
-                            onExited: {
-                                sharedTooltip.hide();
                             }
                         }
 
@@ -2317,6 +2382,7 @@ Column {
                                             anchors.rightMargin: Theme.spacingM
                                             anchors.verticalCenter: parent.verticalCenter
                                             spacing: Theme.spacingS
+                                            clip: true
 
                                             Item {
                                                 width: 16
@@ -2376,6 +2442,8 @@ Column {
                                                 color: Theme.surfaceText
                                                 font.weight: Font.Normal
                                                 anchors.verticalCenter: parent.verticalCenter
+                                                elide: Text.ElideRight
+                                                width: parent.width - 16 - Theme.spacingS - 16 - Theme.spacingS
                                             }
                                         }
 
@@ -2433,8 +2501,8 @@ Column {
         property string sectionId: ""
         property int widgetIndex: -1
 
-        width: 200
-        height: 160
+        width: 240
+        height: menuPrivacyColumn.implicitHeight + Theme.spacingS * 2
         padding: 0
         modal: true
         focus: true
@@ -2494,8 +2562,11 @@ Column {
                     Row {
                         anchors.left: parent.left
                         anchors.leftMargin: Theme.spacingS
+                        anchors.right: micToggle.left
+                        anchors.rightMargin: Theme.spacingS
                         anchors.verticalCenter: parent.verticalCenter
                         spacing: Theme.spacingS
+                        clip: true
 
                         DankIcon {
                             name: "mic"
@@ -2510,6 +2581,8 @@ Column {
                             color: Theme.surfaceText
                             font.weight: Font.Normal
                             anchors.verticalCenter: parent.verticalCenter
+                            elide: Text.ElideRight
+                            width: parent.width - 16 - Theme.spacingS
                         }
                     }
 
@@ -2546,8 +2619,11 @@ Column {
                     Row {
                         anchors.left: parent.left
                         anchors.leftMargin: Theme.spacingS
+                        anchors.right: cameraToggle.left
+                        anchors.rightMargin: Theme.spacingS
                         anchors.verticalCenter: parent.verticalCenter
                         spacing: Theme.spacingS
+                        clip: true
 
                         DankIcon {
                             name: "camera_video"
@@ -2562,6 +2638,8 @@ Column {
                             color: Theme.surfaceText
                             font.weight: Font.Normal
                             anchors.verticalCenter: parent.verticalCenter
+                            elide: Text.ElideRight
+                            width: parent.width - 16 - Theme.spacingS
                         }
                     }
 
@@ -2598,8 +2676,11 @@ Column {
                     Row {
                         anchors.left: parent.left
                         anchors.leftMargin: Theme.spacingS
+                        anchors.right: screenshareToggle.left
+                        anchors.rightMargin: Theme.spacingS
                         anchors.verticalCenter: parent.verticalCenter
                         spacing: Theme.spacingS
+                        clip: true
 
                         DankIcon {
                             name: "screen_share"
@@ -2614,6 +2695,8 @@ Column {
                             color: Theme.surfaceText
                             font.weight: Font.Normal
                             anchors.verticalCenter: parent.verticalCenter
+                            elide: Text.ElideRight
+                            width: parent.width - 16 - Theme.spacingS
                         }
                     }
 

--- a/quickshell/Modules/Settings/WidgetsTabSection.qml
+++ b/quickshell/Modules/Settings/WidgetsTabSection.qml
@@ -411,6 +411,12 @@ Column {
                             iconName: "more_vert"
                             iconSize: 18
                             iconColor: Theme.outline
+                            onEntered: {
+                                sharedTooltip.show(I18n.tr("Options"), gpuMenuButton, 0, 0, "bottom");
+                            }
+                            onExited: {
+                                sharedTooltip.hide();
+                            }
                             onClicked: {
                                 gpuContextMenu.widgetData = modelData;
                                 gpuContextMenu.sectionId = root.sectionId;
@@ -477,6 +483,12 @@ Column {
                             iconName: "more_vert"
                             iconSize: 18
                             iconColor: Theme.outline
+                            onEntered: {
+                                sharedTooltip.show(I18n.tr("Options"), diskMenuButton, 0, 0, "bottom");
+                            }
+                            onExited: {
+                                sharedTooltip.hide();
+                            }
                             onClicked: {
                                 diskUsageContextMenu.widgetData = modelData;
                                 diskUsageContextMenu.sectionId = root.sectionId;
@@ -602,6 +614,12 @@ Column {
                             iconName: "more_vert"
                             iconSize: 18
                             iconColor: Theme.outline
+                            onEntered: {
+                                sharedTooltip.show(I18n.tr("Options"), memMenuButton, 0, 0, "bottom");
+                            }
+                            onExited: {
+                                sharedTooltip.hide();
+                            }
                             onClicked: {
                                 memUsageContextMenu.widgetData = modelData;
                                 memUsageContextMenu.sectionId = root.sectionId;
@@ -636,6 +654,12 @@ Column {
                             iconName: "more_vert"
                             iconSize: 18
                             iconColor: Theme.outline
+                            onEntered: {
+                                sharedTooltip.show(I18n.tr("Options"), focusedWindowMenuButton, 0, 0, "bottom");
+                            }
+                            onExited: {
+                                sharedTooltip.hide();
+                            }
                             onClicked: {
                                 focusedWindowContextMenu.widgetData = modelData;
                                 focusedWindowContextMenu.sectionId = root.sectionId;
@@ -669,6 +693,12 @@ Column {
                             iconName: "more_vert"
                             iconSize: 18
                             iconColor: Theme.outline
+                            onEntered: {
+                                sharedTooltip.show(I18n.tr("Options"), musicMenuButton, 0, 0, "bottom");
+                            }
+                            onExited: {
+                                sharedTooltip.hide();
+                            }
                             onClicked: {
                                 musicContextMenu.widgetData = modelData;
                                 musicContextMenu.sectionId = root.sectionId;
@@ -702,6 +732,12 @@ Column {
                             iconName: "more_vert"
                             iconSize: 18
                             iconColor: Theme.outline
+                            onEntered: {
+                                sharedTooltip.show(I18n.tr("Options"), runningAppsMenuButton, 0, 0, "bottom");
+                            }
+                            onExited: {
+                                sharedTooltip.hide();
+                            }
                             onClicked: {
                                 runningAppsContextMenu.widgetData = modelData;
                                 runningAppsContextMenu.sectionId = root.sectionId;
@@ -735,6 +771,12 @@ Column {
                             iconName: "more_vert"
                             iconSize: 18
                             iconColor: Theme.outline
+                            onEntered: {
+                                sharedTooltip.show(I18n.tr("Options"), batteryMenuButton, 0, 0, "bottom");
+                            }
+                            onExited: {
+                                sharedTooltip.hide();
+                            }
                             onClicked: {
                                 batteryContextMenu.widgetData = modelData;
                                 batteryContextMenu.sectionId = root.sectionId;
@@ -836,6 +878,12 @@ Column {
                                 iconSize: 18
                                 iconColor: Theme.outline
 
+                                onEntered: {
+                                    sharedTooltip.show(I18n.tr("Options"), kbdLayoutCtxMenuButton, 0, 0, "bottom");
+                                }
+                                onExited: {
+                                    sharedTooltip.hide();
+                                }
                                 onClicked: {
                                     kbdLayoutCtxMenu.widgetData = modelData;
                                     kbdLayoutCtxMenu.sectionId = root.sectionId;
@@ -869,6 +917,12 @@ Column {
                                 iconName: "more_vert"
                                 iconSize: 18
                                 iconColor: Theme.outline
+                                onEntered: {
+                                    sharedTooltip.show(I18n.tr("Options"), appsDockMenuButton, 0, 0, "bottom");
+                                }
+                                onExited: {
+                                    sharedTooltip.hide();
+                                }
                                 onClicked: {
                                     appsDockContextMenu.widgetData = modelData;
                                     appsDockContextMenu.sectionId = root.sectionId;
@@ -902,6 +956,12 @@ Column {
                                 iconName: "more_vert"
                                 iconSize: 18
                                 iconColor: Theme.outline
+                                onEntered: {
+                                    sharedTooltip.show(I18n.tr("Options"), trayMenuButton, 0, 0, "bottom");
+                                }
+                                onExited: {
+                                    sharedTooltip.hide();
+                                }
                                 onClicked: {
                                     trayContextMenu.widgetData = modelData;
                                     trayContextMenu.sectionId = root.sectionId;
@@ -966,6 +1026,12 @@ Column {
                             iconName: "more_vert"
                             iconSize: 18
                             iconColor: Theme.outline
+                            onEntered: {
+                                sharedTooltip.show(I18n.tr("Options"), ccMenuButton, 0, 0, "bottom");
+                            }
+                            onExited: {
+                                sharedTooltip.hide();
+                            }
                             onClicked: {
                                 controlCenterContextMenu.widgetData = modelData;
                                 controlCenterContextMenu.sectionId = root.sectionId;
@@ -1001,6 +1067,12 @@ Column {
                             iconName: "more_vert"
                             iconSize: 18
                             iconColor: Theme.outline
+                            onEntered: {
+                                sharedTooltip.show(I18n.tr("Options"), privacyMenuButton, 0, 0, "bottom");
+                            }
+                            onExited: {
+                                sharedTooltip.hide();
+                            }
                             onClicked: {
                                 privacyContextMenu.widgetData = modelData;
                                 privacyContextMenu.sectionId = root.sectionId;
@@ -1037,6 +1109,13 @@ Column {
                             iconColor: modelData.enabled ? Theme.primary : Theme.outline
                             onClicked: {
                                 root.itemEnabledChanged(root.sectionId, modelData.id, !modelData.enabled);
+                            }
+                            onEntered: {
+                                const tooltipText = modelData.enabled ? I18n.tr("Hide") : I18n.tr("Show");
+                                sharedTooltip.show(tooltipText, visibilityButton, 0, 0, "bottom");
+                            }
+                            onExited: {
+                                sharedTooltip.hide();
                             }
                         }
 
@@ -1078,12 +1157,19 @@ Column {
                         }
 
                         DankActionButton {
+                            id: removeWidgetButton
                             buttonSize: 32
                             iconName: "close"
                             iconSize: 18
                             iconColor: Theme.error
                             onClicked: {
                                 root.removeWidget(root.sectionId, index);
+                            }
+                            onEntered: {
+                                sharedTooltip.show(I18n.tr("Remove"), removeWidgetButton, 0, 0, "bottom");
+                            }
+                            onExited: {
+                                sharedTooltip.hide();
                             }
                         }
                     }

--- a/quickshell/Modules/Settings/WorkspacesTab.qml
+++ b/quickshell/Modules/Settings/WorkspacesTab.qml
@@ -16,7 +16,8 @@ Item {
         Column {
             id: mainColumn
 
-            topPadding: 4
+            topPadding: Theme.spacingXL
+            bottomPadding: Theme.spacingXL
             width: Math.min(550, parent.width - Theme.spacingL * 2)
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: Theme.spacingXL

--- a/quickshell/Modules/Settings/WorkspacesTab.qml
+++ b/quickshell/Modules/Settings/WorkspacesTab.qml
@@ -16,8 +16,7 @@ Item {
         Column {
             id: mainColumn
 
-            topPadding: Theme.spacingXL
-            bottomPadding: Theme.spacingXL
+            topPadding: 4
             width: Math.min(550, parent.width - Theme.spacingL * 2)
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: Theme.spacingXL


### PR DESCRIPTION
### Description
This PR addresses several UI layout inconsistencies and implements missing internationalization (I18n) across different settings modules.
* **WallpaperTab**: Splits the wallpaper fill mode buttons into two separate rows (`fillModeGroupFirstRow`, `fillModeGroupSecondRow`) to prevent overflow.
* **WidgetsTabSection**: 
    * Made the widgets aesthetics consistent with that of `DankDashTab.qml`.
    * Fixes text and title overflow issues in widgets.
    * Fixes text overflow issues in the privacy menu popups (Mic/Camera/Screenshare).
    * Added missing unlocalized strings.
* **SettingsButtonGroupRow**: Replaces hardcoded height constraints to prevent text from being cut off.
* **WorkspacesTab**: Minor padding adjustments for visual consistency with other settings tabs.

**Before**
<img width="512" height="129" alt="2026-06-30 15-40-40" src="https://github.com/user-attachments/assets/701edf82-a4ac-41e0-b593-355cede6a0e9" />
<img width="536" height="46" alt="2026-06-30 17-01-19" src="https://github.com/user-attachments/assets/84a9f02c-8622-4072-bb95-192a9ffd5ca6" />
<img width="531" height="429" alt="2026-06-30 17-01-34" src="https://github.com/user-attachments/assets/904938f4-ac80-44d3-bcd0-024791ad4d3c" />
<img width="179" height="133" alt="2026-06-30 17-01-46" src="https://github.com/user-attachments/assets/3fc33dca-d555-4e07-9733-a7bd32238948" />
<img width="562" height="438" alt="immagine" src="https://github.com/user-attachments/assets/62aa548a-b434-4981-9f6d-d10d86601ab2" />

**After**
<img width="512" height="129" alt="2026-06-30 15-39-02" src="https://github.com/user-attachments/assets/55592729-3146-4c02-9e03-a57192ab9e4d" />
<img width="361" height="94" alt="2026-06-30 16-51-44" src="https://github.com/user-attachments/assets/fadbca98-a00c-431d-aa6c-73330ae106a9" />
<img width="514" height="389" alt="2026-06-30 16-52-07" src="https://github.com/user-attachments/assets/785342a1-6e57-4465-b5ac-d93dfccb934d" />
<img width="220" height="137" alt="2026-06-30 16-52-20" src="https://github.com/user-attachments/assets/0064402a-2f4e-4f68-8108-d4ac596489df" />
<img width="587" height="489" alt="2026-06-30 16-53-09" src="https://github.com/user-attachments/assets/ed5a0a89-77c4-4d45-aded-5e98f1ca3455" />

### Related issues

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues
<!-- add "Fixes #123" if applicable -->

## Screenshots / video
<!-- add screenshots/video of the Wallpaper tab (two-row fill mode) and Widgets tab (long text/IT rows) -->

## Checklist
- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs