### PR TITLE
fix(lockscreen): clock off-center with single hour digit

### DIFF
--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -358,7 +358,7 @@ Item {
                 property bool hasSeconds: timeParts.length > 2
 
                 ClockDigitText {
-                    width: 75
+                    width: clockText.hours.length > 1 ? 75 : 0
                     text: clockText.hours.length > 1 ? clockText.hours[0] : ""
                 }
 


### PR DESCRIPTION
## Description

Fix the lockscreen clock when only one digit is visible for the hour. It was one digit-witdth off to the right.

The fix is to make the 75px space conditional on digit length. Now the clock is perfectly centered regardless of number of digits in the time.

Tested both with and without the "pad hours" setting. Both now lock visually correct. I would share a screenshot here, but I'm not able to capture a screenshot while my screen is locked 🙃 

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
