### PR TITLE
fix(settings): missing vpn confirm delete modal

### DIFF
--- a/quickshell/Modules/Settings/NetworkVpnTab.qml
+++ b/quickshell/Modules/Settings/NetworkVpnTab.qml
@@ -368,7 +368,7 @@ Item {
                                                 hoverEnabled: true
                                                 cursorShape: Qt.PointingHandCursor
                                                 onClicked: {
-                                                    deleteVpnConfirm.showWithOptions({
+                                                    root.deleteVpnConfirm.showWithOptions({
                                                         title: I18n.tr("Delete VPN"),
                                                         message: I18n.tr("Delete \"%1\"?").arg(modelData.name),
                                                         confirmText: I18n.tr("Delete"),


### PR DESCRIPTION
## Description

The modal to remove VPNs was not appearing. Checked WiFi and that was working fine.

Simple one line fix to get the modal back and now VPNs can be deleted again.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
