### PR TITLE
fix(clipboard): fix action buttons hover cursor shape

### DIFF
--- a/quickshell/Modals/Clipboard/ClipboardEntry.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEntry.qml
@@ -49,6 +49,15 @@ Rectangle {
         cornerRadius: root.radius
     }
 
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.RightButton
+        onClicked: mouse => {
+            const scenePos = mapToItem(null, mouse.x, mouse.y);
+            contextMenuRequested(scenePos.x, scenePos.y);
+        }
+    }
+
     Rectangle {
         id: indexBadge
         anchors.left: parent.left
@@ -232,15 +241,6 @@ Rectangle {
             } else {
                 copyRequested();
             }
-        }
-    }
-
-    MouseArea {
-        anchors.fill: parent
-        acceptedButtons: Qt.RightButton
-        onClicked: mouse => {
-            const scenePos = mapToItem(null, mouse.x, mouse.y);
-            contextMenuRequested(scenePos.x, scenePos.y);
         }
     }
 }


### PR DESCRIPTION
## Description

This pull request fixes an issue in the Clipboard entry delegate where hover and pointing hand cursor shapes were blocked on the action buttons (Pin, Edit, Delete).

- **Cause**: The background right-click `MouseArea` was declared at the end of `ClipboardEntry.qml`, stacking it on top of the action buttons and overriding/blocking their cursor shape.
- **Fix**: Moved the right-click `MouseArea` to be declared right after the ripple layer (at the bottom of the visual stack) so it no longer interferes with the hover states and cursors of the action buttons.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

None.

## Screenshots / video
Before
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/c971b0b4-207b-4ef3-85d9-f25209b87def" />
After
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/103c724a-94ef-42d4-be28-b2188ecbda1b" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs