### PR TITLE
fix(spotlight): select last query text on open; last-query persistence in connected frame mode

### DIFF
--- a/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalConnected.qml
+++ b/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalConnected.qml
@@ -359,8 +359,10 @@ Item {
         contentVisible = true;
         spotlightContent.closeTransientUi?.();
 
+        const targetQuery = query || (SettingsData.rememberLastQuery ? (SessionData.launcherLastQuery || "") : "");
+
         if (spotlightContent.searchField) {
-            spotlightContent.searchField.text = query;
+            spotlightContent.searchField.text = targetQuery;
         }
         if (spotlightContent.controller) {
             var targetMode = mode || SessionData.getLauncherRestoreMode();
@@ -375,8 +377,8 @@ Item {
             spotlightContent.controller.collapsedSections = {};
             spotlightContent.controller.selectedFlatIndex = 0;
             spotlightContent.controller.selectedItem = null;
-            if (query) {
-                spotlightContent.controller.setSearchQuery(query);
+            if (targetQuery) {
+                spotlightContent.controller.setSearchQuery(targetQuery);
             } else {
                 spotlightContent.controller.searchQuery = "";
                 spotlightContent.controller.performSearch();

--- a/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalConnected.qml
+++ b/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalConnected.qml
@@ -424,8 +424,10 @@ Item {
 
             Qt.callLater(() => {
                 root.keyboardActive = true;
-                if (root.spotlightContent && root.spotlightContent.searchField)
+                if (root.spotlightContent && root.spotlightContent.searchField) {
                     root.spotlightContent.searchField.forceActiveFocus();
+                    root.spotlightContent.searchField.selectAll();
+                }
             });
         });
     }

--- a/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalSpotlight.qml
+++ b/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalSpotlight.qml
@@ -155,7 +155,7 @@ Item {
         }
         if (spotlightContent.searchField) {
             spotlightContent.searchField.forceActiveFocus();
-            spotlightContent.searchField.cursorPosition = spotlightContent.searchField.text.length;
+            spotlightContent.searchField.selectAll();
         }
     }
 

--- a/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalStandalone.qml
+++ b/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalStandalone.qml
@@ -139,6 +139,7 @@ Item {
 
         if (spotlightContent.searchField) {
             spotlightContent.searchField.text = targetQuery;
+            spotlightContent.searchField.selectAll();
         }
         if (spotlightContent.controller) {
             var targetMode = mode || SessionData.getLauncherRestoreMode();


### PR DESCRIPTION
## Changes

- **fix(spotlight)**: Fixes 'remember last query' being ignored in connected frame mode.
- **fix(spotlight)**: Select last query text when spotlight opens instead of placing cursor at end

 "Fixes #2617"

https://github.com/user-attachments/assets/9617c911-546f-490e-a148-8f9ae3909ded




