### PR TITLE
feat: lockscreen screen filter

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -889,7 +889,6 @@ Singleton {
     readonly property bool greeterU2fReady: Processes.greeterU2fReady
     readonly property string greeterU2fReason: Processes.greeterU2fReason
     readonly property string greeterU2fSource: Processes.greeterU2fSource
-    property string lockScreenActiveMonitor: "all"
     property string lockScreenInactiveColor: "#000000"
     property int lockScreenNotificationMode: 0
     property bool lockScreenVideoEnabled: false
@@ -1743,6 +1742,17 @@ Singleton {
                     _pendingMigration = migrated;
                     obj = migrated;
                 }
+            }
+
+            if (obj?.lockScreenActiveMonitor !== undefined) {
+                var oldVal = obj.lockScreenActiveMonitor;
+                if (oldVal && oldVal !== "all") {
+                    if (!obj.screenPreferences) obj.screenPreferences = {};
+                    if (obj.screenPreferences.lockScreen === undefined) {
+                        obj.screenPreferences.lockScreen = [oldVal];
+                    }
+                }
+                delete obj.lockScreenActiveMonitor;
             }
 
             Store.parse(root, obj);

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -451,7 +451,6 @@ var SPEC = {
     maxFprintTries: { def: 15 },
     enableU2f: { def: false, onChange: "scheduleAuthApply" },
     u2fMode: { def: "or" },
-    lockScreenActiveMonitor: { def: "all" },
     lockScreenInactiveColor: { def: "#000000" },
     lockScreenNotificationMode: { def: 0 },
     lockScreenVideoEnabled: { def: false },

--- a/quickshell/Modules/Lock/Lock.qml
+++ b/quickshell/Modules/Lock/Lock.qml
@@ -196,9 +196,7 @@ Scope {
             property bool isActiveScreen: {
                 if (Quickshell.screens.length <= 1)
                     return true;
-                if (SettingsData.lockScreenActiveMonitor === "all")
-                    return true;
-                return currentScreenName === SettingsData.lockScreenActiveMonitor;
+                return SettingsData.getFilteredScreens("lockScreen").includes(screen);
             }
 
             color: isActiveScreen ? "transparent" : SettingsData.lockScreenInactiveColor

--- a/quickshell/Modules/Settings/LockScreenTab.qml
+++ b/quickshell/Modules/Settings/LockScreenTab.qml
@@ -398,64 +398,33 @@ Item {
                 iconName: "monitor"
                 title: I18n.tr("Lock Screen Display")
                 settingKey: "lockDisplay"
-                visible: Quickshell.screens.length > 1
 
                 StyledText {
-                    text: I18n.tr("Choose which monitor shows the lock screen interface. Other monitors will display a solid color for OLED burn-in protection.")
+                    text: I18n.tr("Choose which monitors show the lock screen interface. Other monitors will display a solid color for OLED burn-in protection.")
                     font.pixelSize: Theme.fontSizeSmall
                     color: Theme.surfaceVariantText
                     width: parent.width
                     wrapMode: Text.Wrap
                 }
 
-                SettingsDropdownRow {
-                    id: lockScreenMonitorDropdown
-                    settingKey: "lockScreenActiveMonitor"
-                    tags: ["lock", "screen", "monitor", "display", "active"]
-                    text: I18n.tr("Active Lock Screen Monitor")
-                    options: {
-                        var opts = [I18n.tr("All Monitors")];
-                        var screens = Quickshell.screens;
-                        for (var i = 0; i < screens.length; i++) {
-                            opts.push(SettingsData.getScreenDisplayName(screens[i]));
-                        }
-                        return opts;
-                    }
-
-                    Component.onCompleted: {
-                        if (SettingsData.lockScreenActiveMonitor === "all") {
-                            currentValue = I18n.tr("All Monitors");
-                            return;
-                        }
-                        var screens = Quickshell.screens;
-                        for (var i = 0; i < screens.length; i++) {
-                            if (screens[i].name === SettingsData.lockScreenActiveMonitor) {
-                                currentValue = SettingsData.getScreenDisplayName(screens[i]);
-                                return;
-                            }
-                        }
-                        currentValue = I18n.tr("All Monitors");
-                    }
-
-                    onValueChanged: value => {
-                        if (value === I18n.tr("All Monitors")) {
-                            SettingsData.set("lockScreenActiveMonitor", "all");
-                            return;
-                        }
-                        var screens = Quickshell.screens;
-                        for (var i = 0; i < screens.length; i++) {
-                            if (SettingsData.getScreenDisplayName(screens[i]) === value) {
-                                SettingsData.set("lockScreenActiveMonitor", screens[i].name);
-                                return;
-                            }
-                        }
+                SettingsDisplayPicker {
+                    width: parent.width
+                    displayPreferences: SettingsData.screenPreferences?.lockScreen || ["all"]
+                    onPreferencesChanged: prefs => {
+                        var p = SettingsData.screenPreferences || {};
+                        var updated = Object.assign({}, p);
+                        updated["lockScreen"] = prefs;
+                        SettingsData.set("screenPreferences", updated);
                     }
                 }
 
                 Row {
                     width: parent.width
                     spacing: Theme.spacingM
-                    visible: SettingsData.lockScreenActiveMonitor !== "all"
+                    visible: {
+                        var prefs = SettingsData.screenPreferences?.lockScreen;
+                        return Array.isArray(prefs) && !prefs.includes("all") && prefs.length > 0;
+                    }
 
                     Column {
                         width: parent.width - inactiveColorPreview.width - Theme.spacingM

--- a/quickshell/Modules/Settings/Widgets/SettingsDisplayPicker.qml
+++ b/quickshell/Modules/Settings/Widgets/SettingsDisplayPicker.qml
@@ -80,7 +80,7 @@ Item {
 
                     width: parent.width
                     text: SettingsData.getScreenDisplayName(modelData)
-                    description: modelData.width + "×" + modelData.height
+                    description: modelData.width + "×" + modelData.height + " • " + (SettingsData.displayNameMode === "system" ? (modelData.model || I18n.tr("Unknown Model")) : modelData.name)
                     checked: localChecked
                     onToggled: isChecked => {
                         var prefs = JSON.parse(JSON.stringify(root.displayPreferences));

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -4557,23 +4557,6 @@
     ]
   },
   {
-    "section": "lockScreenActiveMonitor",
-    "label": "Active Lock Screen Monitor",
-    "tabIndex": 11,
-    "category": "Lock Screen",
-    "keywords": [
-      "active",
-      "display",
-      "lock",
-      "lockscreen",
-      "login",
-      "monitor",
-      "password",
-      "screen",
-      "security"
-    ]
-  },
-  {
     "section": "lockScreenVideoCycling",
     "label": "Automatic Cycling",
     "tabIndex": 11,
@@ -4724,7 +4707,6 @@
     "tabIndex": 11,
     "category": "Lock Screen",
     "keywords": [
-      "active",
       "display",
       "lock",
       "lockscreen",


### PR DESCRIPTION
## Description

this makes use of the existing `getFilteredScreens` function and settings node to allow users to specify which displays the lockscreen should appear on. prior to this change, it was "all" or just one. This PR also handles the migrating of the old setting (if required).

New setting removes the old drop-down, and follows the same style/behaviour as the DankBar display settings.

**Before**:

<img width="672" height="293" alt="image" src="https://github.com/user-attachments/assets/d23107f3-25b6-430d-bfcc-e6f3ad01887d" />

**After**:

<img width="696" height="500" alt="1783129753400971680" src="https://github.com/user-attachments/assets/25cf814b-e88d-4344-9c0d-b27700c27611" />

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
