### PR TITLE
fix(nix): update qt env launched apps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -138,8 +138,11 @@
                 install -D ${rootSrc}/core/assets/danklogo.svg \
                   $out/share/hicolor/scalable/apps/danklogo.svg
 
+                # Snapshot pre-wrap Qt paths for launched apps to restore.
                 wrapProgram $out/bin/dms \
                   --add-flags "-c $out/share/quickshell/dms" \
+                  --run 'export DMS_ORIG_NIXPKGS_QT6_QML_IMPORT_PATH="''${NIXPKGS_QT6_QML_IMPORT_PATH:-}"' \
+                  --run 'export DMS_ORIG_QT_PLUGIN_PATH="''${QT_PLUGIN_PATH:-}"' \
                   --prefix "NIXPKGS_QT6_QML_IMPORT_PATH" ":" "${mkQmlImportPath pkgs qtPackages}" \
                   --prefix "QT_PLUGIN_PATH" ":" "${mkQtPluginPath pkgs qtPackages}"
 

--- a/quickshell/Services/SessionService.qml
+++ b/quickshell/Services/SessionService.qml
@@ -192,6 +192,19 @@ Singleton {
         return envObj;
     }
 
+    // Restore pre-wrap Qt paths (Nix) so launched apps use their own.
+    function restoreWrapperEnv(env) {
+        const restore = (target, snapshot) => {
+            const orig = Quickshell.env(snapshot);
+            if (orig === null)
+                return;
+            env[target] = orig.length > 0 ? orig : null;
+        };
+        restore("NIXPKGS_QT6_QML_IMPORT_PATH", "DMS_ORIG_NIXPKGS_QT6_QML_IMPORT_PATH");
+        restore("QT_PLUGIN_PATH", "DMS_ORIG_QT_PLUGIN_PATH");
+        return env;
+    }
+
     function launchDesktopEntry(desktopEntry, useNvidia) {
         if (!desktopEntry || !desktopEntry.command)
             return;
@@ -216,7 +229,7 @@ Singleton {
         const cursorEnv = typeof SettingsData.getCursorEnvironment === "function" ? SettingsData.getCursorEnvironment() : {};
 
         const overrideEnv = override?.envVars ? parseEnvVars(override.envVars) : {};
-        const finalEnv = Object.assign({}, cursorEnv, overrideEnv);
+        const finalEnv = restoreWrapperEnv(Object.assign({}, cursorEnv, overrideEnv));
 
         if (desktopEntry.runInTerminal) {
             const terminal = SessionData.resolveTerminal() || "xterm";
@@ -266,13 +279,14 @@ Singleton {
         const prefix = userPrefix.length > 0 ? userPrefix : defaultPrefix;
         const workDir = desktopEntry.workingDirectory || Quickshell.env("HOME");
         const cursorEnv = typeof SettingsData.getCursorEnvironment === "function" ? SettingsData.getCursorEnvironment() : {};
+        const finalEnv = restoreWrapperEnv(Object.assign({}, cursorEnv));
 
         if (prefix.length > 0 && needsShellExecution(prefix)) {
             const escapedCmd = cmd.map(arg => escapeShellArg(arg)).join(" ");
             Quickshell.execDetached({
                 command: ["sh", "-c", `${prefix} ${escapedCmd}`],
                 workingDirectory: workDir,
-                environment: cursorEnv
+                environment: finalEnv
             });
             return;
         }
@@ -283,7 +297,7 @@ Singleton {
         Quickshell.execDetached({
             command: cmd,
             workingDirectory: workDir,
-            environment: cursorEnv
+            environment: finalEnv
         });
     }
 


### PR DESCRIPTION
## Problem
On NixOS, apps launched from the DMS launcher inherited DMS's own pinned Qt/kirigami paths. Apps built against a different nixpkgs (e.g. easyeffects) picked up the wrong kirigami and crashed.

## Fix
Save the original Qt paths before wrapping and restore them when launching apps. Non-Nix installs are unaffected.

Fixes #2039