### PR TITLE
fix: add missing vertical anchor for cava/music icon

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/Media.qml
+++ b/quickshell/Modules/DankBar/Widgets/Media.qml
@@ -282,6 +282,7 @@ BasePill {
                 Row {
                     id: mediaInfo
                     spacing: Theme.spacingXS
+                    anchors.verticalCenter: parent.verticalCenter
 
                     Item {
                         width: 20


### PR DESCRIPTION
## Description

Add the missing vertical center anchor for the mpris widget. 

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

## Screenshots / video
Before:
<img width="208" height="66" alt="Screenshot from 2026-07-04 10-16-27" src="https://github.com/user-attachments/assets/daf5aab5-6fd6-47c4-b4ed-3427da7c5cc3" />
After:
<img width="208" height="66" alt="Screenshot from 2026-07-04 10-18-49" src="https://github.com/user-attachments/assets/6716581d-5cd0-4d92-bedb-54147b46b078" />


## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
