### PR TITLE
Add Korean translation

### DIFF
--- a/quickshell/scripts/i18nsync.py
+++ b/quickshell/scripts/i18nsync.py
@@ -15,6 +15,7 @@ SYNC_STATE = REPO_ROOT / ".git" / "i18n_sync_state.json"
 
 LANGUAGES = {
     "ja": "ja.json",
+    "ko": "ko.json",
     "zh-Hans": "zh_CN.json",
     "zh-Hant": "zh_TW.json",
     "pt-br": "pt.json",

--- a/quickshell/translations/poexports/ko.json
+++ b/quickshell/translations/poexports/ko.json
@@ -1,0 +1,9254 @@
+{
+  "%1 (+%2 more)": {
+    "%1 (+%2 more)": "%1 (+%2개 더)"
+  },
+  "%1 Animation Speed": {
+    "%1 Animation Speed": "%1 애니메이션 속도"
+  },
+  "%1 Sessions": {
+    "%1 Sessions": "%1 세션"
+  },
+  "%1 Startup Failed": {
+    "%1 Startup Failed": "%1 시작 실패"
+  },
+  "%1 active session": {
+    "%1 active session": "%1 활성 세션"
+  },
+  "%1 active sessions": {
+    "%1 active sessions": "%1 활성 세션"
+  },
+  "%1 adapter, none connected": {
+    "%1 adapter, none connected": "%1 어댑터, 연결 안 됨"
+  },
+  "%1 adapters, none connected": {
+    "%1 adapters, none connected": "%1 어댑터, 연결 안 됨"
+  },
+  "%1 character": {
+    "%1 character": "%1 문자"
+  },
+  "%1 characters": {
+    "%1 characters": "%1 문자"
+  },
+  "%1 connected": {
+    "%1 connected": "%1 연결됨"
+  },
+  "%1 copied": {
+    "%1 copied": "%1 복사됨"
+  },
+  "%1 custom animation duration": {
+    "%1 custom animation duration": "%1 사용자 지정 애니메이션 지속 시간"
+  },
+  "%1 disconnected": {
+    "%1 disconnected": "%1 연결 끊김"
+  },
+  "%1 disconnected (hidden)": {
+    "%1 disconnected (hidden)": "%1 연결 끊김(숨김)"
+  },
+  "%1 display": {
+    "%1 display": "%1 디스플레이"
+  },
+  "%1 displays": {
+    "%1 displays": "%1 디스플레이"
+  },
+  "%1 filtered": {
+    "%1 filtered": "%1 필터링됨"
+  },
+  "%1 h %2 m left": {
+    "%1 h %2 m left": "%1시간 %2분 남음"
+  },
+  "%1 h left": {
+    "%1 h left": "%1시간 남음"
+  },
+  "%1 is now included in config": {
+    "%1 is now included in config": "%1이(가) 구성에 포함됨"
+  },
+  "%1 issue found": {
+    "%1 issue found": "%1개의 문제 발견"
+  },
+  "%1 issues found": {
+    "%1 issues found": "%1개의 문제 발견"
+  },
+  "%1 min left": {
+    "%1 min left": "%1분 남음"
+  },
+  "%1 notifications": {
+    "%1 notifications": "%1 알림"
+  },
+  "%1 online": {
+    "%1 online": "%1명 온라인"
+  },
+  "%1 tasks": {
+    "%1 tasks": "%1개 작업"
+  },
+  "%1 update": {
+    "%1 update": "%1 업데이트"
+  },
+  "%1 updates": {
+    "%1 updates": "%1 업데이트"
+  },
+  "%1 variants": {
+    "%1 variants": "%1 변형"
+  },
+  "%1 wallpaper  •  %2 / %3": {
+    "%1 wallpaper  •  %2 / %3": "%1 배경화면  •  %2 / %3"
+  },
+  "%1 wallpapers  •  %2 / %3": {
+    "%1 wallpapers  •  %2 / %3": "%1 배경화면  •  %2 / %3"
+  },
+  "%1 widgets": {
+    "%1 widgets": "%1 위젯"
+  },
+  "%1 window": {
+    "%1 window": "%1 창"
+  },
+  "%1 windows": {
+    "%1 windows": "%1 창"
+  },
+  "%1: %2": {
+    "%1: %2": "%1: %2"
+  },
+  "%1m ago": {
+    "%1m ago": "%1분 전"
+  },
+  "%command%": {
+    "%command%": "%command%"
+  },
+  "'Alternative' lets the key unlock on its own. 'Second factor' requires password or fingerprint first, then the key.": {
+    "'Alternative' lets the key unlock on its own. 'Second factor' requires password or fingerprint first, then the key.": "'Alternative'는 키 단독으로 잠금을 해제합니다. 'Second factor'는 암호나 지문을 먼저 요구한 뒤 키를 요구합니다."
+  },
+  "(Default)": {
+    "(Default)": "(기본값)"
+  },
+  "(Unnamed)": {
+    "(Unnamed)": "(이름 없음)"
+  },
+  "+ %1 more": {
+    "+ %1 more": "+ %1개 더"
+  },
+  "/path/to/videos": {
+    "/path/to/videos": "/path/to/videos"
+  },
+  "0 = square corners": {
+    "0 = square corners": "0 = 직각 모서리"
+  },
+  "1 day": {
+    "1 day": "1일"
+  },
+  "1 day before": {
+    "1 day before": "1일 전"
+  },
+  "1 hour": {
+    "1 hour": "1시간"
+  },
+  "1 hour 30 minutes": {
+    "1 hour 30 minutes": "1시간 30분"
+  },
+  "1 hour before": {
+    "1 hour before": "1시간 전"
+  },
+  "1 minute": {
+    "1 minute": "1분"
+  },
+  "1 notification": {
+    "1 notification": "1 알림"
+  },
+  "1 second": {
+    "1 second": "1초"
+  },
+  "1 task": {
+    "1 task": "1개 작업"
+  },
+  "10 min before": {
+    "10 min before": "10분 전"
+  },
+  "10 minutes": {
+    "10 minutes": "10분"
+  },
+  "10 seconds": {
+    "10 seconds": "10초"
+  },
+  "10-bit Color": {
+    "10-bit Color": "10비트 색상"
+  },
+  "12 hours": {
+    "12 hours": "12시간"
+  },
+  "14 days": {
+    "14 days": "14일"
+  },
+  "15 min": {
+    "15 min": "15분"
+  },
+  "15 min before": {
+    "15 min before": "15분 전"
+  },
+  "15 minutes": {
+    "15 minutes": "15분"
+  },
+  "15 seconds": {
+    "15 seconds": "15초"
+  },
+  "180°": {
+    "180°": "180°"
+  },
+  "2 hours": {
+    "2 hours": "2시간"
+  },
+  "2 minutes": {
+    "2 minutes": "2분"
+  },
+  "2 seconds": {
+    "2 seconds": "2초"
+  },
+  "20 minutes": {
+    "20 minutes": "20분"
+  },
+  "20 seconds": {
+    "20 seconds": "20초"
+  },
+  "24-Hour Format": {
+    "24-Hour Format": "24시간 형식"
+  },
+  "24-hour clock": {
+    "24-hour clock": "24시간 시계"
+  },
+  "25 seconds": {
+    "25 seconds": "25초"
+  },
+  "250 ms": {
+    "250 ms": "250ms"
+  },
+  "270°": {
+    "270°": "270°"
+  },
+  "3 days": {
+    "3 days": "3일"
+  },
+  "3 hours": {
+    "3 hours": "3시간"
+  },
+  "3 minutes": {
+    "3 minutes": "3분"
+  },
+  "3 seconds": {
+    "3 seconds": "3초"
+  },
+  "30 days": {
+    "30 days": "30일"
+  },
+  "30 min": {
+    "30 min": "30분"
+  },
+  "30 min before": {
+    "30 min before": "30분 전"
+  },
+  "30 minutes": {
+    "30 minutes": "30분"
+  },
+  "30 seconds": {
+    "30 seconds": "30초"
+  },
+  "35 seconds": {
+    "35 seconds": "35초"
+  },
+  "3rd party": {
+    "3rd party": "타사"
+  },
+  "4 hours": {
+    "4 hours": "4시간"
+  },
+  "4 seconds": {
+    "4 seconds": "4초"
+  },
+  "40 seconds": {
+    "40 seconds": "40초"
+  },
+  "45 seconds": {
+    "45 seconds": "45초"
+  },
+  "5 min before": {
+    "5 min before": "5분 전"
+  },
+  "5 minutes": {
+    "5 minutes": "5분"
+  },
+  "5 seconds": {
+    "5 seconds": "5초"
+  },
+  "50 seconds": {
+    "50 seconds": "50초"
+  },
+  "500 ms": {
+    "500 ms": "500ms"
+  },
+  "55 seconds": {
+    "55 seconds": "55초"
+  },
+  "6 hours": {
+    "6 hours": "6시간"
+  },
+  "7 days": {
+    "7 days": "7일"
+  },
+  "750 ms": {
+    "750 ms": "750ms"
+  },
+  "8 hours": {
+    "8 hours": "8시간"
+  },
+  "8 seconds": {
+    "8 seconds": "8초"
+  },
+  "90 days": {
+    "90 days": "90일"
+  },
+  "90°": {
+    "90°": "90°"
+  },
+  "<a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/LICENSE\" style=\"text-decoration:none; color:%1;\">MIT License</a>": {
+    "<a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/LICENSE\" style=\"text-decoration:none; color:%1;\">MIT License</a>": "<a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/LICENSE\" style=\"text-decoration:none; color:%1;\">MIT 라이선스</a>"
+  },
+  "A file with this name already exists. Do you want to overwrite it?": {
+    "A file with this name already exists. Do you want to overwrite it?": "이 이름의 파일이 이미 있습니다. 덮어쓰시겠습니까?"
+  },
+  "A modern desktop shell for Wayland compositors": {
+    "A modern desktop shell for Wayland compositors": "Wayland 컴포지터를 위한 모던 데스크톱 셸"
+  },
+  "A separate minimal launcher action that works in Standalone, Separate Frame Mode, and Connected Frame Mode.": {
+    "A separate minimal launcher action that works in Standalone, Separate Frame Mode, and Connected Frame Mode.": "독립 실행형, 개별 프레임 모드 및 연결된 프레임 모드에서 작동하는 분리된 최소 런처 작업입니다."
+  },
+  "A user with that name already exists.": {
+    "A user with that name already exists.": "해당 이름의 사용자가 이미 존재합니다."
+  },
+  "AC Adapter (Plugged In)": {
+    "AC Adapter (Plugged In)": "AC 어댑터 (연결됨)"
+  },
+  "AC Power": {
+    "AC Power": "AC 전원"
+  },
+  "API": {
+    "API": "API"
+  },
+  "AUR helpers are interactive — see the terminal window for prompts. This popout will return to idle when the upgrade exits.": {
+    "AUR helpers are interactive — see the terminal window for prompts. This popout will return to idle when the upgrade exits.": "AUR 헬퍼는 대화형입니다 — 터미널 창의 프롬프트를 확인하세요. 업그레이드가 종료되면 이 팝아웃은 유휴 상태로 돌아갑니다."
+  },
+  "Aborted": {
+    "Aborted": "중단됨"
+  },
+  "About": {
+    "About": "정보"
+  },
+  "Accent Color": {
+    "Accent Color": "강조 색상"
+  },
+  "Accept": {
+    "Accept": "수락"
+  },
+  "Accept Jobs": {
+    "Accept Jobs": "작업 수락"
+  },
+  "Accepting": {
+    "Accepting": "수락 중"
+  },
+  "Access clipboard history": {
+    "Access clipboard history": "클립보드 기록에 액세스"
+  },
+  "Access to notifications and do not disturb": {
+    "Access to notifications and do not disturb": "알림 및 방해 금지 모드에 액세스"
+  },
+  "Access to system controls and settings": {
+    "Access to system controls and settings": "시스템 제어 및 설정에 액세스"
+  },
+  "Action": {
+    "Action": "작업"
+  },
+  "Action failed or terminal was closed.": {
+    "Action failed or terminal was closed.": "작업이 실패했거나 터미널이 닫혔습니다."
+  },
+  "Action performed when scrolling horizontally on the bar": {
+    "Action performed when scrolling horizontally on the bar": "표시줄에서 가로로 스크롤할 때 수행되는 작업"
+  },
+  "Action performed when scrolling vertically on the bar": {
+    "Action performed when scrolling vertically on the bar": "표시줄에서 세로로 스크롤할 때 수행되는 작업"
+  },
+  "Actions": {
+    "Actions": "작업"
+  },
+  "Activate": {
+    "Activate": "활성화"
+  },
+  "Activate Greeter": {
+    "Activate Greeter": "Greeter 활성화"
+  },
+  "Activate the DMS greeter? A terminal will open for sudo authentication. Run Sync after activation to apply your settings.": {
+    "Activate the DMS greeter? A terminal will open for sudo authentication. Run Sync after activation to apply your settings.": "DMS Greeter를 활성화하시겠습니까? sudo 인증을 위해 터미널이 열립니다. 활성화 후 동기화를 실행하여 설정을 적용하세요."
+  },
+  "Activation": {
+    "Activation": "활성화"
+  },
+  "Active": {
+    "Active": "활성"
+  },
+  "Active Color": {
+    "Active Color": "활성 색상"
+  },
+  "Active VPN": {
+    "Active VPN": "활성 VPN"
+  },
+  "Active in Column": {
+    "Active in Column": "열에서 활성"
+  },
+  "Active tile background and icon color": {
+    "Active tile background and icon color": "활성 타일 배경 및 아이콘 색상"
+  },
+  "Active: %1": {
+    "Active: %1": "활성: %1"
+  },
+  "Active: %1 +%2": {
+    "Active: %1 +%2": "활성: %1 +%2"
+  },
+  "Active: None": {
+    "Active: None": "활성: 없음"
+  },
+  "Adapters": {
+    "Adapters": "어댑터"
+  },
+  "Adaptive Media Width": {
+    "Adaptive Media Width": "적응형 미디어 너비"
+  },
+  "Add": {
+    "Add": "추가"
+  },
+  "Add \"%1\" to the %2 group?": {
+    "Add \"%1\" to the %2 group?": "\"%1\" 사용자를 %2 그룹에 추가하시겠습니까?"
+  },
+  "Add \"%1\" to the %2 group? They must log out and back in, then run dms greeter sync --profile to publish their login-screen theme.": {
+    "Add \"%1\" to the %2 group? They must log out and back in, then run dms greeter sync --profile to publish their login-screen theme.": "\"%1\" 사용자를 %2 그룹에 추가하시겠습니까? 로그아웃 후 다시 로그인한 다음 `dms greeter sync --profile`을 실행해야 로그인 화면 테마가 게시됩니다."
+  },
+  "Add Bar": {
+    "Add Bar": "표시줄 추가"
+  },
+  "Add Desktop Widget": {
+    "Add Desktop Widget": "데스크톱 위젯 추가"
+  },
+  "Add Entry": {
+    "Add Entry": "항목 추가"
+  },
+  "Add Printer": {
+    "Add Printer": "프린터 추가"
+  },
+  "Add Title": {
+    "Add Title": "제목 추가"
+  },
+  "Add Widget": {
+    "Add Widget": "위젯 추가"
+  },
+  "Add Widget to %1": {
+    "Add Widget to %1": "%1에 위젯 추가"
+  },
+  "Add Window Rule": {
+    "Add Window Rule": "창 규칙 추가"
+  },
+  "Add a border around the dock": {
+    "Add a border around the dock": "독 주위에 테두리 추가"
+  },
+  "Add a custom prefix to all application launches. This can be used for things like 'uwsm-app', 'systemd-run', or other command wrappers.": {
+    "Add a custom prefix to all application launches. This can be used for things like 'uwsm-app', 'systemd-run', or other command wrappers.": "모든 애플리케이션 실행에 사용자 지정 접두사를 추가합니다. 'uwsm-app', 'systemd-run' 또는 기타 명령 래퍼 등에 사용할 수 있습니다."
+  },
+  "Add a task...": {
+    "Add a task...": "작업 추가..."
+  },
+  "Add and configure widgets that appear on your desktop": {
+    "Add and configure widgets that appear on your desktop": "데스크톱에 표시되는 위젯을 추가하고 구성합니다"
+  },
+  "Add by Address": {
+    "Add by Address": "주소로 추가"
+  },
+  "Add location": {
+    "Add location": "위치 추가"
+  },
+  "Add match": {
+    "Add match": "일치 항목 추가"
+  },
+  "Add notes": {
+    "Add notes": "메모 추가"
+  },
+  "Add the new user to the %1 group so they can run dms greeter sync --profile.": {
+    "Add the new user to the %1 group so they can run dms greeter sync --profile.": "새 사용자를 %1 그룹에 추가하여 `dms greeter sync --profile`을 실행할 수 있도록 합니다."
+  },
+  "Add the new user to the %1 group so they can use sudo.": {
+    "Add the new user to the %1 group so they can use sudo.": "새 사용자를 %1 그룹에 추가하여 sudo를 사용할 수 있도록 합니다."
+  },
+  "Add to Autostart": {
+    "Add to Autostart": "자동 시작에 추가"
+  },
+  "Adjust the bar height via inner padding": {
+    "Adjust the bar height via inner padding": "내부 패딩을 통해 표시줄 높이 조정"
+  },
+  "Adjust the number of columns in grid view mode.": {
+    "Adjust the number of columns in grid view mode.": "그리드 뷰 모드에서 열 수를 조정합니다."
+  },
+  "Adjust volume per scroll indent": {
+    "Adjust volume per scroll indent": "스크롤 단계별 볼륨 조정"
+  },
+  "Adjusts contrast of generated colors (-100 = minimum, 0 = standard, 100 = maximum)": {
+    "Adjusts contrast of generated colors (-100 = minimum, 0 = standard, 100 = maximum)": "생성된 색상의 대비를 조정합니다 (-100 = 최소, 0 = 표준, 100 = 최대)"
+  },
+  "Administrator access is required. Use the Sync button in Settings → Greeter to apply.": {
+    "Administrator access is required. Use the Sync button in Settings → Greeter to apply.": "관리자 권한이 필요합니다. 적용하려면 설정 → Greeter에서 동기화 버튼을 사용하세요."
+  },
+  "Administrator group:": {
+    "Administrator group:": "관리자 그룹:"
+  },
+  "Advanced": {
+    "Advanced": "고급"
+  },
+  "Afternoon": {
+    "Afternoon": "오후"
+  },
+  "All": {
+    "All": "모두"
+  },
+  "All checks passed": {
+    "All checks passed": "모든 검사 통과"
+  },
+  "All day": {
+    "All day": "종일"
+  },
+  "All displays": {
+    "All displays": "모든 디스플레이"
+  },
+  "Allow": {
+    "Allow": "허용"
+  },
+  "Allow LAN access": {
+    "Allow LAN access": "LAN 액세스 허용"
+  },
+  "Allow adjusting device volume by scrolling on the right half of items in the device list": {
+    "Allow adjusting device volume by scrolling on the right half of items in the device list": "기기 목록 항목의 오른쪽 절반을 스크롤하여 기기 볼륨을 조정할 수 있도록 허용"
+  },
+  "Allow clicks to pass through the widget": {
+    "Allow clicks to pass through the widget": "위젯을 통과하는 클릭 허용"
+  },
+  "Allow greeter access?": {
+    "Allow greeter access?": "Greeter 액세스를 허용하시겠습니까?"
+  },
+  "Allow greeter login access": {
+    "Allow greeter login access": "Greeter 로그인 액세스 허용"
+  },
+  "Already on that session": {
+    "Already on that session": "이미 해당 세션에 있습니다"
+  },
+  "Also group repeated application icons on the active workspace": {
+    "Also group repeated application icons on the active workspace": "활성 작업 공간에 반복되는 애플리케이션 아이콘도 그룹화"
+  },
+  "Alt+←/Backspace: Back • F1/I: File Info • F10: Help • Esc: Close": {
+    "Alt+←/Backspace: Back • F1/I: File Info • F10: Help • Esc: Close": "Alt+←/Backspace: 뒤로 • F1/I: 파일 정보 • F10: 도움말 • Esc: 닫기"
+  },
+  "Alternative (OR)": {
+    "Alternative (OR)": "'Alternative'는 키 단독으로 잠금을 해제합니다. 'Second factor'는 암호나 지문을 먼저 요구한 뒤 키를 요구합니다."
+  },
+  "Always Active": {
+    "Always Active": "항상 활성"
+  },
+  "Always Show Percentage": {
+    "Always Show Percentage": "항상 백분율 표시"
+  },
+  "Always blur against the wallpaper, even with Xray off": {
+    "Always blur against the wallpaper, even with Xray off": "Xray가 꺼져 있더라도 항상 배경화면을 기준으로 블러 처리"
+  },
+  "Always hide the dock and reveal it when hovering near the dock area": {
+    "Always hide the dock and reveal it when hovering near the dock area": "항상 독을 숨기고 독 영역 근처에 마우스를 올릴 때 표시"
+  },
+  "Always on icons": {
+    "Always on icons": "항상 아이콘에 표시"
+  },
+  "Always show a minimum of 3 workspaces, even if fewer are available": {
+    "Always show a minimum of 3 workspaces, even if fewer are available": "사용 가능한 작업 공간이 적더라도 항상 최소 3개의 작업 공간 표시"
+  },
+  "Always show the dock when niri's overview is open": {
+    "Always show the dock when niri's overview is open": "niri의 오버뷰가 열려 있을 때 항상 독 표시"
+  },
+  "Always show when there's only one connected display": {
+    "Always show when there's only one connected display": "연결된 디스플레이가 하나만 있을 때 항상 표시"
+  },
+  "Always use this app for %1": {
+    "Always use this app for %1": "%1에 항상 이 앱 사용"
+  },
+  "Amount": {
+    "Amount": "양"
+  },
+  "An xray rule at %1 may conflict with the Xray settings below": {
+    "An xray rule at %1 may conflict with the Xray settings below": "%1의 Xray 규칙이 아래의 Xray 설정과 충돌할 수 있습니다"
+  },
+  "Analog": {
+    "Analog": "아날로그"
+  },
+  "Analog, digital, or stacked clock display": {
+    "Analog, digital, or stacked clock display": "아날로그, 디지털 또는 스택형 시계 표시"
+  },
+  "Analyzing configuration...": {
+    "Analyzing configuration...": "구성을 분석하는 중..."
+  },
+  "Anchor": {
+    "Anchor": "앵커"
+  },
+  "Animation Duration": {
+    "Animation Duration": "애니메이션 지속 시간"
+  },
+  "Animation Speed": {
+    "Animation Speed": "애니메이션 속도"
+  },
+  "Animation Style": {
+    "Animation Style": "애니메이션 스타일"
+  },
+  "Anonymous Identity": {
+    "Anonymous Identity": "익명 신원"
+  },
+  "Anonymous Identity (optional)": {
+    "Anonymous Identity (optional)": "익명 신원 (선택 사항)"
+  },
+  "Any window": {
+    "Any window": "모든 창"
+  },
+  "App Customizations": {
+    "App Customizations": "앱 사용자 지정"
+  },
+  "App ID": {
+    "App ID": "앱 ID"
+  },
+  "App ID (e.g. firefox)": {
+    "App ID (e.g. firefox)": "앱 ID (예: firefox)"
+  },
+  "App ID Substitutions": {
+    "App ID Substitutions": "앱 ID 대체"
+  },
+  "App ID regex": {
+    "App ID regex": "앱 ID 정규식"
+  },
+  "App ID regex (e.g. ^firefox$)": {
+    "App ID regex (e.g. ^firefox$)": "앱 ID 정규식 (예: ^firefox$)"
+  },
+  "App Launcher": {
+    "App Launcher": "앱 런처"
+  },
+  "App Names": {
+    "App Names": "앱 이름"
+  },
+  "App Theming": {
+    "App Theming": "앱 테마"
+  },
+  "App name or identity (e.g., firefox)": {
+    "App name or identity (e.g., firefox)": "앱 이름 또는 식별자 (예: firefox)"
+  },
+  "Appearance": {
+    "Appearance": "모양"
+  },
+  "Application": {
+    "Application": "애플리케이션"
+  },
+  "Application Dock": {
+    "Application Dock": "애플리케이션 독"
+  },
+  "Applications": {
+    "Applications": "애플리케이션"
+  },
+  "Applications and commands to start automatically when you log in": {
+    "Applications and commands to start automatically when you log in": "로그인할 때 자동으로 시작할 애플리케이션 및 명령"
+  },
+  "Apply Changes": {
+    "Apply Changes": "변경 사항 적용"
+  },
+  "Apply Flatpak updates alongside system updates when running 'Update All'.": {
+    "Apply Flatpak updates alongside system updates when running 'Update All'.": "'모두 업데이트'를 실행할 때 시스템 업데이트와 함께 Flatpak 업데이트를 적용합니다."
+  },
+  "Apply GTK Colors": {
+    "Apply GTK Colors": "GTK 색상 적용"
+  },
+  "Apply Qt Colors": {
+    "Apply Qt Colors": "Qt 색상 적용"
+  },
+  "Apply compositor blur behind the frame border": {
+    "Apply compositor blur behind the frame border": "프레임 테두리 뒤에 컴포지터 블러 적용"
+  },
+  "Apply inverse concave corner cutouts to the bar": {
+    "Apply inverse concave corner cutouts to the bar": "표시줄에 오목한 모서리 컷아웃 반전 적용"
+  },
+  "Apply to Hardware": {
+    "Apply to Hardware": "하드웨어에 적용"
+  },
+  "Apply warm color temperature to reduce eye strain. Use automation settings below to control when it activates.": {
+    "Apply warm color temperature to reduce eye strain. Use automation settings below to control when it activates.": "눈의 피로를 줄이기 위해 따뜻한 색 온도를 적용합니다. 아래 자동화 설정을 사용하여 활성화 시기를 제어하세요."
+  },
+  "Applying authentication changes...": {
+    "Applying authentication changes...": "인증 변경 사항 적용 중..."
+  },
+  "Applying auto-login on startup...": {
+    "Applying auto-login on startup...": "시작 시 자동 로그인 적용 중..."
+  },
+  "Apps": {
+    "Apps": "앱"
+  },
+  "Apps Dock": {
+    "Apps Dock": "앱 독"
+  },
+  "Apps Dock Settings": {
+    "Apps Dock Settings": "앱 독 설정"
+  },
+  "Apps Icon": {
+    "Apps Icon": "앱 아이콘"
+  },
+  "Apps are ordered by usage frequency, then last used, then alphabetically.": {
+    "Apps are ordered by usage frequency, then last used, then alphabetically.": "앱은 사용 빈도, 최근 사용, 알파벳순으로 정렬됩니다."
+  },
+  "Apps with custom display name, icon, or launch options. Right-click an app and select 'Edit App' to customize.": {
+    "Apps with custom display name, icon, or launch options. Right-click an app and select 'Edit App' to customize.": "사용자 지정 표시 이름, 아이콘 또는 실행 옵션이 있는 앱입니다. 앱을 마우스 오른쪽 버튼으로 클릭하고 '앱 편집'을 선택하여 사용자 지정하세요."
+  },
+  "Apps with notification popups muted. Unmute or delete to remove.": {
+    "Apps with notification popups muted. Unmute or delete to remove.": "알림 팝업이 음소거된 앱입니다. 음소거를 해제하거나 삭제하여 제거하세요."
+  },
+  "Arc Extender": {
+    "Arc Extender": "아크 확장기"
+  },
+  "Architecture": {
+    "Architecture": "아키텍처"
+  },
+  "Are you sure you want to kill session \"%1\"?": {
+    "Are you sure you want to kill session \"%1\"?": "\"%1\" 세션을 강제 종료하시겠습니까?"
+  },
+  "Arrange displays and configure resolution, refresh rate, and VRR": {
+    "Arrange displays and configure resolution, refresh rate, and VRR": "디스플레이를 배치하고 해상도, 주사율, VRR을 구성합니다"
+  },
+  "At Startup": {
+    "At Startup": "시작 시"
+  },
+  "At least one output must remain enabled": {
+    "At least one output must remain enabled": "최소 하나 이상의 출력이 활성화되어 있어야 합니다"
+  },
+  "At start": {
+    "At start": "시작 시"
+  },
+  "Attach": {
+    "Attach": "연결"
+  },
+  "Audio": {
+    "Audio": "오디오"
+  },
+  "Audio Codec": {
+    "Audio Codec": "오디오 코덱"
+  },
+  "Audio Codec Selection": {
+    "Audio Codec Selection": "오디오 코덱 선택"
+  },
+  "Audio Devices": {
+    "Audio Devices": "오디오 기기"
+  },
+  "Audio Input": {
+    "Audio Input": "오디오 입력"
+  },
+  "Audio Output": {
+    "Audio Output": "오디오 출력"
+  },
+  "Audio Output Devices (": {
+    "Audio Output Devices (": "오디오 출력 기기 ("
+  },
+  "Audio Output Switch": {
+    "Audio Output Switch": "오디오 출력 전환"
+  },
+  "Audio Visualizer": {
+    "Audio Visualizer": "오디오 비주얼라이저"
+  },
+  "Audio system restarted": {
+    "Audio system restarted": "오디오 시스템이 다시 시작되었습니다"
+  },
+  "Audio volume control": {
+    "Audio volume control": "오디오 볼륨 제어"
+  },
+  "Auth": {
+    "Auth": "인증"
+  },
+  "Auth Type": {
+    "Auth Type": "인증 유형"
+  },
+  "Authenticate": {
+    "Authenticate": "인증"
+  },
+  "Authenticating...": {
+    "Authenticating...": "인증 중..."
+  },
+  "Authentication": {
+    "Authentication": "인증"
+  },
+  "Authentication Required": {
+    "Authentication Required": "인증 필요"
+  },
+  "Authentication changes applied.": {
+    "Authentication changes applied.": "인증 변경 사항이 적용되었습니다."
+  },
+  "Authentication changes apply automatically.": {
+    "Authentication changes apply automatically.": "인증 변경 사항은 자동으로 적용됩니다."
+  },
+  "Authentication changes apply automatically. Fingerprint-only login may not unlock Keyring.": {
+    "Authentication changes apply automatically. Fingerprint-only login may not unlock Keyring.": "인증 변경 사항은 자동으로 적용됩니다. 지문 전용 로그인은 Keyring의 잠금을 해제하지 못할 수 있습니다."
+  },
+  "Authentication changes need sudo. Opening terminal so you can use password or fingerprint.": {
+    "Authentication changes need sudo. Opening terminal so you can use password or fingerprint.": "인증 변경 사항에는 sudo가 필요합니다. 비밀번호나 지문을 사용할 수 있도록 터미널을 엽니다."
+  },
+  "Authentication error - try again": {
+    "Authentication error - try again": "인증 오류 - 다시 시도"
+  },
+  "Authentication failed, please try again": {
+    "Authentication failed, please try again": "인증 실패, 다시 시도해 주세요"
+  },
+  "Authorize": {
+    "Authorize": "권한 부여"
+  },
+  "Authorize pairing with ": {
+    "Authorize pairing with ": "페어링 권한 부여:"
+  },
+  "Authorize service for ": {
+    "Authorize service for ": "서비스 권한 부여:"
+  },
+  "Auto": {
+    "Auto": "자동"
+  },
+  "Auto (Bar-aware)": {
+    "Auto (Bar-aware)": "자동 (표시줄 인식)"
+  },
+  "Auto (Wide)": {
+    "Auto (Wide)": "자동 (넓게)"
+  },
+  "Auto Compositor Gaps": {
+    "Auto Compositor Gaps": "자동 컴포지터 간격"
+  },
+  "Auto Location": {
+    "Auto Location": "자동 위치"
+  },
+  "Auto Overflow": {
+    "Auto Overflow": "자동 오버플로"
+  },
+  "Auto Popup Gaps": {
+    "Auto Popup Gaps": "자동 팝업 간격"
+  },
+  "Auto Power Saver": {
+    "Auto Power Saver": "자동 절전"
+  },
+  "Auto matches bar spacing; Off leaves gaps to your Hyprland config": {
+    "Auto matches bar spacing; Off leaves gaps to your Hyprland config": "자동은 표시줄 간격과 일치시키고, 끄기는 Hyprland 구성에 간격을 맡깁니다"
+  },
+  "Auto matches bar spacing; Off leaves gaps to your MangoWC config": {
+    "Auto matches bar spacing; Off leaves gaps to your MangoWC config": "자동은 표시줄 간격과 일치시키고, 끄기는 MangoWC 구성에 간격을 맡깁니다"
+  },
+  "Auto matches bar spacing; Off leaves gaps to your niri config": {
+    "Auto matches bar spacing; Off leaves gaps to your niri config": "자동은 표시줄 간격과 일치시키고, 끄기는 niri 구성에 간격을 맡깁니다"
+  },
+  "Auto mode is on. Manual profile selection is disabled.": {
+    "Auto mode is on. Manual profile selection is disabled.": "자동 모드가 켜져 있습니다. 수동 프로필 선택이 비활성화되었습니다."
+  },
+  "Auto saved": {
+    "Auto saved": "자동 저장됨"
+  },
+  "Auto-Clear After": {
+    "Auto-Clear After": "이후 자동 지우기"
+  },
+  "Auto-Hide Timeout": {
+    "Auto-Hide Timeout": "자동 숨기기 시간 제한"
+  },
+  "Auto-close Niri overview when launching apps.": {
+    "Auto-close Niri overview when launching apps.": "앱을 실행할 때 niri 오버뷰를 자동으로 닫습니다."
+  },
+  "Auto-delete notifications older than this": {
+    "Auto-delete notifications older than this": "이보다 오래된 알림 자동 삭제"
+  },
+  "Auto-hide": {
+    "Auto-hide": "자동 숨기기"
+  },
+  "Auto-hide Dock": {
+    "Auto-hide Dock": "독 자동 숨기기"
+  },
+  "Auto-login": {
+    "Auto-login": "자동 로그인"
+  },
+  "Auto-login change needs a sync": {
+    "Auto-login change needs a sync": "자동 로그인 변경 시 동기화가 필요합니다"
+  },
+  "Auto-login disabled": {
+    "Auto-login disabled": "자동 로그인 비활성화됨"
+  },
+  "Auto-login enabled": {
+    "Auto-login enabled": "자동 로그인 활성화됨"
+  },
+  "Auto-login on startup": {
+    "Auto-login on startup": "시작 시 자동 로그인"
+  },
+  "Auto-save to disk": {
+    "Auto-save to disk": "디스크에 자동 저장"
+  },
+  "Autoconnect": {
+    "Autoconnect": "자동 연결"
+  },
+  "Autoconnect disabled": {
+    "Autoconnect disabled": "자동 연결 비활성화됨"
+  },
+  "Autoconnect enabled": {
+    "Autoconnect enabled": "자동 연결 활성화됨"
+  },
+  "Autofill last remembered query when opened": {
+    "Autofill last remembered query when opened": "열 때 마지막으로 기억된 검색어 자동 완성"
+  },
+  "Automatic Color Mode": {
+    "Automatic Color Mode": "자동 색상 모드"
+  },
+  "Automatic Control": {
+    "Automatic Control": "자동 제어"
+  },
+  "Automatic Cycling": {
+    "Automatic Cycling": "자동 순환"
+  },
+  "Automatically calculate popup gap based on bar spacing": {
+    "Automatically calculate popup gap based on bar spacing": "표시줄 간격을 기준으로 팝업 간격 자동 계산"
+  },
+  "Automatically cycle through wallpapers in the same folder": {
+    "Automatically cycle through wallpapers in the same folder": "같은 폴더의 배경화면을 자동으로 순환"
+  },
+  "Automatically delete entries older than this": {
+    "Automatically delete entries older than this": "이보다 오래된 항목 자동 삭제"
+  },
+  "Automatically detect location based on IP address": {
+    "Automatically detect location based on IP address": "IP 주소를 기반으로 위치 자동 감지"
+  },
+  "Automatically determine your location using your IP address": {
+    "Automatically determine your location using your IP address": "IP 주소를 사용하여 위치를 자동으로 확인"
+  },
+  "Automatically hide the bar when the pointer moves away": {
+    "Automatically hide the bar when the pointer moves away": "포인터가 멀어지면 표시줄을 자동으로 숨김"
+  },
+  "Automatically lock after": {
+    "Automatically lock after": "이후 자동 잠금"
+  },
+  "Automatically lock the screen when DMS starts": {
+    "Automatically lock the screen when DMS starts": "DMS가 시작될 때 화면을 자동으로 잠금"
+  },
+  "Automatically lock the screen when the system prepares to suspend": {
+    "Automatically lock the screen when the system prepares to suspend": "시스템이 대기 모드를 준비할 때 화면을 자동으로 잠금"
+  },
+  "Automatically save changes to opened files as you type": {
+    "Automatically save changes to opened files as you type": "입력할 때 열린 파일의 변경 사항 자동 저장"
+  },
+  "Automatically turn on Power Saver profile when battery is low.": {
+    "Automatically turn on Power Saver profile when battery is low.": "배터리가 부족할 때 절전 모드 프로필을 자동으로 켭니다."
+  },
+  "Automation": {
+    "Automation": "자동화"
+  },
+  "Autostart Apps": {
+    "Autostart Apps": "자동 시작 앱"
+  },
+  "Autostart Entries": {
+    "Autostart Entries": "자동 시작 항목"
+  },
+  "Available": {
+    "Available": "사용 가능"
+  },
+  "Available Layouts": {
+    "Available Layouts": "사용 가능한 레이아웃"
+  },
+  "Available Networks": {
+    "Available Networks": "사용 가능한 네트워크"
+  },
+  "Available Plugins": {
+    "Available Plugins": "사용 가능한 플러그인"
+  },
+  "Available Screens (%1)": {
+    "Available Screens (%1)": "사용 가능한 화면 (%1)"
+  },
+  "Available Updates (%1)": {
+    "Available Updates (%1)": "사용 가능한 업데이트 (%1)"
+  },
+  "Available in Detailed and Forecast view modes": {
+    "Available in Detailed and Forecast view modes": "상세 및 일기예보 보기 모드에서 사용 가능"
+  },
+  "Available.": {
+    "Available.": "사용 가능."
+  },
+  "BSSID": {
+    "BSSID": "BSSID"
+  },
+  "Back": {
+    "Back": "뒤로"
+  },
+  "Back to user list": {
+    "Back to user list": "사용자 목록으로 돌아가기"
+  },
+  "Backend": {
+    "Backend": "백엔드"
+  },
+  "Backends: %1": {
+    "Backends: %1": "백엔드: %1"
+  },
+  "Background": {
+    "Background": "배경"
+  },
+  "Background Blur": {
+    "Background Blur": "배경 블러"
+  },
+  "Background Color": {
+    "Background Color": "배경 색상"
+  },
+  "Background Effect": {
+    "Background Effect": "배경 효과"
+  },
+  "Background Opacity": {
+    "Background Opacity": "배경 불투명도"
+  },
+  "Background authentication sync failed. Trying terminal mode.": {
+    "Background authentication sync failed. Trying terminal mode.": "백그라운드 인증 동기화에 실패했습니다. 터미널 모드로 시도합니다."
+  },
+  "Background image": {
+    "Background image": "배경 이미지"
+  },
+  "Backlight device": {
+    "Backlight device": "백라이트 기기"
+  },
+  "Balance power and performance": {
+    "Balance power and performance": "전력과 성능의 균형 유지"
+  },
+  "Balanced": {
+    "Balanced": "균형"
+  },
+  "Balanced palette with focused accents (default).": {
+    "Balanced palette with focused accents (default).": "강조색이 초점을 맞추는 균형 잡힌 팔레트(기본값)."
+  },
+  "Bar": {
+    "Bar": "표시줄"
+  },
+  "Bar %1": {
+    "Bar %1": "표시줄 %1"
+  },
+  "Bar Configurations": {
+    "Bar Configurations": "표시줄 구성"
+  },
+  "Bar Inset Padding": {
+    "Bar Inset Padding": "표시줄 내부 패딩"
+  },
+  "Bar Opacity": {
+    "Bar Opacity": "표시줄 불투명도"
+  },
+  "Bar Shadows": {
+    "Bar Shadows": "표시줄 그림자"
+  },
+  "Bar Spacing": {
+    "Bar Spacing": "표시줄 간격"
+  },
+  "Bar corners and background": {
+    "Bar corners and background": "표시줄 모서리 및 배경"
+  },
+  "Bar shadow, border, and corners": {
+    "Bar shadow, border, and corners": "표시줄 그림자, 테두리 및 모서리"
+  },
+  "Base color for shadows (opacity is applied automatically)": {
+    "Base color for shadows (opacity is applied automatically)": "그림자 기본 색상 (불투명도는 자동으로 적용됨)"
+  },
+  "Base duration for animations (drag to use Custom)": {
+    "Base duration for animations (drag to use Custom)": "애니메이션 기본 지속 시간 (드래그하여 사용자 지정 사용)"
+  },
+  "Battery": {
+    "Battery": "배터리"
+  },
+  "Battery %1": {
+    "Battery %1": "배터리 %1"
+  },
+  "Battery Alerts": {
+    "Battery Alerts": "배터리 알림"
+  },
+  "Battery Charge Limit": {
+    "Battery Charge Limit": "배터리 충전 제한"
+  },
+  "Battery Health": {
+    "Battery Health": "배터리 상태"
+  },
+  "Battery Power": {
+    "Battery Power": "배터리 전원"
+  },
+  "Battery Protection": {
+    "Battery Protection": "배터리 보호"
+  },
+  "Battery Status": {
+    "Battery Status": "배터리 상태"
+  },
+  "Battery and power management": {
+    "Battery and power management": "배터리 및 전원 관리"
+  },
+  "Battery has charged to your set limit of %1%": {
+    "Battery has charged to your set limit of %1%": "배터리가 설정된 한도인 %1%까지 충전되었습니다"
+  },
+  "Battery is at %1% - Connect charger immediately!": {
+    "Battery is at %1% - Connect charger immediately!": "배터리가 %1%입니다 - 즉시 충전기를 연결하세요!"
+  },
+  "Battery is at %1% - Consider charging soon": {
+    "Battery is at %1% - Consider charging soon": "배터리가 %1%입니다 - 곧 충전을 고려하세요"
+  },
+  "Battery level and power management": {
+    "Battery level and power management": "배터리 잔량 및 전원 관리"
+  },
+  "Battery percentage to trigger a critical alert.": {
+    "Battery percentage to trigger a critical alert.": "치명적인 알림을 트리거할 배터리 비율입니다."
+  },
+  "Behavior": {
+    "Behavior": "동작"
+  },
+  "Bind lock screen to dbus signals from loginctl. Disable if using an external lock screen": {
+    "Bind lock screen to dbus signals from loginctl. Disable if using an external lock screen": "잠금 화면을 loginctl의 dbus 신호에 바인딩합니다. 외부 잠금 화면을 사용하는 경우 비활성화하세요."
+  },
+  "Bind the spotlight IPC action in your compositor config.": {
+    "Bind the spotlight IPC action in your compositor config.": "컴포지터 구성에서 spotlight IPC 작업을 바인딩합니다."
+  },
+  "Bind the spotlight-bar IPC action in your compositor config.": {
+    "Bind the spotlight-bar IPC action in your compositor config.": "컴포지터 구성에서 spotlight-bar IPC 작업을 바인딩합니다."
+  },
+  "Binds include added": {
+    "Binds include added": "바인딩 포함 추가됨"
+  },
+  "Bit Depth": {
+    "Bit Depth": "비트 심도"
+  },
+  "Black": {
+    "Black": "Black"
+  },
+  "Blend between Surface High and the selected custom color": {
+    "Blend between Surface High and the selected custom color": "Surface High와 선택한 사용자 지정 색상 혼합"
+  },
+  "Block Out": {
+    "Block Out": "차단"
+  },
+  "Block Out From": {
+    "Block Out From": "다음 시간부터 차단"
+  },
+  "Block notifications": {
+    "Block notifications": "알림 차단"
+  },
+  "Blocked": {
+    "Blocked": "차단됨"
+  },
+  "Blue light filter": {
+    "Blue light filter": "블루라이트 필터"
+  },
+  "Bluetooth": {
+    "Bluetooth": "블루투스"
+  },
+  "Bluetooth Settings": {
+    "Bluetooth Settings": "블루투스 설정"
+  },
+  "Bluetooth not available": {
+    "Bluetooth not available": "블루투스를 사용할 수 없음"
+  },
+  "Blur": {
+    "Blur": "블러"
+  },
+  "Blur Wallpaper Layer": {
+    "Blur Wallpaper Layer": "배경화면 레이어 블러"
+  },
+  "Blur on Overview": {
+    "Blur on Overview": "오버뷰 시 블러"
+  },
+  "Blur the background behind bars, popouts, modals, and notifications. Requires compositor support. Adjust Opacity accordingly.": {
+    "Blur the background behind bars, popouts, modals, and notifications. Requires compositor support. Adjust Opacity accordingly.": "표시줄, 팝아웃, 모달 및 알림 뒤의 배경을 블러 처리합니다. 컴포지터 지원이 필요합니다. 그에 맞춰 불투명도를 조정하세요."
+  },
+  "Blur wallpaper when niri overview is open": {
+    "Blur wallpaper when niri overview is open": "niri 오버뷰가 열려 있을 때 배경화면 블러 처리"
+  },
+  "Blurred surfaces show the wallpaper instead of the content beneath": {
+    "Blurred surfaces show the wallpaper instead of the content beneath": "블러 처리된 표면은 아래의 콘텐츠 대신 배경화면을 표시합니다"
+  },
+  "Body": {
+    "Body": "본문"
+  },
+  "Body Font Size": {
+    "Body Font Size": "본문 글꼴 크기"
+  },
+  "Bold": {
+    "Bold": "Bold"
+  },
+  "Border": {
+    "Border": "테두리"
+  },
+  "Border Color": {
+    "Border Color": "테두리 색상"
+  },
+  "Border Off": {
+    "Border Off": "테두리 끄기"
+  },
+  "Border Opacity": {
+    "Border Opacity": "테두리 불투명도"
+  },
+  "Border Radius": {
+    "Border Radius": "테두리 반경"
+  },
+  "Border Size": {
+    "Border Size": "테두리 크기"
+  },
+  "Border Thickness": {
+    "Border Thickness": "테두리 두께"
+  },
+  "Border Width": {
+    "Border Width": "테두리 너비"
+  },
+  "Border color around popouts, modals, and other shell surfaces": {
+    "Border color around popouts, modals, and other shell surfaces": "팝아웃, 모달 및 기타 셸 표면 주변의 테두리 색상"
+  },
+  "Border w/ Bg": {
+    "Border w/ Bg": "테두리 및 배경"
+  },
+  "Border with Background": {
+    "Border with Background": "배경 포함 테두리"
+  },
+  "Bottom": {
+    "Bottom": "하단"
+  },
+  "Bottom Center": {
+    "Bottom Center": "하단 중앙"
+  },
+  "Bottom Left": {
+    "Bottom Left": "하단 좌측"
+  },
+  "Bottom Right": {
+    "Bottom Right": "하단 우측"
+  },
+  "Bottom Section": {
+    "Bottom Section": "하단 구역"
+  },
+  "Bottom dock for pinned and running applications": {
+    "Bottom dock for pinned and running applications": "고정 및 실행 중인 애플리케이션을 위한 하단 독"
+  },
+  "Brightness": {
+    "Brightness": "밝기"
+  },
+  "Brightness Slider": {
+    "Brightness Slider": "밝기 슬라이더"
+  },
+  "Brightness Value": {
+    "Brightness Value": "밝기 값"
+  },
+  "Brightness control not available": {
+    "Brightness control not available": "밝기 제어를 사용할 수 없음"
+  },
+  "Browse": {
+    "Browse": "찾아보기"
+  },
+  "Browse Files": {
+    "Browse Files": "파일 찾아보기"
+  },
+  "Browse Plugins": {
+    "Browse Plugins": "플러그인 찾아보기"
+  },
+  "Browse Themes": {
+    "Browse Themes": "테마 찾아보기"
+  },
+  "Browse and set wallpapers": {
+    "Browse and set wallpapers": "배경화면 찾아보기 및 설정"
+  },
+  "Browse or search plugins": {
+    "Browse or search plugins": "플러그인 찾아보기 또는 검색"
+  },
+  "Button Color": {
+    "Button Color": "버튼 색상"
+  },
+  "By %1": {
+    "By %1": "%1 제작"
+  },
+  "CPU": {
+    "CPU": "CPU"
+  },
+  "CPU Graph": {
+    "CPU Graph": "CPU 그래프"
+  },
+  "CPU Temperature": {
+    "CPU Temperature": "CPU 온도"
+  },
+  "CPU Usage": {
+    "CPU Usage": "CPU 사용량"
+  },
+  "CPU temperature display": {
+    "CPU temperature display": "CPU 온도 표시"
+  },
+  "CPU usage indicator": {
+    "CPU usage indicator": "CPU 사용량 표시기"
+  },
+  "CPU, memory, network, and disk monitoring": {
+    "CPU, memory, network, and disk monitoring": "CPU, 메모리, 네트워크 및 디스크 모니터링"
+  },
+  "CUPS Insecure Filter Warning": {
+    "CUPS Insecure Filter Warning": "CUPS 보안되지 않은 필터 경고"
+  },
+  "CUPS Missing Filter Warning": {
+    "CUPS Missing Filter Warning": "CUPS 누락된 필터 경고"
+  },
+  "CUPS Print Server": {
+    "CUPS Print Server": "CUPS 인쇄 서버"
+  },
+  "CUPS not available": {
+    "CUPS not available": "CUPS를 사용할 수 없음"
+  },
+  "Calendar": {
+    "Calendar": "달력"
+  },
+  "Calendar Backend": {
+    "Calendar Backend": "달력 백엔드"
+  },
+  "Camera": {
+    "Camera": "카메라"
+  },
+  "Cancel": {
+    "Cancel": "취소"
+  },
+  "Cancel all jobs for \"%1\"?": {
+    "Cancel all jobs for \"%1\"?": "\"%1\"에 대한 모든 작업을 취소하시겠습니까?"
+  },
+  "Canceled": {
+    "Canceled": "취소됨"
+  },
+  "Cannot delete the only administrator": {
+    "Cannot delete the only administrator": "유일한 관리자는 삭제할 수 없습니다"
+  },
+  "Cannot disable the only output": {
+    "Cannot disable the only output": "유일한 출력을 비활성화할 수 없습니다"
+  },
+  "Cannot open trash: '%1' is not installed": {
+    "Cannot open trash: '%1' is not installed": "휴지통을 열 수 없음: '%1'이(가) 설치되지 않았습니다"
+  },
+  "Cannot open trash: no custom command set": {
+    "Cannot open trash: no custom command set": "휴지통을 열 수 없음: 사용자 지정 명령이 설정되지 않았습니다"
+  },
+  "Cannot pair": {
+    "Cannot pair": "페어링할 수 없습니다"
+  },
+  "Cannot remove the only administrator": {
+    "Cannot remove the only administrator": "유일한 관리자는 제거할 수 없습니다"
+  },
+  "Capabilities": {
+    "Capabilities": "기능"
+  },
+  "Capacity": {
+    "Capacity": "용량"
+  },
+  "Caps Lock": {
+    "Caps Lock": "Caps Lock"
+  },
+  "Caps Lock Indicator": {
+    "Caps Lock Indicator": "Caps Lock 표시기"
+  },
+  "Caps Lock is on": {
+    "Caps Lock is on": "Caps Lock이 켜져 있습니다"
+  },
+  "Cast Target": {
+    "Cast Target": "캐스트 대상"
+  },
+  "Category": {
+    "Category": "카테고리"
+  },
+  "Center Section": {
+    "Center Section": "중앙 구역"
+  },
+  "Center Single Column": {
+    "Center Single Column": "중앙 단일 열"
+  },
+  "Center Tiling": {
+    "Center Tiling": "중앙 타일링"
+  },
+  "Certificate Password": {
+    "Certificate Password": "인증서 비밀번호"
+  },
+  "Change Song": {
+    "Change Song": "곡 변경"
+  },
+  "Change Volume": {
+    "Change Volume": "볼륨 변경"
+  },
+  "Change the locale used by the DMS interface.": {
+    "Change the locale used by the DMS interface.": "DMS 인터페이스에서 사용하는 로케일을 변경합니다."
+  },
+  "Change the locale used for date and time formatting, independent of the interface language.": {
+    "Change the locale used for date and time formatting, independent of the interface language.": "인터페이스 언어와 독립적으로 날짜 및 시간 형식에 사용되는 로케일을 변경합니다."
+  },
+  "Channel": {
+    "Channel": "채널"
+  },
+  "Charge Level": {
+    "Charge Level": "충전량"
+  },
+  "Charge Limit Reached": {
+    "Charge Limit Reached": "충전 한도 도달"
+  },
+  "Charge limit applied successfully": {
+    "Charge limit applied successfully": "충전 한도가 성공적으로 적용되었습니다"
+  },
+  "Charging": {
+    "Charging": "충전 중"
+  },
+  "Check for system updates": {
+    "Check for system updates": "시스템 업데이트 확인"
+  },
+  "Check interval": {
+    "Check interval": "확인 주기"
+  },
+  "Check on startup": {
+    "Check on startup": "시작 시 확인"
+  },
+  "Check your custom command in Settings → Dock → Trash.": {
+    "Check your custom command in Settings → Dock → Trash.": "설정 → 독 → 휴지통에서 사용자 지정 명령을 확인하세요."
+  },
+  "Checking for updates...": {
+    "Checking for updates...": "업데이트 확인 중..."
+  },
+  "Checking whether sudo authentication is needed...": {
+    "Checking whether sudo authentication is needed...": "sudo 인증이 필요한지 확인 중..."
+  },
+  "Checking...": {
+    "Checking...": "확인 중..."
+  },
+  "Choose Color": {
+    "Choose Color": "색상 선택"
+  },
+  "Choose Dark Mode Color": {
+    "Choose Dark Mode Color": "다크 모드 색상 선택"
+  },
+  "Choose Dock Launcher Logo Color": {
+    "Choose Dock Launcher Logo Color": "독 런처 로고 색상 선택"
+  },
+  "Choose Launcher Logo Color": {
+    "Choose Launcher Logo Color": "런처 로고 색상 선택"
+  },
+  "Choose Light Mode Color": {
+    "Choose Light Mode Color": "라이트 모드 색상 선택"
+  },
+  "Choose Wallpaper Color": {
+    "Choose Wallpaper Color": "배경화면 색상 선택"
+  },
+  "Choose a color": {
+    "Choose a color": "색상 선택"
+  },
+  "Choose a power profile": {
+    "Choose a power profile": "전원 프로필 선택"
+  },
+  "Choose colors from palette": {
+    "Choose colors from palette": "팔레트에서 색상 선택"
+  },
+  "Choose how the weather widget is displayed": {
+    "Choose how the weather widget is displayed": "날씨 위젯이 표시되는 방식을 선택하세요"
+  },
+  "Choose how this bar resolves shadow direction": {
+    "Choose how this bar resolves shadow direction": "이 표시줄이 그림자 방향을 확인하는 방식을 선택하세요"
+  },
+  "Choose how to be notified about critical battery alerts.": {
+    "Choose how to be notified about critical battery alerts.": "위험 수준 배터리 알림을 받는 방식을 선택하세요."
+  },
+  "Choose how to be notified about low battery alerts.": {
+    "Choose how to be notified about low battery alerts.": "배터리 부족 알림을 받는 방식을 선택하세요."
+  },
+  "Choose how to be notified when charge limit is reached.": {
+    "Choose how to be notified when charge limit is reached.": "충전 한도에 도달했을 때 알림을 받는 방식을 선택하세요."
+  },
+  "Choose icon": {
+    "Choose icon": "아이콘 선택"
+  },
+  "Choose monochrome or a theme color tint for system tray icons": {
+    "Choose monochrome or a theme color tint for system tray icons": "시스템 트레이 아이콘에 단색 또는 테마 색조를 선택하세요"
+  },
+  "Choose neutral or accent-colored widget text": {
+    "Choose neutral or accent-colored widget text": "중립적 또는 강조 색상의 위젯 텍스트를 선택하세요"
+  },
+  "Choose the background color for widgets": {
+    "Choose the background color for widgets": "위젯 배경 색상을 선택하세요"
+  },
+  "Choose the border accent color": {
+    "Choose the border accent color": "테두리 강조 색상을 선택하세요"
+  },
+  "Choose the logo displayed on the launcher button in DankBar": {
+    "Choose the logo displayed on the launcher button in DankBar": "DankBar의 런처 버튼에 표시되는 로고를 선택하세요"
+  },
+  "Choose wallpaper folder": {
+    "Choose wallpaper folder": "배경화면 폴더 선택"
+  },
+  "Choose where notification popups appear on screen": {
+    "Choose where notification popups appear on screen": "화면에서 알림 팝업이 나타날 위치를 선택하세요"
+  },
+  "Choose where on-screen displays appear on screen": {
+    "Choose where on-screen displays appear on screen": "화면에서 OSD가 나타날 위치를 선택하세요"
+  },
+  "Choose whether to launch a desktop app or a command": {
+    "Choose whether to launch a desktop app or a command": "데스크톱 앱 실행 여부 또는 명령을 선택하세요"
+  },
+  "Choose which action buttons appear on clipboard entries": {
+    "Choose which action buttons appear on clipboard entries": "클립보드 항목에 나타날 작업 버튼을 선택하세요"
+  },
+  "Choose which displays show this widget": {
+    "Choose which displays show this widget": "이 위젯이 표시될 디스플레이를 선택하세요"
+  },
+  "Choose which monitors show the lock screen interface. Other monitors will display a solid color for OLED burn-in protection.": {
+    "Choose which monitors show the lock screen interface. Other monitors will display a solid color for OLED burn-in protection.": "잠금 화면 인터페이스를 표시할 모니터를 선택하세요. 다른 모니터는 OLED 번인 방지를 위해 단색을 표시합니다."
+  },
+  "Chroma Style": {
+    "Chroma Style": "크로마 스타일"
+  },
+  "Cipher": {
+    "Cipher": "암호화 방식"
+  },
+  "Circle": {
+    "Circle": "원형"
+  },
+  "Class regex": {
+    "Class regex": "클래스 정규식"
+  },
+  "Class regex (e.g. ^firefox$)": {
+    "Class regex (e.g. ^firefox$)": "클래스 정규식 (예: ^firefox$)"
+  },
+  "Clear": {
+    "Clear": "지우기"
+  },
+  "Clear All": {
+    "Clear All": "모두 지우기"
+  },
+  "Clear All Jobs": {
+    "Clear All Jobs": "모든 작업 지우기"
+  },
+  "Clear History?": {
+    "Clear History?": "기록을 지우시겠습니까?"
+  },
+  "Clear Sky": {
+    "Clear Sky": "맑은 하늘"
+  },
+  "Clear all history when server starts": {
+    "Clear all history when server starts": "서버 시작 시 모든 기록 지우기"
+  },
+  "Clear at Startup": {
+    "Clear at Startup": "시작 시 지우기"
+  },
+  "Click 'Setup' to create %1 and add include to your compositor config.": {
+    "Click 'Setup' to create %1 and add include to your compositor config.": "'설정'을 클릭하여 %1을(를) 생성하고 컴포지터 구성에 포함을 추가하세요."
+  },
+  "Click 'Setup' to create the outputs config and add include to your compositor config.": {
+    "Click 'Setup' to create the outputs config and add include to your compositor config.": "'설정'을 클릭하여 출력 구성을 생성하고 컴포지터 구성에 포함을 추가하세요."
+  },
+  "Click Import to add a .ovpn or .conf": {
+    "Click Import to add a .ovpn or .conf": ".ovpn 또는 .conf를 추가하려면 가져오기를 클릭하세요"
+  },
+  "Click Refresh to check status.": {
+    "Click Refresh to check status.": "상태를 확인하려면 새로 고침을 클릭하세요."
+  },
+  "Click Through": {
+    "Click Through": "클릭 통과"
+  },
+  "Click an entry to paste directly instead of copying": {
+    "Click an entry to paste directly instead of copying": "항목을 클릭하면 복사하는 대신 바로 붙여넣습니다"
+  },
+  "Click any shortcut to edit. Changes save to %1": {
+    "Click any shortcut to edit. Changes save to %1": "편집할 바로 가기를 클릭하세요. 변경 사항은 %1에 저장됩니다"
+  },
+  "Click to Paste": {
+    "Click to Paste": "클릭하여 붙여넣기"
+  },
+  "Click to capture": {
+    "Click to capture": "클릭하여 캡처"
+  },
+  "Click to select a custom theme JSON file": {
+    "Click to select a custom theme JSON file": "클릭하여 사용자 지정 테마 JSON 파일을 선택하세요"
+  },
+  "Clip": {
+    "Clip": "자르기"
+  },
+  "Clip to Geometry": {
+    "Clip to Geometry": "도형에 맞게 자르기"
+  },
+  "Clipboard": {
+    "Clipboard": "클립보드"
+  },
+  "Clipboard History": {
+    "Clipboard History": "클립보드 기록"
+  },
+  "Clipboard Manager": {
+    "Clipboard Manager": "클립보드 관리자"
+  },
+  "Clipboard Saved": {
+    "Clipboard Saved": "클립보드 저장됨"
+  },
+  "Clipboard sent": {
+    "Clipboard sent": "클립보드 전송됨"
+  },
+  "Clipboard works but nothing saved to disk": {
+    "Clipboard works but nothing saved to disk": "클립보드가 작동하지만 디스크에 아무것도 저장되지 않았습니다"
+  },
+  "Clock": {
+    "Clock": "시계"
+  },
+  "Clock Style": {
+    "Clock Style": "시계 스타일"
+  },
+  "Clock, calendar, system info and profile": {
+    "Clock, calendar, system info and profile": "시계, 달력, 시스템 정보 및 프로필"
+  },
+  "Close": {
+    "Close": "닫기"
+  },
+  "Close All Windows": {
+    "Close All Windows": "모든 창 닫기"
+  },
+  "Close Overview on Launch": {
+    "Close Overview on Launch": "실행 시 개요 닫기"
+  },
+  "Close Window": {
+    "Close Window": "창 닫기"
+  },
+  "Color": {
+    "Color": "색상"
+  },
+  "Color %1 copied": {
+    "Color %1 copied": "색상 %1 복사됨"
+  },
+  "Color Gamut": {
+    "Color Gamut": "색 영역"
+  },
+  "Color Management": {
+    "Color Management": "색상 관리"
+  },
+  "Color Mode": {
+    "Color Mode": "색상 모드"
+  },
+  "Color Override": {
+    "Color Override": "색상 재정의"
+  },
+  "Color Picker": {
+    "Color Picker": "색상 선택기"
+  },
+  "Color Temperature": {
+    "Color Temperature": "색온도"
+  },
+  "Color displayed on monitors without the lock screen": {
+    "Color displayed on monitors without the lock screen": "잠금 화면이 없는 모니터에 표시되는 색상"
+  },
+  "Color for primary action buttons": {
+    "Color for primary action buttons": "기본 작업 버튼 색상"
+  },
+  "Color shown for areas not covered by wallpaper": {
+    "Color shown for areas not covered by wallpaper": "배경화면으로 덮이지 않은 영역에 표시되는 색상"
+  },
+  "Color temperature for day time": {
+    "Color temperature for day time": "주간 색온도"
+  },
+  "Color temperature for night mode": {
+    "Color temperature for night mode": "야간 모드 색온도"
+  },
+  "Color theme for syntax highlighting.": {
+    "Color theme for syntax highlighting.": "구문 강조를 위한 색상 테마입니다."
+  },
+  "Color theme for syntax highlighting. %1 themes available.": {
+    "Color theme for syntax highlighting. %1 themes available.": "구문 강조를 위한 색상 테마입니다. %1개의 테마를 사용할 수 있습니다."
+  },
+  "Color theme from DMS registry": {
+    "Color theme from DMS registry": "DMS 레지스트리의 색상 테마"
+  },
+  "Colorful": {
+    "Colorful": "다채로움"
+  },
+  "Colorful mix of bright contrasting accents.": {
+    "Colorful mix of bright contrasting accents.": "밝고 대비되는 강조 색상의 다채로운 조합입니다."
+  },
+  "Colorize Active": {
+    "Colorize Active": "활성 상태 색상화"
+  },
+  "Colors from wallpaper": {
+    "Colors from wallpaper": "배경화면에서 추출한 색상"
+  },
+  "Column": {
+    "Column": "열"
+  },
+  "Column Display": {
+    "Column Display": "열 표시"
+  },
+  "Column Width": {
+    "Column Width": "열 너비"
+  },
+  "Comma-separated list of session names to hide. Wrap in slashes for regex (e.g., /^_.*/).": {
+    "Comma-separated list of session names to hide. Wrap in slashes for regex (e.g., /^_.*/).": "숨길 세션 이름의 쉼표로 구분된 목록입니다. 정규식의 경우 슬래시로 묶습니다(예: /^_.*/)."
+  },
+  "Command": {
+    "Command": "명령"
+  },
+  "Command Line": {
+    "Command Line": "명령줄"
+  },
+  "Commands": {
+    "Commands": "명령"
+  },
+  "Communication": {
+    "Communication": "통신"
+  },
+  "Community themes": {
+    "Community themes": "커뮤니티 테마"
+  },
+  "Compact": {
+    "Compact": "컴팩트"
+  },
+  "Compact Mode": {
+    "Compact Mode": "컴팩트 모드"
+  },
+  "Completed": {
+    "Completed": "완료됨"
+  },
+  "Compositor": {
+    "Compositor": "컴포지터"
+  },
+  "Compositor Settings": {
+    "Compositor Settings": "컴포지터 설정"
+  },
+  "Config Format": {
+    "Config Format": "구성 형식"
+  },
+  "Config action: %1": {
+    "Config action: %1": "구성 작업: %1"
+  },
+  "Config validation failed": {
+    "Config validation failed": "구성 유효성 검사 실패"
+  },
+  "Configuration": {
+    "Configuration": "구성"
+  },
+  "Configuration activated": {
+    "Configuration activated": "구성 활성화됨"
+  },
+  "Configuration will be preserved when this display reconnects": {
+    "Configuration will be preserved when this display reconnects": "이 디스플레이가 다시 연결될 때 구성이 보존됩니다"
+  },
+  "Configure": {
+    "Configure": "구성"
+  },
+  "Configure Keybinds": {
+    "Configure Keybinds": "키 바인딩 구성"
+  },
+  "Configure a new printer": {
+    "Configure a new printer": "새 프린터 구성"
+  },
+  "Configure icons for named workspaces. Icons take priority over numbers when both are enabled.": {
+    "Configure icons for named workspaces. Icons take priority over numbers when both are enabled.": "이름이 지정된 작업 공간의 아이콘을 구성합니다. 둘 다 활성화된 경우 아이콘이 숫자보다 우선합니다."
+  },
+  "Configure match criteria and actions": {
+    "Configure match criteria and actions": "일치 기준 및 작업 구성"
+  },
+  "Configure one in Settings → Dock → Trash.": {
+    "Configure one in Settings → Dock → Trash.": "설정 → 독 → 휴지통에서 하나를 구성하세요."
+  },
+  "Configure which displays show \"%1\"": {
+    "Configure which displays show \"%1\"": "\"%1\"을(를) 표시할 디스플레이 구성"
+  },
+  "Configure which displays show shell components": {
+    "Configure which displays show shell components": "셸 구성 요소를 표시할 디스플레이 구성"
+  },
+  "Confirm": {
+    "Confirm": "확인"
+  },
+  "Confirm Delete": {
+    "Confirm Delete": "삭제 확인"
+  },
+  "Confirm Display Changes": {
+    "Confirm Display Changes": "디스플레이 변경 사항 확인"
+  },
+  "Confirm passkey for ": {
+    "Confirm passkey for ": "패스키 확인 대상:"
+  },
+  "Confirm password": {
+    "Confirm password": "비밀번호 확인"
+  },
+  "Conflicts with: %1": {
+    "Conflicts with: %1": "다음과 충돌함: %1"
+  },
+  "Connect": {
+    "Connect": "연결"
+  },
+  "Connect to Hidden Network": {
+    "Connect to Hidden Network": "숨겨진 네트워크에 연결"
+  },
+  "Connect to VPN": {
+    "Connect to VPN": "VPN에 연결"
+  },
+  "Connect to Wi-Fi": {
+    "Connect to Wi-Fi": "Wi-Fi에 연결"
+  },
+  "Connected": {
+    "Connected": "연결됨"
+  },
+  "Connected Device": {
+    "Connected Device": "연결된 기기"
+  },
+  "Connected Displays": {
+    "Connected Displays": "연결된 디스플레이"
+  },
+  "Connected Frame Mode uses the connected launcher for default launcher shortcuts.": {
+    "Connected Frame Mode uses the connected launcher for default launcher shortcuts.": "연결된 프레임 모드는 기본 런처 단축키로 연결된 런처를 사용합니다."
+  },
+  "Connected Options": {
+    "Connected Options": "연결 옵션"
+  },
+  "Connected to %1": {
+    "Connected to %1": "%1에 연결됨"
+  },
+  "Connecting to Device": {
+    "Connecting to Device": "기기에 연결 중"
+  },
+  "Connecting to clipboard service...": {
+    "Connecting to clipboard service...": "클립보드 서비스에 연결 중..."
+  },
+  "Connecting...": {
+    "Connecting...": "연결 중..."
+  },
+  "Connecting…": {
+    "Connecting…": "연결 중…"
+  },
+  "Connection failed": {
+    "Connection failed": "연결 실패"
+  },
+  "Contains": {
+    "Contains": "포함"
+  },
+  "Content": {
+    "Content": "콘텐츠"
+  },
+  "Content copied": {
+    "Content copied": "콘텐츠 복사됨"
+  },
+  "Contrast": {
+    "Contrast": "대비"
+  },
+  "Contributor": {
+    "Contributor": "기여자"
+  },
+  "Control Center": {
+    "Control Center": "제어 센터"
+  },
+  "Control Center Tile Color": {
+    "Control Center Tile Color": "제어 센터 타일 색상"
+  },
+  "Control animation duration for notification popups and history": {
+    "Control animation duration for notification popups and history": "알림 팝업 및 기록의 애니메이션 시간 제어"
+  },
+  "Control currently playing media": {
+    "Control currently playing media": "현재 재생 중인 미디어 제어"
+  },
+  "Control what notification information is shown on the lock screen": {
+    "Control what notification information is shown on the lock screen": "잠금 화면에 표시할 알림 정보 제어"
+  },
+  "Control which plugins appear in 'All' mode without requiring a trigger prefix. Drag to reorder.": {
+    "Control which plugins appear in 'All' mode without requiring a trigger prefix. Drag to reorder.": "트리거 접두사 없이 '전체' 모드에 표시할 플러그인을 제어합니다. 드래그하여 순서를 변경하세요."
+  },
+  "Control workspaces and columns by scrolling on the bar": {
+    "Control workspaces and columns by scrolling on the bar": "표시줄을 스크롤하여 작업 공간 및 열 제어"
+  },
+  "Controls how much original icon color is removed before applying tint": {
+    "Controls how much original icon color is removed before applying tint": "색조를 적용하기 전에 제거할 원래 아이콘 색상의 양 제어"
+  },
+  "Controls how strongly the selected tint color is applied": {
+    "Controls how strongly the selected tint color is applied": "선택한 색조의 적용 강도 제어"
+  },
+  "Controls opacity of shell surfaces, popouts, and modals": {
+    "Controls opacity of shell surfaces, popouts, and modals": "셸 표면, 팝아웃 및 모달의 불투명도 제어"
+  },
+  "Controls opacity of the bar background": {
+    "Controls opacity of the bar background": "표시줄 배경의 불투명도 제어"
+  },
+  "Controls opacity of the border": {
+    "Controls opacity of the border": "테두리의 불투명도 제어"
+  },
+  "Controls opacity of the shadow layer": {
+    "Controls opacity of the shadow layer": "그림자 레이어의 불투명도 제어"
+  },
+  "Controls opacity of the widget outline": {
+    "Controls opacity of the widget outline": "위젯 윤곽선의 불투명도 제어"
+  },
+  "Controls opacity of widget backgrounds": {
+    "Controls opacity of widget backgrounds": "위젯 배경의 불투명도 제어"
+  },
+  "Controls outlines around foreground cards, pills, and notification cards": {
+    "Controls outlines around foreground cards, pills, and notification cards": "전경 카드, 알약 버튼 및 알림 카드 주변의 윤곽선 제어"
+  },
+  "Controls shadow cast direction for elevation layers": {
+    "Controls shadow cast direction for elevation layers": "입체 레이어의 그림자 방향 제어"
+  },
+  "Controls the base blur radius and offset of shadows": {
+    "Controls the base blur radius and offset of shadows": "그림자의 기본 흐림 반경 및 오프셋 제어"
+  },
+  "Controls the opacity of the shadow": {
+    "Controls the opacity of the shadow": "그림자의 불투명도 제어"
+  },
+  "Controls the outline of popouts, modals, and other shell surfaces": {
+    "Controls the outline of popouts, modals, and other shell surfaces": "팝아웃, 모달 및 기타 셸 표면의 윤곽선 제어"
+  },
+  "Convenience options for the login screen. Sync to apply.": {
+    "Convenience options for the login screen. Sync to apply.": "로그인 화면 편의 옵션입니다. 동기화하여 적용하세요."
+  },
+  "Convert to DMS": {
+    "Convert to DMS": "DMS로 변환"
+  },
+  "Cooldown": {
+    "Cooldown": "재사용 대기시간"
+  },
+  "Copied GIF": {
+    "Copied GIF": "GIF 복사됨"
+  },
+  "Copied MP4": {
+    "Copied MP4": "MP4 복사됨"
+  },
+  "Copied WebP": {
+    "Copied WebP": "WebP 복사됨"
+  },
+  "Copied to clipboard": {
+    "Copied to clipboard": "클립보드에 복사됨"
+  },
+  "Copied!": {
+    "Copied!": "복사 완료!"
+  },
+  "Copy": {
+    "Copy": "복사"
+  },
+  "Copy Content": {
+    "Copy Content": "콘텐츠 복사"
+  },
+  "Copy Full Command": {
+    "Copy Full Command": "전체 명령어 복사"
+  },
+  "Copy HTML": {
+    "Copy HTML": "HTML 복사"
+  },
+  "Copy Name": {
+    "Copy Name": "이름 복사"
+  },
+  "Copy PID": {
+    "Copy PID": "PID 복사"
+  },
+  "Copy Text": {
+    "Copy Text": "텍스트 복사"
+  },
+  "Copy path": {
+    "Copy path": "경로 복사"
+  },
+  "Corner Radius": {
+    "Corner Radius": "모서리 둥글기"
+  },
+  "Corner Radius Override": {
+    "Corner Radius Override": "모서리 둥글기 덮어쓰기"
+  },
+  "Corners & Background": {
+    "Corners & Background": "모서리 및 배경"
+  },
+  "Count Only": {
+    "Count Only": "개수만 표시"
+  },
+  "Cover Open": {
+    "Cover Open": "덮개 열림"
+  },
+  "Create": {
+    "Create": "생성"
+  },
+  "Create Dir": {
+    "Create Dir": "디렉터리 생성"
+  },
+  "Create Printer": {
+    "Create Printer": "프린터 생성"
+  },
+  "Create User": {
+    "Create User": "사용자 생성"
+  },
+  "Create Window Rule": {
+    "Create Window Rule": "창 규칙 생성"
+  },
+  "Create a new %1 session (^N)": {
+    "Create a new %1 session (^N)": "새로운 %1 세션 생성 (^N)"
+  },
+  "Create rule for:": {
+    "Create rule for:": "규칙 생성 대상:"
+  },
+  "Create rules to mute, ignore, hide from history, or override notification priority. Default only overrides priority; notifications still show normally.": {
+    "Create rules to mute, ignore, hide from history, or override notification priority. Default only overrides priority; notifications still show normally.": "알림을 숨기거나, 무시하거나, 기록에서 제외하거나, 알림 우선순위를 덮어쓰는 규칙을 만듭니다. 기본값은 우선순위만 덮어쓰며, 알림은 정상적으로 표시됩니다."
+  },
+  "Created plugin directory: %1": {
+    "Created plugin directory: %1": "생성된 플러그인 디렉터리: %1"
+  },
+  "Creating...": {
+    "Creating...": "생성 중..."
+  },
+  "Credentials": {
+    "Credentials": "자격 증명"
+  },
+  "Critical Battery": {
+    "Critical Battery": "배터리 매우 부족"
+  },
+  "Critical Battery Alert": {
+    "Critical Battery Alert": "배터리 매우 부족 경고"
+  },
+  "Critical Battery Notifications": {
+    "Critical Battery Notifications": "배터리 매우 부족 알림"
+  },
+  "Critical Priority": {
+    "Critical Priority": "매우 높은 우선순위"
+  },
+  "Critical Threshold": {
+    "Critical Threshold": "위험 임계값"
+  },
+  "Ctrl+A: Select All • Ctrl+P: Preview • Enter/Shift+Enter: Find Next/Previous • Esc: Close": {
+    "Ctrl+A: Select All • Ctrl+P: Preview • Enter/Shift+Enter: Find Next/Previous • Esc: Close": "Ctrl+A: 모두 선택 • Ctrl+P: 미리보기 • Enter/Shift+Enter: 다음/이전 찾기 • Esc: 닫기"
+  },
+  "Ctrl+S: Save • Ctrl+O: Open • Ctrl+N: New • Ctrl+F: Find": {
+    "Ctrl+S: Save • Ctrl+O: Open • Ctrl+N: New • Ctrl+F: Find": "Ctrl+S: 저장 • Ctrl+O: 열기 • Ctrl+N: 새로 만들기 • Ctrl+F: 찾기"
+  },
+  "Ctrl+Tab: Switch Tab • Ctrl+S: Pin/Unpin • Shift+Del: Clear All • Esc: Close": {
+    "Ctrl+Tab: Switch Tab • Ctrl+S: Pin/Unpin • Shift+Del: Clear All • Esc: Close": "Ctrl+Tab: 탭 전환 • Ctrl+S: 고정/고정 해제 • Shift+Del: 모두 지우기 • Esc: 닫기"
+  },
+  "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Copy • Shift+Del: Clear All • F10: Help • Esc: Close": {
+    "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Copy • Shift+Del: Clear All • F10: Help • Esc: Close": "Ctrl+Tab: 탭 전환 • Ctrl+S: 고정/고정 해제 • Shift+Enter: 복사 • Shift+Del: 모두 지우기 • F10: 도움말 • Esc: 닫기"
+  },
+  "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Paste • Shift+Del: Clear All • F10: Help • Esc: Close": {
+    "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Paste • Shift+Del: Clear All • F10: Help • Esc: Close": "Ctrl+Tab: 탭 전환 • Ctrl+S: 고정/고정 해제 • Shift+Enter: 붙여넣기 • Shift+Del: 모두 지우기 • F10: 도움말 • Esc: 닫기"
+  },
+  "Current": {
+    "Current": "현재"
+  },
+  "Current Items": {
+    "Current Items": "현재 항목"
+  },
+  "Current Locale": {
+    "Current Locale": "현재 로케일"
+  },
+  "Current Monitor": {
+    "Current Monitor": "현재 모니터"
+  },
+  "Current Period": {
+    "Current Period": "현재 기간"
+  },
+  "Current Status": {
+    "Current Status": "현재 상태"
+  },
+  "Current Temp": {
+    "Current Temp": "현재 온도"
+  },
+  "Current Theme: %1": {
+    "Current Theme: %1": "현재 테마: %1"
+  },
+  "Current Weather": {
+    "Current Weather": "현재 날씨"
+  },
+  "Current Workspace": {
+    "Current Workspace": "현재 작업 공간"
+  },
+  "Current time and date display": {
+    "Current time and date display": "현재 시간 및 날짜 표시"
+  },
+  "Current weather conditions and temperature": {
+    "Current weather conditions and temperature": "현재 날씨 상태 및 온도"
+  },
+  "Current: %1": {
+    "Current: %1": "현재: %1"
+  },
+  "Cursor Size": {
+    "Cursor Size": "커서 크기"
+  },
+  "Cursor Theme": {
+    "Cursor Theme": "커서 테마"
+  },
+  "Curve": {
+    "Curve": "곡선"
+  },
+  "Curve: curve rasterizer.": {
+    "Curve: curve rasterizer.": "곡선: 곡선 래스터라이저."
+  },
+  "Custom": {
+    "Custom": "사용자 지정"
+  },
+  "Custom Blend": {
+    "Custom Blend": "사용자 지정 혼합"
+  },
+  "Custom Color": {
+    "Custom Color": "사용자 지정 색상"
+  },
+  "Custom Duration": {
+    "Custom Duration": "사용자 지정 시간"
+  },
+  "Custom Hibernate Command": {
+    "Custom Hibernate Command": "사용자 지정 최대 절전 모드 명령어"
+  },
+  "Custom Location": {
+    "Custom Location": "사용자 지정 위치"
+  },
+  "Custom Lock Command": {
+    "Custom Lock Command": "사용자 지정 잠금 명령어"
+  },
+  "Custom Logout Command": {
+    "Custom Logout Command": "사용자 지정 로그아웃 명령어"
+  },
+  "Custom Name": {
+    "Custom Name": "사용자 지정 이름"
+  },
+  "Custom Power Actions": {
+    "Custom Power Actions": "사용자 지정 전원 작업"
+  },
+  "Custom Power Off Command": {
+    "Custom Power Off Command": "사용자 지정 전원 끄기 명령어"
+  },
+  "Custom Reboot Command": {
+    "Custom Reboot Command": "사용자 지정 재부팅 명령어"
+  },
+  "Custom Shadow Color": {
+    "Custom Shadow Color": "사용자 지정 그림자 색상"
+  },
+  "Custom Shadow Override": {
+    "Custom Shadow Override": "사용자 지정 그림자 덮어쓰기"
+  },
+  "Custom Suspend Command": {
+    "Custom Suspend Command": "사용자 지정 절전 모드 명령어"
+  },
+  "Custom command and terminal params are split on whitespace; paths with spaces will break.": {
+    "Custom command and terminal params are split on whitespace; paths with spaces will break.": "사용자 지정 명령어와 터미널 매개변수는 공백을 기준으로 분리됩니다. 공백이 포함된 경로는 사용할 수 없습니다."
+  },
+  "Custom open-trash command": {
+    "Custom open-trash command": "휴지통 열기 사용자 지정 명령어"
+  },
+  "Custom power profile": {
+    "Custom power profile": "사용자 지정 전원 프로필"
+  },
+  "Custom theme loaded from JSON file": {
+    "Custom theme loaded from JSON file": "JSON 파일에서 로드한 사용자 지정 테마"
+  },
+  "Custom update command": {
+    "Custom update command": "사용자 지정 업데이트 명령어"
+  },
+  "Custom...": {
+    "Custom...": "사용자 지정..."
+  },
+  "Custom: ": {
+    "Custom: ": "사용자 지정:"
+  },
+  "Customizable empty space": {
+    "Customizable empty space": "사용자 지정 가능한 빈 공간"
+  },
+  "Customize the font and background of the lock screen, or leave empty to use your theme font and desktop wallpaper. Changes apply instantly.": {
+    "Customize the font and background of the lock screen, or leave empty to use your theme font and desktop wallpaper. Changes apply instantly.": "잠금 화면의 글꼴과 배경을 사용자 지정하거나, 비워두어 테마 글꼴과 바탕 화면 배경을 사용합니다. 변경 사항은 즉시 적용됩니다."
+  },
+  "Customize which actions appear in the power menu": {
+    "Customize which actions appear in the power menu": "전원 메뉴에 표시할 작업 사용자 지정"
+  },
+  "DDC/CI monitor": {
+    "DDC/CI monitor": "DDC/CI 모니터"
+  },
+  "DEMO MODE - Click anywhere to exit": {
+    "DEMO MODE - Click anywhere to exit": "데모 모드 - 종료하려면 아무 곳이나 클릭하세요"
+  },
+  "DMS Chooser": {
+    "DMS Chooser": "DMS 선택기"
+  },
+  "DMS Plugin Manager Unavailable": {
+    "DMS Plugin Manager Unavailable": "DMS 플러그인 관리자를 사용할 수 없음"
+  },
+  "DMS Settings": {
+    "DMS Settings": "DMS 설정"
+  },
+  "DMS Settings writes Lua keybinds. Add the DMS include so edits apply.": {
+    "DMS Settings writes Lua keybinds. Add the DMS include so edits apply.": "DMS 설정은 Lua 키 바인딩을 작성합니다. 편집 내용이 적용되도록 DMS include를 추가하세요."
+  },
+  "DMS Shortcuts": {
+    "DMS Shortcuts": "DMS 바로 가기"
+  },
+  "DMS out of date": {
+    "DMS out of date": "DMS가 구버전임"
+  },
+  "DMS server is outdated (API v%1, expected v%2)": {
+    "DMS server is outdated (API v%1, expected v%2)": "DMS 서버가 구버전입니다(API v%1, 예상 v%2)."
+  },
+  "DMS service is not connected. Clipboard settings are unavailable.": {
+    "DMS service is not connected. Clipboard settings are unavailable.": "DMS 서비스가 연결되지 않았습니다. 클립보드 설정을 사용할 수 없습니다."
+  },
+  "DMS shell actions (launcher, clipboard, etc.)": {
+    "DMS shell actions (launcher, clipboard, etc.)": "DMS 셸 작업(런처, 클립보드 등)"
+  },
+  "DMS_SOCKET not available": {
+    "DMS_SOCKET not available": "DMS_SOCKET을 사용할 수 없음"
+  },
+  "Daily": {
+    "Daily": "매일"
+  },
+  "Daily at:": {
+    "Daily at:": "매일 다음 시간:"
+  },
+  "Dank": {
+    "Dank": "Dank"
+  },
+  "Dank Bar": {
+    "Dank Bar": "Dank Bar"
+  },
+  "Dank Bar Xray": {
+    "Dank Bar Xray": "Dank Bar Xray"
+  },
+  "Dank Dash": {
+    "Dank Dash": "Dank Dash"
+  },
+  "DankBar": {
+    "DankBar": "DankBar"
+  },
+  "DankCalendar": {
+    "DankCalendar": "DankCalendar"
+  },
+  "DankCalendar isn't installed": {
+    "DankCalendar isn't installed": "DankCalendar가 설치되지 않음"
+  },
+  "DankCalendar isn't running": {
+    "DankCalendar isn't running": "DankCalendar가 실행 중이 아님"
+  },
+  "DankMaterialShell is ready to use": {
+    "DankMaterialShell is ready to use": "DankMaterialShell을 사용할 준비가 되었습니다"
+  },
+  "DankShell & System Icons (requires restart)": {
+    "DankShell & System Icons (requires restart)": "DankShell 및 시스템 아이콘(재시작 필요)"
+  },
+  "Dark Mode": {
+    "Dark Mode": "다크 모드"
+  },
+  "Dark Mode Icon Theme": {
+    "Dark Mode Icon Theme": "다크 모드 아이콘 테마"
+  },
+  "Dark mode base": {
+    "Dark mode base": "다크 모드 기본"
+  },
+  "Dark mode harmony": {
+    "Dark mode harmony": "다크 모드 조화"
+  },
+  "Darken Modal Background": {
+    "Darken Modal Background": "모달 배경 어둡게 하기"
+  },
+  "Date Format": {
+    "Date Format": "날짜 형식"
+  },
+  "Date format on greeter": {
+    "Date format on greeter": "로그인 화면의 날짜 형식"
+  },
+  "Dawn (Astronomical Twilight)": {
+    "Dawn (Astronomical Twilight)": "새벽(천문 여명)"
+  },
+  "Dawn (Civil Twilight)": {
+    "Dawn (Civil Twilight)": "새벽(시민 여명)"
+  },
+  "Dawn (Nautical Twilight)": {
+    "Dawn (Nautical Twilight)": "새벽(항해 여명)"
+  },
+  "Day Date": {
+    "Day Date": "요일 날짜"
+  },
+  "Day Month Date": {
+    "Day Month Date": "요일 월 날짜"
+  },
+  "Day Temperature": {
+    "Day Temperature": "주간 온도"
+  },
+  "Daytime": {
+    "Daytime": "낮"
+  },
+  "Deck": {
+    "Deck": "덱"
+  },
+  "Default": {
+    "Default": "기본값"
+  },
+  "Default (Black)": {
+    "Default (Black)": "기본값(검은색)"
+  },
+  "Default (Global)": {
+    "Default (Global)": "기본값(전역)"
+  },
+  "Default Apps": {
+    "Default Apps": "기본 앱"
+  },
+  "Default Launcher": {
+    "Default Launcher": "기본 런처"
+  },
+  "Default Launcher Shortcut": {
+    "Default Launcher Shortcut": "기본 런처 바로 가기"
+  },
+  "Default Mode": {
+    "Default Mode": "기본 모드"
+  },
+  "Default Opens": {
+    "Default Opens": "기본 열기"
+  },
+  "Default Width (%)": {
+    "Default Width (%)": "기본 너비(%)"
+  },
+  "Default launcher shortcuts open the full launcher with mode tabs, grid view, and action panel.": {
+    "Default launcher shortcuts open the full launcher with mode tabs, grid view, and action panel.": "기본 런처 바로 가기는 모드 탭, 그리드 보기 및 작업 패널이 있는 전체 런처를 엽니다."
+  },
+  "Default launcher shortcuts open the minimal Spotlight Bar. The dedicated Spotlight Bar shortcut below stays independent.": {
+    "Default launcher shortcuts open the minimal Spotlight Bar. The dedicated Spotlight Bar shortcut below stays independent.": "기본 런처 바로 가기는 최소화된 Spotlight Bar를 엽니다. 아래의 전용 Spotlight Bar 바로 가기는 독립적으로 유지됩니다."
+  },
+  "Default selected action": {
+    "Default selected action": "기본 선택 작업"
+  },
+  "Defaults": {
+    "Defaults": "기본값"
+  },
+  "Define rules for window behavior. Saves to %1": {
+    "Define rules for window behavior. Saves to %1": "창 동작 규칙을 정의합니다. %1에 저장됩니다."
+  },
+  "Del: Clear • Shift+Del: Clear All • 1-9: Actions • F10: Help • Esc: Close": {
+    "Del: Clear • Shift+Del: Clear All • 1-9: Actions • F10: Help • Esc: Close": "Del: 지우기 • Shift+Del: 모두 지우기 • 1-9: 작업 • F10: 도움말 • Esc: 닫기"
+  },
+  "Delete": {
+    "Delete": "삭제"
+  },
+  "Delete \"%1\" and remove the home directory? This cannot be undone.": {
+    "Delete \"%1\" and remove the home directory? This cannot be undone.": "\"%1\"을(를) 삭제하고 홈 디렉터리를 제거하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+  },
+  "Delete \"%1\"?": {
+    "Delete \"%1\"?": "\"%1\"을(를) 삭제하시겠습니까?"
+  },
+  "Delete Class": {
+    "Delete Class": "클래스 삭제"
+  },
+  "Delete Printer": {
+    "Delete Printer": "프린터 삭제"
+  },
+  "Delete Rule": {
+    "Delete Rule": "규칙 삭제"
+  },
+  "Delete Saved Item?": {
+    "Delete Saved Item?": "저장된 항목을 삭제하시겠습니까?"
+  },
+  "Delete VPN": {
+    "Delete VPN": "VPN 삭제"
+  },
+  "Delete class \"%1\"?": {
+    "Delete class \"%1\"?": "\"%1\" 클래스를 삭제하시겠습니까?"
+  },
+  "Delete profile \"%1\"?": {
+    "Delete profile \"%1\"?": "\"%1\" 프로필을 삭제하시겠습니까?"
+  },
+  "Delete user": {
+    "Delete user": "사용자 삭제"
+  },
+  "Delete user?": {
+    "Delete user?": "사용자를 삭제하시겠습니까?"
+  },
+  "Demi Bold": {
+    "Demi Bold": "데미 볼드"
+  },
+  "Dependencies & documentation": {
+    "Dependencies & documentation": "종속성 및 문서"
+  },
+  "Depth": {
+    "Depth": "깊이"
+  },
+  "Depth: Panels scale up from small as they slide in — a dramatic pop-forward depth effect.": {
+    "Depth: Panels scale up from small as they slide in — a dramatic pop-forward depth effect.": "깊이: 패널이 슬라이드될 때 작은 크기에서 확대되며, 극적인 앞으로 튀어나오는 깊이 효과를 줍니다."
+  },
+  "Derives colors that closely match the underlying image.": {
+    "Derives colors that closely match the underlying image.": "기본 이미지와 밀접하게 일치하는 색상을 추출합니다."
+  },
+  "Description": {
+    "Description": "설명"
+  },
+  "Desktop": {
+    "Desktop": "데스크톱"
+  },
+  "Desktop Application": {
+    "Desktop Application": "데스크톱 애플리케이션"
+  },
+  "Desktop Clock": {
+    "Desktop Clock": "데스크톱 시계"
+  },
+  "Desktop Entry": {
+    "Desktop Entry": "데스크톱 항목"
+  },
+  "Desktop Widget": {
+    "Desktop Widget": "데스크톱 위젯"
+  },
+  "Desktop Widgets": {
+    "Desktop Widgets": "데스크톱 위젯"
+  },
+  "Desktop background images": {
+    "Desktop background images": "데스크톱 배경 이미지"
+  },
+  "Detailed": {
+    "Detailed": "자세히"
+  },
+  "Details for \"%1\"": {
+    "Details for \"%1\"": "\"%1\" 세부 정보"
+  },
+  "Detected backends: %1": {
+    "Detected backends: %1": "감지된 백엔드: %1"
+  },
+  "Development": {
+    "Development": "개발"
+  },
+  "Device": {
+    "Device": "기기"
+  },
+  "Device connections": {
+    "Device connections": "기기 연결"
+  },
+  "Device list scroll volume": {
+    "Device list scroll volume": "기기 목록 스크롤 볼륨"
+  },
+  "Device names updated": {
+    "Device names updated": "기기 이름이 업데이트됨"
+  },
+  "Device paired": {
+    "Device paired": "기기 페어링됨"
+  },
+  "Device unpaired": {
+    "Device unpaired": "기기 페어링 해제됨"
+  },
+  "Diff": {
+    "Diff": "차이점(Diff)"
+  },
+  "Digital": {
+    "Digital": "디지털"
+  },
+  "Direction Source": {
+    "Direction Source": "방향 소스"
+  },
+  "Directional": {
+    "Directional": "방향성"
+  },
+  "Directional: Panels glide in from a larger distance at full size — no scale change, pure clean motion.": {
+    "Directional: Panels glide in from a larger distance at full size — no scale change, pure clean motion.": "방향성: 패널이 원래 크기 그대로 먼 거리에서 미끄러져 들어옵니다 — 크기 변화 없는 깔끔한 움직임."
+  },
+  "Disable Autoconnect": {
+    "Disable Autoconnect": "자동 연결 비활성화"
+  },
+  "Disable Built-in Wallpapers": {
+    "Disable Built-in Wallpapers": "내장 배경화면 비활성화"
+  },
+  "Disable History Persistence": {
+    "Disable History Persistence": "기록 유지 비활성화"
+  },
+  "Disable Output": {
+    "Disable Output": "출력 비활성화"
+  },
+  "Disabled": {
+    "Disabled": "비활성화됨"
+  },
+  "Disabled by Frame Mode": {
+    "Disabled by Frame Mode": "프레임 모드에 의해 비활성화됨"
+  },
+  "Disabling WiFi...": {
+    "Disabling WiFi...": "Wi-Fi 비활성화 중..."
+  },
+  "Disabling auto-login on startup...": {
+    "Disabling auto-login on startup...": "시작 시 자동 로그인 비활성화 중..."
+  },
+  "Disc": {
+    "Disc": "디스크"
+  },
+  "Discard": {
+    "Discard": "폐기"
+  },
+  "Discharging": {
+    "Discharging": "방전 중"
+  },
+  "Disconnect": {
+    "Disconnect": "연결 끊기"
+  },
+  "Disconnected": {
+    "Disconnected": "연결 끊김"
+  },
+  "Disconnected from WiFi": {
+    "Disconnected from WiFi": "Wi-Fi 연결 끊김"
+  },
+  "Discover Devices": {
+    "Discover Devices": "기기 검색"
+  },
+  "Disk": {
+    "Disk": "디스크"
+  },
+  "Disk I/O": {
+    "Disk I/O": "디스크 I/O"
+  },
+  "Disk Usage": {
+    "Disk Usage": "디스크 사용량"
+  },
+  "Disk Usage Display": {
+    "Disk Usage Display": "디스크 사용량 표시"
+  },
+  "Disks": {
+    "Disks": "디스크"
+  },
+  "Dismiss": {
+    "Dismiss": "무시"
+  },
+  "Display": {
+    "Display": "디스플레이"
+  },
+  "Display Assignment": {
+    "Display Assignment": "디스플레이 할당"
+  },
+  "Display Control": {
+    "Display Control": "디스플레이 제어"
+  },
+  "Display Name Format": {
+    "Display Name Format": "표시 이름 형식"
+  },
+  "Display Profiles": {
+    "Display Profiles": "디스플레이 프로필"
+  },
+  "Display Settings": {
+    "Display Settings": "디스플레이 설정"
+  },
+  "Display a dock with pinned and running applications": {
+    "Display a dock with pinned and running applications": "고정 및 실행 중인 애플리케이션 독 표시"
+  },
+  "Display all priorities over fullscreen apps": {
+    "Display all priorities over fullscreen apps": "전체 화면 앱 위에 모든 우선순위 표시"
+  },
+  "Display and switch MangoWC layouts": {
+    "Display and switch MangoWC layouts": "MangoWC 레이아웃 표시 및 전환"
+  },
+  "Display application icons in workspace indicators": {
+    "Display application icons in workspace indicators": "작업 공간 표시기에 애플리케이션 아이콘 표시"
+  },
+  "Display brightness control": {
+    "Display brightness control": "디스플레이 밝기 제어"
+  },
+  "Display configuration is not available. WLR output management protocol not supported.": {
+    "Display configuration is not available. WLR output management protocol not supported.": "디스플레이 구성을 사용할 수 없습니다. WLR 출력 관리 프로토콜이 지원되지 않습니다."
+  },
+  "Display currently focused application title": {
+    "Display currently focused application title": "현재 초점이 맞춰진 애플리케이션 제목 표시"
+  },
+  "Display hourly weather predictions": {
+    "Display hourly weather predictions": "시간별 날씨 예보 표시"
+  },
+  "Display line numbers in editor": {
+    "Display line numbers in editor": "편집기에 줄 번호 표시"
+  },
+  "Display name for this entry": {
+    "Display name for this entry": "이 항목의 표시 이름"
+  },
+  "Display only workspaces that contain windows": {
+    "Display only workspaces that contain windows": "창이 있는 작업 공간만 표시"
+  },
+  "Display power menu actions in a grid instead of a list": {
+    "Display power menu actions in a grid instead of a list": "목록 대신 그리드에 전원 메뉴 작업 표시"
+  },
+  "Display seconds in the clock": {
+    "Display seconds in the clock": "시계에 초 표시"
+  },
+  "Display setup failed": {
+    "Display setup failed": "디스플레이 설정 실패"
+  },
+  "Display the power system menu": {
+    "Display the power system menu": "전원 시스템 메뉴 표시"
+  },
+  "Display volume and brightness percentage values in OSD popups": {
+    "Display volume and brightness percentage values in OSD popups": "OSD 팝업에 볼륨 및 밝기 백분율 값 표시"
+  },
+  "Displays": {
+    "Displays": "디스플레이"
+  },
+  "Displays count when overflow is active": {
+    "Displays count when overflow is active": "오버플로가 활성화될 때 개수 표시"
+  },
+  "Displays the active keyboard layout and allows switching": {
+    "Displays the active keyboard layout and allows switching": "활성 키보드 레이아웃을 표시하고 전환 허용"
+  },
+  "Distribution": {
+    "Distribution": "배포판"
+  },
+  "Diverse palette spanning the full spectrum.": {
+    "Diverse palette spanning the full spectrum.": "전체 스펙트럼을 아우르는 다양한 팔레트."
+  },
+  "Do Not Disturb": {
+    "Do Not Disturb": "방해 금지 모드"
+  },
+  "Dock": {
+    "Dock": "독"
+  },
+  "Dock & Launcher": {
+    "Dock & Launcher": "독 및 런처"
+  },
+  "Dock Opacity": {
+    "Dock Opacity": "독 불투명도"
+  },
+  "Dock Visibility": {
+    "Dock Visibility": "독 가시성"
+  },
+  "Dock margin, opacity, and border": {
+    "Dock margin, opacity, and border": "독 여백, 불투명도 및 테두리"
+  },
+  "Dock window": {
+    "Dock window": "독 창"
+  },
+  "Docs": {
+    "Docs": "문서"
+  },
+  "Documents": {
+    "Documents": "문서"
+  },
+  "Domain (optional)": {
+    "Domain (optional)": "도메인 (선택 사항)"
+  },
+  "Don't Change": {
+    "Don't Change": "변경 안 함"
+  },
+  "Don't Save": {
+    "Don't Save": "저장 안 함"
+  },
+  "Door Open": {
+    "Door Open": "문 열림"
+  },
+  "Downloads": {
+    "Downloads": "다운로드"
+  },
+  "Drag a widget by its handle here to reorder it or drop it into another group": {
+    "Drag a widget by its handle here to reorder it or drop it into another group": "위젯의 핸들을 잡고 드래그하여 순서를 변경하거나 다른 그룹에 놓으세요"
+  },
+  "Drag to Reorder": {
+    "Drag to Reorder": "드래그하여 순서 변경"
+  },
+  "Drag to reorder or click to hide tabs. Use ↑/↓ to highlight a tab and Ctrl+↑/↓ to move it.": {
+    "Drag to reorder or click to hide tabs. Use ↑/↓ to highlight a tab and Ctrl+↑/↓ to move it.": "드래그하여 순서를 변경하거나 클릭하여 탭을 숨기세요. ↑/↓ 키로 탭을 강조 표시하고 Ctrl+↑/↓ 키로 이동하세요."
+  },
+  "Drag widgets to reorder within sections. Use the eye icon to hide/show widgets (maintains spacing), or X to remove them completely.": {
+    "Drag widgets to reorder within sections. Use the eye icon to hide/show widgets (maintains spacing), or X to remove them completely.": "위젯을 드래그하여 섹션 내에서 순서를 변경하세요. 눈 모양 아이콘을 사용하여 위젯을 숨기거나 표시하고(간격 유지), X를 눌러 완전히 제거하세요."
+  },
+  "Drag workspace indicators to reorder them": {
+    "Drag workspace indicators to reorder them": "작업 공간 표시기를 드래그하여 순서를 변경하세요"
+  },
+  "Draw a connected picture-frame border around the entire display": {
+    "Draw a connected picture-frame border around the entire display": "전체 디스플레이 주변에 연결된 액자 테두리 그리기"
+  },
+  "Driver": {
+    "Driver": "드라이버"
+  },
+  "Drizzle": {
+    "Drizzle": "이슬비"
+  },
+  "Drop here": {
+    "Drop here": "여기에 놓기"
+  },
+  "Drop your override for %1 so the DMS default action re-applies?": {
+    "Drop your override for %1 so the DMS default action re-applies?": "DMS 기본 작업을 다시 적용하도록 %1의 덮어쓰기를 취소하시겠습니까?"
+  },
+  "Duplicate": {
+    "Duplicate": "복제"
+  },
+  "Duplicate Wallpaper with Blur": {
+    "Duplicate Wallpaper with Blur": "블러 처리된 배경화면 복제"
+  },
+  "Duration": {
+    "Duration": "지속 시간"
+  },
+  "Dusk (Astronomical Twilight)": {
+    "Dusk (Astronomical Twilight)": "해 질 녘 (천문 박명)"
+  },
+  "Dusk (Civil Twighlight)": {
+    "Dusk (Civil Twighlight)": "해 질 녘 (시민 박명)"
+  },
+  "Dusk (Nautical Twilight)": {
+    "Dusk (Nautical Twilight)": "해 질 녘 (항해 박명)"
+  },
+  "Dynamic": {
+    "Dynamic": "다이내믹"
+  },
+  "Dynamic Properties": {
+    "Dynamic Properties": "동적 속성"
+  },
+  "Dynamic Theming": {
+    "Dynamic Theming": "동적 테마"
+  },
+  "Dynamic Width": {
+    "Dynamic Width": "동적 너비"
+  },
+  "Dynamic colors from wallpaper": {
+    "Dynamic colors from wallpaper": "배경화면에서 동적 색상 추출"
+  },
+  "Dynamic colors parse error: %1": {
+    "Dynamic colors parse error: %1": "동적 색상 파싱 오류: %1"
+  },
+  "Dynamic colors, presets": {
+    "Dynamic colors, presets": "동적 색상, 사전 설정"
+  },
+  "Dynamic: Spring bezier with overshoot — entry briefly exceeds its target then settles. Expressive and alive.": {
+    "Dynamic: Spring bezier with overshoot — entry briefly exceeds its target then settles. Expressive and alive.": "다이내믹: 오버슛이 있는 스프링 베지에 — 항목이 대상 위치를 짧게 넘어갔다가 안착합니다. 생동감 넘치고 표현력이 풍부합니다."
+  },
+  "Edge Hover Reveal": {
+    "Edge Hover Reveal": "가장자리 호버 시 드러내기"
+  },
+  "Edge Spacing": {
+    "Edge Spacing": "가장자리 간격"
+  },
+  "Edge spacing, exclusive zone, and popup gaps are managed by Frame": {
+    "Edge spacing, exclusive zone, and popup gaps are managed by Frame": "가장자리 간격, 배타적 영역, 팝업 여백은 프레임에 의해 관리됩니다"
+  },
+  "Edge the launcher slides from": {
+    "Edge the launcher slides from": "런처가 슬라이드하는 가장자리 위치"
+  },
+  "Edit": {
+    "Edit": "편집"
+  },
+  "Edit App": {
+    "Edit App": "앱 편집"
+  },
+  "Edit Clipboard": {
+    "Edit Clipboard": "클립보드 편집"
+  },
+  "Edit Rule": {
+    "Edit Rule": "규칙 편집"
+  },
+  "Edit Window Rule": {
+    "Edit Window Rule": "창 규칙 편집"
+  },
+  "Edit clipboard text": {
+    "Edit clipboard text": "클립보드 텍스트 편집"
+  },
+  "Edit event": {
+    "Edit event": "이벤트 편집"
+  },
+  "Editing changes on %1": {
+    "Editing changes on %1": "%1의 변경 사항 편집 중"
+  },
+  "Education": {
+    "Education": "교육"
+  },
+  "Empty": {
+    "Empty": "비어 있음"
+  },
+  "Empty Trash": {
+    "Empty Trash": "휴지통 비우기"
+  },
+  "Empty Trash (%1)": {
+    "Empty Trash (%1)": "휴지통 비우기 (%1)"
+  },
+  "Empty Trash?": {
+    "Empty Trash?": "휴지통을 비우시겠습니까?"
+  },
+  "Enable 10-bit color depth for wider color gamut and HDR support": {
+    "Enable 10-bit color depth for wider color gamut and HDR support": "더 넓은 색 영역과 HDR 지원을 위해 10비트 색 심도 활성화"
+  },
+  "Enable Autoconnect": {
+    "Enable Autoconnect": "자동 연결 활성화"
+  },
+  "Enable Bar": {
+    "Enable Bar": "표시줄 활성화"
+  },
+  "Enable Do Not Disturb": {
+    "Enable Do Not Disturb": "방해 금지 모드 켜기"
+  },
+  "Enable Frame": {
+    "Enable Frame": "프레임 활성화"
+  },
+  "Enable History": {
+    "Enable History": "기록 사용"
+  },
+  "Enable Overview Overlay": {
+    "Enable Overview Overlay": "개요 오버레이 활성화"
+  },
+  "Enable Ripple Effects": {
+    "Enable Ripple Effects": "물결 효과 활성화"
+  },
+  "Enable System Sounds": {
+    "Enable System Sounds": "시스템 소리 활성화"
+  },
+  "Enable Video Screensaver": {
+    "Enable Video Screensaver": "비디오 화면 보호기 활성화"
+  },
+  "Enable Weather": {
+    "Enable Weather": "날씨 활성화"
+  },
+  "Enable WiFi": {
+    "Enable WiFi": "Wi-Fi 활성화"
+  },
+  "Enable a custom override below to set per-bar shadow intensity, opacity, and color.": {
+    "Enable a custom override below to set per-bar shadow intensity, opacity, and color.": "아래에서 사용자 지정 덮어쓰기를 활성화하여 표시줄별 그림자 강도, 불투명도 및 색상을 설정하세요."
+  },
+  "Enable compositor-targetable blur layer (namespace: dms:blurwallpaper). Requires manual niri configuration.": {
+    "Enable compositor-targetable blur layer (namespace: dms:blurwallpaper). Requires manual niri configuration.": "컴포지터 대상 지정 블러 레이어를 활성화합니다(네임스페이스: dms:blurwallpaper). 수동 niri 구성이 필요합니다."
+  },
+  "Enable fingerprint at login": {
+    "Enable fingerprint at login": "로그인 시 지문 활성화"
+  },
+  "Enable fingerprint authentication": {
+    "Enable fingerprint authentication": "지문 인증 활성화"
+  },
+  "Enable fingerprint or security key for DMS Greeter. Authentication changes apply automatically.": {
+    "Enable fingerprint or security key for DMS Greeter. Authentication changes apply automatically.": "DMS Greeter에 지문 또는 보안 키를 활성화합니다. 인증 변경 사항은 자동으로 적용됩니다."
+  },
+  "Enable loginctl lock integration": {
+    "Enable loginctl lock integration": "loginctl 잠금 통합 활성화"
+  },
+  "Enable security key at login": {
+    "Enable security key at login": "로그인 시 보안 키 활성화"
+  },
+  "Enable security key authentication": {
+    "Enable security key authentication": "잠금 화면에 FIDO2/U2F 하드웨어 보안 키 인증 활성화"
+  },
+  "Enabled": {
+    "Enabled": "활성화됨"
+  },
+  "Enabled, but fingerprint availability could not be confirmed.": {
+    "Enabled, but fingerprint availability could not be confirmed.": "활성화되었지만 지문 사용 가능 여부를 확인할 수 없습니다."
+  },
+  "Enabled, but no fingerprint reader was detected.": {
+    "Enabled, but no fingerprint reader was detected.": "활성화되었지만 지문 인식기가 감지되지 않았습니다."
+  },
+  "Enabled, but no prints are enrolled yet. Authentication changes apply automatically once you enroll fingerprints.": {
+    "Enabled, but no prints are enrolled yet. Authentication changes apply automatically once you enroll fingerprints.": "활성화되었지만 아직 등록된 지문이 없습니다. 지문을 등록하면 인증 변경 사항이 자동으로 적용됩니다."
+  },
+  "Enabled, but no prints are enrolled yet. Enroll fingerprints and run Sync.": {
+    "Enabled, but no prints are enrolled yet. Enroll fingerprints and run Sync.": "활성화되었지만 아직 등록된 지문이 없습니다. 지문을 등록하고 동기화를 실행하세요."
+  },
+  "Enabled, but no registered security key was found yet. Authentication changes apply automatically once your key is registered or your U2F config is updated.": {
+    "Enabled, but no registered security key was found yet. Authentication changes apply automatically once your key is registered or your U2F config is updated.": "활성화되었지만 등록된 보안 키를 아직 찾을 수 없습니다. 키를 등록하거나 U2F 구성이 업데이트되면 인증 변경 사항이 자동으로 적용됩니다."
+  },
+  "Enabled, but no registered security key was found yet. Register a key and run Sync.": {
+    "Enabled, but no registered security key was found yet. Register a key and run Sync.": "활성화되었지만 등록된 보안 키를 아직 찾을 수 없습니다. 키를 등록하고 동기화를 실행하세요."
+  },
+  "Enabled, but security-key availability could not be confirmed.": {
+    "Enabled, but security-key availability could not be confirmed.": "활성화되었지만 보안 키 사용 가능 여부를 확인할 수 없습니다."
+  },
+  "Enabled. PAM already provides fingerprint auth.": {
+    "Enabled. PAM already provides fingerprint auth.": "활성화됨. PAM에서 이미 지문 인증을 제공합니다."
+  },
+  "Enabled. PAM already provides security-key auth.": {
+    "Enabled. PAM already provides security-key auth.": "활성화됨. PAM에서 이미 보안 키 인증을 제공합니다."
+  },
+  "Enabled. PAM provides fingerprint auth, but no prints are enrolled yet.": {
+    "Enabled. PAM provides fingerprint auth, but no prints are enrolled yet.": "활성화됨. PAM에서 지문 인증을 제공하지만 아직 등록된 지문이 없습니다."
+  },
+  "Enabling WiFi...": {
+    "Enabling WiFi...": "Wi-Fi 켜는 중..."
+  },
+  "End": {
+    "End": "끝"
+  },
+  "End must be after start": {
+    "End must be after start": "끝은 시작 이후여야 합니다"
+  },
+  "Enlarge on Hover": {
+    "Enlarge on Hover": "마우스 오버 시 확대"
+  },
+  "Enlargement %": {
+    "Enlargement %": "확대율 %"
+  },
+  "Enter 6-digit passkey": {
+    "Enter 6-digit passkey": "6자리 패스키 입력"
+  },
+  "Enter PIN": {
+    "Enter PIN": "PIN 입력"
+  },
+  "Enter PIN for ": {
+    "Enter PIN for ": "PIN 입력:"
+  },
+  "Enter URI or text to share": {
+    "Enter URI or text to share": "공유할 URI 또는 텍스트 입력"
+  },
+  "Enter a new name for session \"%1\"": {
+    "Enter a new name for session \"%1\"": "\"%1\" 세션의 새 이름 입력"
+  },
+  "Enter a new name for this workspace": {
+    "Enter a new name for this workspace": "이 작업 공간의 새 이름 입력"
+  },
+  "Enter command or script path": {
+    "Enter command or script path": "명령어 또는 스크립트 경로 입력"
+  },
+  "Enter credentials for ": {
+    "Enter credentials for ": "자격 증명 입력:"
+  },
+  "Enter custom lock screen format (e.g., dddd, MMMM d)": {
+    "Enter custom lock screen format (e.g., dddd, MMMM d)": "사용자 지정 잠금 화면 형식 입력 (예: dddd, MMMM d)"
+  },
+  "Enter custom top bar format (e.g., ddd MMM d)": {
+    "Enter custom top bar format (e.g., ddd MMM d)": "사용자 지정 상단 표시줄 형식 입력 (예: ddd MMM d)"
+  },
+  "Enter device name...": {
+    "Enter device name...": "기기 이름 입력..."
+  },
+  "Enter filename...": {
+    "Enter filename...": "파일 이름 입력..."
+  },
+  "Enter launch prefix (e.g., 'uwsm-app')": {
+    "Enter launch prefix (e.g., 'uwsm-app')": "실행 접두사 입력 (예: 'uwsm-app')"
+  },
+  "Enter network name and password": {
+    "Enter network name and password": "네트워크 이름 및 비밀번호 입력"
+  },
+  "Enter passkey for ": {
+    "Enter passkey for ": "패스키 입력:"
+  },
+  "Enter password for ": {
+    "Enter password for ": "비밀번호 입력:"
+  },
+  "Enter this passkey on ": {
+    "Enter this passkey on ": "이 패스키를 입력할 곳:"
+  },
+  "Enter to Paste": {
+    "Enter to Paste": "Enter를 눌러 붙여넣기"
+  },
+  "Enterprise": {
+    "Enterprise": "기업용"
+  },
+  "Entry Type": {
+    "Entry Type": "항목 유형"
+  },
+  "Entry pinned": {
+    "Entry pinned": "항목 고정됨"
+  },
+  "Entry unpinned": {
+    "Entry unpinned": "항목 고정 해제됨"
+  },
+  "Environment Variables": {
+    "Environment Variables": "환경 변수"
+  },
+  "Error": {
+    "Error": "오류"
+  },
+  "Errors": {
+    "Errors": "오류"
+  },
+  "Estimated Time": {
+    "Estimated Time": "예상 시간"
+  },
+  "Ethernet": {
+    "Ethernet": "이더넷"
+  },
+  "Event title": {
+    "Event title": "이벤트 제목"
+  },
+  "Every 15 minutes": {
+    "Every 15 minutes": "15분마다"
+  },
+  "Every 30 minutes": {
+    "Every 30 minutes": "30분마다"
+  },
+  "Every 4 hours": {
+    "Every 4 hours": "4시간마다"
+  },
+  "Every hour": {
+    "Every hour": "매시간"
+  },
+  "Exact": {
+    "Exact": "정확히 일치"
+  },
+  "Excluded Media Players": {
+    "Excluded Media Players": "제외된 미디어 플레이어"
+  },
+  "Exclusive Zone Offset": {
+    "Exclusive Zone Offset": "독점 영역 오프셋"
+  },
+  "Existing Users": {
+    "Existing Users": "기존 사용자"
+  },
+  "Exit node": {
+    "Exit node": "출구 노드"
+  },
+  "Experimental Feature": {
+    "Experimental Feature": "실험적 기능"
+  },
+  "Explore": {
+    "Explore": "탐색"
+  },
+  "Exponential": {
+    "Exponential": "기하급수적"
+  },
+  "Expose the Arcs": {
+    "Expose the Arcs": "호 노출"
+  },
+  "Expressive": {
+    "Expressive": "표현력 풍부함"
+  },
+  "Extend battery life": {
+    "Extend battery life": "배터리 수명 연장"
+  },
+  "Extensible architecture": {
+    "Extensible architecture": "확장 가능한 아키텍처"
+  },
+  "External Wallpaper Management": {
+    "External Wallpaper Management": "외부 배경화면 관리"
+  },
+  "Extra Arguments": {
+    "Extra Arguments": "추가 인수"
+  },
+  "Extra Bold": {
+    "Extra Bold": "매우 굵게"
+  },
+  "Extra Light": {
+    "Extra Light": "매우 얇게"
+  },
+  "F1/I: Toggle • F10: Help": {
+    "F1/I: Toggle • F10: Help": "F1/I: 전환 • F10: 도움말"
+  },
+  "Fade": {
+    "Fade": "페이드"
+  },
+  "Fade to lock screen": {
+    "Fade to lock screen": "잠금 화면으로 페이드"
+  },
+  "Fade to monitor off": {
+    "Fade to monitor off": "모니터 끄기로 페이드"
+  },
+  "Failed to accept pairing": {
+    "Failed to accept pairing": "페어링 수락 실패"
+  },
+  "Failed to activate configuration": {
+    "Failed to activate configuration": "구성 활성화 실패"
+  },
+  "Failed to add binds include": {
+    "Failed to add binds include": "바인딩 포함 추가 실패"
+  },
+  "Failed to add printer to class": {
+    "Failed to add printer to class": "클래스에 프린터 추가 실패"
+  },
+  "Failed to apply GTK colors": {
+    "Failed to apply GTK colors": "GTK 색상 적용 실패"
+  },
+  "Failed to apply Qt colors": {
+    "Failed to apply Qt colors": "Qt 색상 적용 실패"
+  },
+  "Failed to apply charge limit to system": {
+    "Failed to apply charge limit to system": "시스템에 충전 제한 적용 실패"
+  },
+  "Failed to apply profile": {
+    "Failed to apply profile": "프로필 적용 실패"
+  },
+  "Failed to browse device": {
+    "Failed to browse device": "기기 찾아보기 실패"
+  },
+  "Failed to cancel all jobs": {
+    "Failed to cancel all jobs": "모든 작업 취소 실패"
+  },
+  "Failed to cancel selected job": {
+    "Failed to cancel selected job": "선택한 작업 취소 실패"
+  },
+  "Failed to check pin limit": {
+    "Failed to check pin limit": "고정 제한 확인 실패"
+  },
+  "Failed to connect VPN": {
+    "Failed to connect VPN": "VPN 연결 실패"
+  },
+  "Failed to connect to %1": {
+    "Failed to connect to %1": "%1에 연결 실패"
+  },
+  "Failed to copy entry": {
+    "Failed to copy entry": "항목 복사 실패"
+  },
+  "Failed to create printer": {
+    "Failed to create printer": "프린터 생성 실패"
+  },
+  "Failed to delete VPN": {
+    "Failed to delete VPN": "VPN 삭제 실패"
+  },
+  "Failed to delete class": {
+    "Failed to delete class": "클래스 삭제 실패"
+  },
+  "Failed to delete printer": {
+    "Failed to delete printer": "프린터 삭제 실패"
+  },
+  "Failed to disable job acceptance": {
+    "Failed to disable job acceptance": "작업 수락 비활성화 실패"
+  },
+  "Failed to disable night mode": {
+    "Failed to disable night mode": "야간 모드 비활성화 실패"
+  },
+  "Failed to disable plugin: %1": {
+    "Failed to disable plugin: %1": "플러그인 비활성화 실패: %1"
+  },
+  "Failed to disconnect VPN": {
+    "Failed to disconnect VPN": "VPN 연결 해제 실패"
+  },
+  "Failed to disconnect VPNs": {
+    "Failed to disconnect VPNs": "VPN 연결 해제 실패"
+  },
+  "Failed to disconnect WiFi": {
+    "Failed to disconnect WiFi": "Wi-Fi 연결 해제 실패"
+  },
+  "Failed to empty trash": {
+    "Failed to empty trash": "휴지통 비우기 실패"
+  },
+  "Failed to enable IP location": {
+    "Failed to enable IP location": "IP 위치 활성화 실패"
+  },
+  "Failed to enable WiFi": {
+    "Failed to enable WiFi": "Wi-Fi 활성화 실패"
+  },
+  "Failed to enable job acceptance": {
+    "Failed to enable job acceptance": "작업 수락 활성화 실패"
+  },
+  "Failed to enable night mode": {
+    "Failed to enable night mode": "야간 모드 활성화 실패"
+  },
+  "Failed to fetch network QR code: %1": {
+    "Failed to fetch network QR code: %1": "네트워크 QR 코드 가져오기 실패: %1"
+  },
+  "Failed to generate systemd override": {
+    "Failed to generate systemd override": "systemd 덮어쓰기 생성 실패"
+  },
+  "Failed to hold job": {
+    "Failed to hold job": "작업 보류 실패"
+  },
+  "Failed to import VPN": {
+    "Failed to import VPN": "VPN 가져오기 실패"
+  },
+  "Failed to launch SMS app": {
+    "Failed to launch SMS app": "SMS 앱 실행 실패"
+  },
+  "Failed to load VPN config": {
+    "Failed to load VPN config": "VPN 구성 로드 실패"
+  },
+  "Failed to load clipboard configuration.": {
+    "Failed to load clipboard configuration.": "클립보드 구성을 로드하지 못했습니다."
+  },
+  "Failed to move job": {
+    "Failed to move job": "작업 이동 실패"
+  },
+  "Failed to move to trash": {
+    "Failed to move to trash": "휴지통으로 이동 실패"
+  },
+  "Failed to parse plugin_settings.json": {
+    "Failed to parse plugin_settings.json": "plugin_settings.json 파싱 실패"
+  },
+  "Failed to parse session.json": {
+    "Failed to parse session.json": "session.json 파싱 실패"
+  },
+  "Failed to parse settings.json": {
+    "Failed to parse settings.json": "settings.json 파싱 파싱 실패"
+  },
+  "Failed to pause printer": {
+    "Failed to pause printer": "프린터 일시 중지 실패"
+  },
+  "Failed to pin entry": {
+    "Failed to pin entry": "항목 고정 실패"
+  },
+  "Failed to print test page": {
+    "Failed to print test page": "테스트 페이지 인쇄 실패"
+  },
+  "Failed to read theme file: %1": {
+    "Failed to read theme file: %1": "테마 파일 읽기 실패: %1"
+  },
+  "Failed to reject pairing": {
+    "Failed to reject pairing": "페어링 거부 실패"
+  },
+  "Failed to reload plugin: %1": {
+    "Failed to reload plugin: %1": "플러그인 다시 로드 실패: %1"
+  },
+  "Failed to remove QR code at %1: %2": {
+    "Failed to remove QR code at %1: %2": "%1에서 QR 코드 제거 실패: %2"
+  },
+  "Failed to remove device": {
+    "Failed to remove device": "기기 제거 실패"
+  },
+  "Failed to remove keybind": {
+    "Failed to remove keybind": "키 바인딩 제거 실패"
+  },
+  "Failed to remove printer from class": {
+    "Failed to remove printer from class": "클래스에서 프린터 제거 실패"
+  },
+  "Failed to restart audio system": {
+    "Failed to restart audio system": "오디오 시스템 재시작 실패"
+  },
+  "Failed to restart job": {
+    "Failed to restart job": "작업 재시작 실패"
+  },
+  "Failed to resume printer": {
+    "Failed to resume printer": "프린터 재개 실패"
+  },
+  "Failed to ring device": {
+    "Failed to ring device": "기기 소리 울리기 실패"
+  },
+  "Failed to run 'dms greeter status'. Ensure DMS is installed and dms is in PATH.": {
+    "Failed to run 'dms greeter status'. Ensure DMS is installed and dms is in PATH.": "'dms greeter status' 실행에 실패했습니다. DMS가 설치되어 있고 PATH에 dms가 있는지 확인하세요."
+  },
+  "Failed to save VPN credentials": {
+    "Failed to save VPN credentials": "VPN 자격 증명 저장 실패"
+  },
+  "Failed to save audio config": {
+    "Failed to save audio config": "오디오 구성 저장 실패"
+  },
+  "Failed to save clipboard setting": {
+    "Failed to save clipboard setting": "클립보드 설정 저장 실패"
+  },
+  "Failed to save keybind": {
+    "Failed to save keybind": "키 바인딩 저장 실패"
+  },
+  "Failed to save profile": {
+    "Failed to save profile": "프로필 저장 실패"
+  },
+  "Failed to send SMS": {
+    "Failed to send SMS": "SMS 전송 실패"
+  },
+  "Failed to send clipboard": {
+    "Failed to send clipboard": "클립보드 전송 실패"
+  },
+  "Failed to send file": {
+    "Failed to send file": "파일 전송 실패"
+  },
+  "Failed to send ping": {
+    "Failed to send ping": "핑 전송 실패"
+  },
+  "Failed to set brightness": {
+    "Failed to set brightness": "밝기 설정 실패"
+  },
+  "Failed to set night mode location": {
+    "Failed to set night mode location": "야간 모드 위치 설정 실패"
+  },
+  "Failed to set night mode schedule": {
+    "Failed to set night mode schedule": "야간 모드 일정 설정 실패"
+  },
+  "Failed to set night mode temperature": {
+    "Failed to set night mode temperature": "야간 모드 온도 설정 실패"
+  },
+  "Failed to set power profile": {
+    "Failed to set power profile": "전원 프로필 설정 실패"
+  },
+  "Failed to set profile image": {
+    "Failed to set profile image": "프로필 이미지 설정 실패"
+  },
+  "Failed to set profile image: %1": {
+    "Failed to set profile image: %1": "프로필 이미지 설정 실패: %1"
+  },
+  "Failed to share": {
+    "Failed to share": "공유 실패"
+  },
+  "Failed to start connection to %1": {
+    "Failed to start connection to %1": "%1에 대한 연결 시작 실패"
+  },
+  "Failed to unpin entry": {
+    "Failed to unpin entry": "항목 고정 해제 실패"
+  },
+  "Failed to update %1: %2": {
+    "Failed to update %1: %2": "%1 업데이트 실패: %2"
+  },
+  "Failed to update VPN": {
+    "Failed to update VPN": "VPN 업데이트 실패"
+  },
+  "Failed to update autoconnect": {
+    "Failed to update autoconnect": "자동 연결 업데이트 실패"
+  },
+  "Failed to update clipboard": {
+    "Failed to update clipboard": "클립보드 업데이트 실패"
+  },
+  "Failed to update description": {
+    "Failed to update description": "설명 업데이트 실패"
+  },
+  "Failed to update location": {
+    "Failed to update location": "위치 업데이트 실패"
+  },
+  "Failed to update sharing": {
+    "Failed to update sharing": "공유 기능 업데이트 실패"
+  },
+  "Failed to write autostart entry": {
+    "Failed to write autostart entry": "자동 시작 항목 쓰기 실패"
+  },
+  "Failed to write outputs config.": {
+    "Failed to write outputs config.": "출력 구성을 쓰는 데 실패했습니다."
+  },
+  "Failed to write temp file for validation": {
+    "Failed to write temp file for validation": "유효성 검사를 위한 임시 파일 쓰기 실패"
+  },
+  "Failed: %1": {
+    "Failed: %1": "실패: %1"
+  },
+  "Features": {
+    "Features": "기능"
+  },
+  "Feels": {
+    "Feels": "체감 온도"
+  },
+  "Feels Like": {
+    "Feels Like": "체감 온도"
+  },
+  "Feels Like %1°": {
+    "Feels Like %1°": "체감 온도 %1°"
+  },
+  "Fidelity": {
+    "Fidelity": "충실도"
+  },
+  "Field": {
+    "Field": "필드"
+  },
+  "File": {
+    "File": "파일"
+  },
+  "File Already Exists": {
+    "File Already Exists": "파일이 이미 존재함"
+  },
+  "File Information": {
+    "File Information": "파일 정보"
+  },
+  "File Manager": {
+    "File Manager": "파일 관리자"
+  },
+  "File changed on disk": {
+    "File changed on disk": "디스크에서 파일이 변경됨"
+  },
+  "File manager used to open the trash. Pick \"custom\" to enter your own command.": {
+    "File manager used to open the trash. Pick \"custom\" to enter your own command.": "휴지통을 열 때 사용되는 파일 관리자입니다. 자신만의 명령어를 입력하려면 \"사용자 지정\"을 선택하세요."
+  },
+  "File received from": {
+    "File received from": "다음으로부터 파일을 받음:"
+  },
+  "File search requires dsearch\nInstall from github.com/AvengeMedia/danksearch": {
+    "File search requires dsearch\nInstall from github.com/AvengeMedia/danksearch": "파일 검색에는 dsearch가 필요합니다\ngithub.com/AvengeMedia/danksearch에서 설치하세요"
+  },
+  "File search unavailable": {
+    "File search unavailable": "파일 검색을 사용할 수 없음"
+  },
+  "Files": {
+    "Files": "파일"
+  },
+  "Filesystem usage monitoring": {
+    "Filesystem usage monitoring": "파일 시스템 사용량 모니터링"
+  },
+  "Fill": {
+    "Fill": "채우기"
+  },
+  "Fill Mode": {
+    "Fill Mode": "채우기 모드"
+  },
+  "Filter": {
+    "Filter": "필터"
+  },
+  "Filter by type": {
+    "Filter by type": "유형별 필터"
+  },
+  "Find in Text": {
+    "Find in Text": "텍스트에서 찾기"
+  },
+  "Find in note...": {
+    "Find in note...": "노트에서 찾기..."
+  },
+  "Fine-tune the space reserved for the bar from the screen edge": {
+    "Fine-tune the space reserved for the bar from the screen edge": "화면 가장자리에서 바를 위해 예약된 공간 미세 조정"
+  },
+  "Fingerprint availability could not be confirmed.": {
+    "Fingerprint availability could not be confirmed.": "지문 인식 가능 여부를 확인할 수 없습니다."
+  },
+  "Fingerprint error": {
+    "Fingerprint error": "지문 인식 오류"
+  },
+  "Fingerprint not recognized (%1/%2). Please try again or use password.": {
+    "Fingerprint not recognized (%1/%2). Please try again or use password.": "지문이 인식되지 않았습니다(%1/%2). 다시 시도하거나 비밀번호를 사용하세요."
+  },
+  "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and enroll later.": {
+    "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and enroll later.": "지문 판독기가 감지되었으나 아직 등록된 지문이 없습니다. 지금 활성화하고 나중에 등록할 수 있습니다."
+  },
+  "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and run Sync later.": {
+    "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and run Sync later.": "지문 판독기가 감지되었으나 아직 등록된 지문이 없습니다. 지금 활성화하고 나중에 동기화를 실행할 수 있습니다."
+  },
+  "Finish": {
+    "Finish": "마침"
+  },
+  "First Day of Week": {
+    "First Day of Week": "한 주의 시작일"
+  },
+  "First Time Setup": {
+    "First Time Setup": "초기 설정"
+  },
+  "Fit": {
+    "Fit": "맞춤"
+  },
+  "Flags": {
+    "Flags": "플래그"
+  },
+  "Flipped": {
+    "Flipped": "뒤집힘"
+  },
+  "Flipped 180°": {
+    "Flipped 180°": "180° 뒤집힘"
+  },
+  "Flipped 270°": {
+    "Flipped 270°": "270° 뒤집힘"
+  },
+  "Flipped 90°": {
+    "Flipped 90°": "90° 뒤집힘"
+  },
+  "Float": {
+    "Float": "플로트"
+  },
+  "Float Anchor": {
+    "Float Anchor": "플로트 앵커"
+  },
+  "Float X": {
+    "Float X": "플로트 X"
+  },
+  "Float Y": {
+    "Float Y": "플로트 Y"
+  },
+  "Floating": {
+    "Floating": "플로팅"
+  },
+  "Floating Position": {
+    "Floating Position": "플로팅 위치"
+  },
+  "Fluent": {
+    "Fluent": "Fluent"
+  },
+  "Fluent: Smooth cubic deceleration in, quick snap out — clean, elegant curves.": {
+    "Fluent: Smooth cubic deceleration in, quick snap out — clean, elegant curves.": "Fluent: 부드러운 3차 감속 진입, 빠른 스냅 아웃 — 깔끔하고 우아한 곡선."
+  },
+  "Focus": {
+    "Focus": "포커스"
+  },
+  "Focus Ring Color": {
+    "Focus Ring Color": "포커스 링 색상"
+  },
+  "Focus Ring Off": {
+    "Focus Ring Off": "포커스 링 끄기"
+  },
+  "Focus at Startup": {
+    "Focus at Startup": "시작 시 포커스"
+  },
+  "Focused": {
+    "Focused": "포커스됨"
+  },
+  "Focused Border": {
+    "Focused Border": "포커스된 테두리"
+  },
+  "Focused Color": {
+    "Focused Color": "포커스된 색상"
+  },
+  "Focused Display": {
+    "Focused Display": "포커스된 디스플레이"
+  },
+  "Focused Monitor Only": {
+    "Focused Monitor Only": "포커스된 모니터 전용"
+  },
+  "Focused Window": {
+    "Focused Window": "포커스된 창"
+  },
+  "Fog": {
+    "Fog": "안개"
+  },
+  "Folder": {
+    "Folder": "폴더"
+  },
+  "Folders": {
+    "Folders": "폴더"
+  },
+  "Follow DMS background color": {
+    "Follow DMS background color": "DMS 배경색 따르기"
+  },
+  "Follow Monitor Focus": {
+    "Follow Monitor Focus": "모니터 포커스 따르기"
+  },
+  "Follow focus": {
+    "Follow focus": "포커스 따르기"
+  },
+  "Follows the default launcher choice selected above.": {
+    "Follows the default launcher choice selected above.": "위에서 선택한 기본 런처 선택을 따릅니다."
+  },
+  "Font": {
+    "Font": "글꼴"
+  },
+  "Font Family": {
+    "Font Family": "글꼴 패밀리"
+  },
+  "Font Scale": {
+    "Font Scale": "글꼴 배율"
+  },
+  "Font Size": {
+    "Font Size": "글꼴 크기"
+  },
+  "Font Weight": {
+    "Font Weight": "글꼴 두께"
+  },
+  "Font used for the clock and date on the lock screen": {
+    "Font used for the clock and date on the lock screen": "잠금 화면의 시계 및 날짜에 사용되는 글꼴"
+  },
+  "Font used on the login screen": {
+    "Font used on the login screen": "로그인 화면에 사용되는 글꼴"
+  },
+  "For 1 hour": {
+    "For 1 hour": "1시간 동안"
+  },
+  "For 15 minutes": {
+    "For 15 minutes": "15분 동안"
+  },
+  "For 3 hours": {
+    "For 3 hours": "3시간 동안"
+  },
+  "For 30 minutes": {
+    "For 30 minutes": "30분 동안"
+  },
+  "For 8 hours": {
+    "For 8 hours": "8시간 동안"
+  },
+  "For editing plain text files": {
+    "For editing plain text files": "일반 텍스트 파일 편집용"
+  },
+  "For reading PDF files": {
+    "For reading PDF files": "PDF 파일 읽기용"
+  },
+  "Force HDR": {
+    "Force HDR": "HDR 강제"
+  },
+  "Force Kill (SIGKILL)": {
+    "Force Kill (SIGKILL)": "강제 종료(SIGKILL)"
+  },
+  "Force Padding": {
+    "Force Padding": "여백 강제"
+  },
+  "Force RGBX": {
+    "Force RGBX": "RGBX 강제"
+  },
+  "Force Wide Color": {
+    "Force Wide Color": "광색역 강제"
+  },
+  "Force terminal applications to always use dark color schemes": {
+    "Force terminal applications to always use dark color schemes": "터미널 앱이 항상 어두운 색상 체계를 사용하도록 강제"
+  },
+  "Forecast": {
+    "Forecast": "일기예보"
+  },
+  "Forecast Days": {
+    "Forecast Days": "예보 일수"
+  },
+  "Forecast Not Available": {
+    "Forecast Not Available": "일기예보를 사용할 수 없음"
+  },
+  "Forecast and conditions": {
+    "Forecast and conditions": "일기예보 및 상태"
+  },
+  "Foreground Layers": {
+    "Foreground Layers": "전경 레이어"
+  },
+  "Forever": {
+    "Forever": "영원히"
+  },
+  "Forget": {
+    "Forget": "지우기"
+  },
+  "Forget \"%1\"?": {
+    "Forget \"%1\"?": "\"%1\"을(를) 지우시겠습니까?"
+  },
+  "Forget Device": {
+    "Forget Device": "기기 지우기"
+  },
+  "Forget Network": {
+    "Forget Network": "네트워크 지우기"
+  },
+  "Forgot network %1": {
+    "Forgot network %1": "네트워크 %1을(를) 지웠습니다"
+  },
+  "Format Legend": {
+    "Format Legend": "형식 범례"
+  },
+  "Forward 10s": {
+    "Forward 10s": "10초 앞으로"
+  },
+  "Frame": {
+    "Frame": "프레임"
+  },
+  "Frame Blur": {
+    "Frame Blur": "프레임 블러"
+  },
+  "Frame Blur follows Background Blur in Theme & Colors": {
+    "Frame Blur follows Background Blur in Theme & Colors": "프레임 블러가 테마 및 색상의 배경 블러를 따름"
+  },
+  "Frame Border Color": {
+    "Frame Border Color": "프레임 테두리 색상"
+  },
+  "Frame Xray": {
+    "Frame Xray": "프레임 Xray"
+  },
+  "Free VRAM/memory when the launcher is closed. May cause a slight delay when reopening.": {
+    "Free VRAM/memory when the launcher is closed. May cause a slight delay when reopening.": "런처를 닫을 때 VRAM/메모리를 확보합니다. 다시 열 때 약간의 지연이 발생할 수 있습니다."
+  },
+  "Freezing Drizzle": {
+    "Freezing Drizzle": "어는 이슬비"
+  },
+  "Frequency": {
+    "Frequency": "빈도"
+  },
+  "Fruit Salad": {
+    "Fruit Salad": "후르츠 샐러드"
+  },
+  "Full": {
+    "Full": "전체"
+  },
+  "Full Command:": {
+    "Full Command:": "전체 명령어:"
+  },
+  "Full Content": {
+    "Full Content": "전체 내용"
+  },
+  "Full Day & Month": {
+    "Full Day & Month": "전체 일 및 월"
+  },
+  "Full Size": {
+    "Full Size": "전체 크기"
+  },
+  "Full command to execute": {
+    "Full command to execute": "실행할 전체 명령어"
+  },
+  "Full with Year": {
+    "Full with Year": "연도 포함 전체"
+  },
+  "Fullscreen": {
+    "Fullscreen": "전체 화면"
+  },
+  "Fullscreen Only": {
+    "Fullscreen Only": "전체 화면 전용"
+  },
+  "Fully Charged": {
+    "Fully Charged": "충전 완료"
+  },
+  "Fun": {
+    "Fun": "재미"
+  },
+  "G: grid • Z/X: size": {
+    "G: grid • Z/X: size": "G: 그리드 • Z/X: 크기"
+  },
+  "GPU": {
+    "GPU": "GPU"
+  },
+  "GPU Monitoring": {
+    "GPU Monitoring": "GPU 모니터링"
+  },
+  "GPU Temperature": {
+    "GPU Temperature": "GPU 온도"
+  },
+  "GPU temperature display": {
+    "GPU temperature display": "GPU 온도 표시"
+  },
+  "GTK colors applied successfully": {
+    "GTK colors applied successfully": "GTK 색상이 성공적으로 적용됨"
+  },
+  "GTK, Qt, IDEs, more": {
+    "GTK, Qt, IDEs, more": "GTK, Qt, IDE 등"
+  },
+  "Games": {
+    "Games": "게임"
+  },
+  "Gamma Control": {
+    "Gamma Control": "감마 제어"
+  },
+  "Gamma control not available. Requires DMS API v6+.": {
+    "Gamma control not available. Requires DMS API v6+.": "감마 제어를 사용할 수 없습니다. DMS API v6+가 필요합니다."
+  },
+  "Gap between the end widgets and the bar ends (0 = edge-to-edge)": {
+    "Gap between the end widgets and the bar ends (0 = edge-to-edge)": "양쪽 끝 위젯과 바 끝 사이의 간격(0 = 가장자리에 맞춤)"
+  },
+  "Gaps": {
+    "Gaps": "간격"
+  },
+  "Generate Override": {
+    "Generate Override": "오버라이드 생성"
+  },
+  "Generate baseline GTK3/4 or QT5/QT6 (requires qt6ct-kde) configurations to follow DMS colors. Only needed once.<br /><br />It is recommended to configure <a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/README.md#Theming\" style=\"text-decoration:none; color:%1;\">adw-gtk3</a> prior to applying GTK themes.": {
+    "Generate baseline GTK3/4 or QT5/QT6 (requires qt6ct-kde) configurations to follow DMS colors. Only needed once.<br /><br />It is recommended to configure <a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/README.md#Theming\" style=\"text-decoration:none; color:%1;\">adw-gtk3</a> prior to applying GTK themes.": "DMS 색상을 따르도록 기본 GTK3/4 또는 QT5/QT6(qt6ct-kde 필요) 구성을 생성합니다. 한 번만 필요합니다.<br /><br />GTK 테마를 적용하기 전에 <a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/README.md#Theming\" style=\"text-decoration:none; color:%1;\">adw-gtk3</a>를 구성하는 것이 좋습니다."
+  },
+  "Generic": {
+    "Generic": "일반"
+  },
+  "Get Started": {
+    "Get Started": "시작하기"
+  },
+  "GitHub": {
+    "GitHub": "GitHub"
+  },
+  "Global fonts can be configured in Settings → Personalization": {
+    "Global fonts can be configured in Settings → Personalization": "설정 → 개인 설정에서 전역 글꼴을 구성할 수 있습니다"
+  },
+  "Globally scale all animation durations": {
+    "Globally scale all animation durations": "모든 애니메이션 재생 시간을 전역적으로 배율 조정"
+  },
+  "Golden Hour": {
+    "Golden Hour": "골든 아워"
+  },
+  "Good": {
+    "Good": "좋음"
+  },
+  "Goth Corner Radius": {
+    "Goth Corner Radius": "고딕 모서리 반경"
+  },
+  "Goth Corners": {
+    "Goth Corners": "고딕 모서리"
+  },
+  "Gradually fade the screen before locking with a configurable grace period": {
+    "Gradually fade the screen before locking with a configurable grace period": "구성 가능한 유예 기간을 두고 잠그기 전에 화면을 서서히 페이드 아웃"
+  },
+  "Gradually fade the screen before turning off monitors with a configurable grace period": {
+    "Gradually fade the screen before turning off monitors with a configurable grace period": "구성 가능한 유예 기간을 두고 모니터를 끄기 전에 화면을 서서히 페이드 아웃"
+  },
+  "Grant": {
+    "Grant": "권한 부여"
+  },
+  "Grant admin?": {
+    "Grant admin?": "관리자 권한을 부여하시겠습니까?"
+  },
+  "Grant administrator privileges": {
+    "Grant administrator privileges": "관리자 권한 부여"
+  },
+  "Granted administrator privileges": {
+    "Granted administrator privileges": "관리자 권한 부여됨"
+  },
+  "Granted greeter login access": {
+    "Granted greeter login access": "로그인 화면 로그인 접근 권한 부여됨"
+  },
+  "Graph Time Range": {
+    "Graph Time Range": "그래프 시간 범위"
+  },
+  "Graphics": {
+    "Graphics": "그래픽"
+  },
+  "Greeter": {
+    "Greeter": "로그인 화면"
+  },
+  "Greeter Appearance": {
+    "Greeter Appearance": "로그인 화면 모양"
+  },
+  "Greeter Behavior": {
+    "Greeter Behavior": "로그인 화면 동작"
+  },
+  "Greeter Status": {
+    "Greeter Status": "로그인 화면 상태"
+  },
+  "Greeter activated. greetd is now enabled.": {
+    "Greeter activated. greetd is now enabled.": "로그인 화면이 활성화되었습니다. 이제 greetd가 활성화됩니다."
+  },
+  "Greeter font": {
+    "Greeter font": "로그인 화면 글꼴"
+  },
+  "Greeter group members can sync their login-screen theme with dms greeter sync --profile after logging out and back in.": {
+    "Greeter group members can sync their login-screen theme with dms greeter sync --profile after logging out and back in.": "로그인 화면 그룹 구성원은 로그아웃했다가 다시 로그인한 후 dms greeter sync --profile을 사용하여 로그인 화면 테마를 동기화할 수 있습니다."
+  },
+  "Greeter group:": {
+    "Greeter group:": "로그인 화면 그룹:"
+  },
+  "Greeter only — does not affect main clock": {
+    "Greeter only — does not affect main clock": "로그인 화면 전용 — 기본 시계에 영향을 주지 않음"
+  },
+  "Greeter only — format for the date on the login screen": {
+    "Greeter only — format for the date on the login screen": "로그인 화면 전용 — 로그인 화면의 날짜 형식"
+  },
+  "Greeter sync complete": {
+    "Greeter sync complete": "로그인 화면 동기화 완료"
+  },
+  "Grid": {
+    "Grid": "그리드"
+  },
+  "Grid Columns": {
+    "Grid Columns": "그리드 열"
+  },
+  "Grid: OFF": {
+    "Grid: OFF": "그리드: 끄기"
+  },
+  "Grid: ON": {
+    "Grid: ON": "그리드: 켜기"
+  },
+  "Group": {
+    "Group": "그룹"
+  },
+  "Group Active Workspace": {
+    "Group Active Workspace": "활성 작업 공간 그룹화"
+  },
+  "Group Workspace Apps": {
+    "Group Workspace Apps": "작업 공간 앱 그룹화"
+  },
+  "Group by App": {
+    "Group by App": "앱별 그룹화"
+  },
+  "Group multiple windows of the same app together with a window count indicator": {
+    "Group multiple windows of the same app together with a window count indicator": "창 수 표시기와 함께 같은 앱의 여러 창을 그룹화"
+  },
+  "Group removed": {
+    "Group removed": "그룹 제거됨"
+  },
+  "Group repeated application icons in unfocused workspaces": {
+    "Group repeated application icons in unfocused workspaces": "포커스되지 않은 작업 공간에서 반복되는 애플리케이션 아이콘 그룹화"
+  },
+  "Groups": {
+    "Groups": "그룹"
+  },
+  "HDR (EDID)": {
+    "HDR (EDID)": "HDR (EDID)"
+  },
+  "HDR Tone Mapping": {
+    "HDR Tone Mapping": "HDR 톤 매핑"
+  },
+  "HDR mode is experimental. Verify your monitor supports HDR before enabling.": {
+    "HDR mode is experimental. Verify your monitor supports HDR before enabling.": "HDR 모드는 실험적입니다. 활성화하기 전에 모니터가 HDR을 지원하는지 확인하세요."
+  },
+  "HSV": {
+    "HSV": "HSV"
+  },
+  "HSV %1 copied": {
+    "HSV %1 copied": "HSV %1 복사됨"
+  },
+  "HTML copied to clipboard": {
+    "HTML copied to clipboard": "HTML이 클립보드에 복사됨"
+  },
+  "Handles links and opens HTML files": {
+    "Handles links and opens HTML files": "링크 처리 및 HTML 파일 열기"
+  },
+  "Handles mailto links": {
+    "Handles mailto links": "mailto 링크 처리"
+  },
+  "Health": {
+    "Health": "수명"
+  },
+  "Heavy Rain": {
+    "Heavy Rain": "강한 비"
+  },
+  "Heavy Snow": {
+    "Heavy Snow": "폭설"
+  },
+  "Heavy Snow Showers": {
+    "Heavy Snow Showers": "강한 소낙눈"
+  },
+  "Height": {
+    "Height": "높이"
+  },
+  "Held": {
+    "Held": "보류됨"
+  },
+  "Help": {
+    "Help": "도움말"
+  },
+  "Hex": {
+    "Hex": "Hex"
+  },
+  "Hibernate": {
+    "Hibernate": "최대 절전 모드"
+  },
+  "Hibernate failed": {
+    "Hibernate failed": "최대 절전 모드 실패"
+  },
+  "Hidden": {
+    "Hidden": "숨김"
+  },
+  "Hidden (%1)": {
+    "Hidden (%1)": "숨김(%1)"
+  },
+  "Hidden Apps": {
+    "Hidden Apps": "숨겨진 앱"
+  },
+  "Hidden apps won't appear in the launcher. Right-click an app and select 'Hide App' to hide it.": {
+    "Hidden apps won't appear in the launcher. Right-click an app and select 'Hide App' to hide it.": "숨겨진 앱은 런처에 나타나지 않습니다. 앱을 마우스 오른쪽 버튼으로 클릭하고 '앱 숨기기'를 선택하여 숨깁니다."
+  },
+  "Hidden until weather is enabled": {
+    "Hidden until weather is enabled": "날씨가 활성화될 때까지 숨김"
+  },
+  "Hide": {
+    "Hide": "숨기기"
+  },
+  "Hide 3rd Party": {
+    "Hide 3rd Party": "타사 숨기기"
+  },
+  "Hide App": {
+    "Hide App": "앱 숨기기"
+  },
+  "Hide Delay": {
+    "Hide Delay": "숨기기 지연"
+  },
+  "Hide Indicators": {
+    "Hide Indicators": "표시기 숨기기"
+  },
+  "Hide When Typing": {
+    "Hide When Typing": "입력 시 숨기기"
+  },
+  "Hide When Windows Open": {
+    "Hide When Windows Open": "창이 열릴 때 숨기기"
+  },
+  "Hide cursor after inactivity (0 = disabled)": {
+    "Hide cursor after inactivity (0 = disabled)": "활동이 없을 때 커서 숨기기(0 = 비활성화)"
+  },
+  "Hide cursor when pressing keyboard keys": {
+    "Hide cursor when pressing keyboard keys": "키보드 키를 누를 때 커서 숨기기"
+  },
+  "Hide cursor when using touch input": {
+    "Hide cursor when using touch input": "터치 입력 시 커서 숨기기"
+  },
+  "Hide device": {
+    "Hide device": "기기 숨기기"
+  },
+  "Hide installed": {
+    "Hide installed": "설치됨 숨기기"
+  },
+  "Hide notification content until expanded": {
+    "Hide notification content until expanded": "확장될 때까지 알림 내용 숨기기"
+  },
+  "Hide notification content until expanded; popups show collapsed by default": {
+    "Hide notification content until expanded; popups show collapsed by default": "확장될 때까지 알림 내용 숨기기; 팝업은 기본적으로 접힌 상태로 표시됨"
+  },
+  "Hide on Touch": {
+    "Hide on Touch": "터치 시 숨기기"
+  },
+  "Hide the bar when the pointer leaves even if a popout is still open": {
+    "Hide the bar when the pointer leaves even if a popout is still open": "팝아웃이 열려 있어도 포인터가 벗어나면 바 숨기기"
+  },
+  "Hide when no updates: OFF": {
+    "Hide when no updates: OFF": "업데이트가 없을 때 숨기기: 끄기"
+  },
+  "Hide when no updates: ON": {
+    "Hide when no updates: ON": "업데이트가 없을 때 숨기기: 켜기"
+  },
+  "High": {
+    "High": "높음"
+  },
+  "High-fidelity palette that preserves source hues.": {
+    "High-fidelity palette that preserves source hues.": "원본 색조를 유지하는 고충실도 팔레트."
+  },
+  "Highlight Active Workspace App": {
+    "Highlight Active Workspace App": "활성 작업 공간 앱 강조"
+  },
+  "Highlight the currently focused app inside workspace indicators": {
+    "Highlight the currently focused app inside workspace indicators": "작업 공간 표시기 내에서 현재 포커스된 앱 강조"
+  },
+  "History": {
+    "History": "기록"
+  },
+  "History Retention": {
+    "History Retention": "기록 유지"
+  },
+  "History Settings": {
+    "History Settings": "기록 설정"
+  },
+  "History cleared. %1 pinned entries kept.": {
+    "History cleared. %1 pinned entries kept.": "기록이 지워졌습니다. %1개의 고정된 항목이 유지됩니다."
+  },
+  "Hold Duration": {
+    "Hold Duration": "길게 누르기 시간"
+  },
+  "Hold longer to confirm": {
+    "Hold longer to confirm": "확인하려면 더 길게 누르세요"
+  },
+  "Hold to Confirm Power Actions": {
+    "Hold to Confirm Power Actions": "길게 눌러 전원 작업 확인"
+  },
+  "Hold to confirm (%1 ms)": {
+    "Hold to confirm (%1 ms)": "길게 눌러 확인(%1 ms)"
+  },
+  "Hold to confirm (%1s)": {
+    "Hold to confirm (%1s)": "길게 눌러 확인(%1s)"
+  },
+  "Home": {
+    "Home": "홈"
+  },
+  "Horizontal and vertical bar thickness": {
+    "Horizontal and vertical bar thickness": "가로 및 세로 바 두께"
+  },
+  "Host": {
+    "Host": "호스트"
+  },
+  "Hostname": {
+    "Hostname": "호스트 이름"
+  },
+  "Hot Corners": {
+    "Hot Corners": "핫 코너"
+  },
+  "Hotkey overlay title (optional)": {
+    "Hotkey overlay title (optional)": "단축키 오버레이 제목(선택 사항)"
+  },
+  "Hour": {
+    "Hour": "시간"
+  },
+  "Hourly": {
+    "Hourly": "매시간"
+  },
+  "Hourly Forecast Count": {
+    "Hourly Forecast Count": "시간별 예보 수"
+  },
+  "Hover Popouts": {
+    "Hover Popouts": "가리킬 때 팝아웃"
+  },
+  "How often the server polls for new updates.": {
+    "How often the server polls for new updates.": "서버가 새 업데이트를 확인하는 빈도입니다."
+  },
+  "How often to change wallpaper": {
+    "How often to change wallpaper": "배경화면 변경 빈도"
+  },
+  "How the background image is scaled": {
+    "How the background image is scaled": "배경 이미지 배율 조정 방법"
+  },
+  "How the wallpaper is scaled to fit the screen": {
+    "How the wallpaper is scaled to fit the screen": "배경화면이 화면에 맞게 배율 조정되는 방법"
+  },
+  "Humidity": {
+    "Humidity": "습도"
+  },
+  "Hyprland Discord Server": {
+    "Hyprland Discord Server": "Hyprland Discord 서버"
+  },
+  "Hyprland Layout Overrides": {
+    "Hyprland Layout Overrides": "Hyprland 레이아웃 오버라이드"
+  },
+  "Hyprland Options": {
+    "Hyprland Options": "Hyprland 옵션"
+  },
+  "Hyprland Website": {
+    "Hyprland Website": "Hyprland 웹사이트"
+  },
+  "Hyprland conf mode": {
+    "Hyprland conf mode": "Hyprland 구성 모드"
+  },
+  "Hyprland conf mode is read-only in Settings": {
+    "Hyprland conf mode is read-only in Settings": "설정에서 Hyprland 구성 모드는 읽기 전용입니다"
+  },
+  "Hyprland config include missing": {
+    "Hyprland config include missing": "Hyprland 구성 include 누락됨"
+  },
+  "I Understand": {
+    "I Understand": "이해했습니다"
+  },
+  "IP": {
+    "IP": "IP"
+  },
+  "IP Address:": {
+    "IP Address:": "IP 주소:"
+  },
+  "IP address or hostname": {
+    "IP address or hostname": "IP 주소 또는 호스트 이름"
+  },
+  "ISO Date": {
+    "ISO Date": "ISO 날짜"
+  },
+  "Icon": {
+    "Icon": "아이콘"
+  },
+  "Icon Scale": {
+    "Icon Scale": "아이콘 배율"
+  },
+  "Icon Size": {
+    "Icon Size": "아이콘 크기"
+  },
+  "Icon Size %": {
+    "Icon Size %": "아이콘 크기 %"
+  },
+  "Icon Theme": {
+    "Icon Theme": "아이콘 테마"
+  },
+  "Icon theme changed outside DMS; switched to System Default": {
+    "Icon theme changed outside DMS; switched to System Default": "외부에서 아이콘 테마가 변경됨; 시스템 기본값으로 전환됨"
+  },
+  "Identical alerts show as one popup instead of stacking": {
+    "Identical alerts show as one popup instead of stacking": "동일한 알림이 쌓이지 않고 하나의 팝업으로 표시됨"
+  },
+  "Identical alerts stack as separate notification cards": {
+    "Identical alerts stack as separate notification cards": "동일한 알림이 별도의 알림 카드로 쌓임"
+  },
+  "Identify": {
+    "Identify": "식별"
+  },
+  "Idle": {
+    "Idle": "대기 상태"
+  },
+  "Idle Inhibit": {
+    "Idle Inhibit": "대기 금지"
+  },
+  "Idle Inhibitor": {
+    "Idle Inhibitor": "대기 금지기"
+  },
+  "Idle Settings": {
+    "Idle Settings": "대기 설정"
+  },
+  "If autostart app icons don't appear in the system tray, generate a systemd override to ensure DMS starts before autostart apps": {
+    "If autostart app icons don't appear in the system tray, generate a systemd override to ensure DMS starts before autostart apps": "자동 시작 앱 아이콘이 시스템 트레이에 나타나지 않으면 자동 시작 앱보다 DMS가 먼저 시작되도록 systemd 오버라이드를 생성합니다"
+  },
+  "If the field is hidden, it will appear as soon as a key is pressed.": {
+    "If the field is hidden, it will appear as soon as a key is pressed.": "필드가 숨겨져 있어도 키를 누르는 즉시 나타납니다."
+  },
+  "Ignore Completely": {
+    "Ignore Completely": "완전히 무시"
+  },
+  "Image": {
+    "Image": "이미지"
+  },
+  "Image Viewer": {
+    "Image Viewer": "이미지 뷰어"
+  },
+  "Image copied to clipboard": {
+    "Image copied to clipboard": "이미지가 클립보드에 복사됨"
+  },
+  "Import": {
+    "Import": "가져오기"
+  },
+  "Import VPN": {
+    "Import VPN": "VPN 가져오기"
+  },
+  "Inactive Monitor Color": {
+    "Inactive Monitor Color": "비활성 모니터 색상"
+  },
+  "Include AUR updates": {
+    "Include AUR updates": "AUR 업데이트 포함"
+  },
+  "Include Files in All Tab": {
+    "Include Files in All Tab": "모든 탭에 파일 포함"
+  },
+  "Include Flatpak updates": {
+    "Include Flatpak updates": "Flatpak 업데이트 포함"
+  },
+  "Include Folders in All Tab": {
+    "Include Folders in All Tab": "모든 탭에 폴더 포함"
+  },
+  "Include Transitions": {
+    "Include Transitions": "전환 포함"
+  },
+  "Include desktop actions (shortcuts) in search results.": {
+    "Include desktop actions (shortcuts) in search results.": "검색 결과에 데스크톱 작업(바로 가기)을 포함합니다."
+  },
+  "Incompatible Plugins Loaded": {
+    "Incompatible Plugins Loaded": "호환되지 않는 플러그인 로드됨"
+  },
+  "Incorrect password": {
+    "Incorrect password": "잘못된 비밀번호"
+  },
+  "Incorrect password - attempt %1 of %2 (lockout may follow)": {
+    "Incorrect password - attempt %1 of %2 (lockout may follow)": "잘못된 비밀번호 - %1/%2회 시도(잠길 수 있음)"
+  },
+  "Incorrect password - next failures may trigger account lockout": {
+    "Incorrect password - next failures may trigger account lockout": "잘못된 비밀번호 - 다음에 실패하면 계정이 잠길 수 있음"
+  },
+  "Incorrect password - try again": {
+    "Incorrect password - try again": "잘못된 비밀번호 - 다시 시도하세요"
+  },
+  "Indicator Style": {
+    "Indicator Style": "표시기 스타일"
+  },
+  "Individual Batteries": {
+    "Individual Batteries": "개별 배터리"
+  },
+  "Individual bar configuration": {
+    "Individual bar configuration": "개별 바 구성"
+  },
+  "Info": {
+    "Info": "정보"
+  },
+  "Inherit": {
+    "Inherit": "상속"
+  },
+  "Inherit Global (Default)": {
+    "Inherit Global (Default)": "전역 상속(기본값)"
+  },
+  "Inhibitable": {
+    "Inhibitable": "억제 가능"
+  },
+  "Initial position for floating windows. Set both X and Y; anchor controls which corner/edge they're relative to.": {
+    "Initial position for floating windows. Set both X and Y; anchor controls which corner/edge they're relative to.": "플로팅 창의 초기 위치. X 및 Y를 모두 설정합니다. 앵커는 상대적인 모서리/가장자리를 제어합니다."
+  },
+  "Initialised": {
+    "Initialised": "초기화됨"
+  },
+  "Inner Gaps": {
+    "Inner Gaps": "내부 간격"
+  },
+  "Inner padding applied to each widget": {
+    "Inner padding applied to each widget": "각 위젯에 적용되는 내부 여백"
+  },
+  "Input Devices": {
+    "Input Devices": "입력 장치"
+  },
+  "Input Volume Slider": {
+    "Input Volume Slider": "입력 볼륨 슬라이더"
+  },
+  "Insert your security key...": {
+    "Insert your security key...": "보안 키를 삽입하세요..."
+  },
+  "Inset the Notepad from screen edges using the compositor's configured gaps": {
+    "Inset the Notepad from screen edges using the compositor's configured gaps": "컴포지터에 구성된 간격을 사용하여 화면 가장자리에서 노트패드를 들여쓰기"
+  },
+  "Install": {
+    "Install": "설치"
+  },
+  "Install Greeter": {
+    "Install Greeter": "로그인 화면 설치"
+  },
+  "Install Plugin": {
+    "Install Plugin": "플러그인 설치"
+  },
+  "Install Theme": {
+    "Install Theme": "테마 설치"
+  },
+  "Install color themes from the DMS theme registry": {
+    "Install color themes from the DMS theme registry": "DMS 테마 레지스트리에서 색상 테마 설치"
+  },
+  "Install complete. Greeter has been installed.": {
+    "Install complete. Greeter has been installed.": "설치 완료. 로그인 화면이 설치되었습니다."
+  },
+  "Install dsearch to search files.": {
+    "Install dsearch to search files.": "파일을 검색하려면 dsearch를 설치하세요."
+  },
+  "Install failed: %1": {
+    "Install failed: %1": "설치 실패: %1"
+  },
+  "Install matugen package for dynamic theming": {
+    "Install matugen package for dynamic theming": "동적 테마를 위해 matugen 패키지 설치"
+  },
+  "Install plugin '%1' from the DMS registry?": {
+    "Install plugin '%1' from the DMS registry?": "DMS 레지스트리에서 플러그인 '%1'을(를) 설치하시겠습니까?"
+  },
+  "Install plugins from the DMS plugin registry": {
+    "Install plugins from the DMS plugin registry": "DMS 플러그인 레지스트리에서 플러그인 설치"
+  },
+  "Install the DMS greeter? A terminal will open for sudo authentication.": {
+    "Install the DMS greeter? A terminal will open for sudo authentication.": "DMS 로그인 화면을 설치하시겠습니까? sudo 인증을 위해 터미널이 열립니다."
+  },
+  "Install theme '%1' from the DMS registry?": {
+    "Install theme '%1' from the DMS registry?": "DMS 레지스트리에서 테마 '%1'을(를) 설치하시겠습니까?"
+  },
+  "Installation and PAM setup: see the ": {
+    "Installation and PAM setup: see the ": "설치 및 PAM 설정: 다음을 참조하세요"
+  },
+  "Installed": {
+    "Installed": "설치됨"
+  },
+  "Installed first": {
+    "Installed first": "설치됨 먼저"
+  },
+  "Installed: %1": {
+    "Installed: %1": "설치됨: %1"
+  },
+  "Installing: %1": {
+    "Installing: %1": "설치 중: %1"
+  },
+  "Integrations": {
+    "Integrations": "통합"
+  },
+  "Intelligent Auto-hide": {
+    "Intelligent Auto-hide": "지능형 자동 숨기기"
+  },
+  "Intensity": {
+    "Intensity": "강도"
+  },
+  "Interface:": {
+    "Interface:": "인터페이스:"
+  },
+  "Interlock Open": {
+    "Interlock Open": "인터록 열림"
+  },
+  "Internet": {
+    "Internet": "인터넷"
+  },
+  "Interval": {
+    "Interval": "간격"
+  },
+  "Invalid JSON format: %1": {
+    "Invalid JSON format: %1": "잘못된 JSON 형식: %1"
+  },
+  "Invalid configuration": {
+    "Invalid configuration": "잘못된 구성"
+  },
+  "Invalid password for %1": {
+    "Invalid password for %1": "%1의 비밀번호가 잘못되었습니다"
+  },
+  "Invalid username": {
+    "Invalid username": "잘못된 사용자 이름"
+  },
+  "Invert on mode change": {
+    "Invert on mode change": "모드 변경 시 반전"
+  },
+  "Invert touchpad scroll direction": {
+    "Invert touchpad scroll direction": "터치패드 스크롤 방향 반전"
+  },
+  "Iris Bloom": {
+    "Iris Bloom": "아이리스 블룸"
+  },
+  "Isolate Displays": {
+    "Isolate Displays": "디스플레이 분리"
+  },
+  "Jobs": {
+    "Jobs": "작업"
+  },
+  "Jobs: ": {
+    "Jobs: ": "작업:"
+  },
+  "Jump to page": {
+    "Jump to page": "페이지로 이동"
+  },
+  "Jump to page (1 - %1)": {
+    "Jump to page (1 - %1)": "페이지로 이동(1 - %1)"
+  },
+  "Keep Awake": {
+    "Keep Awake": "깨어있기 유지"
+  },
+  "Keep Changes": {
+    "Keep Changes": "변경 사항 유지"
+  },
+  "Keep My Edits": {
+    "Keep My Edits": "내 편집 내용 유지"
+  },
+  "Keep in Bar": {
+    "Keep in Bar": "바에 유지"
+  },
+  "Keep the clipboard type filter when reopening history": {
+    "Keep the clipboard type filter when reopening history": "기록을 다시 열 때 클립보드 유형 필터 유지"
+  },
+  "Keep typing": {
+    "Keep typing": "계속 입력하세요"
+  },
+  "Keeping Awake": {
+    "Keeping Awake": "깨어있기 유지 중"
+  },
+  "Kernel": {
+    "Kernel": "커널"
+  },
+  "Key": {
+    "Key": "키"
+  },
+  "Keybind Sources": {
+    "Keybind Sources": "단축키 소스"
+  },
+  "Keybinds": {
+    "Keybinds": "단축키"
+  },
+  "Keybinds Search Settings": {
+    "Keybinds Search Settings": "단축키 검색 설정"
+  },
+  "Keybinds shown alongside regular search results": {
+    "Keybinds shown alongside regular search results": "일반 검색 결과와 함께 표시되는 단축키"
+  },
+  "Keyboard Layout Name": {
+    "Keyboard Layout Name": "키보드 레이아웃 이름"
+  },
+  "Keyboard Shortcuts": {
+    "Keyboard Shortcuts": "키보드 바로 가기"
+  },
+  "Keys": {
+    "Keys": "키"
+  },
+  "Kill": {
+    "Kill": "종료"
+  },
+  "Kill Process": {
+    "Kill Process": "프로세스 종료"
+  },
+  "Kill Session": {
+    "Kill Session": "세션 종료"
+  },
+  "Ko-fi": {
+    "Ko-fi": "Ko-fi"
+  },
+  "LED device": {
+    "LED device": "LED 장치"
+  },
+  "LabWC IRC Channel": {
+    "LabWC IRC Channel": "LabWC IRC 채널"
+  },
+  "LabWC Website": {
+    "LabWC Website": "LabWC 웹사이트"
+  },
+  "Large": {
+    "Large": "큼"
+  },
+  "Largest": {
+    "Largest": "가장 큼"
+  },
+  "Last hour": {
+    "Last hour": "지난 1시간"
+  },
+  "Last launched %1": {
+    "Last launched %1": "마지막 실행 %1"
+  },
+  "Last launched %1 day ago": {
+    "Last launched %1 day ago": "%1일 전 마지막 실행"
+  },
+  "Last launched %1 days ago": {
+    "Last launched %1 days ago": "%1일 전 마지막 실행"
+  },
+  "Last launched %1 hour ago": {
+    "Last launched %1 hour ago": "%1시간 전 마지막 실행"
+  },
+  "Last launched %1 hours ago": {
+    "Last launched %1 hours ago": "%1시간 전 마지막 실행"
+  },
+  "Last launched %1 minute ago": {
+    "Last launched %1 minute ago": "%1분 전 마지막 실행"
+  },
+  "Last launched %1 minutes ago": {
+    "Last launched %1 minutes ago": "%1분 전 마지막 실행"
+  },
+  "Last launched just now": {
+    "Last launched just now": "방금 전 마지막 실행"
+  },
+  "Latitude": {
+    "Latitude": "위도"
+  },
+  "Launch": {
+    "Launch": "실행"
+  },
+  "Launch Prefix": {
+    "Launch Prefix": "실행 접두사"
+  },
+  "Launch on dGPU": {
+    "Launch on dGPU": "dGPU에서 실행"
+  },
+  "Launcher": {
+    "Launcher": "런처"
+  },
+  "Launcher Button": {
+    "Launcher Button": "런처 버튼"
+  },
+  "Launcher Button Logo": {
+    "Launcher Button Logo": "런처 버튼 로고"
+  },
+  "Launcher Emerge Side": {
+    "Launcher Emerge Side": "런처 나타나는 방향"
+  },
+  "Layer Outline Opacity": {
+    "Layer Outline Opacity": "레이어 윤곽선 불투명도"
+  },
+  "Layout": {
+    "Layout": "레이어"
+  },
+  "Layout Overrides": {
+    "Layout Overrides": "레이아웃 오버라이드"
+  },
+  "Left": {
+    "Left": "왼쪽"
+  },
+  "Left Center": {
+    "Left Center": "왼쪽 중앙"
+  },
+  "Left Section": {
+    "Left Section": "왼쪽 구역"
+  },
+  "Light": {
+    "Light": "얇게"
+  },
+  "Light Direction": {
+    "Light Direction": "빛 방향"
+  },
+  "Light Mode": {
+    "Light Mode": "라이트 모드"
+  },
+  "Light Mode Icon Theme": {
+    "Light Mode Icon Theme": "라이트 모드 아이콘 테마"
+  },
+  "Light Rain": {
+    "Light Rain": "약한 비"
+  },
+  "Light Snow": {
+    "Light Snow": "약한 눈"
+  },
+  "Light Snow Showers": {
+    "Light Snow Showers": "약한 소낙눈"
+  },
+  "Light mode base": {
+    "Light mode base": "라이트 모드 기본"
+  },
+  "Light mode harmony": {
+    "Light mode harmony": "라이트 모드 조화"
+  },
+  "Limit set to %1%": {
+    "Limit set to %1%": "제한이 %1%로 설정됨"
+  },
+  "Limit the maximum battery charge level to extend lifespan.": {
+    "Limit the maximum battery charge level to extend lifespan.": "수명 연장을 위해 최대 배터리 충전 수준을 제한합니다."
+  },
+  "Line": {
+    "Line": "선"
+  },
+  "Line: %1": {
+    "Line: %1": "줄: %1"
+  },
+  "Linear": {
+    "Linear": "선형"
+  },
+  "Lines: %1": {
+    "Lines: %1": "줄 수: %1"
+  },
+  "List": {
+    "List": "목록"
+  },
+  "Lively palette with saturated accents.": {
+    "Lively palette with saturated accents.": "채도가 높은 악센트가 있는 활기찬 팔레트."
+  },
+  "Load Average": {
+    "Load Average": "로드 평균"
+  },
+  "Loading codecs...": {
+    "Loading codecs...": "코덱 로드 중..."
+  },
+  "Loading keybinds...": {
+    "Loading keybinds...": "단축키 로드 중..."
+  },
+  "Loading trending...": {
+    "Loading trending...": "인기 항목 로드 중..."
+  },
+  "Loading...": {
+    "Loading...": "로드 중..."
+  },
+  "Local": {
+    "Local": "로컬"
+  },
+  "Local Weather": {
+    "Local Weather": "현지 날씨"
+  },
+  "Locale": {
+    "Locale": "로캘"
+  },
+  "Locale Settings": {
+    "Locale Settings": "로캘 설정"
+  },
+  "Location": {
+    "Location": "위치"
+  },
+  "Location Search": {
+    "Location Search": "위치 검색"
+  },
+  "Lock": {
+    "Lock": "잠금"
+  },
+  "Lock Screen": {
+    "Lock Screen": "잠금 화면"
+  },
+  "Lock Screen Appearance": {
+    "Lock Screen Appearance": "잠금 화면 모양"
+  },
+  "Lock Screen Display": {
+    "Lock Screen Display": "잠금 화면 표시"
+  },
+  "Lock Screen Format": {
+    "Lock Screen Format": "잠금 화면 형식"
+  },
+  "Lock Screen behaviour": {
+    "Lock Screen behaviour": "잠금 화면 동작"
+  },
+  "Lock Screen layout": {
+    "Lock Screen layout": "잠금 화면 레이아웃"
+  },
+  "Lock at startup": {
+    "Lock at startup": "시작 시 잠금"
+  },
+  "Lock before suspend": {
+    "Lock before suspend": "절전 전 잠금"
+  },
+  "Lock fade grace period": {
+    "Lock fade grace period": "잠금 페이드 유예 기간"
+  },
+  "Lock screen authentication changes apply automatically and may open a terminal when sudo authentication is required.": {
+    "Lock screen authentication changes apply automatically and may open a terminal when sudo authentication is required.": "잠금 화면 인증 변경 사항은 자동으로 적용되며 sudo 인증이 필요한 경우 터미널을 열 수 있습니다."
+  },
+  "Lock screen font": {
+    "Lock screen font": "잠금 화면 글꼴"
+  },
+  "Locked": {
+    "Locked": "잠김"
+  },
+  "Log Out": {
+    "Log Out": "로그아웃"
+  },
+  "Logging in...": {
+    "Logging in...": "로그인 중..."
+  },
+  "Login": {
+    "Login": "로그인"
+  },
+  "Login Authentication": {
+    "Login Authentication": "로그인 인증"
+  },
+  "Long": {
+    "Long": "긺"
+  },
+  "Long Text": {
+    "Long Text": "긴 텍스트"
+  },
+  "Long press": {
+    "Long press": "길게 누르기"
+  },
+  "Longitude": {
+    "Longitude": "경도"
+  },
+  "Low": {
+    "Low": "낮음"
+  },
+  "Low Battery": {
+    "Low Battery": "배터리 부족"
+  },
+  "Low Battery Notifications": {
+    "Low Battery Notifications": "배터리 부족 알림"
+  },
+  "Low Battery Threshold": {
+    "Low Battery Threshold": "배터리 부족 임계값"
+  },
+  "Low Priority": {
+    "Low Priority": "낮은 우선순위"
+  },
+  "MAC": {
+    "MAC": "MAC"
+  },
+  "MTU": {
+    "MTU": "MTU"
+  },
+  "Mail": {
+    "Mail": "메일"
+  },
+  "Make admin": {
+    "Make admin": "관리자 만들기"
+  },
+  "Make sure KDE Connect or Valent is running on your other devices": {
+    "Make sure KDE Connect or Valent is running on your other devices": "다른 기기에서 KDE Connect 또는 Valent가 실행 중인지 확인하세요"
+  },
+  "Make the bar background fully transparent": {
+    "Make the bar background fully transparent": "바 배경을 완전히 투명하게 만들기"
+  },
+  "Manage and configure plugins for extending DMS functionality": {
+    "Manage and configure plugins for extending DMS functionality": "DMS 기능을 확장하기 위한 플러그인 관리 및 구성"
+  },
+  "Manage up to 4 independent bar configurations. Each bar has its own position, widgets, styling, and display assignment.": {
+    "Manage up to 4 independent bar configurations. Each bar has its own position, widgets, styling, and display assignment.": "최대 4개의 독립적인 바 구성을 관리합니다. 각 바에는 고유한 위치, 위젯, 스타일 지정 및 디스플레이 할당이 있습니다."
+  },
+  "Managed by Frame": {
+    "Managed by Frame": "프레임에서 관리"
+  },
+  "Managed by Frame in Connected Mode": {
+    "Managed by Frame in Connected Mode": "연결된 모드에서 프레임이 관리"
+  },
+  "Management": {
+    "Management": "관리"
+  },
+  "Manages calendar events": {
+    "Manages calendar events": "캘린더 이벤트 관리"
+  },
+  "Manages files and directories": {
+    "Manages files and directories": "파일 및 디렉터리 관리"
+  },
+  "Mango Options": {
+    "Mango Options": "Mango 옵션"
+  },
+  "Mango service not available": {
+    "Mango service not available": "Mango 서비스를 사용할 수 없음"
+  },
+  "MangoWC Layout Overrides": {
+    "MangoWC Layout Overrides": "MangoWC 레이아웃 오버라이드"
+  },
+  "Manual": {
+    "Manual": "수동"
+  },
+  "Manual Coordinates": {
+    "Manual Coordinates": "수동 좌표"
+  },
+  "Manual Direction": {
+    "Manual Direction": "수동 방향"
+  },
+  "Manual Gap Size": {
+    "Manual Gap Size": "수동 간격 크기"
+  },
+  "Manual Gaps": {
+    "Manual Gaps": "수동 간격"
+  },
+  "Manual Show/Hide": {
+    "Manual Show/Hide": "수동 표시/숨기기"
+  },
+  "Manual config": {
+    "Manual config": "수동 구성"
+  },
+  "Map window class names to icon names for proper icon display": {
+    "Map window class names to icon names for proper icon display": "올바른 아이콘 표시를 위해 창 클래스 이름을 아이콘 이름에 매핑"
+  },
+  "Margin": {
+    "Margin": "여백"
+  },
+  "Marker Supply Empty": {
+    "Marker Supply Empty": "마커 공급 부족"
+  },
+  "Marker Supply Low": {
+    "Marker Supply Low": "마커 공급 적음"
+  },
+  "Marker Waste Almost Full": {
+    "Marker Waste Almost Full": "마커 폐기물 거의 참"
+  },
+  "Marker Waste Full": {
+    "Marker Waste Full": "마커 폐기물 꽉 참"
+  },
+  "Match (%1)": {
+    "Match (%1)": "일치(%1)"
+  },
+  "Match Conditions": {
+    "Match Conditions": "조건 일치"
+  },
+  "Match Criteria": {
+    "Match Criteria": "기준 일치"
+  },
+  "Material": {
+    "Material": "Material"
+  },
+  "Material Battery Style": {
+    "Material Battery Style": "Material 배터리 스타일"
+  },
+  "Material Colors": {
+    "Material Colors": "Material 색상"
+  },
+  "Material Design inspired color themes": {
+    "Material Design inspired color themes": "Material Design에서 영감을 받은 색상 테마"
+  },
+  "Material colors generated from wallpaper": {
+    "Material colors generated from wallpaper": "배경화면에서 생성된 Material 색상"
+  },
+  "Material inspired shadows and elevation on modals, popouts, and dialogs": {
+    "Material inspired shadows and elevation on modals, popouts, and dialogs": "모달, 팝아웃, 대화 상자의 Material에서 영감을 받은 그림자와 고도"
+  },
+  "Material: Material Design 3 Expressive bezier curves. The DMS default feel.": {
+    "Material: Material Design 3 Expressive bezier curves. The DMS default feel.": "Material: Material Design 3 표현형 베지에 곡선. DMS의 기본 느낌."
+  },
+  "Matugen Contrast": {
+    "Matugen Contrast": "Matugen 대비"
+  },
+  "Matugen Missing": {
+    "Matugen Missing": "Matugen 누락됨"
+  },
+  "Matugen Palette": {
+    "Matugen Palette": "Matugen 팔레트"
+  },
+  "Matugen Target Monitor": {
+    "Matugen Target Monitor": "Matugen 대상 모니터"
+  },
+  "Matugen Templates": {
+    "Matugen Templates": "Matugen 템플릿"
+  },
+  "Max Edges": {
+    "Max Edges": "최대 가장자리"
+  },
+  "Max H": {
+    "Max H": "최대 높이"
+  },
+  "Max Pinned Apps": {
+    "Max Pinned Apps": "최대 고정 앱 수"
+  },
+  "Max Pinned Apps (0 = Unlimited)": {
+    "Max Pinned Apps (0 = Unlimited)": "최대 고정 앱 수(0 = 무제한)"
+  },
+  "Max Running Apps": {
+    "Max Running Apps": "최대 실행 앱 수"
+  },
+  "Max Running Apps (0 = Unlimited)": {
+    "Max Running Apps (0 = Unlimited)": "최대 실행 앱 수(0 = 무제한)"
+  },
+  "Max Visible": {
+    "Max Visible": "최대 표시"
+  },
+  "Max Volume": {
+    "Max Volume": "최대 볼륨"
+  },
+  "Max W": {
+    "Max W": "최대 너비"
+  },
+  "Max apps to show": {
+    "Max apps to show": "표시할 최대 앱 수"
+  },
+  "Max to Edges": {
+    "Max to Edges": "가장자리까지 최대화"
+  },
+  "Maximize": {
+    "Maximize": "최대화"
+  },
+  "Maximize Detection": {
+    "Maximize Detection": "최대화 감지"
+  },
+  "Maximize Widget Icons": {
+    "Maximize Widget Icons": "위젯 아이콘 최대화"
+  },
+  "Maximize Widget Text": {
+    "Maximize Widget Text": "위젯 텍스트 최대화"
+  },
+  "Maximum Entry Size": {
+    "Maximum Entry Size": "최대 항목 크기"
+  },
+  "Maximum History": {
+    "Maximum History": "최대 기록"
+  },
+  "Maximum Pinned Entries": {
+    "Maximum Pinned Entries": "최대 고정 항목"
+  },
+  "Maximum fingerprint attempts reached. Please use password.": {
+    "Maximum fingerprint attempts reached. Please use password.": "최대 지문 시도 횟수에 도달했습니다. 비밀번호를 사용하세요."
+  },
+  "Maximum number of clipboard entries to keep": {
+    "Maximum number of clipboard entries to keep": "유지할 클립보드 항목의 최대 개수"
+  },
+  "Maximum number of entries that can be saved": {
+    "Maximum number of entries that can be saved": "저장할 수 있는 최대 항목 수"
+  },
+  "Maximum number of notifications to keep": {
+    "Maximum number of notifications to keep": "유지할 최대 알림 수"
+  },
+  "Maximum pinned entries reached": {
+    "Maximum pinned entries reached": "최대 고정 항목 수에 도달함"
+  },
+  "Maximum size per clipboard entry": {
+    "Maximum size per clipboard entry": "클립보드 항목당 최대 크기"
+  },
+  "Media": {
+    "Media": "미디어"
+  },
+  "Media Controls": {
+    "Media Controls": "미디어 컨트롤"
+  },
+  "Media Empty": {
+    "Media Empty": "미디어 비어 있음"
+  },
+  "Media Jam": {
+    "Media Jam": "미디어 걸림"
+  },
+  "Media Low": {
+    "Media Low": "미디어 부족"
+  },
+  "Media Needed": {
+    "Media Needed": "미디어 필요"
+  },
+  "Media Playback": {
+    "Media Playback": "미디어 재생"
+  },
+  "Media Player": {
+    "Media Player": "미디어 플레이어"
+  },
+  "Media Player Settings": {
+    "Media Player Settings": "미디어 플레이어 설정"
+  },
+  "Media Players (": {
+    "Media Players (": "미디어 플레이어 ("
+  },
+  "Media Volume": {
+    "Media Volume": "미디어 볼륨"
+  },
+  "Medium": {
+    "Medium": "중간"
+  },
+  "Memory": {
+    "Memory": "메모리"
+  },
+  "Memory Graph": {
+    "Memory Graph": "메모리 그래프"
+  },
+  "Memory Usage": {
+    "Memory Usage": "메모리 사용량"
+  },
+  "Memory usage indicator": {
+    "Memory usage indicator": "메모리 사용량 표시기"
+  },
+  "Merge indexed file results into the All tab (requires dsearch).": {
+    "Merge indexed file results into the All tab (requires dsearch).": "인덱싱된 파일 결과를 전체 탭에 병합합니다(dsearch 필요)."
+  },
+  "Merge indexed folder results into the All tab (requires dsearch).": {
+    "Merge indexed folder results into the All tab (requires dsearch).": "인덱싱된 폴더 결과를 전체 탭에 병합합니다(dsearch 필요)."
+  },
+  "Message": {
+    "Message": "메시지"
+  },
+  "Message Content": {
+    "Message Content": "메시지 내용"
+  },
+  "Microphone": {
+    "Microphone": "마이크"
+  },
+  "Microphone Mute": {
+    "Microphone Mute": "마이크 음소거"
+  },
+  "Microphone Volume": {
+    "Microphone Volume": "마이크 볼륨"
+  },
+  "Microphone settings": {
+    "Microphone settings": "마이크 설정"
+  },
+  "Microphone volume control": {
+    "Microphone volume control": "마이크 볼륨 제어"
+  },
+  "Middle Section": {
+    "Middle Section": "가운데 구역"
+  },
+  "Min H": {
+    "Min H": "최소 높이"
+  },
+  "Min W": {
+    "Min W": "최소 너비"
+  },
+  "Minimal palette built around a single hue.": {
+    "Minimal palette built around a single hue.": "단일 색조를 중심으로 구축된 미니멀한 팔레트."
+  },
+  "Minute": {
+    "Minute": "분"
+  },
+  "Mirror Display": {
+    "Mirror Display": "디스플레이 미러링"
+  },
+  "Missing Environment Variables": {
+    "Missing Environment Variables": "환경 변수 누락됨"
+  },
+  "Modal Background": {
+    "Modal Background": "모달 배경"
+  },
+  "Modal Shadows": {
+    "Modal Shadows": "모달 그림자"
+  },
+  "Modals": {
+    "Modals": "모달"
+  },
+  "Mode": {
+    "Mode": "모드"
+  },
+  "Mode:": {
+    "Mode:": "모드:"
+  },
+  "Model": {
+    "Model": "모델"
+  },
+  "Modified": {
+    "Modified": "수정됨"
+  },
+  "Modular widget bar": {
+    "Modular widget bar": "모듈식 위젯 바"
+  },
+  "Monitor": {
+    "Monitor": "모니터"
+  },
+  "Monitor Configuration": {
+    "Monitor Configuration": "모니터 구성"
+  },
+  "Monitor fade grace period": {
+    "Monitor fade grace period": "모니터 페이드 유예 기간"
+  },
+  "Monitor whose wallpaper drives dynamic theming colors": {
+    "Monitor whose wallpaper drives dynamic theming colors": "배경화면이 동적 테마 색상을 구동하는 모니터"
+  },
+  "Monitors in \"%1\":": {
+    "Monitors in \"%1\":": "\"%1\"의 모니터:"
+  },
+  "Monochrome": {
+    "Monochrome": "흑백"
+  },
+  "Monocle": {
+    "Monocle": "단안"
+  },
+  "Monospace Font": {
+    "Monospace Font": "고정폭 글꼴"
+  },
+  "Month Date": {
+    "Month Date": "월 날짜"
+  },
+  "Morning": {
+    "Morning": "아침"
+  },
+  "Motion Effects": {
+    "Motion Effects": "모션 효과"
+  },
+  "Mount Points": {
+    "Mount Points": "마운트 지점"
+  },
+  "Mouse clicks pass through the bar to windows behind it": {
+    "Mouse clicks pass through the bar to windows behind it": "마우스 클릭이 바를 통과하여 뒤에 있는 창으로 전달됨"
+  },
+  "Mouse pointer appearance": {
+    "Mouse pointer appearance": "마우스 포인터 모양"
+  },
+  "Mouse pointer size in pixels": {
+    "Mouse pointer size in pixels": "마우스 포인터 크기(픽셀)"
+  },
+  "Move": {
+    "Move": "이동"
+  },
+  "Move Widget": {
+    "Move Widget": "위젯 이동"
+  },
+  "Move to Trash": {
+    "Move to Trash": "휴지통으로 이동"
+  },
+  "Moving to Paused": {
+    "Moving to Paused": "일시 중지로 이동"
+  },
+  "Multi-Monitor": {
+    "Multi-Monitor": "다중 모니터"
+  },
+  "Multimedia": {
+    "Multimedia": "멀티미디어"
+  },
+  "Multiplexer": {
+    "Multiplexer": "멀티플렉서"
+  },
+  "Multiplexer Type": {
+    "Multiplexer Type": "멀티플렉서 유형"
+  },
+  "Multiplexers": {
+    "Multiplexers": "멀티플렉서"
+  },
+  "Music": {
+    "Music": "음악"
+  },
+  "Music Player": {
+    "Music Player": "음악 플레이어"
+  },
+  "Mute During Playback": {
+    "Mute During Playback": "재생 중 음소거"
+  },
+  "Mute Popups": {
+    "Mute Popups": "팝업 음소거"
+  },
+  "Mute popups for %1": {
+    "Mute popups for %1": "%1에 대한 팝업 음소거"
+  },
+  "Muted": {
+    "Muted": "음소거됨"
+  },
+  "Muted Apps": {
+    "Muted Apps": "음소거된 앱"
+  },
+  "Muted palette with subdued, calming tones.": {
+    "Muted palette with subdued, calming tones.": "차분하고 차분한 톤의 차분한 팔레트."
+  },
+  "My Online": {
+    "My Online": "내 온라인"
+  },
+  "NM not supported": {
+    "NM not supported": "NM 지원되지 않음"
+  },
+  "Name": {
+    "Name": "이름"
+  },
+  "Named Workspace Icons": {
+    "Named Workspace Icons": "명명된 작업 공간 아이콘"
+  },
+  "Native": {
+    "Native": "네이티브"
+  },
+  "Native: platform renderer (FreeType).": {
+    "Native: platform renderer (FreeType).": "네이티브: 플랫폼 렌더러(FreeType)."
+  },
+  "Natural Touchpad Scrolling": {
+    "Natural Touchpad Scrolling": "터치패드 자연스러운 스크롤"
+  },
+  "Navigate": {
+    "Navigate": "탐색"
+  },
+  "Navigation": {
+    "Navigation": "탐색"
+  },
+  "Network": {
+    "Network": "네트워크"
+  },
+  "Network Graph": {
+    "Network Graph": "네트워크 그래프"
+  },
+  "Network Info": {
+    "Network Info": "네트워크 정보"
+  },
+  "Network Information": {
+    "Network Information": "네트워크 정보"
+  },
+  "Network Name (SSID)": {
+    "Network Name (SSID)": "네트워크 이름(SSID)"
+  },
+  "Network Speed Monitor": {
+    "Network Speed Monitor": "네트워크 속도 모니터"
+  },
+  "Network Status": {
+    "Network Status": "네트워크 상태"
+  },
+  "Network Type": {
+    "Network Type": "네트워크 유형"
+  },
+  "Network download and upload speed display": {
+    "Network download and upload speed display": "네트워크 다운로드 및 업로드 속도 표시"
+  },
+  "Network not found": {
+    "Network not found": "네트워크를 찾을 수 없음"
+  },
+  "Neutral": {
+    "Neutral": "뉴트럴"
+  },
+  "Never": {
+    "Never": "안 함"
+  },
+  "Never used": {
+    "Never used": "사용 안 함"
+  },
+  "New": {
+    "New": "새로 만들기"
+  },
+  "New Key": {
+    "New Key": "새 키"
+  },
+  "New Keybind": {
+    "New Keybind": "새 단축키"
+  },
+  "New Notification": {
+    "New Notification": "새 알림"
+  },
+  "New Session": {
+    "New Session": "새 세션"
+  },
+  "New Window Rule": {
+    "New Window Rule": "새 창 규칙"
+  },
+  "New York, NY": {
+    "New York, NY": "뉴욕, NY"
+  },
+  "New event": {
+    "New event": "새 이벤트"
+  },
+  "New group name...": {
+    "New group name...": "새 그룹 이름..."
+  },
+  "Next": {
+    "Next": "다음"
+  },
+  "Next Transition": {
+    "Next Transition": "다음 전환"
+  },
+  "Next page": {
+    "Next page": "다음 페이지"
+  },
+  "Night": {
+    "Night": "밤"
+  },
+  "Night Mode": {
+    "Night Mode": "야간 모드"
+  },
+  "Night Temperature": {
+    "Night Temperature": "야간 온도"
+  },
+  "Night mode & gamma": {
+    "Night mode & gamma": "야간 모드 및 감마"
+  },
+  "Night mode failed: DMS gamma control not available": {
+    "Night mode failed: DMS gamma control not available": "야간 모드 실패: DMS 감마 제어를 사용할 수 없음"
+  },
+  "Niri Integration": {
+    "Niri Integration": "Niri 통합"
+  },
+  "Niri Layout Overrides": {
+    "Niri Layout Overrides": "Niri 레이아웃 오버라이드"
+  },
+  "Niri compositor actions (focus, move, etc.)": {
+    "Niri compositor actions (focus, move, etc.)": "Niri 컴포지터 작업(포커스, 이동 등)"
+  },
+  "No": {
+    "No": "아니요"
+  },
+  "No Active Players": {
+    "No Active Players": "활성 플레이어 없음"
+  },
+  "No Anim": {
+    "No Anim": "애니메이션 없음"
+  },
+  "No Background": {
+    "No Background": "배경 없음"
+  },
+  "No Bluetooth adapter found": {
+    "No Bluetooth adapter found": "Bluetooth 어댑터를 찾을 수 없음"
+  },
+  "No Blur": {
+    "No Blur": "블러 없음"
+  },
+  "No Border": {
+    "No Border": "테두리 없음"
+  },
+  "No DMS shortcuts configured": {
+    "No DMS shortcuts configured": "구성된 DMS 바로 가기 없음"
+  },
+  "No Dim": {
+    "No Dim": "어둡게 하지 않음"
+  },
+  "No Focus": {
+    "No Focus": "포커스 없음"
+  },
+  "No GPU detected": {
+    "No GPU detected": "GPU 감지되지 않음"
+  },
+  "No GPUs detected": {
+    "No GPUs detected": "GPU 감지되지 않음"
+  },
+  "No History": {
+    "No History": "기록 없음"
+  },
+  "No Media": {
+    "No Media": "미디어 없음"
+  },
+  "No Round": {
+    "No Round": "둥글게 하지 않음"
+  },
+  "No Rounding": {
+    "No Rounding": "둥글게 처리 없음"
+  },
+  "No Shadow": {
+    "No Shadow": "그림자 없음"
+  },
+  "No VPN profiles": {
+    "No VPN profiles": "VPN 프로필 없음"
+  },
+  "No Weather": {
+    "No Weather": "날씨 없음"
+  },
+  "No Weather Data": {
+    "No Weather Data": "날씨 데이터 없음"
+  },
+  "No Weather Data Available": {
+    "No Weather Data Available": "사용할 수 있는 날씨 데이터 없음"
+  },
+  "No action": {
+    "No action": "작업 없음"
+  },
+  "No active %1 sessions": {
+    "No active %1 sessions": "활성 %1 세션 없음"
+  },
+  "No active session found for %1": {
+    "No active session found for %1": "%1에 대한 활성 세션을 찾을 수 없음"
+  },
+  "No adapter": {
+    "No adapter": "어댑터 없음"
+  },
+  "No adapters": {
+    "No adapters": "어댑터 없음"
+  },
+  "No app customizations.": {
+    "No app customizations.": "앱 사용자 지정 없음."
+  },
+  "No application selected": {
+    "No application selected": "선택된 애플리케이션 없음"
+  },
+  "No apps found": {
+    "No apps found": "앱을 찾을 수 없음"
+  },
+  "No apps have been launched yet.": {
+    "No apps have been launched yet.": "아직 실행된 앱이 없습니다."
+  },
+  "No apps muted. Right-click a notification and choose \"Mute popups\" to add one here.": {
+    "No apps muted. Right-click a notification and choose \"Mute popups\" to add one here.": "음소거된 앱이 없습니다. 알림을 마우스 오른쪽 버튼으로 클릭하고 \"팝업 음소거\"를 선택하여 여기에 추가하세요."
+  },
+  "No autostart entries": {
+    "No autostart entries": "자동 시작 항목 없음"
+  },
+  "No battery": {
+    "No battery": "배터리 없음"
+  },
+  "No brightness devices available": {
+    "No brightness devices available": "사용할 수 있는 밝기 장치 없음"
+  },
+  "No calendar source available": {
+    "No calendar source available": "사용할 수 있는 캘린더 소스 없음"
+  },
+  "No changes": {
+    "No changes": "변경 사항 없음"
+  },
+  "No checks passed": {
+    "No checks passed": "통과된 검사 없음"
+  },
+  "No custom theme file": {
+    "No custom theme file": "사용자 지정 테마 파일 없음"
+  },
+  "No devices": {
+    "No devices": "기기 없음"
+  },
+  "No devices found": {
+    "No devices found": "기기를 찾을 수 없음"
+  },
+  "No disk data": {
+    "No disk data": "디스크 데이터 없음"
+  },
+  "No disk data available": {
+    "No disk data available": "사용할 수 있는 디스크 데이터 없음"
+  },
+  "No display profiles found. Create them in Settings > Displays.": {
+    "No display profiles found. Create them in Settings > Displays.": "디스플레이 프로필을 찾을 수 없습니다. 설정 > 디스플레이에서 생성하세요."
+  },
+  "No drivers found": {
+    "No drivers found": "드라이버를 찾을 수 없음"
+  },
+  "No errors": {
+    "No errors": "오류 없음"
+  },
+  "No excluded players configured": {
+    "No excluded players configured": "구성된 제외 플레이어 없음"
+  },
+  "No features enabled": {
+    "No features enabled": "활성화된 기능 없음"
+  },
+  "No files found": {
+    "No files found": "파일을 찾을 수 없음"
+  },
+  "No fingerprint reader detected.": {
+    "No fingerprint reader detected.": "지문 판독기가 감지되지 않았습니다."
+  },
+  "No folders found": {
+    "No folders found": "폴더를 찾을 수 없음"
+  },
+  "No hidden apps.": {
+    "No hidden apps.": "숨겨진 앱 없음."
+  },
+  "No human user accounts found.": {
+    "No human user accounts found.": "실제 사용자 계정을 찾을 수 없습니다."
+  },
+  "No images found": {
+    "No images found": "이미지를 찾을 수 없음"
+  },
+  "No info items": {
+    "No info items": "정보 항목 없음"
+  },
+  "No information available": {
+    "No information available": "사용 가능한 정보 없음"
+  },
+  "No input device": {
+    "No input device": "입력 장치 없음"
+  },
+  "No input devices found": {
+    "No input devices found": "입력 장치를 찾을 수 없음"
+  },
+  "No items added yet": {
+    "No items added yet": "아직 추가된 항목 없음"
+  },
+  "No keybinds found": {
+    "No keybinds found": "단축키를 찾을 수 없음"
+  },
+  "No launcher plugins installed.": {
+    "No launcher plugins installed.": "설치된 런처 플러그인 없음."
+  },
+  "No match criteria": {
+    "No match criteria": "일치 기준 없음"
+  },
+  "No matches": {
+    "No matches": "일치 항목 없음"
+  },
+  "No matching devices": {
+    "No matching devices": "일치하는 장치 없음"
+  },
+  "No matching processes": {
+    "No matching processes": "일치하는 프로세스 없음"
+  },
+  "No monitors": {
+    "No monitors": "모니터 없음"
+  },
+  "No mount points found": {
+    "No mount points found": "마운트 지점을 찾을 수 없음"
+  },
+  "No other active sessions on this seat": {
+    "No other active sessions on this seat": "이 자리에 다른 활성 세션 없음"
+  },
+  "No output device": {
+    "No output device": "출력 장치 없음"
+  },
+  "No output devices found": {
+    "No output devices found": "출력 장치를 찾을 수 없음"
+  },
+  "No peers found": {
+    "No peers found": "피어를 찾을 수 없음"
+  },
+  "No plugin results": {
+    "No plugin results": "플러그인 결과 없음"
+  },
+  "No plugins found": {
+    "No plugins found": "플러그인을 찾을 수 없음"
+  },
+  "No plugins found.": {
+    "No plugins found.": "플러그인을 찾을 수 없습니다."
+  },
+  "No printer found": {
+    "No printer found": "프린터를 찾을 수 없음"
+  },
+  "No printers configured": {
+    "No printers configured": "구성된 프린터 없음"
+  },
+  "No printers found": {
+    "No printers found": "프린터를 찾을 수 없음"
+  },
+  "No profiles": {
+    "No profiles": "프로필 없음"
+  },
+  "No recent clipboard entries found": {
+    "No recent clipboard entries found": "최근 클립보드 항목을 찾을 수 없음"
+  },
+  "No reminder": {
+    "No reminder": "미리 알림 없음"
+  },
+  "No results": {
+    "No results": "결과 없음"
+  },
+  "No results found": {
+    "No results found": "결과를 찾을 수 없음"
+  },
+  "No saved clipboard entries": {
+    "No saved clipboard entries": "저장된 클립보드 항목 없음"
+  },
+  "No screenshot provided": {
+    "No screenshot provided": "제공된 스크린샷 없음"
+  },
+  "No session selected": {
+    "No session selected": "선택된 세션 없음"
+  },
+  "No sessions found": {
+    "No sessions found": "세션을 찾을 수 없음"
+  },
+  "No status output.": {
+    "No status output.": "상태 출력 없음."
+  },
+  "No supported package manager found.": {
+    "No supported package manager found.": "지원되는 패키지 관리자를 찾을 수 없습니다."
+  },
+  "No terminal configured": {
+    "No terminal configured": "구성된 터미널 없음"
+  },
+  "No themes found": {
+    "No themes found": "테마를 찾을 수 없음"
+  },
+  "No themes installed. Browse themes to install from the registry.": {
+    "No themes installed. Browse themes to install from the registry.": "설치된 테마가 없습니다. 레지스트리에서 설치할 테마를 찾아보세요."
+  },
+  "No trigger": {
+    "No trigger": "트리거 없음"
+  },
+  "No updates available.": {
+    "No updates available.": "사용할 수 있는 업데이트가 없습니다."
+  },
+  "No user specified": {
+    "No user specified": "지정된 사용자 없음"
+  },
+  "No video found in folder": {
+    "No video found in folder": "폴더에서 동영상을 찾을 수 없음"
+  },
+  "No wallpaper selected": {
+    "No wallpaper selected": "선택된 배경화면 없음"
+  },
+  "No wallpapers": {
+    "No wallpapers": "배경화면 없음"
+  },
+  "No wallpapers found\n\nClick the folder icon below to browse": {
+    "No wallpapers found\n\nClick the folder icon below to browse": "배경화면을 찾을 수 없습니다\n\n찾아보려면 아래 폴더 아이콘을 클릭하세요"
+  },
+  "No warnings": {
+    "No warnings": "경고 없음"
+  },
+  "No widgets added. Click \"Add Widget\" to get started.": {
+    "No widgets added. Click \"Add Widget\" to get started.": "추가된 위젯이 없습니다. 시작하려면 \"위젯 추가\"를 클릭하세요."
+  },
+  "No widgets available": {
+    "No widgets available": "사용 가능한 위젯 없음"
+  },
+  "No widgets match your search": {
+    "No widgets match your search": "검색과 일치하는 위젯이 없습니다"
+  },
+  "No window rules configured": {
+    "No window rules configured": "구성된 창 규칙 없음"
+  },
+  "No writable calendar available": {
+    "No writable calendar available": "쓸 수 있는 캘린더 없음"
+  },
+  "Noise": {
+    "Noise": "노이즈"
+  },
+  "None": {
+    "None": "없음"
+  },
+  "None active": {
+    "None active": "활성 없음"
+  },
+  "Normal": {
+    "Normal": "보통"
+  },
+  "Normal Font": {
+    "Normal Font": "보통 글꼴"
+  },
+  "Normal Priority": {
+    "Normal Priority": "보통 우선순위"
+  },
+  "Not available": {
+    "Not available": "사용할 수 없음"
+  },
+  "Not available — install fprintd and pam_fprintd, or configure greetd PAM.": {
+    "Not available — install fprintd and pam_fprintd, or configure greetd PAM.": "사용할 수 없음 — fprintd 및 pam_fprintd를 설치하거나 greetd PAM을 구성하세요."
+  },
+  "Not available — install fprintd and pam_fprintd.": {
+    "Not available — install fprintd and pam_fprintd.": "사용할 수 없음 — fprintd 및 pam_fprintd를 설치하세요."
+  },
+  "Not available — install or configure pam_u2f, or configure greetd PAM.": {
+    "Not available — install or configure pam_u2f, or configure greetd PAM.": "사용할 수 없음 — pam_u2f를 설치 또는 구성하거나 greetd PAM을 구성하세요."
+  },
+  "Not available — install or configure pam_u2f.": {
+    "Not available — install or configure pam_u2f.": "사용할 수 없음 — pam_u2f를 설치하거나 구성하세요."
+  },
+  "Not bound": {
+    "Not bound": "바인딩되지 않음"
+  },
+  "Not connected": {
+    "Not connected": "연결되지 않음"
+  },
+  "Not detected": {
+    "Not detected": "감지되지 않음"
+  },
+  "Not listed?": {
+    "Not listed?": "목록에 없습니까?"
+  },
+  "Not paired": {
+    "Not paired": "페어링되지 않음"
+  },
+  "Not set": {
+    "Not set": "설정되지 않음"
+  },
+  "Notepad": {
+    "Notepad": "노트패드"
+  },
+  "Notepad Settings": {
+    "Notepad Settings": "노트패드 설정"
+  },
+  "Notepad Slideout": {
+    "Notepad Slideout": "노트패드 슬라이드아웃"
+  },
+  "Notes": {
+    "Notes": "노트"
+  },
+  "Nothing": {
+    "Nothing": "아무것도 안 함"
+  },
+  "Nothing to see here": {
+    "Nothing to see here": "여기에 표시할 내용이 없습니다"
+  },
+  "Notification": {
+    "Notification": "알림"
+  },
+  "Notification Center": {
+    "Notification Center": "알림 센터"
+  },
+  "Notification Display": {
+    "Notification Display": "알림 표시"
+  },
+  "Notification Overlay": {
+    "Notification Overlay": "알림 오버레이"
+  },
+  "Notification Popups": {
+    "Notification Popups": "알림 팝업"
+  },
+  "Notification Rules": {
+    "Notification Rules": "알림 규칙"
+  },
+  "Notification Settings": {
+    "Notification Settings": "알림 설정"
+  },
+  "Notification Timeouts": {
+    "Notification Timeouts": "알림 시간 초과"
+  },
+  "Notification Type": {
+    "Notification Type": "알림 유형"
+  },
+  "Notification toast popups": {
+    "Notification toast popups": "알림 토스트 팝업"
+  },
+  "Notifications": {
+    "Notifications": "알림"
+  },
+  "Notify when limit is reached": {
+    "Notify when limit is reached": "한도에 도달하면 알림"
+  },
+  "Now playing and media controls": {
+    "Now playing and media controls": "지금 재생 중 및 미디어 컨트롤"
+  },
+  "Numbers": {
+    "Numbers": "숫자"
+  },
+  "Numeric (D/M)": {
+    "Numeric (D/M)": "숫자(일/월)"
+  },
+  "Numeric (M/D)": {
+    "Numeric (M/D)": "숫자(월/일)"
+  },
+  "OK": {
+    "OK": "확인"
+  },
+  "OS Logo": {
+    "OS Logo": "OS 로고"
+  },
+  "OSD Position": {
+    "OSD Position": "OSD 위치"
+  },
+  "Occupied Color": {
+    "Occupied Color": "점유된 색상"
+  },
+  "Off": {
+    "Off": "꺼짐"
+  },
+  "Office": {
+    "Office": "사무실"
+  },
+  "Offline": {
+    "Offline": "오프라인"
+  },
+  "Offline Report": {
+    "Offline Report": "오프라인 보고서"
+  },
+  "Older": {
+    "Older": "이전"
+  },
+  "On": {
+    "On": "켜짐"
+  },
+  "On indefinitely": {
+    "On indefinitely": "무기한 켜짐"
+  },
+  "On-Demand": {
+    "On-Demand": "주문형"
+  },
+  "On-screen Displays": {
+    "On-screen Displays": "온스크린 디스플레이"
+  },
+  "Once a day": {
+    "Once a day": "하루에 한 번"
+  },
+  "Online": {
+    "Online": "온라인"
+  },
+  "Only adjust gamma based on time or location rules.": {
+    "Only adjust gamma based on time or location rules.": "시간 또는 위치 규칙에 따라서만 감마를 조정합니다."
+  },
+  "Only affects DMS-managed PAM. If greetd already includes pam_fprintd, fingerprint stays enabled.": {
+    "Only affects DMS-managed PAM. If greetd already includes pam_fprintd, fingerprint stays enabled.": "DMS 관리 PAM에만 영향을 줍니다. greetd에 이미 pam_fprintd가 포함된 경우 지문은 활성화된 상태로 유지됩니다."
+  },
+  "Only on Battery": {
+    "Only on Battery": "배터리 사용 시만"
+  },
+  "Only show windows from the current monitor on each dock": {
+    "Only show windows from the current monitor on each dock": "각 독에 현재 모니터의 창만 표시"
+  },
+  "Only visible if hibernate is supported by your system": {
+    "Only visible if hibernate is supported by your system": "시스템에서 최대 절전 모드를 지원하는 경우에만 표시됨"
+  },
+  "Opacity": {
+    "Opacity": "불투명도"
+  },
+  "Opaque": {
+    "Opaque": "불투명"
+  },
+  "Open": {
+    "Open": "열기"
+  },
+  "Open App": {
+    "Open App": "앱 열기"
+  },
+  "Open Delay": {
+    "Open Delay": "열기 지연"
+  },
+  "Open Dir": {
+    "Open Dir": "디렉터리 열기"
+  },
+  "Open Frame": {
+    "Open Frame": "프레임 열기"
+  },
+  "Open From": {
+    "Open From": "열기"
+  },
+  "Open Notepad File": {
+    "Open Notepad File": "노트패드 파일 열기"
+  },
+  "Open Trash": {
+    "Open Trash": "휴지통 열기"
+  },
+  "Open Trash With": {
+    "Open Trash With": "휴지통 열기 앱"
+  },
+  "Open a new note": {
+    "Open a new note": "새 노트 열기"
+  },
+  "Open a terminal and run a custom command instead of the in-shell upgrade flow.": {
+    "Open a terminal and run a custom command instead of the in-shell upgrade flow.": "터미널을 열고 셸 내부 업그레이드 흐름 대신 사용자 지정 명령을 실행합니다."
+  },
+  "Open as window": {
+    "Open as window": "창으로 열기"
+  },
+  "Open folder": {
+    "Open folder": "폴더 열기"
+  },
+  "Open in Browser": {
+    "Open in Browser": "브라우저에서 열기"
+  },
+  "Open in terminal": {
+    "Open in terminal": "터미널에서 열기"
+  },
+  "Open search bar to find text": {
+    "Open search bar to find text": "텍스트를 찾기 위해 검색창 열기"
+  },
+  "Open the launcher by hovering the emerge edge (when free of bar and dock)": {
+    "Open the launcher by hovering the emerge edge (when free of bar and dock)": "나타나는 가장자리 위로 마우스를 가져가서 런처 열기(바와 독이 없을 때)"
+  },
+  "Open widget popouts by hovering over the bar. Moving to another widget switches the popout.": {
+    "Open widget popouts by hovering over the bar. Moving to another widget switches the popout.": "바 위로 마우스를 가져가 위젯 팝아웃을 엽니다. 다른 위젯으로 이동하면 팝아웃이 전환됩니다."
+  },
+  "Open with...": {
+    "Open with...": "연결 프로그램..."
+  },
+  "Opening SMS app": {
+    "Opening SMS app": "SMS 앱 여는 중"
+  },
+  "Opening file browser": {
+    "Opening file browser": "파일 브라우저 여는 중"
+  },
+  "Opening terminal: ": {
+    "Opening terminal: ": "터미널 여는 중:"
+  },
+  "Opens a picker of other active sessions on this seat": {
+    "Opens a picker of other active sessions on this seat": "이 자리의 다른 활성 세션 선택기를 엽니다"
+  },
+  "Opens image files": {
+    "Opens image files": "이미지 파일 열기"
+  },
+  "Opens the connected launcher in Connected Frame Mode.": {
+    "Opens the connected launcher in Connected Frame Mode.": "연결된 프레임 모드에서 연결된 런처를 엽니다."
+  },
+  "Optional description": {
+    "Optional description": "선택적 설명"
+  },
+  "Optional location": {
+    "Optional location": "선택적 위치"
+  },
+  "Optional state-based conditions applied to the first match.": {
+    "Optional state-based conditions applied to the first match.": "첫 번째 일치 항목에 적용되는 선택적 상태 기반 조건입니다."
+  },
+  "Options": {
+    "Options": "옵션"
+  },
+  "Organize widgets into collapsible groups": {
+    "Organize widgets into collapsible groups": "위젯을 축소 가능한 그룹으로 구성"
+  },
+  "Original: %1": {
+    "Original: %1": "원본: %1"
+  },
+  "Other": {
+    "Other": "기타"
+  },
+  "Outer Gaps": {
+    "Outer Gaps": "외부 간격"
+  },
+  "Outline": {
+    "Outline": "윤곽선"
+  },
+  "Output": {
+    "Output": "출력"
+  },
+  "Output Area Almost Full": {
+    "Output Area Almost Full": "출력 영역 거의 꽉 참"
+  },
+  "Output Area Full": {
+    "Output Area Full": "출력 영역 꽉 참"
+  },
+  "Output Devices": {
+    "Output Devices": "출력 장치"
+  },
+  "Output Tray Missing": {
+    "Output Tray Missing": "출력 용지함 누락됨"
+  },
+  "Overcast": {
+    "Overcast": "흐림"
+  },
+  "Overflow": {
+    "Overflow": "오버플로"
+  },
+  "Overlay": {
+    "Overlay": "오버레이"
+  },
+  "Overridden by config": {
+    "Overridden by config": "구성에 의해 재정의됨"
+  },
+  "Override": {
+    "Override": "오버라이드"
+  },
+  "Override Border Size": {
+    "Override Border Size": "테두리 크기 오버라이드"
+  },
+  "Override Corner Radius": {
+    "Override Corner Radius": "모서리 반경 오버라이드"
+  },
+  "Override global layout settings for this output": {
+    "Override global layout settings for this output": "이 출력에 대한 전역 레이아웃 설정 오버라이드"
+  },
+  "Override global transparency for Notepad": {
+    "Override global transparency for Notepad": "노트패드에 대한 전역 투명도 오버라이드"
+  },
+  "Override terminal with a custom command or script": {
+    "Override terminal with a custom command or script": "터미널을 사용자 지정 명령 또는 스크립트로 오버라이드"
+  },
+  "Override the global shadow with per-bar settings": {
+    "Override the global shadow with per-bar settings": "전역 그림자를 바별 설정으로 오버라이드"
+  },
+  "Override the popup gap size when auto is disabled": {
+    "Override the popup gap size when auto is disabled": "자동이 비활성화된 경우 팝업 간격 크기 오버라이드"
+  },
+  "Overrides": {
+    "Overrides": "오버라이드"
+  },
+  "Overview": {
+    "Overview": "개요"
+  },
+  "Overview of your network connections": {
+    "Overview of your network connections": "네트워크 연결 개요"
+  },
+  "Overwrite": {
+    "Overwrite": "덮어쓰기"
+  },
+  "Owner: %1": {
+    "Owner: %1": "소유자: %1"
+  },
+  "PAM already provides fingerprint auth. Enable this to show it at login.": {
+    "PAM already provides fingerprint auth. Enable this to show it at login.": "PAM은 이미 지문 인증을 제공합니다. 로그인 시 표시하려면 활성화하세요."
+  },
+  "PAM already provides security-key auth. Enable this to show it at login.": {
+    "PAM already provides security-key auth. Enable this to show it at login.": "PAM은 이미 보안 키 인증을 제공합니다. 로그인 시 표시하려면 활성화하세요."
+  },
+  "PAM provides fingerprint auth, but availability could not be confirmed.": {
+    "PAM provides fingerprint auth, but availability could not be confirmed.": "PAM은 지문 인증을 제공하지만 가용성을 확인할 수 없습니다."
+  },
+  "PAM provides fingerprint auth, but no prints are enrolled yet.": {
+    "PAM provides fingerprint auth, but no prints are enrolled yet.": "PAM은 지문 인증을 제공하지만 아직 등록된 지문이 없습니다."
+  },
+  "PAM provides fingerprint auth, but no reader was detected.": {
+    "PAM provides fingerprint auth, but no reader was detected.": "PAM은 지문 인증을 제공하지만 판독기가 감지되지 않았습니다."
+  },
+  "PDF Reader": {
+    "PDF Reader": "PDF 리더"
+  },
+  "PIN": {
+    "PIN": "PIN"
+  },
+  "Pad": {
+    "Pad": "패드"
+  },
+  "Pad Hours": {
+    "Pad Hours": "시간 패딩"
+  },
+  "Pad hours (02:00 vs 2:00)": {
+    "Pad hours (02:00 vs 2:00)": "시간 패딩(02:00 대 2:00)"
+  },
+  "Padding": {
+    "Padding": "여백"
+  },
+  "Pair": {
+    "Pair": "페어링"
+  },
+  "Pair Bluetooth Device": {
+    "Pair Bluetooth Device": "Bluetooth 장치 페어링"
+  },
+  "Paired": {
+    "Paired": "페어링됨"
+  },
+  "Pairing": {
+    "Pairing": "페어링 중"
+  },
+  "Pairing failed": {
+    "Pairing failed": "페어링 실패"
+  },
+  "Pairing request from": {
+    "Pairing request from": "페어링 요청 발신자:"
+  },
+  "Pairing request sent": {
+    "Pairing request sent": "페어링 요청 보냄"
+  },
+  "Pairing requested": {
+    "Pairing requested": "페어링 요청됨"
+  },
+  "Pairing...": {
+    "Pairing...": "페어링 중..."
+  },
+  "Partly Cloudy": {
+    "Partly Cloudy": "대체로 흐림"
+  },
+  "Passkey:": {
+    "Passkey:": "패스키:"
+  },
+  "Password": {
+    "Password": "비밀번호"
+  },
+  "Password cannot be empty": {
+    "Password cannot be empty": "비밀번호는 비워 둘 수 없습니다"
+  },
+  "Password change failed (exit %1)": {
+    "Password change failed (exit %1)": "비밀번호 변경 실패(종료 %1)"
+  },
+  "Password set": {
+    "Password set": "비밀번호 설정됨"
+  },
+  "Password updated": {
+    "Password updated": "비밀번호 업데이트됨"
+  },
+  "Password...": {
+    "Password...": "비밀번호..."
+  },
+  "Passwords do not match.": {
+    "Passwords do not match.": "비밀번호가 일치하지 않습니다."
+  },
+  "Paste": {
+    "Paste": "붙여넣기"
+  },
+  "Paste failed: %1": {
+    "Paste failed: %1": "붙여넣기 실패: %1"
+  },
+  "Path copied to clipboard": {
+    "Path copied to clipboard": "경로가 클립보드에 복사됨"
+  },
+  "Path to a video file or folder containing videos": {
+    "Path to a video file or folder containing videos": "비디오 파일 또는 비디오가 포함된 폴더 경로"
+  },
+  "Pattern": {
+    "Pattern": "패턴"
+  },
+  "Pause": {
+    "Pause": "일시 중지"
+  },
+  "Paused": {
+    "Paused": "일시 중지됨"
+  },
+  "Pending": {
+    "Pending": "대기 중"
+  },
+  "Pending Charge": {
+    "Pending Charge": "충전 대기 중"
+  },
+  "Pending Discharge": {
+    "Pending Discharge": "방전 대기 중"
+  },
+  "Per-Mode Wallpapers": {
+    "Per-Mode Wallpapers": "모드별 배경화면"
+  },
+  "Per-Monitor Wallpapers": {
+    "Per-Monitor Wallpapers": "모니터별 배경화면"
+  },
+  "Per-screen config": {
+    "Per-screen config": "화면별 구성"
+  },
+  "Percentage": {
+    "Percentage": "백분율"
+  },
+  "Performance": {
+    "Performance": "성능"
+  },
+  "Permanently delete %1 item(s)? This cannot be undone.": {
+    "Permanently delete %1 item(s)? This cannot be undone.": "%1개의 항목을 영구적으로 삭제하시겠습니까? 이 작업은 취소할 수 없습니다."
+  },
+  "Permission denied to set profile image.": {
+    "Permission denied to set profile image.": "프로필 이미지를 설정할 수 있는 권한이 거부되었습니다."
+  },
+  "Personalization": {
+    "Personalization": "개인 설정"
+  },
+  "Phone Connect Not Available": {
+    "Phone Connect Not Available": "휴대폰 연결을 사용할 수 없음"
+  },
+  "Phone number": {
+    "Phone number": "전화번호"
+  },
+  "Pick a different file manager in Settings → Dock → Trash.": {
+    "Pick a different file manager in Settings → Dock → Trash.": "설정 → 독 → 휴지통에서 다른 파일 관리자를 선택하세요."
+  },
+  "Pick a different random video each time from the same folder": {
+    "Pick a different random video each time from the same folder": "같은 폴더에서 매번 다른 임의의 비디오를 선택합니다."
+  },
+  "Pick a terminal in Settings → Launcher (or set $TERMINAL).": {
+    "Pick a terminal in Settings → Launcher (or set $TERMINAL).": "설정 → 런처에서 터미널을 선택하세요(또는 $TERMINAL 설정)."
+  },
+  "Pick how long to pause notifications": {
+    "Pick how long to pause notifications": "알림을 일시 중지할 기간 선택"
+  },
+  "Pictures": {
+    "Pictures": "사진"
+  },
+  "Pin": {
+    "Pin": "고정"
+  },
+  "Pin to Dock": {
+    "Pin to Dock": "독에 고정"
+  },
+  "Ping": {
+    "Ping": "핑"
+  },
+  "Ping sent to": {
+    "Ping sent to": "핑 보낸 대상:"
+  },
+  "Pinned": {
+    "Pinned": "고정됨"
+  },
+  "Pinned and running apps with drag-and-drop": {
+    "Pinned and running apps with drag-and-drop": "드래그 앤 드롭으로 고정 및 실행 중인 앱"
+  },
+  "Pixelate": {
+    "Pixelate": "픽셀화"
+  },
+  "Place a trash bin at the end of the dock": {
+    "Place a trash bin at the end of the dock": "독 끝에 휴지통 배치"
+  },
+  "Place plugin directories here. Each plugin should have a plugin.json manifest file.": {
+    "Place plugin directories here. Each plugin should have a plugin.json manifest file.": "여기에 플러그인 디렉터리를 배치하세요. 각 플러그인에는 plugin.json 매니페스트 파일이 있어야 합니다."
+  },
+  "Place plugins in %1": {
+    "Place plugins in %1": "플러그인을 %1에 배치"
+  },
+  "Place the bar on the Wayland overlay layer": {
+    "Place the bar on the Wayland overlay layer": "Wayland 오버레이 레이어에 바 배치"
+  },
+  "Place the dock on the Wayland overlay layer": {
+    "Place the dock on the Wayland overlay layer": "Wayland 오버레이 레이어에 독 배치"
+  },
+  "Play": {
+    "Play": "재생"
+  },
+  "Play a video when the screen locks.": {
+    "Play a video when the screen locks.": "화면이 잠길 때 비디오 재생."
+  },
+  "Play sound after logging in": {
+    "Play sound after logging in": "로그인 후 소리 재생"
+  },
+  "Play sound when new notification arrives": {
+    "Play sound when new notification arrives": "새 알림이 도착하면 소리 재생"
+  },
+  "Play sound when power cable is connected": {
+    "Play sound when power cable is connected": "전원 케이블이 연결되면 소리 재생"
+  },
+  "Play sound when volume is adjusted": {
+    "Play sound when volume is adjusted": "볼륨을 조정할 때 소리 재생"
+  },
+  "Play sounds for system events": {
+    "Play sounds for system events": "시스템 이벤트에 대한 소리 재생"
+  },
+  "Playback": {
+    "Playback": "재생"
+  },
+  "Playback error: ": {
+    "Playback error: ": "재생 오류:"
+  },
+  "Plays audio files": {
+    "Plays audio files": "오디오 파일 재생"
+  },
+  "Plays video files": {
+    "Plays video files": "비디오 파일 재생"
+  },
+  "Please wait...": {
+    "Please wait...": "잠시 기다려 주십시오..."
+  },
+  "Please write a name for your new %1 session": {
+    "Please write a name for your new %1 session": "새 %1 세션의 이름을 작성하세요"
+  },
+  "Plugged In": {
+    "Plugged In": "전원 연결됨"
+  },
+  "Plugin": {
+    "Plugin": "플러그인"
+  },
+  "Plugin Directory": {
+    "Plugin Directory": "플러그인 디렉터리"
+  },
+  "Plugin Management": {
+    "Plugin Management": "플러그인 관리"
+  },
+  "Plugin Visibility": {
+    "Plugin Visibility": "플러그인 가시성"
+  },
+  "Plugin dependency missing": {
+    "Plugin dependency missing": "플러그인 종속성 누락됨"
+  },
+  "Plugin disabled: %1": {
+    "Plugin disabled: %1": "플러그인 비활성화됨: %1"
+  },
+  "Plugin enabled: %1": {
+    "Plugin enabled: %1": "플러그인 활성화됨: %1"
+  },
+  "Plugin is disabled - enable in Plugins settings to use": {
+    "Plugin is disabled - enable in Plugins settings to use": "플러그인이 비활성화됨 - 사용하려면 플러그인 설정에서 활성화하세요"
+  },
+  "Plugin reloaded: %1": {
+    "Plugin reloaded: %1": "플러그인 다시 로드됨: %1"
+  },
+  "Plugin uninstalled: %1": {
+    "Plugin uninstalled: %1": "플러그인 제거됨: %1"
+  },
+  "Plugin updated: %1": {
+    "Plugin updated: %1": "플러그인 업데이트됨: %1"
+  },
+  "Plugins": {
+    "Plugins": "플러그인"
+  },
+  "Pointer": {
+    "Pointer": "포인터"
+  },
+  "Polkit integration is disabled. User management requires Polkit to elevate privileges.": {
+    "Polkit integration is disabled. User management requires Polkit to elevate privileges.": "Polkit 통합이 비활성화되었습니다. 사용자 관리를 위해서는 권한을 높이려면 Polkit이 필요합니다."
+  },
+  "Popout": {
+    "Popout": "팝아웃"
+  },
+  "Popout Shadows": {
+    "Popout Shadows": "팝아웃 그림자"
+  },
+  "Popouts": {
+    "Popouts": "팝아웃"
+  },
+  "Popouts and Modals follow global Animation Speed (disable to customize independently)": {
+    "Popouts and Modals follow global Animation Speed (disable to customize independently)": "팝아웃 및 모달이 전역 애니메이션 속도를 따름(독립적으로 사용자 지정하려면 비활성화)"
+  },
+  "Popup Only": {
+    "Popup Only": "팝업 전용"
+  },
+  "Popup Position": {
+    "Popup Position": "팝업 위치"
+  },
+  "Popup Shadow": {
+    "Popup Shadow": "팝업 그림자"
+  },
+  "Popup behavior, position": {
+    "Popup behavior, position": "팝업 동작, 위치"
+  },
+  "Port": {
+    "Port": "포트"
+  },
+  "Portal": {
+    "Portal": "포털"
+  },
+  "Position": {
+    "Position": "위치"
+  },
+  "Position, pinned apps": {
+    "Position, pinned apps": "위치, 고정된 앱"
+  },
+  "Possible Override Conflicts": {
+    "Possible Override Conflicts": "잠재적 오버라이드 충돌"
+  },
+  "Power": {
+    "Power": "전원"
+  },
+  "Power & Security": {
+    "Power & Security": "전원 및 보안"
+  },
+  "Power & Sleep": {
+    "Power & Sleep": "전원 및 절전"
+  },
+  "Power Action Confirmation": {
+    "Power Action Confirmation": "전원 작업 확인"
+  },
+  "Power Menu Customization": {
+    "Power Menu Customization": "전원 메뉴 사용자 지정"
+  },
+  "Power Mode": {
+    "Power Mode": "전원 모드"
+  },
+  "Power Off": {
+    "Power Off": "전원 끄기"
+  },
+  "Power Options": {
+    "Power Options": "전원 옵션"
+  },
+  "Power Profile": {
+    "Power Profile": "전원 프로필"
+  },
+  "Power Profile Degradation": {
+    "Power Profile Degradation": "전원 프로필 저하"
+  },
+  "Power Profiles & Saving": {
+    "Power Profiles & Saving": "전원 프로필 및 절약"
+  },
+  "Power Saver": {
+    "Power Saver": "절전"
+  },
+  "Power off monitors on lock": {
+    "Power off monitors on lock": "잠금 시 모니터 전원 끄기"
+  },
+  "Power profile management available": {
+    "Power profile management available": "전원 프로필 관리 사용 가능"
+  },
+  "Power profile to use when AC power is connected.": {
+    "Power profile to use when AC power is connected.": "AC 전원이 연결되어 있을 때 사용할 전원 프로필."
+  },
+  "Power profile to use when running on battery power.": {
+    "Power profile to use when running on battery power.": "배터리 전원으로 실행할 때 사용할 전원 프로필."
+  },
+  "Power source": {
+    "Power source": "전원"
+  },
+  "Pre-fill the last successful username on the greeter": {
+    "Pre-fill the last successful username on the greeter": "로그인 화면에 마지막으로 성공한 사용자 이름 미리 채우기"
+  },
+  "Pre-select the last used session on the greeter": {
+    "Pre-select the last used session on the greeter": "로그인 화면에서 마지막으로 사용한 세션 미리 선택"
+  },
+  "Precip": {
+    "Precip": "강수"
+  },
+  "Precipitation": {
+    "Precipitation": "강수량"
+  },
+  "Precipitation Chance": {
+    "Precipitation Chance": "강수 확률"
+  },
+  "Preference": {
+    "Preference": "기본 설정"
+  },
+  "Preset Widths (%)": {
+    "Preset Widths (%)": "사전 설정 너비(%)"
+  },
+  "Press Ctrl+N or click 'New Session' to create one": {
+    "Press Ctrl+N or click 'New Session' to create one": "Ctrl+N을 누르거나 '새 세션'을 클릭하여 생성하세요"
+  },
+  "Press Enter and the audio system will restart to apply the change": {
+    "Press Enter and the audio system will restart to apply the change": "Enter 키를 누르면 변경 사항을 적용하기 위해 오디오 시스템이 다시 시작됩니다"
+  },
+  "Press Enter to paste, Shift+Enter to copy": {
+    "Press Enter to paste, Shift+Enter to copy": "붙여넣으려면 Enter, 복사하려면 Shift+Enter를 누르세요"
+  },
+  "Press key...": {
+    "Press key...": "키 누르기..."
+  },
+  "Pressure": {
+    "Pressure": "기압"
+  },
+  "Prevent screen timeout": {
+    "Prevent screen timeout": "화면 시간 초과 방지"
+  },
+  "Prevent specific applications from displaying in the media controllers (e.g., browser audio streams, background tools). Matches player identity or desktop file name case-insensitively.": {
+    "Prevent specific applications from displaying in the media controllers (e.g., browser audio streams, background tools). Matches player identity or desktop file name case-insensitively.": "미디어 컨트롤러(예: 브라우저 오디오 스트림, 백그라운드 도구)에 특정 애플리케이션이 표시되지 않도록 합니다. 대소문자를 구분하지 않고 플레이어 ID 또는 데스크톱 파일 이름과 일치합니다."
+  },
+  "Preview": {
+    "Preview": "미리보기"
+  },
+  "Preview: %1": {
+    "Preview: %1": "미리보기: %1"
+  },
+  "Previous": {
+    "Previous": "이전"
+  },
+  "Previous page": {
+    "Previous page": "이전 페이지"
+  },
+  "Primary": {
+    "Primary": "기본"
+  },
+  "Primary Container": {
+    "Primary Container": "기본 컨테이너"
+  },
+  "Print Server Management": {
+    "Print Server Management": "인쇄 서버 관리"
+  },
+  "Print Server not available": {
+    "Print Server not available": "인쇄 서버를 사용할 수 없음"
+  },
+  "Printer": {
+    "Printer": "프린터"
+  },
+  "Printer Classes": {
+    "Printer Classes": "프린터 클래스"
+  },
+  "Printer created successfully": {
+    "Printer created successfully": "프린터 생성됨"
+  },
+  "Printer deleted": {
+    "Printer deleted": "프린터 삭제됨"
+  },
+  "Printer name (no spaces)": {
+    "Printer name (no spaces)": "프린터 이름(공백 없음)"
+  },
+  "Printer reachable": {
+    "Printer reachable": "프린터 도달 가능"
+  },
+  "Printers": {
+    "Printers": "프린터"
+  },
+  "Printers: ": {
+    "Printers: ": "프린터:"
+  },
+  "Prioritize performance": {
+    "Prioritize performance": "성능 우선"
+  },
+  "Priority": {
+    "Priority": "우선순위"
+  },
+  "Privacy Indicator": {
+    "Privacy Indicator": "개인 정보 표시기"
+  },
+  "Privacy Mode": {
+    "Privacy Mode": "개인 정보 보호 모드"
+  },
+  "Private Key Password": {
+    "Private Key Password": "개인 키 비밀번호"
+  },
+  "Process Count": {
+    "Process Count": "프로세스 수"
+  },
+  "Process exited with code %1": {
+    "Process exited with code %1": "프로세스가 코드 %1(으)로 종료됨"
+  },
+  "Processes": {
+    "Processes": "프로세스"
+  },
+  "Processes:": {
+    "Processes:": "프로세스:"
+  },
+  "Processing": {
+    "Processing": "처리 중"
+  },
+  "Profile Image Error": {
+    "Profile Image Error": "프로필 이미지 오류"
+  },
+  "Profile activated: %1": {
+    "Profile activated: %1": "프로필 활성화됨: %1"
+  },
+  "Profile deleted": {
+    "Profile deleted": "프로필 삭제됨"
+  },
+  "Profile error": {
+    "Profile error": "프로필 오류"
+  },
+  "Profile image is too large. Please use a smaller image.": {
+    "Profile image is too large. Please use a smaller image.": "프로필 이미지가 너무 큽니다. 더 작은 이미지를 사용하세요."
+  },
+  "Profile name": {
+    "Profile name": "프로필 이름"
+  },
+  "Profile not found": {
+    "Profile not found": "프로필을 찾을 수 없음"
+  },
+  "Profile not found in monitors.json": {
+    "Profile not found in monitors.json": "monitors.json에서 프로필을 찾을 수 없음"
+  },
+  "Profile saved: %1": {
+    "Profile saved: %1": "프로필 저장됨: %1"
+  },
+  "Profile when Plugged In (AC)": {
+    "Profile when Plugged In (AC)": "전원 연결 시 프로필(AC)"
+  },
+  "Profile when on Battery": {
+    "Profile when on Battery": "배터리 사용 시 프로필"
+  },
+  "Protocol": {
+    "Protocol": "프로토콜"
+  },
+  "Qt": {
+    "Qt": "Qt"
+  },
+  "Qt colors applied successfully": {
+    "Qt colors applied successfully": "Qt 색상이 성공적으로 적용됨"
+  },
+  "Qt: distance-field renderer.": {
+    "Qt: distance-field renderer.": "Qt: 거리 필드 렌더러."
+  },
+  "QtMultimedia is not available": {
+    "QtMultimedia is not available": "QtMultimedia를 사용할 수 없음"
+  },
+  "QtMultimedia is not available - video screensaver requires qt multimedia services": {
+    "QtMultimedia is not available - video screensaver requires qt multimedia services": "QtMultimedia를 사용할 수 없음 - 비디오 화면 보호기에는 qt 멀티미디어 서비스가 필요합니다"
+  },
+  "Quality": {
+    "Quality": "품질"
+  },
+  "Quick Access": {
+    "Quick Access": "빠른 액세스"
+  },
+  "Quick access to application launcher": {
+    "Quick access to application launcher": "애플리케이션 런처에 대한 빠른 액세스"
+  },
+  "Quick access to color picker": {
+    "Quick access to color picker": "색상 선택기에 대한 빠른 액세스"
+  },
+  "Quick access to notepad": {
+    "Quick access to notepad": "노트패드에 대한 빠른 액세스"
+  },
+  "Quick note-taking slideout panel": {
+    "Quick note-taking slideout panel": "빠른 메모 작성 슬라이드아웃 패널"
+  },
+  "Quick system toggles": {
+    "Quick system toggles": "빠른 시스템 토글"
+  },
+  "RGB": {
+    "RGB": "RGB"
+  },
+  "Radius": {
+    "Radius": "반경"
+  },
+  "Rain": {
+    "Rain": "비"
+  },
+  "Rain Chance": {
+    "Rain Chance": "비 올 확률"
+  },
+  "Rainbow": {
+    "Rainbow": "레인보우"
+  },
+  "Random": {
+    "Random": "임의"
+  },
+  "Rate": {
+    "Rate": "속도"
+  },
+  "Re-enter password": {
+    "Re-enter password": "비밀번호 다시 입력"
+  },
+  "Reach local network devices while using an exit node": {
+    "Reach local network devices while using an exit node": "출구 노드를 사용하는 동안 로컬 네트워크 장치에 도달"
+  },
+  "Read-only legacy config": {
+    "Read-only legacy config": "읽기 전용 레거시 구성"
+  },
+  "Read:": {
+    "Read:": "읽기:"
+  },
+  "Reason": {
+    "Reason": "이유"
+  },
+  "Reboot": {
+    "Reboot": "재부팅"
+  },
+  "Recent": {
+    "Recent": "최근"
+  },
+  "Recent Colors": {
+    "Recent Colors": "최근 색상"
+  },
+  "Recent Images": {
+    "Recent Images": "최근 이미지"
+  },
+  "Recently Used Apps": {
+    "Recently Used Apps": "최근 사용한 앱"
+  },
+  "Recommended available": {
+    "Recommended available": "권장 사용 가능"
+  },
+  "Refresh": {
+    "Refresh": "새로 고침"
+  },
+  "Refresh Weather": {
+    "Refresh Weather": "날씨 새로 고침"
+  },
+  "Refreshing...": {
+    "Refreshing...": "새로 고침 중..."
+  },
+  "Regex": {
+    "Regex": "정규식"
+  },
+  "Regular": {
+    "Regular": "보통"
+  },
+  "Reject": {
+    "Reject": "거절"
+  },
+  "Reject Jobs": {
+    "Reject Jobs": "작업 거부"
+  },
+  "Related: %1": {
+    "Related: %1": "관련: %1"
+  },
+  "Release": {
+    "Release": "릴리스"
+  },
+  "Reload From Disk": {
+    "Reload From Disk": "디스크에서 다시 로드"
+  },
+  "Reload Plugin": {
+    "Reload Plugin": "플러그인 다시 로드"
+  },
+  "Remaining": {
+    "Remaining": "남음"
+  },
+  "Remaining / Total": {
+    "Remaining / Total": "남음 / 전체"
+  },
+  "Remember Last Mode": {
+    "Remember Last Mode": "마지막 모드 기억"
+  },
+  "Remember Last Query": {
+    "Remember Last Query": "마지막 쿼리 기억"
+  },
+  "Remember Type Filter": {
+    "Remember Type Filter": "유형 필터 기억"
+  },
+  "Remember last session": {
+    "Remember last session": "마지막 세션 기억"
+  },
+  "Remember last user": {
+    "Remember last user": "마지막 사용자 기억"
+  },
+  "Reminder": {
+    "Reminder": "미리 알림"
+  },
+  "Remove": {
+    "Remove": "제거"
+  },
+  "Remove \"%1\" from the %2 group?": {
+    "Remove \"%1\" from the %2 group?": "%2 그룹에서 \"%1\"을(를) 제거하시겠습니까?"
+  },
+  "Remove Shortcut?": {
+    "Remove Shortcut?": "바로 가기를 제거하시겠습니까?"
+  },
+  "Remove Widget Padding": {
+    "Remove Widget Padding": "위젯 여백 제거"
+  },
+  "Remove admin": {
+    "Remove admin": "관리자 권한 제거"
+  },
+  "Remove admin?": {
+    "Remove admin?": "관리자 권한을 제거하시겠습니까?"
+  },
+  "Remove corner rounding from the bar": {
+    "Remove corner rounding from the bar": "바에서 모서리 둥글게 처리 제거"
+  },
+  "Remove gaps and border when windows are maximized": {
+    "Remove gaps and border when windows are maximized": "창이 최대화될 때 간격 및 테두리 제거"
+  },
+  "Remove greeter access?": {
+    "Remove greeter access?": "로그인 화면 접근 권한을 제거하시겠습니까?"
+  },
+  "Remove greeter login access": {
+    "Remove greeter login access": "로그인 화면 로그인 접근 권한 제거"
+  },
+  "Remove inner padding from all widgets": {
+    "Remove inner padding from all widgets": "모든 위젯에서 내부 여백 제거"
+  },
+  "Remove match": {
+    "Remove match": "일치 항목 제거"
+  },
+  "Remove the shortcut %1?": {
+    "Remove the shortcut %1?": "바로 가기 %1을(를) 제거하시겠습니까?"
+  },
+  "Remove the shortcut %1? An unbind entry will be saved to dms/binds-user.lua so it stays removed across DMS updates.": {
+    "Remove the shortcut %1? An unbind entry will be saved to dms/binds-user.lua so it stays removed across DMS updates.": "바로 가기 %1을(를) 제거하시겠습니까? 바인딩 해제 항목이 dms/binds-user.lua에 저장되므로 DMS 업데이트 후에도 제거된 상태로 유지됩니다."
+  },
+  "Removed administrator privileges": {
+    "Removed administrator privileges": "관리자 권한 제거됨"
+  },
+  "Removed greeter login access": {
+    "Removed greeter login access": "로그인 화면 로그인 접근 권한 제거됨"
+  },
+  "Rename": {
+    "Rename": "이름 바꾸기"
+  },
+  "Rename Session": {
+    "Rename Session": "세션 이름 바꾸기"
+  },
+  "Rename Workspace": {
+    "Rename Workspace": "작업 공간 이름 바꾸기"
+  },
+  "Reorder & Group": {
+    "Reorder & Group": "재정렬 및 그룹화"
+  },
+  "Repeat": {
+    "Repeat": "반복"
+  },
+  "Replacement": {
+    "Replacement": "대체"
+  },
+  "Report": {
+    "Report": "보고서"
+  },
+  "Request Pairing": {
+    "Request Pairing": "페어링 요청"
+  },
+  "Require holding button/key to confirm power off, restart, suspend, hibernate and logout": {
+    "Require holding button/key to confirm power off, restart, suspend, hibernate and logout": "전원 끄기, 다시 시작, 절전, 최대 절전 및 로그아웃을 확인하려면 버튼/키를 길게 눌러야 함"
+  },
+  "Required plugin: ": {
+    "Required plugin: ": "필수 플러그인:"
+  },
+  "Requires %1": {
+    "Requires %1": "%1 필요"
+  },
+  "Requires 'dgop' tool": {
+    "Requires 'dgop' tool": "'dgop' 도구 필요"
+  },
+  "Requires DMS %1": {
+    "Requires DMS %1": "DMS %1 필요"
+  },
+  "Requires DMS server with sysupdate capability": {
+    "Requires DMS server with sysupdate capability": "sysupdate 기능이 있는 DMS 서버 필요"
+  },
+  "Requires MangoWC compositor": {
+    "Requires MangoWC compositor": "MangoWC 컴포지터 필요"
+  },
+  "Requires a newer version of Quickshell": {
+    "Requires a newer version of Quickshell": "최신 버전의 Quickshell 필요"
+  },
+  "Requires greetd, dms-greeter, and your user in the greeter group (plus fprintd/pam_fprintd for fingerprint, pam_u2f for security keys). Auth changes apply automatically and may open a terminal for sudo.": {
+    "Requires greetd, dms-greeter, and your user in the greeter group (plus fprintd/pam_fprintd for fingerprint, pam_u2f for security keys). Auth changes apply automatically and may open a terminal for sudo.": "greetd, dms-greeter 및 greeter 그룹의 사용자가 필요합니다(지문의 경우 fprintd/pam_fprintd, 보안 키의 경우 pam_u2f 추가). 인증 변경 사항은 자동으로 적용되며 sudo를 위한 터미널이 열릴 수 있습니다."
+  },
+  "Requires night mode support": {
+    "Requires night mode support": "야간 모드 지원 필요"
+  },
+  "Requires remembering the last user and session. Enable those options first.": {
+    "Requires remembering the last user and session. Enable those options first.": "마지막 사용자 및 세션을 기억해야 합니다. 먼저 해당 옵션을 활성화하세요."
+  },
+  "Reset": {
+    "Reset": "재설정"
+  },
+  "Reset Position": {
+    "Reset Position": "위치 재설정"
+  },
+  "Reset Size": {
+    "Reset Size": "크기 재설정"
+  },
+  "Reset to Default?": {
+    "Reset to Default?": "기본값으로 재설정하시겠습니까?"
+  },
+  "Reset to default": {
+    "Reset to default": "기본값으로 재설정"
+  },
+  "Reset to default name": {
+    "Reset to default name": "기본 이름으로 재설정"
+  },
+  "Resize Widget": {
+    "Resize Widget": "위젯 크기 조정"
+  },
+  "Resize on Border": {
+    "Resize on Border": "테두리에서 크기 조정"
+  },
+  "Resize windows by dragging their edges with the mouse": {
+    "Resize windows by dragging their edges with the mouse": "마우스로 가장자리를 드래그하여 창 크기 조정"
+  },
+  "Resolution & Refresh": {
+    "Resolution & Refresh": "해상도 및 주사율"
+  },
+  "Resolution, position, scale": {
+    "Resolution, position, scale": "해상도, 위치, 배율"
+  },
+  "Restart DMS": {
+    "Restart DMS": "DMS 다시 시작"
+  },
+  "Restart the DankMaterialShell": {
+    "Restart the DankMaterialShell": "DankMaterialShell 다시 시작"
+  },
+  "Restarting audio system...": {
+    "Restarting audio system...": "오디오 시스템 다시 시작 중..."
+  },
+  "Restore Special Workspace Windows": {
+    "Restore Special Workspace Windows": "특수 작업 공간 창 복원"
+  },
+  "Restore the last selected mode (tab) when the launcher is opened": {
+    "Restore the last selected mode (tab) when the launcher is opened": "런처가 열릴 때 마지막으로 선택한 모드(탭) 복원"
+  },
+  "Resume": {
+    "Resume": "다시 시작"
+  },
+  "Reveal the arcs where surfaces meet the frame": {
+    "Reveal the arcs where surfaces meet the frame": "표면이 프레임과 만나는 호 표시"
+  },
+  "Reverse Scrolling Direction": {
+    "Reverse Scrolling Direction": "스크롤 방향 반전"
+  },
+  "Reverse workspace switch direction when scrolling over the bar": {
+    "Reverse workspace switch direction when scrolling over the bar": "바 위에서 스크롤할 때 작업 공간 전환 방향 반전"
+  },
+  "Revert": {
+    "Revert": "되돌리기"
+  },
+  "Rewind 10s": {
+    "Rewind 10s": "10초 되감기"
+  },
+  "Right": {
+    "Right": "오른쪽"
+  },
+  "Right Center": {
+    "Right Center": "오른쪽 중앙"
+  },
+  "Right Section": {
+    "Right Section": "오른쪽 구역"
+  },
+  "Right Tiling": {
+    "Right Tiling": "오른쪽 타일링"
+  },
+  "Right-click and drag anywhere on the widget": {
+    "Right-click and drag anywhere on the widget": "위젯의 아무 곳이나 마우스 오른쪽 버튼으로 클릭하고 드래그"
+  },
+  "Right-click and drag the bottom-right corner": {
+    "Right-click and drag the bottom-right corner": "오른쪽 하단 모서리를 마우스 오른쪽 버튼으로 클릭하고 드래그"
+  },
+  "Right-click bar widget to cycle": {
+    "Right-click bar widget to cycle": "바 위젯을 마우스 오른쪽 버튼으로 클릭하여 순환"
+  },
+  "Ring": {
+    "Ring": "벨 울리기"
+  },
+  "Ringing": {
+    "Ringing": "벨 울리는 중"
+  },
+  "Ripple Effects": {
+    "Ripple Effects": "파문 효과"
+  },
+  "Root Filesystem": {
+    "Root Filesystem": "루트 파일 시스템"
+  },
+  "Rounded corners for windows": {
+    "Rounded corners for windows": "창 모서리 둥글게"
+  },
+  "Rule": {
+    "Rule": "규칙"
+  },
+  "Rule Name": {
+    "Rule Name": "규칙 이름"
+  },
+  "Rules (%1)": {
+    "Rules (%1)": "규칙(%1)"
+  },
+  "Rules found in your compositor config. These are read-only here, use Convert to DMS to make an editable copy.": {
+    "Rules found in your compositor config. These are read-only here, use Convert to DMS to make an editable copy.": "컴포지터 구성에서 규칙을 찾았습니다. 여기서는 읽기 전용이므로 편집 가능한 복사본을 만들려면 DMS로 변환을 사용하세요."
+  },
+  "Run Again": {
+    "Run Again": "다시 실행"
+  },
+  "Run DMS Templates": {
+    "Run DMS Templates": "DMS 템플릿 실행"
+  },
+  "Run User Templates": {
+    "Run User Templates": "사용자 템플릿 실행"
+  },
+  "Run a program (e.g., firefox, kitty)": {
+    "Run a program (e.g., firefox, kitty)": "프로그램 실행(예: firefox, kitty)"
+  },
+  "Run a shell command (e.g., notify-send)": {
+    "Run a shell command (e.g., notify-send)": "셸 명령 실행(예: notify-send)"
+  },
+  "Run paru/yay with AUR enabled when 'Update All' is clicked.": {
+    "Run paru/yay with AUR enabled when 'Update All' is clicked.": "'모두 업데이트'를 클릭하면 AUR이 활성화된 상태에서 paru/yay를 실행합니다."
+  },
+  "Running Apps": {
+    "Running Apps": "실행 중인 앱"
+  },
+  "Running Apps Settings": {
+    "Running Apps Settings": "실행 중인 앱 설정"
+  },
+  "Running greeter sync...": {
+    "Running greeter sync...": "로그인 화면 동기화 실행 중..."
+  },
+  "Running in terminal": {
+    "Running in terminal": "터미널에서 실행 중"
+  },
+  "SDR Brightness": {
+    "SDR Brightness": "SDR 밝기"
+  },
+  "SDR Saturation": {
+    "SDR Saturation": "SDR 채도"
+  },
+  "SMS": {
+    "SMS": "SMS"
+  },
+  "SMS sent successfully": {
+    "SMS sent successfully": "SMS가 성공적으로 전송됨"
+  },
+  "Saturation": {
+    "Saturation": "채도"
+  },
+  "Save": {
+    "Save": "저장"
+  },
+  "Save Notepad File": {
+    "Save Notepad File": "노트패드 파일 저장"
+  },
+  "Save QR Code": {
+    "Save QR Code": "QR 코드 저장"
+  },
+  "Save and close": {
+    "Save and close": "저장 및 닫기"
+  },
+  "Save and paste": {
+    "Save and paste": "저장 및 붙여넣기"
+  },
+  "Save and switch between display configurations": {
+    "Save and switch between display configurations": "저장하고 디스플레이 구성 간 전환"
+  },
+  "Save credentials": {
+    "Save credentials": "자격 증명 저장"
+  },
+  "Save critical priority notifications to history": {
+    "Save critical priority notifications to history": "중요 우선순위 알림을 기록에 저장"
+  },
+  "Save dismissed notifications to history": {
+    "Save dismissed notifications to history": "닫은 알림을 기록에 저장"
+  },
+  "Save low priority notifications to history": {
+    "Save low priority notifications to history": "낮은 우선순위 알림을 기록에 저장"
+  },
+  "Save normal priority notifications to history": {
+    "Save normal priority notifications to history": "보통 우선순위 알림을 기록에 저장"
+  },
+  "Save password": {
+    "Save password": "비밀번호 저장"
+  },
+  "Saved": {
+    "Saved": "저장됨"
+  },
+  "Saved Configurations": {
+    "Saved Configurations": "저장된 구성"
+  },
+  "Saved Networks": {
+    "Saved Networks": "저장된 네트워크"
+  },
+  "Saved Note": {
+    "Saved Note": "저장된 노트"
+  },
+  "Saved item deleted": {
+    "Saved item deleted": "저장된 항목 삭제됨"
+  },
+  "Saving...": {
+    "Saving...": "저장 중..."
+  },
+  "Saving…": {
+    "Saving…": "저장 중…"
+  },
+  "Scale": {
+    "Scale": "배율"
+  },
+  "Scale DankBar font sizes independently": {
+    "Scale DankBar font sizes independently": "DankBar 글꼴 크기 독립적으로 배율 조정"
+  },
+  "Scale DankBar icon sizes independently": {
+    "Scale DankBar icon sizes independently": "DankBar 아이콘 크기 독립적으로 배율 조정"
+  },
+  "Scale all font sizes throughout the shell": {
+    "Scale all font sizes throughout the shell": "셸 전체의 모든 글꼴 크기 배율 조정"
+  },
+  "Scan": {
+    "Scan": "스캔"
+  },
+  "Scanning": {
+    "Scanning": "스캔 중"
+  },
+  "Scanning...": {
+    "Scanning...": "스캔 중..."
+  },
+  "Science": {
+    "Science": "과학"
+  },
+  "Score": {
+    "Score": "점수"
+  },
+  "Screen sharing": {
+    "Screen sharing": "화면 공유"
+  },
+  "Screenshot unavailable": {
+    "Screenshot unavailable": "스크린샷을 사용할 수 없음"
+  },
+  "Scroll": {
+    "Scroll": "스크롤"
+  },
+  "Scroll Factor": {
+    "Scroll Factor": "스크롤 계수"
+  },
+  "Scroll GitHub": {
+    "Scroll GitHub": "GitHub 스크롤"
+  },
+  "Scroll Wheel": {
+    "Scroll Wheel": "스크롤 휠"
+  },
+  "Scroll song title": {
+    "Scroll song title": "노래 제목 스크롤"
+  },
+  "Scroll title if it doesn't fit in widget": {
+    "Scroll title if it doesn't fit in widget": "제목이 위젯에 맞지 않으면 스크롤"
+  },
+  "Scroll wheel behavior on media widget": {
+    "Scroll wheel behavior on media widget": "미디어 위젯의 스크롤 휠 동작"
+  },
+  "Scrolling": {
+    "Scrolling": "스크롤"
+  },
+  "Search App Actions": {
+    "Search App Actions": "앱 작업 검색"
+  },
+  "Search Options": {
+    "Search Options": "검색 옵션"
+  },
+  "Search applications...": {
+    "Search applications...": "애플리케이션 검색..."
+  },
+  "Search by key combo, description, or action name.\n\nDefault action copies the keybind to clipboard.\nRight-click or press Right Arrow to pin frequently used keybinds - they'll appear at the top when not searching.": {
+    "Search by key combo, description, or action name.\n\nDefault action copies the keybind to clipboard.\nRight-click or press Right Arrow to pin frequently used keybinds - they'll appear at the top when not searching.": "키 조합, 설명 또는 작업 이름으로 검색합니다.\n\n기본 작업은 단축키를 클립보드에 복사합니다.\n마우스 오른쪽 버튼을 클릭하거나 오른쪽 화살표를 눌러 자주 사용하는 단축키를 고정합니다 - 검색하지 않을 때 맨 위에 나타납니다."
+  },
+  "Search devices...": {
+    "Search devices...": "장치 검색..."
+  },
+  "Search for a location...": {
+    "Search for a location...": "위치 검색..."
+  },
+  "Search installed plugins...": {
+    "Search installed plugins...": "설치된 플러그인 검색..."
+  },
+  "Search keybinds...": {
+    "Search keybinds...": "단축키 검색..."
+  },
+  "Search keyboard shortcuts from your compositor and applications": {
+    "Search keyboard shortcuts from your compositor and applications": "컴포지터 및 애플리케이션에서 키보드 바로 가기 검색"
+  },
+  "Search plugins...": {
+    "Search plugins...": "플러그인 검색..."
+  },
+  "Search processes...": {
+    "Search processes...": "프로세스 검색..."
+  },
+  "Search sessions...": {
+    "Search sessions...": "세션 검색..."
+  },
+  "Search themes...": {
+    "Search themes...": "테마 검색..."
+  },
+  "Search widgets...": {
+    "Search widgets...": "위젯 검색..."
+  },
+  "Search...": {
+    "Search...": "검색..."
+  },
+  "Searching": {
+    "Searching": "검색 중"
+  },
+  "Searching...": {
+    "Searching...": "검색 중..."
+  },
+  "Second Factor (AND)": {
+    "Second Factor (AND)": "두 번째 요소(AND)"
+  },
+  "Secondary": {
+    "Secondary": "보조"
+  },
+  "Secondary Container": {
+    "Secondary Container": "보조 컨테이너"
+  },
+  "Secured": {
+    "Secured": "보안됨"
+  },
+  "Security": {
+    "Security": "보안"
+  },
+  "Security & privacy": {
+    "Security & privacy": "보안 및 개인 정보 보호"
+  },
+  "Security key mode": {
+    "Security key mode": "보안 키 모드"
+  },
+  "Security-key availability could not be confirmed.": {
+    "Security-key availability could not be confirmed.": "보안 키 가용성을 확인할 수 없습니다."
+  },
+  "Security-key support was detected, but no registered key was found yet. You can enable this now and register one later.": {
+    "Security-key support was detected, but no registered key was found yet. You can enable this now and register one later.": "보안 키 지원이 감지되었으나 아직 등록된 키를 찾을 수 없습니다. 지금 활성화하고 나중에 등록할 수 있습니다."
+  },
+  "Select": {
+    "Select": "선택"
+  },
+  "Select Application": {
+    "Select Application": "애플리케이션 선택"
+  },
+  "Select Bar": {
+    "Select Bar": "바 선택"
+  },
+  "Select Custom Theme": {
+    "Select Custom Theme": "사용자 지정 테마 선택"
+  },
+  "Select Dock Launcher Logo": {
+    "Select Dock Launcher Logo": "독 런처 로고 선택"
+  },
+  "Select File to Send": {
+    "Select File to Send": "보낼 파일 선택"
+  },
+  "Select Launcher Logo": {
+    "Select Launcher Logo": "런처 로고 선택"
+  },
+  "Select Profile Image": {
+    "Select Profile Image": "프로필 이미지 선택"
+  },
+  "Select Video or Folder": {
+    "Select Video or Folder": "비디오 또는 폴더 선택"
+  },
+  "Select Wallpaper": {
+    "Select Wallpaper": "배경화면 선택"
+  },
+  "Select Wallpaper Directory": {
+    "Select Wallpaper Directory": "배경화면 디렉터리 선택"
+  },
+  "Select a color from the palette or use custom sliders": {
+    "Select a color from the palette or use custom sliders": "팔레트에서 색상을 선택하거나 사용자 지정 슬라이더 사용"
+  },
+  "Select a desktop application": {
+    "Select a desktop application": "데스크톱 애플리케이션 선택"
+  },
+  "Select a widget to add to your desktop. Each widget is a separate instance with its own settings.": {
+    "Select a widget to add to your desktop. Each widget is a separate instance with its own settings.": "데스크톱에 추가할 위젯을 선택하세요. 각 위젯은 고유한 설정이 있는 별도의 인스턴스입니다."
+  },
+  "Select a widget to add. You can add multiple instances of the same widget if needed.": {
+    "Select a widget to add. You can add multiple instances of the same widget if needed.": "추가할 위젯을 선택하세요. 필요한 경우 같은 위젯의 여러 인스턴스를 추가할 수 있습니다."
+  },
+  "Select a window...": {
+    "Select a window...": "창 선택..."
+  },
+  "Select an active session to switch to. The current session stays running in the background.": {
+    "Select an active session to switch to. The current session stays running in the background.": "전환할 활성 세션을 선택하세요. 현재 세션은 백그라운드에서 계속 실행됩니다."
+  },
+  "Select an image file...": {
+    "Select an image file...": "이미지 파일 선택..."
+  },
+  "Select at least one provider": {
+    "Select at least one provider": "하나 이상의 공급자 선택"
+  },
+  "Select background image": {
+    "Select background image": "배경 이미지 선택"
+  },
+  "Select device": {
+    "Select device": "기기 선택"
+  },
+  "Select device...": {
+    "Select device...": "기기 선택..."
+  },
+  "Select driver...": {
+    "Select driver...": "드라이버 선택..."
+  },
+  "Select font weight for UI text": {
+    "Select font weight for UI text": "UI 텍스트의 글꼴 두께 선택"
+  },
+  "Select greeter background image": {
+    "Select greeter background image": "로그인 화면 배경 이미지 선택"
+  },
+  "Select lock screen background image": {
+    "Select lock screen background image": "잠금 화면 배경 이미지 선택"
+  },
+  "Select monitor to configure wallpaper": {
+    "Select monitor to configure wallpaper": "배경화면을 구성할 모니터 선택"
+  },
+  "Select monospace font for process list and technical displays": {
+    "Select monospace font for process list and technical displays": "프로세스 목록 및 기술 디스플레이에 사용할 고정폭 글꼴 선택"
+  },
+  "Select network": {
+    "Select network": "네트워크 선택"
+  },
+  "Select system sound theme": {
+    "Select system sound theme": "시스템 소리 테마 선택"
+  },
+  "Select the font family for UI text": {
+    "Select the font family for UI text": "UI 텍스트의 글꼴 패밀리 선택"
+  },
+  "Select the palette algorithm used for wallpaper-based colors": {
+    "Select the palette algorithm used for wallpaper-based colors": "배경화면 기반 색상에 사용할 팔레트 알고리즘 선택"
+  },
+  "Select user...": {
+    "Select user...": "사용자 선택..."
+  },
+  "Select which keybind providers to include": {
+    "Select which keybind providers to include": "포함할 단축키 제공자 선택"
+  },
+  "Select which transitions to include in randomization": {
+    "Select which transitions to include in randomization": "무작위화에 포함할 전환 선택"
+  },
+  "Select...": {
+    "Select...": "선택..."
+  },
+  "Selected image file not found.": {
+    "Selected image file not found.": "선택한 이미지 파일을 찾을 수 없습니다."
+  },
+  "Send": {
+    "Send": "보내기"
+  },
+  "Send Clipboard": {
+    "Send Clipboard": "클립보드 보내기"
+  },
+  "Send SMS": {
+    "Send SMS": "SMS 보내기"
+  },
+  "Sending": {
+    "Sending": "보내는 중"
+  },
+  "Separate": {
+    "Separate": "분리"
+  },
+  "Separate Appearance for Unfocused Display(s)": {
+    "Separate Appearance for Unfocused Display(s)": "포커스되지 않은 디스플레이의 별도 모양"
+  },
+  "Separate Light & Dark Themes": {
+    "Separate Light & Dark Themes": "별도의 라이트 및 다크 테마"
+  },
+  "Separate appearance for unfocused displays is not supported on this compositor.": {
+    "Separate appearance for unfocused displays is not supported on this compositor.": "이 컴포지터에서는 포커스되지 않은 디스플레이에 대한 별도의 모양이 지원되지 않습니다."
+  },
+  "Separator": {
+    "Separator": "구분선"
+  },
+  "Server": {
+    "Server": "서버"
+  },
+  "Session Filter": {
+    "Session Filter": "세션 필터"
+  },
+  "Set Custom Device Name": {
+    "Set Custom Device Name": "사용자 지정 장치 이름 설정"
+  },
+  "Set custom name": {
+    "Set custom name": "사용자 지정 이름 설정"
+  },
+  "Set custom names for your audio input devices": {
+    "Set custom names for your audio input devices": "오디오 입력 장치의 사용자 지정 이름 설정"
+  },
+  "Set custom names for your audio output devices": {
+    "Set custom names for your audio output devices": "오디오 출력 장치의 사용자 지정 이름 설정"
+  },
+  "Set different wallpapers for each connected monitor": {
+    "Set different wallpapers for each connected monitor": "연결된 각 모니터에 다른 배경화면 설정"
+  },
+  "Set different wallpapers for light and dark mode": {
+    "Set different wallpapers for light and dark mode": "라이트 모드와 다크 모드에 다른 배경화면 설정"
+  },
+  "Set initial password": {
+    "Set initial password": "초기 비밀번호 설정"
+  },
+  "Set key and action to save": {
+    "Set key and action to save": "저장할 키 및 작업 설정"
+  },
+  "Set notification rules": {
+    "Set notification rules": "알림 규칙 설정"
+  },
+  "Set the font size for notification body text (htmlBody)": {
+    "Set the font size for notification body text (htmlBody)": "알림 본문 텍스트의 글꼴 크기 설정(htmlBody)"
+  },
+  "Set the font size for notification summary text": {
+    "Set the font size for notification summary text": "알림 요약 텍스트의 글꼴 크기 설정"
+  },
+  "Set the percentage at which the battery is considered low.": {
+    "Set the percentage at which the battery is considered low.": "배터리가 부족한 것으로 간주되는 백분율을 설정합니다."
+  },
+  "Setting": {
+    "Setting": "설정"
+  },
+  "Setting up...": {
+    "Setting up...": "설정 중..."
+  },
+  "Settings": {
+    "Settings": "설정"
+  },
+  "Settings Search": {
+    "Settings Search": "설정 검색"
+  },
+  "Settings are read-only. Changes will not persist.": {
+    "Settings are read-only. Changes will not persist.": "설정은 읽기 전용입니다. 변경 사항은 유지되지 않습니다."
+  },
+  "Setup": {
+    "Setup": "설정"
+  },
+  "Shadow Color": {
+    "Shadow Color": "그림자 색상"
+  },
+  "Shadow Intensity": {
+    "Shadow Intensity": "그림자 강도"
+  },
+  "Shadow Opacity": {
+    "Shadow Opacity": "그림자 불투명도"
+  },
+  "Shadow Override": {
+    "Shadow Override": "그림자 오버라이드"
+  },
+  "Shadow blur radius in pixels": {
+    "Shadow blur radius in pixels": "그림자 블러 반경(픽셀)"
+  },
+  "Shadow elevation on bars and panels": {
+    "Shadow elevation on bars and panels": "바 및 패널의 그림자 고도"
+  },
+  "Shadow elevation on modals and dialogs": {
+    "Shadow elevation on modals and dialogs": "모달 및 대화 상자의 그림자 고도"
+  },
+  "Shadow elevation on popouts, OSDs, and dropdowns": {
+    "Shadow elevation on popouts, OSDs, and dropdowns": "팝아웃, OSD 및 드롭다운의 그림자 고도"
+  },
+  "Shadows": {
+    "Shadows": "그림자"
+  },
+  "Share": {
+    "Share": "공유"
+  },
+  "Share Gamma Control Settings": {
+    "Share Gamma Control Settings": "감마 제어 설정 공유"
+  },
+  "Shared": {
+    "Shared": "공유됨"
+  },
+  "Shell": {
+    "Shell": "Shell"
+  },
+  "Shift+Enter to copy": {
+    "Shift+Enter to copy": "복사하려면 Shift+Enter"
+  },
+  "Shift+Enter to paste": {
+    "Shift+Enter to paste": "붙여넣으려면 Shift+Enter"
+  },
+  "Short": {
+    "Short": "짧음"
+  },
+  "Shortcut (%1)": {
+    "Shortcut (%1)": "바로 가기(%1)"
+  },
+  "Shortcut that opens this settings window": {
+    "Shortcut that opens this settings window": "이 설정 창을 여는 바로 가기"
+  },
+  "Shortcuts": {
+    "Shortcuts": "바로 가기"
+  },
+  "Shortcuts (%1)": {
+    "Shortcuts (%1)": "바로 가기(%1)"
+  },
+  "Show": {
+    "Show": "표시"
+  },
+  "Show 3rd Party": {
+    "Show 3rd Party": "타사 표시"
+  },
+  "Show All Tags": {
+    "Show All Tags": "모든 태그 표시"
+  },
+  "Show All, Apps, Files, and Plugins chips beside the Spotlight Bar input.": {
+    "Show All, Apps, Files, and Plugins chips beside the Spotlight Bar input.": "스포트라이트 바 입력 옆에 모두, 앱, 파일 및 플러그인 칩을 표시합니다."
+  },
+  "Show Badge": {
+    "Show Badge": "배지 표시"
+  },
+  "Show CPU": {
+    "Show CPU": "CPU 표시"
+  },
+  "Show CPU Graph": {
+    "Show CPU Graph": "CPU 그래프 표시"
+  },
+  "Show CPU Temp": {
+    "Show CPU Temp": "CPU 온도 표시"
+  },
+  "Show Date": {
+    "Show Date": "날짜 표시"
+  },
+  "Show Disk": {
+    "Show Disk": "디스크 표시"
+  },
+  "Show Dock": {
+    "Show Dock": "독 표시"
+  },
+  "Show Feels Like Temperature": {
+    "Show Feels Like Temperature": "체감 온도 표시"
+  },
+  "Show Flatpak, Snap, AppImage, or Nix badge icons on launcher items.": {
+    "Show Flatpak, Snap, AppImage, or Nix badge icons on launcher items.": "런처 항목에 Flatpak, Snap, AppImage 또는 Nix 배지 아이콘을 표시합니다."
+  },
+  "Show Footer": {
+    "Show Footer": "바닥글 표시"
+  },
+  "Show Forecast": {
+    "Show Forecast": "일기예보 표시"
+  },
+  "Show GPU Temperature": {
+    "Show GPU Temperature": "GPU 온도 표시"
+  },
+  "Show Header": {
+    "Show Header": "헤더 표시"
+  },
+  "Show Hibernate": {
+    "Show Hibernate": "최대 절전 모드 표시"
+  },
+  "Show Hour Numbers": {
+    "Show Hour Numbers": "시간 숫자 표시"
+  },
+  "Show Hourly Forecast": {
+    "Show Hourly Forecast": "시간별 예보 표시"
+  },
+  "Show Humidity": {
+    "Show Humidity": "습도 표시"
+  },
+  "Show Icon": {
+    "Show Icon": "아이콘 표시"
+  },
+  "Show Launcher Button": {
+    "Show Launcher Button": "런처 버튼 표시"
+  },
+  "Show Line Numbers": {
+    "Show Line Numbers": "줄 번호 표시"
+  },
+  "Show Location": {
+    "Show Location": "위치 표시"
+  },
+  "Show Lock": {
+    "Show Lock": "잠금 표시"
+  },
+  "Show Log Out": {
+    "Show Log Out": "로그아웃 표시"
+  },
+  "Show Material Design ripple animations on interactive elements": {
+    "Show Material Design ripple animations on interactive elements": "대화형 요소에 Material Design 파문 애니메이션 표시"
+  },
+  "Show Media Player": {
+    "Show Media Player": "미디어 플레이어 표시"
+  },
+  "Show Memory": {
+    "Show Memory": "메모리 표시"
+  },
+  "Show Memory Graph": {
+    "Show Memory Graph": "메모리 그래프 표시"
+  },
+  "Show Memory in GB": {
+    "Show Memory in GB": "메모리 GB 단위로 표시"
+  },
+  "Show Mode Chips": {
+    "Show Mode Chips": "모드 칩 표시"
+  },
+  "Show Network": {
+    "Show Network": "네트워크 표시"
+  },
+  "Show Network Graph": {
+    "Show Network Graph": "네트워크 그래프 표시"
+  },
+  "Show Occupied Workspaces Only": {
+    "Show Occupied Workspaces Only": "점유된 작업 공간만 표시"
+  },
+  "Show Overflow Badge Count": {
+    "Show Overflow Badge Count": "오버플로 배지 수 표시"
+  },
+  "Show Package Source Badges": {
+    "Show Package Source Badges": "패키지 소스 배지 표시"
+  },
+  "Show Password Field": {
+    "Show Password Field": "비밀번호 필드 표시"
+  },
+  "Show Percentage": {
+    "Show Percentage": "백분율 표시"
+  },
+  "Show Power Actions": {
+    "Show Power Actions": "전원 작업 표시"
+  },
+  "Show Power Off": {
+    "Show Power Off": "전원 끄기 표시"
+  },
+  "Show Precipitation Probability": {
+    "Show Precipitation Probability": "강수 확률 표시"
+  },
+  "Show Pressure": {
+    "Show Pressure": "기압 표시"
+  },
+  "Show Profile Image": {
+    "Show Profile Image": "프로필 이미지 표시"
+  },
+  "Show Reboot": {
+    "Show Reboot": "재부팅 표시"
+  },
+  "Show Remaining Time": {
+    "Show Remaining Time": "남은 시간 표시"
+  },
+  "Show Restart DMS": {
+    "Show Restart DMS": "DMS 다시 시작 표시"
+  },
+  "Show Saved Items": {
+    "Show Saved Items": "저장된 항목 표시"
+  },
+  "Show Seconds": {
+    "Show Seconds": "초 표시"
+  },
+  "Show Sunrise/Sunset": {
+    "Show Sunrise/Sunset": "일출/일몰 표시"
+  },
+  "Show Suspend": {
+    "Show Suspend": "절전 표시"
+  },
+  "Show Swap": {
+    "Show Swap": "스왑 표시"
+  },
+  "Show Switch User": {
+    "Show Switch User": "사용자 전환 표시"
+  },
+  "Show System Date": {
+    "Show System Date": "시스템 날짜 표시"
+  },
+  "Show System Icons": {
+    "Show System Icons": "시스템 아이콘 표시"
+  },
+  "Show System Time": {
+    "Show System Time": "시스템 시간 표시"
+  },
+  "Show Top Processes": {
+    "Show Top Processes": "상위 프로세스 표시"
+  },
+  "Show Trash in Dock": {
+    "Show Trash in Dock": "독에 휴지통 표시"
+  },
+  "Show Weather Condition": {
+    "Show Weather Condition": "날씨 상태 표시"
+  },
+  "Show Week Number": {
+    "Show Week Number": "주 번호 표시"
+  },
+  "Show Welcome": {
+    "Show Welcome": "환영 표시"
+  },
+  "Show Wind Speed": {
+    "Show Wind Speed": "풍속 표시"
+  },
+  "Show Workspace Apps": {
+    "Show Workspace Apps": "작업 공간 앱 표시"
+  },
+  "Show a bar that drains as the popup's auto-dismiss timer runs": {
+    "Show a bar that drains as the popup's auto-dismiss timer runs": "팝업의 자동 닫힘 타이머가 실행될 때 줄어드는 바 표시"
+  },
+  "Show a notification when battery reaches the charge limit.": {
+    "Show a notification when battery reaches the charge limit.": "배터리가 충전 한도에 도달하면 알림을 표시합니다."
+  },
+  "Show a warning popup when battery is running low.": {
+    "Show a warning popup when battery is running low.": "배터리가 부족할 때 경고 팝업을 표시합니다."
+  },
+  "Show all 9 tags instead of only occupied tags": {
+    "Show all 9 tags instead of only occupied tags": "점유된 태그만 표시하지 않고 9개의 태그 모두 표시"
+  },
+  "Show an outline ring around the focused workspace indicator": {
+    "Show an outline ring around the focused workspace indicator": "포커스된 작업 공간 표시기 주위에 윤곽선 링 표시"
+  },
+  "Show an urgent alert when battery reaches critical level.": {
+    "Show an urgent alert when battery reaches critical level.": "배터리가 위험 수준에 도달하면 긴급 알림을 표시합니다."
+  },
+  "Show cava audio visualizer in media widget": {
+    "Show cava audio visualizer in media widget": "미디어 위젯에 cava 오디오 시각화 표시"
+  },
+  "Show darkened overlay behind modal dialogs": {
+    "Show darkened overlay behind modal dialogs": "모달 대화 상자 뒤에 어두워진 오버레이 표시"
+  },
+  "Show device": {
+    "Show device": "기기 표시"
+  },
+  "Show dock when floating windows don't overlap its area": {
+    "Show dock when floating windows don't overlap its area": "플로팅 창이 영역과 겹치지 않을 때 독 표시"
+  },
+  "Show drop shadow on notification popups. Requires M3 Elevation to be enabled in Theme & Colors.": {
+    "Show drop shadow on notification popups. Requires M3 Elevation to be enabled in Theme & Colors.": "알림 팝업에 그림자를 표시합니다. 테마 및 색상에서 M3 고도를 활성화해야 합니다."
+  },
+  "Show during Niri overview": {
+    "Show during Niri overview": "Niri 개요 중 표시"
+  },
+  "Show foreground surfaces on panels for stronger contrast": {
+    "Show foreground surfaces on panels for stronger contrast": "강한 대비를 위해 패널에 전경 표면 표시"
+  },
+  "Show in GB": {
+    "Show in GB": "GB로 표시"
+  },
+  "Show launcher overlay when typing in Niri overview. Disable to use another launcher.": {
+    "Show launcher overlay when typing in Niri overview. Disable to use another launcher.": "Niri 개요에서 입력할 때 런처 오버레이를 표시합니다. 다른 런처를 사용하려면 비활성화하세요."
+  },
+  "Show mode tabs and keyboard hints at the bottom.": {
+    "Show mode tabs and keyboard hints at the bottom.": "하단에 모드 탭과 키보드 힌트를 표시합니다."
+  },
+  "Show mount path": {
+    "Show mount path": "마운트 경로 표시"
+  },
+  "Show notification popups only on the currently focused monitor": {
+    "Show notification popups only on the currently focused monitor": "현재 포커스된 모니터에만 알림 팝업 표시"
+  },
+  "Show notifications only on the currently focused monitor": {
+    "Show notifications only on the currently focused monitor": "현재 포커스된 모니터에만 알림 표시"
+  },
+  "Show on Last Display": {
+    "Show on Last Display": "마지막 디스플레이에 표시"
+  },
+  "Show on Overlay": {
+    "Show on Overlay": "오버레이에 표시"
+  },
+  "Show on Overview": {
+    "Show on Overview": "개요에 표시"
+  },
+  "Show on Overview Only": {
+    "Show on Overview Only": "개요에만 표시"
+  },
+  "Show on all connected displays": {
+    "Show on all connected displays": "연결된 모든 디스플레이에 표시"
+  },
+  "Show on screens:": {
+    "Show on screens:": "화면에 표시:"
+  },
+  "Show on-screen display when brightness changes": {
+    "Show on-screen display when brightness changes": "밝기가 변경될 때 온스크린 디스플레이 표시"
+  },
+  "Show on-screen display when caps lock state changes": {
+    "Show on-screen display when caps lock state changes": "Caps Lock 상태가 변경될 때 온스크린 디스플레이 표시"
+  },
+  "Show on-screen display when cycling audio output devices": {
+    "Show on-screen display when cycling audio output devices": "오디오 출력 장치를 순환할 때 온스크린 디스플레이 표시"
+  },
+  "Show on-screen display when idle inhibitor state changes": {
+    "Show on-screen display when idle inhibitor state changes": "대기 금지기 상태가 변경될 때 온스크린 디스플레이 표시"
+  },
+  "Show on-screen display when media player status changes": {
+    "Show on-screen display when media player status changes": "미디어 플레이어 상태가 변경될 때 온스크린 디스플레이 표시"
+  },
+  "Show on-screen display when media player volume changes": {
+    "Show on-screen display when media player volume changes": "미디어 플레이어 볼륨이 변경될 때 온스크린 디스플레이 표시"
+  },
+  "Show on-screen display when microphone is muted/unmuted": {
+    "Show on-screen display when microphone is muted/unmuted": "마이크가 음소거/음소거 해제될 때 온스크린 디스플레이 표시"
+  },
+  "Show on-screen display when power profile changes": {
+    "Show on-screen display when power profile changes": "전원 프로필이 변경될 때 온스크린 디스플레이 표시"
+  },
+  "Show on-screen display when volume changes": {
+    "Show on-screen display when volume changes": "볼륨이 변경될 때 온스크린 디스플레이 표시"
+  },
+  "Show the bar only when no windows are open": {
+    "Show the bar only when no windows are open": "열려 있는 창이 없을 때만 바 표시"
+  },
+  "Show the bar when niri overview is active": {
+    "Show the bar when niri overview is active": "niri 개요가 활성화되어 있을 때 바 표시"
+  },
+  "Show weather information in top bar and control center": {
+    "Show weather information in top bar and control center": "상단 바 및 제어 센터에 날씨 정보 표시"
+  },
+  "Show week number in the calendar": {
+    "Show week number in the calendar": "캘린더에 주 번호 표시"
+  },
+  "Show workspace index numbers in the top bar workspace switcher": {
+    "Show workspace index numbers in the top bar workspace switcher": "상단 바 작업 공간 전환기에 작업 공간 인덱스 번호 표시"
+  },
+  "Show workspace name on horizontal bars, and first letter on vertical bars": {
+    "Show workspace name on horizontal bars, and first letter on vertical bars": "가로 바에 작업 공간 이름을 표시하고 세로 바에 첫 글자를 표시"
+  },
+  "Show workspaces of the currently focused monitor": {
+    "Show workspaces of the currently focused monitor": "현재 포커스된 모니터의 작업 공간 표시"
+  },
+  "Shows all running applications with focus indication": {
+    "Shows all running applications with focus indication": "포커스 표시와 함께 실행 중인 모든 애플리케이션 표시"
+  },
+  "Shows current workspace and allows switching": {
+    "Shows current workspace and allows switching": "현재 작업 공간을 표시하고 전환 허용"
+  },
+  "Shows when caps lock is active": {
+    "Shows when caps lock is active": "Caps Lock이 활성화될 때 표시"
+  },
+  "Shows when microphone, camera, or screen sharing is active": {
+    "Shows when microphone, camera, or screen sharing is active": "마이크, 카메라 또는 화면 공유가 활성화될 때 표시"
+  },
+  "Shrink the media widget to fit shorter song titles while still respecting the configured maximum size": {
+    "Shrink the media widget to fit shorter song titles while still respecting the configured maximum size": "구성된 최대 크기를 존중하면서 짧은 노래 제목에 맞게 미디어 위젯을 축소합니다."
+  },
+  "Shutdown": {
+    "Shutdown": "시스템 종료"
+  },
+  "Signal": {
+    "Signal": "신호"
+  },
+  "Signal Strength": {
+    "Signal Strength": "신호 강도"
+  },
+  "Signal:": {
+    "Signal:": "신호:"
+  },
+  "Silence for a while": {
+    "Silence for a while": "잠시 무음"
+  },
+  "Silence notifications": {
+    "Silence notifications": "알림 무음"
+  },
+  "Silence system sounds while media is playing": {
+    "Silence system sounds while media is playing": "미디어 재생 중 시스템 소리 무음"
+  },
+  "Single-Line Popup": {
+    "Single-Line Popup": "한 줄 팝업"
+  },
+  "Size": {
+    "Size": "크기"
+  },
+  "Size Constraints": {
+    "Size Constraints": "크기 제약"
+  },
+  "Size Offset": {
+    "Size Offset": "크기 오프셋"
+  },
+  "Sizing": {
+    "Sizing": "크기 조정"
+  },
+  "Skip": {
+    "Skip": "건너뛰기"
+  },
+  "Skip confirmation": {
+    "Skip confirmation": "확인 건너뛰기"
+  },
+  "Skip setup": {
+    "Skip setup": "설정 건너뛰기"
+  },
+  "Skip the greeter password after boot until you sign out. Lock screen unlock is unchanged. Takes effect on the next reboot after sync.": {
+    "Skip the greeter password after boot until you sign out. Lock screen unlock is unchanged. Takes effect on the next reboot after sync.": "부팅 후 로그아웃할 때까지 로그인 화면 비밀번호를 건너뜁니다. 잠금 화면 잠금 해제는 변경되지 않습니다. 동기화 후 다음 재부팅 시 적용됩니다."
+  },
+  "Slideout": {
+    "Slideout": "슬라이드아웃"
+  },
+  "Small": {
+    "Small": "작음"
+  },
+  "Smartcard Authentication": {
+    "Smartcard Authentication": "스마트카드 인증"
+  },
+  "Snap": {
+    "Snap": "스냅"
+  },
+  "Snow": {
+    "Snow": "눈"
+  },
+  "Some plugins require a newer version of DMS:": {
+    "Some plugins require a newer version of DMS:": "일부 플러그인에는 최신 버전의 DMS가 필요합니다:"
+  },
+  "Sort Alphabetically": {
+    "Sort Alphabetically": "알파벳순 정렬"
+  },
+  "Sort By": {
+    "Sort By": "정렬 기준"
+  },
+  "Sort wallpapers": {
+    "Sort wallpapers": "배경화면 정렬"
+  },
+  "Sorting & Layout": {
+    "Sorting & Layout": "정렬 및 레이아웃"
+  },
+  "Sound Theme": {
+    "Sound Theme": "소리 테마"
+  },
+  "Sounds": {
+    "Sounds": "소리"
+  },
+  "Source: %1": {
+    "Source: %1": "소스: %1"
+  },
+  "Space between the bar and screen edges": {
+    "Space between the bar and screen edges": "바와 화면 가장자리 사이의 간격"
+  },
+  "Space between windows": {
+    "Space between windows": "창 사이의 간격"
+  },
+  "Space between windows and screen edges": {
+    "Space between windows and screen edges": "창과 화면 가장자리 사이의 간격"
+  },
+  "Spacer": {
+    "Spacer": "여백"
+  },
+  "Spacing": {
+    "Spacing": "간격"
+  },
+  "Speaker settings": {
+    "Speaker settings": "스피커 설정"
+  },
+  "Speed": {
+    "Speed": "속도"
+  },
+  "Spool Area Full": {
+    "Spool Area Full": "스풀 영역 꽉 참"
+  },
+  "Spotlight": {
+    "Spotlight": "스포트라이트"
+  },
+  "Spotlight Bar": {
+    "Spotlight Bar": "스포트라이트 바"
+  },
+  "Spotlight Bar Shortcut": {
+    "Spotlight Bar Shortcut": "스포트라이트 바 바로 가기"
+  },
+  "Spotlight Search": {
+    "Spotlight Search": "스포트라이트 검색"
+  },
+  "Square Corners": {
+    "Square Corners": "직각 모서리"
+  },
+  "Stacked": {
+    "Stacked": "누적됨"
+  },
+  "Standard": {
+    "Standard": "표준"
+  },
+  "Standard: Classic Material Design 3 — panels rise from below with a subtle scale. The DMS default.": {
+    "Standard: Classic Material Design 3 — panels rise from below with a subtle scale. The DMS default.": "표준: 클래식 Material Design 3 — 패널이 미묘한 비율로 아래에서 올라옵니다. DMS 기본값."
+  },
+  "Start": {
+    "Start": "시작"
+  },
+  "Start KDE Connect or Valent to use this plugin": {
+    "Start KDE Connect or Valent to use this plugin": "이 플러그인을 사용하려면 KDE Connect 또는 Valent 시작"
+  },
+  "Start typing your notes here...": {
+    "Start typing your notes here...": "여기에 노트를 입력하세요..."
+  },
+  "State": {
+    "State": "상태"
+  },
+  "Status": {
+    "Status": "상태"
+  },
+  "Stopped": {
+    "Stopped": "중지됨"
+  },
+  "Stopped Partly": {
+    "Stopped Partly": "부분적으로 중지됨"
+  },
+  "Stopping": {
+    "Stopping": "중지 중"
+  },
+  "Stretch": {
+    "Stretch": "늘이기"
+  },
+  "Stretch widget icons to fill the available bar height": {
+    "Stretch widget icons to fill the available bar height": "사용 가능한 바 높이를 채우도록 위젯 아이콘 늘이기"
+  },
+  "Stretch widget text to fill the available bar height": {
+    "Stretch widget text to fill the available bar height": "사용 가능한 바 높이를 채우도록 위젯 텍스트 늘이기"
+  },
+  "Strict auto-hide": {
+    "Strict auto-hide": "엄격한 자동 숨기기"
+  },
+  "Stripes": {
+    "Stripes": "줄무늬"
+  },
+  "Summary": {
+    "Summary": "요약"
+  },
+  "Summary Font Size": {
+    "Summary Font Size": "요약 글꼴 크기"
+  },
+  "Sunrise": {
+    "Sunrise": "일출"
+  },
+  "Sunset": {
+    "Sunset": "일몰"
+  },
+  "Suppress Duplicate Notifications": {
+    "Suppress Duplicate Notifications": "중복 알림 억제"
+  },
+  "Suppress notification popups while enabled": {
+    "Suppress notification popups while enabled": "활성화된 동안 알림 팝업 억제"
+  },
+  "Surface": {
+    "Surface": "표면"
+  },
+  "Surface Behavior": {
+    "Surface Behavior": "표면 동작"
+  },
+  "Surface Border Color": {
+    "Surface Border Color": "표면 테두리 색상"
+  },
+  "Surface Border Opacity": {
+    "Surface Border Opacity": "표면 테두리 불투명도"
+  },
+  "Surface Container": {
+    "Surface Container": "표면 컨테이너"
+  },
+  "Surface High": {
+    "Surface High": "표면 높음"
+  },
+  "Surface Highest": {
+    "Surface Highest": "표면 가장 높음"
+  },
+  "Surface Opacity": {
+    "Surface Opacity": "표면 불투명도"
+  },
+  "Surface Text": {
+    "Surface Text": "표면 텍스트"
+  },
+  "Surface Variant": {
+    "Surface Variant": "표면 변형"
+  },
+  "Surfaces emerge flush from the bar": {
+    "Surfaces emerge flush from the bar": "표면이 바에서 같은 높이로 나타남"
+  },
+  "Surfaces float independently of the frame": {
+    "Surfaces float independently of the frame": "표면이 프레임과 독립적으로 떠다님"
+  },
+  "Suspend": {
+    "Suspend": "절전"
+  },
+  "Suspend behavior": {
+    "Suspend behavior": "절전 동작"
+  },
+  "Suspend system after": {
+    "Suspend system after": "다음 시간 후 시스템 절전"
+  },
+  "Suspend then Hibernate": {
+    "Suspend then Hibernate": "절전 후 최대 절전 모드"
+  },
+  "Sway Website": {
+    "Sway Website": "Sway 웹사이트"
+  },
+  "Switch User": {
+    "Switch User": "사용자 전환"
+  },
+  "Switch between display configurations": {
+    "Switch between display configurations": "디스플레이 구성 간 전환"
+  },
+  "Switch to power profile": {
+    "Switch to power profile": "전원 프로필로 전환"
+  },
+  "Sync": {
+    "Sync": "동기화"
+  },
+  "Sync Bar Inset Padding": {
+    "Sync Bar Inset Padding": "바 삽입 여백 동기화"
+  },
+  "Sync Mode with Portal": {
+    "Sync Mode with Portal": "포털과 모드 동기화"
+  },
+  "Sync Popouts & Modals": {
+    "Sync Popouts & Modals": "팝아웃 및 모달 동기화"
+  },
+  "Sync Position Across Screens": {
+    "Sync Position Across Screens": "화면 간 위치 동기화"
+  },
+  "Sync applies your theme and settings to the login screen. Other users should run dms greeter sync --profile instead of a full sync. Authentication changes apply automatically.": {
+    "Sync applies your theme and settings to the login screen. Other users should run dms greeter sync --profile instead of a full sync. Authentication changes apply automatically.": "동기화는 테마 및 설정을 로그인 화면에 적용합니다. 다른 사용자는 전체 동기화 대신 dms greeter sync --profile을 실행해야 합니다. 인증 변경 사항은 자동으로 적용됩니다."
+  },
+  "Sync completed successfully.": {
+    "Sync completed successfully.": "동기화가 성공적으로 완료되었습니다."
+  },
+  "Sync dark mode with settings portals for system-wide theme hints": {
+    "Sync dark mode with settings portals for system-wide theme hints": "시스템 전체 테마 힌트를 위해 설정 포털과 다크 모드 동기화"
+  },
+  "Sync failed in background mode. Trying terminal mode so you can authenticate interactively.": {
+    "Sync failed in background mode. Trying terminal mode so you can authenticate interactively.": "백그라운드 모드에서 동기화에 실패했습니다. 대화식으로 인증할 수 있도록 터미널 모드를 시도합니다."
+  },
+  "Sync needs sudo authentication. Opening terminal so you can use password or fingerprint.": {
+    "Sync needs sudo authentication. Opening terminal so you can use password or fingerprint.": "동기화에는 sudo 인증이 필요합니다. 비밀번호나 지문을 사용할 수 있도록 터미널을 엽니다."
+  },
+  "Sync to apply": {
+    "Sync to apply": "적용하려면 동기화"
+  },
+  "Syncing...": {
+    "Syncing...": "동기화 중..."
+  },
+  "System": {
+    "System": "시스템"
+  },
+  "System App Theming": {
+    "System App Theming": "시스템 앱 테마 지정"
+  },
+  "System Check": {
+    "System Check": "시스템 검사"
+  },
+  "System Default": {
+    "System Default": "시스템 기본값"
+  },
+  "System Information": {
+    "System Information": "시스템 정보"
+  },
+  "System Monitor": {
+    "System Monitor": "시스템 모니터"
+  },
+  "System Monitor Unavailable": {
+    "System Monitor Unavailable": "시스템 모니터를 사용할 수 없음"
+  },
+  "System Sounds": {
+    "System Sounds": "시스템 소리"
+  },
+  "System Tray": {
+    "System Tray": "시스템 트레이"
+  },
+  "System Tray Icon Tint": {
+    "System Tray Icon Tint": "시스템 트레이 아이콘 색조"
+  },
+  "System Update": {
+    "System Update": "시스템 업데이트"
+  },
+  "System Updater": {
+    "System Updater": "시스템 업데이터"
+  },
+  "System Updates": {
+    "System Updates": "시스템 업데이트"
+  },
+  "System notification area icons": {
+    "System notification area icons": "시스템 알림 영역 아이콘"
+  },
+  "System sounds are not available. Install %1 for sound support.": {
+    "System sounds are not available. Install %1 for sound support.": "시스템 소리를 사용할 수 없습니다. 소리 지원을 위해 %1을(를) 설치하세요."
+  },
+  "System theme toggle": {
+    "System theme toggle": "시스템 테마 토글"
+  },
+  "System toast notifications": {
+    "System toast notifications": "시스템 토스트 알림"
+  },
+  "Systemd Override generated": {
+    "Systemd Override generated": "Systemd 오버라이드 생성됨"
+  },
+  "Tab": {
+    "Tab": "탭"
+  },
+  "Tab/Shift+Tab: Nav • ←→↑↓: Grid Nav • Enter/Space: Select": {
+    "Tab/Shift+Tab: Nav • ←→↑↓: Grid Nav • Enter/Space: Select": "Tab/Shift+Tab: 탐색 • ←→↑↓: 그리드 탐색 • Enter/Space: 선택"
+  },
+  "Tags": {
+    "Tags": "태그"
+  },
+  "Tags: %1": {
+    "Tags: %1": "태그: %1"
+  },
+  "Tailscale": {
+    "Tailscale": "Tailscale"
+  },
+  "Tailscale Network": {
+    "Tailscale Network": "Tailscale 네트워크"
+  },
+  "Tailscale action failed": {
+    "Tailscale action failed": "Tailscale 작업 실패"
+  },
+  "Tailscale not available": {
+    "Tailscale not available": "Tailscale을 사용할 수 없음"
+  },
+  "Terminal": {
+    "Terminal": "터미널"
+  },
+  "Terminal additional parameters": {
+    "Terminal additional parameters": "터미널 추가 매개변수"
+  },
+  "Terminal fallback failed. Install a supported terminal emulator or run 'dms auth sync' manually.": {
+    "Terminal fallback failed. Install a supported terminal emulator or run 'dms auth sync' manually.": "터미널 대체를 실패했습니다. 지원되는 터미널 에뮬레이터를 설치하거나 'dms auth sync'를 수동으로 실행하세요."
+  },
+  "Terminal fallback failed. Install one of the supported terminal emulators or run 'dms greeter sync' manually.": {
+    "Terminal fallback failed. Install one of the supported terminal emulators or run 'dms greeter sync' manually.": "터미널 대체를 실패했습니다. 지원되는 터미널 에뮬레이터 중 하나를 설치하거나 'dms greeter sync'를 수동으로 실행하세요."
+  },
+  "Terminal fallback opened. Complete authentication setup there; it will close automatically when done.": {
+    "Terminal fallback opened. Complete authentication setup there; it will close automatically when done.": "터미널 대체가 열렸습니다. 거기에서 인증 설정을 완료하세요. 완료되면 자동으로 닫힙니다."
+  },
+  "Terminal fallback opened. Complete sync there; it will close automatically when done.": {
+    "Terminal fallback opened. Complete sync there; it will close automatically when done.": "터미널 대체가 열렸습니다. 거기에서 동기화를 완료하세요. 완료되면 자동으로 닫힙니다."
+  },
+  "Terminal multiplexer backend to use": {
+    "Terminal multiplexer backend to use": "사용할 터미널 멀티플렉서 백엔드"
+  },
+  "Terminal opened. Complete authentication setup there; it will close automatically when done.": {
+    "Terminal opened. Complete authentication setup there; it will close automatically when done.": "터미널이 열렸습니다. 거기에서 인증 설정을 완료하세요. 완료되면 자동으로 닫힙니다."
+  },
+  "Terminal opened. Complete sync authentication there; it will close automatically when done.": {
+    "Terminal opened. Complete sync authentication there; it will close automatically when done.": "터미널이 열렸습니다. 거기에서 동기화 인증을 완료하세요. 완료되면 자동으로 닫힙니다."
+  },
+  "Terminals - Always use Dark Theme": {
+    "Terminals - Always use Dark Theme": "터미널 - 항상 다크 테마 사용"
+  },
+  "Tertiary": {
+    "Tertiary": "제3의"
+  },
+  "Tertiary Container": {
+    "Tertiary Container": "제3의 컨테이너"
+  },
+  "Test Connection": {
+    "Test Connection": "연결 테스트"
+  },
+  "Test Page": {
+    "Test Page": "테스트 페이지"
+  },
+  "Test page sent to printer": {
+    "Test page sent to printer": "테스트 페이지가 프린터로 전송됨"
+  },
+  "Testing...": {
+    "Testing...": "테스트 중..."
+  },
+  "Text": {
+    "Text": "텍스트"
+  },
+  "Text Color": {
+    "Text Color": "텍스트 색상"
+  },
+  "Text Editor": {
+    "Text Editor": "텍스트 편집기"
+  },
+  "Text Rendering": {
+    "Text Rendering": "텍스트 렌더링"
+  },
+  "The 'dgop' tool is required for system monitoring.\nPlease install dgop to use this feature.": {
+    "The 'dgop' tool is required for system monitoring.\nPlease install dgop to use this feature.": "시스템 모니터링을 위해서는 'dgop' 도구가 필요합니다.\n이 기능을 사용하려면 dgop를 설치하세요."
+  },
+  "The DMS_SOCKET environment variable is not set or the socket is unavailable. Automated plugin management requires the DMS_SOCKET.": {
+    "The DMS_SOCKET environment variable is not set or the socket is unavailable. Automated plugin management requires the DMS_SOCKET.": "DMS_SOCKET 환경 변수가 설정되지 않았거나 소켓을 사용할 수 없습니다. 자동 플러그인 관리에는 DMS_SOCKET이 필요합니다."
+  },
+  "The below settings will modify your GTK and Qt settings. If you wish to preserve your current configurations, please back them up (qt5ct.conf|qt6ct.conf and ~/.config/gtk-3.0|gtk-4.0).": {
+    "The below settings will modify your GTK and Qt settings. If you wish to preserve your current configurations, please back them up (qt5ct.conf|qt6ct.conf and ~/.config/gtk-3.0|gtk-4.0).": "아래 설정은 GTK 및 Qt 설정을 수정합니다. 현재 구성을 유지하려면 백업하세요(qt5ct.conf|qt6ct.conf 및 ~/.config/gtk-3.0|gtk-4.0)."
+  },
+  "The custom command used when attaching to sessions (receives the session name as the first argument)": {
+    "The custom command used when attaching to sessions (receives the session name as the first argument)": "세션에 연결할 때 사용되는 사용자 지정 명령어(세션 이름을 첫 번째 인수로 받음)"
+  },
+  "The job queue of this printer is empty": {
+    "The job queue of this printer is empty": "이 프린터의 작업 대기열이 비어 있습니다."
+  },
+  "The rule applies to any window matching one of these.": {
+    "The rule applies to any window matching one of these.": "규칙은 이 중 하나와 일치하는 모든 창에 적용됩니다."
+  },
+  "Theme & Colors": {
+    "Theme & Colors": "테마 및 색상"
+  },
+  "Theme Color": {
+    "Theme Color": "테마 색상"
+  },
+  "Theme Registry": {
+    "Theme Registry": "테마 레지스트리"
+  },
+  "Theme color used for the border": {
+    "Theme color used for the border": "테마 색상이 테두리에 사용됨"
+  },
+  "Theme color used for the widget outline": {
+    "Theme color used for the widget outline": "테마 색상이 위젯 윤곽선에 사용됨"
+  },
+  "Theme worker failed (%1)": {
+    "Theme worker failed (%1)": "테마 작업자 실패(%1)"
+  },
+  "Themes": {
+    "Themes": "테마"
+  },
+  "These add entries to the XDG autostart directory (~/.config/autostart/*.desktop)": {
+    "These add entries to the XDG autostart directory (~/.config/autostart/*.desktop)": "이는 XDG 자동 시작 디렉터리(~/.config/autostart/*.desktop)에 항목을 추가합니다."
+  },
+  "Thickness": {
+    "Thickness": "두께"
+  },
+  "Thin": {
+    "Thin": "매우 얇게"
+  },
+  "Third-Party Plugin Warning": {
+    "Third-Party Plugin Warning": "타사 플러그인 경고"
+  },
+  "Third-party plugins are created by the community and are not officially supported by DankMaterialShell.\n\nThese plugins may pose security and privacy risks - install at your own risk.": {
+    "Third-party plugins are created by the community and are not officially supported by DankMaterialShell.\n\nThese plugins may pose security and privacy risks - install at your own risk.": "타사 플러그인은 커뮤니티에서 만들었으며 DankMaterialShell에서 공식적으로 지원하지 않습니다.\n\n이러한 플러그인은 보안 및 개인 정보 보호 위험을 초래할 수 있습니다. 본인의 책임하에 설치하세요."
+  },
+  "This bind is overridden by config.kdl": {
+    "This bind is overridden by config.kdl": "이 바인딩은 config.kdl에 의해 오버라이드됨"
+  },
+  "This device": {
+    "This device": "이 기기"
+  },
+  "This install is still using hyprland.conf. Run dms setup to migrate before editing cursor settings.": {
+    "This install is still using hyprland.conf. Run dms setup to migrate before editing cursor settings.": "이 설치는 여전히 hyprland.conf를 사용하고 있습니다. 커서 설정을 편집하기 전에 dms setup을 실행하여 마이그레이션하세요."
+  },
+  "This install is still using hyprland.conf. Run dms setup to migrate before editing display settings.": {
+    "This install is still using hyprland.conf. Run dms setup to migrate before editing display settings.": "이 설치는 여전히 hyprland.conf를 사용하고 있습니다. 디스플레이 설정을 편집하기 전에 dms setup을 실행하여 마이그레이션하세요."
+  },
+  "This install is still using hyprland.conf. Run dms setup to migrate before editing layout settings.": {
+    "This install is still using hyprland.conf. Run dms setup to migrate before editing layout settings.": "이 설치는 여전히 hyprland.conf를 사용하고 있습니다. 레이아웃 설정을 편집하기 전에 dms setup을 실행하여 마이그레이션하세요."
+  },
+  "This install is still using hyprland.conf. Run dms setup to migrate before editing shortcuts in Settings.": {
+    "This install is still using hyprland.conf. Run dms setup to migrate before editing shortcuts in Settings.": "이 설치는 여전히 hyprland.conf를 사용하고 있습니다. 설정에서 바로 가기를 편집하기 전에 dms setup을 실행하여 마이그레이션하세요."
+  },
+  "This install is still using hyprland.conf. Run dms setup to migrate before editing window rules in Settings.": {
+    "This install is still using hyprland.conf. Run dms setup to migrate before editing window rules in Settings.": "이 설치는 여전히 hyprland.conf를 사용하고 있습니다. 설정에서 창 규칙을 편집하기 전에 dms setup을 실행하여 마이그레이션하세요."
+  },
+  "This may take a few seconds": {
+    "This may take a few seconds": "몇 초 정도 걸릴 수 있습니다"
+  },
+  "This output is disabled in the current profile": {
+    "This output is disabled in the current profile": "현재 프로필에서 이 출력이 비활성화됨"
+  },
+  "This plugin does not have 'settings_write' permission.\n\nAdd \"permissions\": [\"settings_read\", \"settings_write\"] to plugin.json": {
+    "This plugin does not have 'settings_write' permission.\n\nAdd \"permissions\": [\"settings_read\", \"settings_write\"] to plugin.json": "이 플러그인에는 'settings_write' 권한이 없습니다.\n\nplugin.json에 \"permissions\": [\"settings_read\", \"settings_write\"]를 추가하세요."
+  },
+  "This widget prevents GPU power off states, which can significantly impact battery life on laptops. It is not recommended to use this on laptops with hybrid graphics.": {
+    "This widget prevents GPU power off states, which can significantly impact battery life on laptops. It is not recommended to use this on laptops with hybrid graphics.": "이 위젯은 GPU 전원 끄기 상태를 방지하여 노트북의 배터리 수명에 큰 영향을 미칠 수 있습니다. 하이브리드 그래픽이 있는 노트북에서는 사용하지 않는 것이 좋습니다."
+  },
+  "This will delete all unpinned entries. %1 pinned entries will be kept.": {
+    "This will delete all unpinned entries. %1 pinned entries will be kept.": "모든 고정 해제된 항목이 삭제됩니다. %1개의 고정된 항목이 유지됩니다."
+  },
+  "This will permanently delete all clipboard history.": {
+    "This will permanently delete all clipboard history.": "클립보드 기록이 영구적으로 삭제됩니다."
+  },
+  "This will permanently remove this saved clipboard item. This action cannot be undone.": {
+    "This will permanently remove this saved clipboard item. This action cannot be undone.": "이 저장된 클립보드 항목이 영구적으로 제거됩니다. 이 작업은 취소할 수 없습니다."
+  },
+  "Thunderstorm": {
+    "Thunderstorm": "뇌우"
+  },
+  "Thunderstorm with Hail": {
+    "Thunderstorm with Hail": "우박을 동반한 뇌우"
+  },
+  "Tile": {
+    "Tile": "타일"
+  },
+  "Tile Horizontally": {
+    "Tile Horizontally": "가로로 타일"
+  },
+  "Tile Vertically": {
+    "Tile Vertically": "세로로 타일"
+  },
+  "Tiled": {
+    "Tiled": "타일링됨"
+  },
+  "Tiled State": {
+    "Tiled State": "타일링된 상태"
+  },
+  "Tiling": {
+    "Tiling": "타일링"
+  },
+  "Time": {
+    "Time": "시간"
+  },
+  "Time & Date Locale": {
+    "Time & Date Locale": "시간 및 날짜 로캘"
+  },
+  "Time & Weather": {
+    "Time & Weather": "시간 및 날짜"
+  },
+  "Time Format": {
+    "Time Format": "시간 형식"
+  },
+  "Time remaining: %1": {
+    "Time remaining: %1": "남은 시간: %1"
+  },
+  "Time to rest on a widget before its popout opens": {
+    "Time to rest on a widget before its popout opens": "팝아웃이 열리기 전에 위젯에 머무를 시간"
+  },
+  "Time to wait before hiding after the pointer leaves": {
+    "Time to wait before hiding after the pointer leaves": "포인터가 벗어난 후 숨기기 전에 대기할 시간"
+  },
+  "Time until full: %1": {
+    "Time until full: %1": "가득 찰 때까지 남은 시간: %1"
+  },
+  "Timed Out": {
+    "Timed Out": "시간 초과됨"
+  },
+  "Timeout Progress Bar": {
+    "Timeout Progress Bar": "시간 초과 진행률 바"
+  },
+  "Timeout for critical priority notifications": {
+    "Timeout for critical priority notifications": "중요 우선순위 알림의 시간 초과"
+  },
+  "Timeout for low priority notifications": {
+    "Timeout for low priority notifications": "낮은 우선순위 알림의 시간 초과"
+  },
+  "Timeout for normal priority notifications": {
+    "Timeout for normal priority notifications": "보통 우선순위 알림의 시간 초과"
+  },
+  "Tint Saturation": {
+    "Tint Saturation": "색조 채도"
+  },
+  "Tint Strength": {
+    "Tint Strength": "색조 강도"
+  },
+  "Title": {
+    "Title": "제목"
+  },
+  "Title (optional)": {
+    "Title (optional)": "제목(선택 사항)"
+  },
+  "Title is required": {
+    "Title is required": "제목은 필수입니다"
+  },
+  "Title regex (optional)": {
+    "Title regex (optional)": "제목 정규식(선택 사항)"
+  },
+  "To Full": {
+    "To Full": "가득 참으로"
+  },
+  "To sign in as a different user, log out and pick the account from the greeter. Creating a fresh session in parallel needs a multi-session greeter (greetd-flexiserver / GDM / LightDM).": {
+    "To sign in as a different user, log out and pick the account from the greeter. Creating a fresh session in parallel needs a multi-session greeter (greetd-flexiserver / GDM / LightDM).": "다른 사용자로 로그인하려면 로그아웃하고 로그인 화면에서 계정을 선택하세요. 병렬로 새 세션을 만들려면 다중 세션 로그인 화면(greetd-flexiserver / GDM / LightDM)이 필요합니다."
+  },
+  "To update, run the following command:": {
+    "To update, run the following command:": "업데이트하려면 다음 명령을 실행하세요:"
+  },
+  "To use this DMS bind, remove or change the keybind in your config.kdl": {
+    "To use this DMS bind, remove or change the keybind in your config.kdl": "이 DMS 바인딩을 사용하려면 config.kdl에서 단축키를 제거하거나 변경하세요"
+  },
+  "Toast": {
+    "Toast": "토스트"
+  },
+  "Toast Messages": {
+    "Toast Messages": "토스트 메시지"
+  },
+  "Today": {
+    "Today": "오늘"
+  },
+  "Toggle bar visibility manually via IPC": {
+    "Toggle bar visibility manually via IPC": "IPC를 통해 수동으로 바 가시성 토글"
+  },
+  "Toggle fonts": {
+    "Toggle fonts": "글꼴 토글"
+  },
+  "Toggle visibility of this bar configuration": {
+    "Toggle visibility of this bar configuration": "이 바 구성의 가시성 토글"
+  },
+  "Toggling...": {
+    "Toggling...": "토글 중..."
+  },
+  "Tomorrow": {
+    "Tomorrow": "내일"
+  },
+  "Tonal Spot": {
+    "Tonal Spot": "색조 지점"
+  },
+  "Toner Empty": {
+    "Toner Empty": "토너 부족"
+  },
+  "Toner Low": {
+    "Toner Low": "토너 적음"
+  },
+  "Too many attempts - locked out": {
+    "Too many attempts - locked out": "시도 횟수 너무 많음 - 잠김"
+  },
+  "Too many failed attempts - account may be locked": {
+    "Too many failed attempts - account may be locked": "실패한 시도 횟수 너무 많음 - 계정이 잠길 수 있음"
+  },
+  "Tools": {
+    "Tools": "도구"
+  },
+  "Top": {
+    "Top": "위쪽"
+  },
+  "Top (Default)": {
+    "Top (Default)": "위쪽(기본값)"
+  },
+  "Top Bar Format": {
+    "Top Bar Format": "상단 바 형식"
+  },
+  "Top Center": {
+    "Top Center": "상단 중앙"
+  },
+  "Top Left": {
+    "Top Left": "왼쪽 상단"
+  },
+  "Top Processes": {
+    "Top Processes": "상위 프로세스"
+  },
+  "Top Right": {
+    "Top Right": "오른쪽 상단"
+  },
+  "Top Section": {
+    "Top Section": "상단 구역"
+  },
+  "Total": {
+    "Total": "전체"
+  },
+  "Total Jobs": {
+    "Total Jobs": "전체 작업"
+  },
+  "Touch your security key...": {
+    "Touch your security key...": "보안 키를 터치하세요..."
+  },
+  "Transform": {
+    "Transform": "변환"
+  },
+  "Transition Effect": {
+    "Transition Effect": "전환 효과"
+  },
+  "Transparency": {
+    "Transparency": "투명도"
+  },
+  "Trash": {
+    "Trash": "휴지통"
+  },
+  "Trash command failed (exit %1)": {
+    "Trash command failed (exit %1)": "휴지통 명령 실패(종료 %1)"
+  },
+  "Tray Icon Fix": {
+    "Tray Icon Fix": "트레이 아이콘 수정"
+  },
+  "Trending GIFs": {
+    "Trending GIFs": "인기 있는 GIF"
+  },
+  "Trending Stickers": {
+    "Trending Stickers": "인기 있는 스티커"
+  },
+  "Trigger": {
+    "Trigger": "트리거"
+  },
+  "Trigger Prefix": {
+    "Trigger Prefix": "트리거 접두사"
+  },
+  "Trigger: %1": {
+    "Trigger: %1": "트리거: %1"
+  },
+  "Trust": {
+    "Trust": "신뢰"
+  },
+  "Try a different search": {
+    "Try a different search": "다른 검색 시도"
+  },
+  "Try a different search or switch filters.": {
+    "Try a different search or switch filters.": "다른 검색을 시도하거나 필터를 전환하세요."
+  },
+  "Turn off": {
+    "Turn off": "끄기"
+  },
+  "Turn off Do Not Disturb": {
+    "Turn off Do Not Disturb": "방해 금지 끄기"
+  },
+  "Turn off all displays immediately when the lock screen activates": {
+    "Turn off all displays immediately when the lock screen activates": "잠금 화면이 활성화되면 즉시 모든 디스플레이 끄기"
+  },
+  "Turn off monitors after": {
+    "Turn off monitors after": "다음 시간 후 모니터 끄기"
+  },
+  "Turn off monitors after lock": {
+    "Turn off monitors after lock": "잠금 후 모니터 끄기"
+  },
+  "Turn off now": {
+    "Turn off now": "지금 끄기"
+  },
+  "Type": {
+    "Type": "유형"
+  },
+  "Type at least 2 characters": {
+    "Type at least 2 characters": "2자 이상 입력"
+  },
+  "Type at least 2 characters to search files.": {
+    "Type at least 2 characters to search files.": "파일을 검색하려면 2자 이상 입력하세요."
+  },
+  "Type this prefix to search keybinds": {
+    "Type this prefix to search keybinds": "단축키를 검색하려면 이 접두사 입력"
+  },
+  "Type to search files": {
+    "Type to search files": "파일을 검색하려면 입력"
+  },
+  "Typography": {
+    "Typography": "타이포그래피"
+  },
+  "Typography & Motion": {
+    "Typography & Motion": "타이포그래피 및 모션"
+  },
+  "URI": {
+    "URI": "URI"
+  },
+  "Unavailable": {
+    "Unavailable": "사용할 수 없음"
+  },
+  "Uncategorized": {
+    "Uncategorized": "미분류"
+  },
+  "Unfocused Color": {
+    "Unfocused Color": "포커스되지 않은 색상"
+  },
+  "Unfocused Display(s)": {
+    "Unfocused Display(s)": "포커스되지 않은 디스플레이"
+  },
+  "Ungrouped": {
+    "Ungrouped": "그룹화되지 않음"
+  },
+  "Uninstall": {
+    "Uninstall": "제거"
+  },
+  "Uninstall Greeter": {
+    "Uninstall Greeter": "로그인 화면 제거"
+  },
+  "Uninstall Plugin": {
+    "Uninstall Plugin": "플러그인 제거"
+  },
+  "Uninstall complete. Greeter has been removed.": {
+    "Uninstall complete. Greeter has been removed.": "제거 완료. 로그인 화면이 제거되었습니다."
+  },
+  "Uninstall failed: %1": {
+    "Uninstall failed: %1": "제거 실패: %1"
+  },
+  "Uninstall the DMS greeter? This will remove configuration and restore your previous display manager. A terminal will open for sudo authentication.": {
+    "Uninstall the DMS greeter? This will remove configuration and restore your previous display manager. A terminal will open for sudo authentication.": "DMS 로그인 화면을 제거하시겠습니까? 구성을 제거하고 이전 디스플레이 관리자를 복원합니다. sudo 인증을 위해 터미널이 열립니다."
+  },
+  "Uninstalled: %1": {
+    "Uninstalled: %1": "제거됨: %1"
+  },
+  "Uninstalling: %1": {
+    "Uninstalling: %1": "제거 중: %1"
+  },
+  "Unknown": {
+    "Unknown": "알 수 없음"
+  },
+  "Unknown App": {
+    "Unknown App": "알 수 없는 앱"
+  },
+  "Unknown Artist": {
+    "Unknown Artist": "알 수 없는 아티스트"
+  },
+  "Unknown Config": {
+    "Unknown Config": "알 수 없는 구성"
+  },
+  "Unknown Device": {
+    "Unknown Device": "알 수 없는 기기"
+  },
+  "Unknown GPU": {
+    "Unknown GPU": "알 수 없는 GPU"
+  },
+  "Unknown Model": {
+    "Unknown Model": "알 수 없는 모델"
+  },
+  "Unknown Monitor": {
+    "Unknown Monitor": "알 수 없는 모니터"
+  },
+  "Unknown Network": {
+    "Unknown Network": "알 수 없는 네트워크"
+  },
+  "Unknown Title": {
+    "Unknown Title": "알 수 없는 제목"
+  },
+  "Unknown Track": {
+    "Unknown Track": "알 수 없는 트랙"
+  },
+  "Unload on Close": {
+    "Unload on Close": "닫을 때 언로드"
+  },
+  "Unmute": {
+    "Unmute": "음소거 해제"
+  },
+  "Unmute popups for %1": {
+    "Unmute popups for %1": "%1에 대한 팝업 음소거 해제"
+  },
+  "Unnamed Rule": {
+    "Unnamed Rule": "이름 없는 규칙"
+  },
+  "Unpair": {
+    "Unpair": "페어링 해제"
+  },
+  "Unpair failed": {
+    "Unpair failed": "페어링 해제 실패"
+  },
+  "Unpin": {
+    "Unpin": "고정 해제"
+  },
+  "Unpin from Dock": {
+    "Unpin from Dock": "독에서 고정 해제"
+  },
+  "Unsaved Changes": {
+    "Unsaved Changes": "저장되지 않은 변경 사항"
+  },
+  "Unsaved changes": {
+    "Unsaved changes": "저장되지 않은 변경 사항"
+  },
+  "Unset": {
+    "Unset": "설정 해제"
+  },
+  "Until %1": {
+    "Until %1": "%1까지"
+  },
+  "Until 8 AM": {
+    "Until 8 AM": "오전 8시까지"
+  },
+  "Until I turn it off": {
+    "Until I turn it off": "끌 때까지"
+  },
+  "Until tomorrow, 8:00 AM": {
+    "Until tomorrow, 8:00 AM": "내일 오전 8:00까지"
+  },
+  "Untitled": {
+    "Untitled": "제목 없음"
+  },
+  "Untrust": {
+    "Untrust": "신뢰 해제"
+  },
+  "Up to date": {
+    "Up to date": "최신 상태"
+  },
+  "Update": {
+    "Update": "업데이트"
+  },
+  "Update All": {
+    "Update All": "모두 업데이트"
+  },
+  "Update Plugin": {
+    "Update Plugin": "플러그인 업데이트"
+  },
+  "Update failed: %1": {
+    "Update failed: %1": "업데이트 실패: %1"
+  },
+  "Updating %1...": {
+    "Updating %1...": "%1 업데이트 중..."
+  },
+  "Updating plugins...": {
+    "Updating plugins...": "플러그인 업데이트 중..."
+  },
+  "Upgrading...": {
+    "Upgrading...": "업그레이드 중..."
+  },
+  "Uptime": {
+    "Uptime": "가동 시간"
+  },
+  "Uptime:": {
+    "Uptime:": "가동 시간:"
+  },
+  "Urgent": {
+    "Urgent": "긴급"
+  },
+  "Urgent Color": {
+    "Urgent Color": "긴급 색상"
+  },
+  "Usage Tips": {
+    "Usage Tips": "사용 팁"
+  },
+  "Use 24-hour time format instead of 12-hour AM/PM": {
+    "Use 24-hour time format instead of 12-hour AM/PM": "12시간제 AM/PM 대신 24시간제 형식 사용"
+  },
+  "Use Custom Command": {
+    "Use Custom Command": "사용자 지정 명령 사용"
+  },
+  "Use Grid Layout": {
+    "Use Grid Layout": "그리드 레이아웃 사용"
+  },
+  "Use HH:MM time format": {
+    "Use HH:MM time format": "HH:MM 시간 형식 사용"
+  },
+  "Use IP Location": {
+    "Use IP Location": "IP 위치 사용"
+  },
+  "Use Imperial Units": {
+    "Use Imperial Units": "야드파운드법 단위 사용"
+  },
+  "Use Imperial units (°F, mph, inHg) instead of Metric (°C, km/h, hPa)": {
+    "Use Imperial units (°F, mph, inHg) instead of Metric (°C, km/h, hPa)": "미터법(°C, km/h, hPa) 대신 야드파운드법 단위(°F, mph, inHg) 사용"
+  },
+  "Use Inline Expansion": {
+    "Use Inline Expansion": "인라인 확장 사용"
+  },
+  "Use Monospace Font": {
+    "Use Monospace Font": "고정폭 글꼴 사용"
+  },
+  "Use Overlay Layer": {
+    "Use Overlay Layer": "오버레이 레이어 사용"
+  },
+  "Use System Theme": {
+    "Use System Theme": "시스템 테마 사용"
+  },
+  "Use a custom image for the lock screen, or leave empty to use your desktop wallpaper.": {
+    "Use a custom image for the lock screen, or leave empty to use your desktop wallpaper.": "잠금 화면에 사용자 지정 이미지를 사용하거나 데스크톱 배경화면을 사용하려면 비워 두세요."
+  },
+  "Use a custom image for the login screen, or leave empty to use your desktop wallpaper.": {
+    "Use a custom image for the login screen, or leave empty to use your desktop wallpaper.": "로그인 화면에 사용자 지정 이미지를 사용하거나 데스크톱 배경화면을 사용하려면 비워 두세요."
+  },
+  "Use a custom radius for goth corner cutouts": {
+    "Use a custom radius for goth corner cutouts": "고딕 모서리 절단에 사용자 지정 반경 사용"
+  },
+  "Use a fixed shadow direction for this bar": {
+    "Use a fixed shadow direction for this bar": "이 바에 고정된 그림자 방향 사용"
+  },
+  "Use a security key for lock screen authentication.": {
+    "Use a security key for lock screen authentication.": "잠금 화면 인증에 보안 키를 사용합니다."
+  },
+  "Use an external wallpaper manager like swww, hyprpaper, or swaybg.": {
+    "Use an external wallpaper manager like swww, hyprpaper, or swaybg.": "swww, hyprpaper 또는 swaybg와 같은 외부 배경화면 관리자를 사용합니다."
+  },
+  "Use animated wave progress bars for media playback": {
+    "Use animated wave progress bars for media playback": "미디어 재생에 애니메이션 웨이브 진행률 바 사용"
+  },
+  "Use custom border size": {
+    "Use custom border size": "사용자 지정 테두리 크기 사용"
+  },
+  "Use custom border/focus-ring width": {
+    "Use custom border/focus-ring width": "사용자 지정 테두리/포커스 링 너비 사용"
+  },
+  "Use custom window radius instead of theme radius": {
+    "Use custom window radius instead of theme radius": "테마 반경 대신 사용자 지정 창 반경 사용"
+  },
+  "Use desktop wallpaper": {
+    "Use desktop wallpaper": "데스크톱 배경화면 사용"
+  },
+  "Use different icon themes for light and dark mode": {
+    "Use different icon themes for light and dark mode": "라이트 모드와 다크 모드에 다른 아이콘 테마 사용"
+  },
+  "Use different workspace colors on displays that are not focused": {
+    "Use different workspace colors on displays that are not focused": "포커스되지 않은 디스플레이에 다른 작업 공간 색상 사용"
+  },
+  "Use fingerprint authentication for the lock screen.": {
+    "Use fingerprint authentication for the lock screen.": "잠금 화면에 지문 인증을 사용합니다."
+  },
+  "Use keys 1-3 or arrows, Enter/Space to select": {
+    "Use keys 1-3 or arrows, Enter/Space to select": "키 1-3 또는 화살표, Enter/Space를 사용하여 선택"
+  },
+  "Use light theme instead of dark theme": {
+    "Use light theme instead of dark theme": "다크 테마 대신 라이트 테마 사용"
+  },
+  "Use meters per second instead of km/h for wind speed": {
+    "Use meters per second instead of km/h for wind speed": "풍속에 km/h 대신 초당 미터 사용"
+  },
+  "Use one inset value for every bar": {
+    "Use one inset value for every bar": "모든 바에 하나의 삽입 값 사용"
+  },
+  "Use smaller notification cards": {
+    "Use smaller notification cards": "더 작은 알림 카드 사용"
+  },
+  "Use sound theme from system settings": {
+    "Use sound theme from system settings": "시스템 설정의 소리 테마 사용"
+  },
+  "Use the extended surface for launcher content": {
+    "Use the extended surface for launcher content": "런처 내용에 확장된 표면 사용"
+  },
+  "Use the overlay layer when opening the launcher": {
+    "Use the overlay layer when opening the launcher": "런처를 열 때 오버레이 레이어 사용"
+  },
+  "Use the same position and size on all displays": {
+    "Use the same position and size on all displays": "모든 디스플레이에 같은 위치 및 크기 사용"
+  },
+  "Use trigger prefix to activate": {
+    "Use trigger prefix to activate": "활성화하려면 트리거 접두사 사용"
+  },
+  "Used for xdg-terminal-exec": {
+    "Used for xdg-terminal-exec": "xdg-terminal-exec에 사용됨"
+  },
+  "Used when accent color is set to Custom": {
+    "Used when accent color is set to Custom": "강조 색상이 사용자 지정으로 설정된 경우 사용됨"
+  },
+  "User": {
+    "User": "사용자"
+  },
+  "User Window Rules (%1)": {
+    "User Window Rules (%1)": "사용자 창 규칙(%1)"
+  },
+  "User already exists": {
+    "User already exists": "사용자가 이미 존재함"
+  },
+  "User created": {
+    "User created": "사용자 생성됨"
+  },
+  "User created with administrator and greeter login access": {
+    "User created with administrator and greeter login access": "관리자 및 로그인 화면 로그인 접근 권한이 있는 사용자 생성됨"
+  },
+  "User created with administrator privileges": {
+    "User created with administrator privileges": "관리자 권한이 있는 사용자 생성됨"
+  },
+  "User created with greeter login access": {
+    "User created with greeter login access": "로그인 화면 로그인 접근 권한이 있는 사용자 생성됨"
+  },
+  "User deleted": {
+    "User deleted": "사용자 삭제됨"
+  },
+  "User not found": {
+    "User not found": "사용자를 찾을 수 없음"
+  },
+  "Username": {
+    "Username": "사용자 이름"
+  },
+  "Username must start with a lowercase letter or underscore and contain only lowercase letters, digits, hyphens, or underscores.": {
+    "Username must start with a lowercase letter or underscore and contain only lowercase letters, digits, hyphens, or underscores.": "사용자 이름은 소문자나 밑줄로 시작해야 하며 소문자, 숫자, 하이픈 또는 밑줄만 포함해야 합니다."
+  },
+  "Username...": {
+    "Username...": "사용자 이름..."
+  },
+  "Users": {
+    "Users": "사용자"
+  },
+  "Uses sunrise/sunset times based on your location.": {
+    "Uses sunrise/sunset times based on your location.": "위치에 따라 일출/일몰 시간을 사용합니다."
+  },
+  "Uses sunrise/sunset times to automatically adjust night mode based on your location.": {
+    "Uses sunrise/sunset times to automatically adjust night mode based on your location.": "위치에 따라 야간 모드를 자동으로 조정하기 위해 일출/일몰 시간을 사용합니다."
+  },
+  "Uses the spotlight-bar IPC action and always opens the minimal bar.": {
+    "Uses the spotlight-bar IPC action and always opens the minimal bar.": "스포트라이트 바 IPC 작업을 사용하며 항상 최소 바를 엽니다."
+  },
+  "Using DankCalendar%1": {
+    "Using DankCalendar%1": "DankCalendar 사용 중%1"
+  },
+  "Using global monospace font from Settings → Personalization": {
+    "Using global monospace font from Settings → Personalization": "설정 → 개인 설정에서 전역 고정폭 글꼴 사용 중"
+  },
+  "Using khal": {
+    "Using khal": "khal 사용 중"
+  },
+  "Using shared settings from Gamma Control": {
+    "Using shared settings from Gamma Control": "감마 제어에서 공유 설정 사용 중"
+  },
+  "Utilities": {
+    "Utilities": "유틸리티"
+  },
+  "VPN": {
+    "VPN": "VPN"
+  },
+  "VPN Connections": {
+    "VPN Connections": "VPN 연결"
+  },
+  "VPN configuration updated": {
+    "VPN configuration updated": "VPN 구성 업데이트됨"
+  },
+  "VPN credentials saved": {
+    "VPN credentials saved": "VPN 자격 증명 저장됨"
+  },
+  "VPN deleted": {
+    "VPN deleted": "VPN 삭제됨"
+  },
+  "VPN imported: %1": {
+    "VPN imported: %1": "VPN 가져옴: %1"
+  },
+  "VPN not available": {
+    "VPN not available": "VPN을 사용할 수 없음"
+  },
+  "VPN status and quick connect": {
+    "VPN status and quick connect": "VPN 상태 및 빠른 연결"
+  },
+  "VRR": {
+    "VRR": "VRR"
+  },
+  "VRR Fullscreen Only": {
+    "VRR Fullscreen Only": "VRR 전체 화면 전용"
+  },
+  "VRR On-Demand": {
+    "VRR On-Demand": "주문형 VRR"
+  },
+  "Variable Refresh Rate": {
+    "Variable Refresh Rate": "가변 주사율"
+  },
+  "Verification": {
+    "Verification": "확인"
+  },
+  "Version": {
+    "Version": "버전"
+  },
+  "Vertical Deck": {
+    "Vertical Deck": "세로 데크"
+  },
+  "Vertical Grid": {
+    "Vertical Grid": "세로 그리드"
+  },
+  "Vertical Scrolling": {
+    "Vertical Scrolling": "세로 스크롤"
+  },
+  "Vertical Tiling": {
+    "Vertical Tiling": "세로 타일링"
+  },
+  "Very High": {
+    "Very High": "매우 높음"
+  },
+  "Vibrant": {
+    "Vibrant": "생생함"
+  },
+  "Vibrant palette with playful saturation.": {
+    "Vibrant palette with playful saturation.": "장난스러운 채도가 있는 생생한 팔레트."
+  },
+  "Video Path": {
+    "Video Path": "비디오 경로"
+  },
+  "Video Player": {
+    "Video Player": "비디오 플레이어"
+  },
+  "Video Screensaver": {
+    "Video Screensaver": "비디오 화면 보호기"
+  },
+  "Videos": {
+    "Videos": "비디오"
+  },
+  "View Mode": {
+    "View Mode": "보기 모드"
+  },
+  "Visibility": {
+    "Visibility": "가시성"
+  },
+  "Visible Entry Actions": {
+    "Visible Entry Actions": "표시되는 항목 작업"
+  },
+  "Visual Effects": {
+    "Visual Effects": "시각 효과"
+  },
+  "Visual divider between widgets": {
+    "Visual divider between widgets": "위젯 사이의 시각적 구분선"
+  },
+  "Visual effect used when wallpaper changes": {
+    "Visual effect used when wallpaper changes": "배경화면이 변경될 때 사용되는 시각 효과"
+  },
+  "Volume": {
+    "Volume": "볼륨"
+  },
+  "Volume Changed": {
+    "Volume Changed": "볼륨 변경됨"
+  },
+  "Volume Slider": {
+    "Volume Slider": "볼륨 슬라이더"
+  },
+  "Volume, brightness, and other system OSDs": {
+    "Volume, brightness, and other system OSDs": "볼륨, 밝기 및 기타 시스템 OSD"
+  },
+  "Votes": {
+    "Votes": "투표수"
+  },
+  "WPA/WPA2": {
+    "WPA/WPA2": "WPA/WPA2"
+  },
+  "Wallpaper": {
+    "Wallpaper": "배경화면"
+  },
+  "Wallpaper Error": {
+    "Wallpaper Error": "배경화면 오류"
+  },
+  "Wallpaper Monitor": {
+    "Wallpaper Monitor": "배경화면 모니터"
+  },
+  "Wallpaper fill mode": {
+    "Wallpaper fill mode": "배경화면 채우기 모드"
+  },
+  "Wallpaper processing failed": {
+    "Wallpaper processing failed": "배경화면 처리 실패"
+  },
+  "Wallpaper processing failed - check wallpaper path": {
+    "Wallpaper processing failed - check wallpaper path": "배경화면 처리 실패 - 배경화면 경로 확인"
+  },
+  "Wallpapers": {
+    "Wallpapers": "배경화면"
+  },
+  "Warm color temperature to apply": {
+    "Warm color temperature to apply": "적용할 따뜻한 색 온도"
+  },
+  "Warning": {
+    "Warning": "경고"
+  },
+  "Warnings": {
+    "Warnings": "경고"
+  },
+  "Wave Progress Bars": {
+    "Wave Progress Bars": "웨이브 진행률 바"
+  },
+  "Weather": {
+    "Weather": "날씨"
+  },
+  "Weather Widget": {
+    "Weather Widget": "날씨 위젯"
+  },
+  "Web Browser": {
+    "Web Browser": "웹 브라우저"
+  },
+  "Welcome": {
+    "Welcome": "환영합니다"
+  },
+  "Welcome to DankMaterialShell": {
+    "Welcome to DankMaterialShell": "DankMaterialShell에 오신 것을 환영합니다"
+  },
+  "When clicking a dock window in a Hyprland special workspace, bring that special workspace back before focusing the window": {
+    "When clicking a dock window in a Hyprland special workspace, bring that special workspace back before focusing the window": "Hyprland 특수 작업 공간에서 독 창을 클릭할 때 창에 포커스를 맞추기 전에 해당 특수 작업 공간을 다시 가져옵니다."
+  },
+  "When enabled, apps are sorted alphabetically. When disabled, apps are sorted by usage frequency.": {
+    "When enabled, apps are sorted alphabetically. When disabled, apps are sorted by usage frequency.": "활성화되면 앱이 알파벳순으로 정렬됩니다. 비활성화되면 앱이 사용 빈도순으로 정렬됩니다."
+  },
+  "When enabled, checks updates on startup. When disabled, only the interval above or a manual refresh runs a check.": {
+    "When enabled, checks updates on startup. When disabled, only the interval above or a manual refresh runs a check.": "활성화되면 시작 시 업데이트를 확인합니다. 비활성화되면 위의 간격 또는 수동 새로 고침만 검사를 실행합니다."
+  },
+  "When locked": {
+    "When locked": "잠겼을 때"
+  },
+  "White": {
+    "White": "흰색"
+  },
+  "Wi-Fi and Ethernet connection": {
+    "Wi-Fi and Ethernet connection": "Wi-Fi 및 이더넷 연결"
+  },
+  "Wi-Fi not available": {
+    "Wi-Fi not available": "Wi-Fi를 사용할 수 없음"
+  },
+  "WiFi": {
+    "WiFi": "WiFi"
+  },
+  "WiFi Device": {
+    "WiFi Device": "WiFi 장치"
+  },
+  "WiFi QR code for ": {
+    "WiFi QR code for ": "WiFi QR 코드:"
+  },
+  "WiFi disabled": {
+    "WiFi disabled": "WiFi 비활성화됨"
+  },
+  "WiFi enabled": {
+    "WiFi enabled": "WiFi 활성화됨"
+  },
+  "WiFi is off": {
+    "WiFi is off": "WiFi가 꺼져 있습니다"
+  },
+  "WiFi off": {
+    "WiFi off": "WiFi 꺼짐"
+  },
+  "Wide (BT2020)": {
+    "Wide (BT2020)": "와이드(BT2020)"
+  },
+  "Widget Background Color": {
+    "Widget Background Color": "위젯 배경색"
+  },
+  "Widget Management": {
+    "Widget Management": "위젯 관리"
+  },
+  "Widget Opacity": {
+    "Widget Opacity": "위젯 불투명도"
+  },
+  "Widget Outline": {
+    "Widget Outline": "위젯 윤곽선"
+  },
+  "Widget Styling": {
+    "Widget Styling": "위젯 스타일"
+  },
+  "Widget Text Style": {
+    "Widget Text Style": "위젯 텍스트 스타일"
+  },
+  "Widget added": {
+    "Widget added": "위젯 추가됨"
+  },
+  "Widget removed": {
+    "Widget removed": "위젯 제거됨"
+  },
+  "Widgets": {
+    "Widgets": "위젯"
+  },
+  "Widgets & Notifications": {
+    "Widgets & Notifications": "위젯 및 알림"
+  },
+  "Widgets, layout, style": {
+    "Widgets, layout, style": "위젯, 레이아웃, 스타일"
+  },
+  "Width": {
+    "Width": "너비"
+  },
+  "Width of the border in pixels": {
+    "Width of the border in pixels": "테두리 너비(픽셀)"
+  },
+  "Width of the widget outline in pixels": {
+    "Width of the widget outline in pixels": "위젯 윤곽선 너비(픽셀)"
+  },
+  "Width of window border": {
+    "Width of window border": "창 테두리 너비"
+  },
+  "Width of window border and focus ring": {
+    "Width of window border and focus ring": "창 테두리 및 포커스 링 너비"
+  },
+  "Wind": {
+    "Wind": "바람"
+  },
+  "Wind Speed": {
+    "Wind Speed": "풍속"
+  },
+  "Wind Speed in m/s": {
+    "Wind Speed in m/s": "풍속(m/s)"
+  },
+  "Window Corner Radius": {
+    "Window Corner Radius": "창 모서리 반경"
+  },
+  "Window Gaps": {
+    "Window Gaps": "창 간격"
+  },
+  "Window Gaps (px)": {
+    "Window Gaps (px)": "창 간격(px)"
+  },
+  "Window Height": {
+    "Window Height": "창 높이"
+  },
+  "Window Opening": {
+    "Window Opening": "창 열기"
+  },
+  "Window Rules": {
+    "Window Rules": "창 규칙"
+  },
+  "Wipe": {
+    "Wipe": "닦아내기"
+  },
+  "Working...": {
+    "Working...": "작업 중..."
+  },
+  "Workspace": {
+    "Workspace": "작업 공간"
+  },
+  "Workspace Appearance": {
+    "Workspace Appearance": "작업 공간 모양"
+  },
+  "Workspace Index Numbers": {
+    "Workspace Index Numbers": "작업 공간 인덱스 번호"
+  },
+  "Workspace Names": {
+    "Workspace Names": "작업 공간 이름"
+  },
+  "Workspace Padding": {
+    "Workspace Padding": "작업 공간 여백"
+  },
+  "Workspace Settings": {
+    "Workspace Settings": "작업 공간 설정"
+  },
+  "Workspace Switcher": {
+    "Workspace Switcher": "작업 공간 전환기"
+  },
+  "Workspace name": {
+    "Workspace name": "작업 공간 이름"
+  },
+  "Workspaces": {
+    "Workspaces": "작업 공간"
+  },
+  "Wrap the app command. %command% is replaced with the actual executable": {
+    "Wrap the app command. %command% is replaced with the actual executable": "앱 명령을 래핑합니다. %command%는 실제 실행 파일로 바뀝니다."
+  },
+  "Write:": {
+    "Write:": "쓰기:"
+  },
+  "X": {
+    "X": "X"
+  },
+  "X Axis": {
+    "X Axis": "X축"
+  },
+  "X-Ray": {
+    "X-Ray": "X-Ray"
+  },
+  "XWayland": {
+    "XWayland": "XWayland"
+  },
+  "Xray Blur Effect": {
+    "Xray Blur Effect": "Xray 블러 효과"
+  },
+  "Xray blurs only the wallpaper (efficient) and is the default when Blur is on. Set Xray to Off for regular full blur of everything beneath the window (more expensive).": {
+    "Xray blurs only the wallpaper (efficient) and is the default when Blur is on. Set Xray to Off for regular full blur of everything beneath the window (more expensive).": "Xray는 배경화면만 흐리게 하며(효율적) 블러가 켜져 있을 때 기본값입니다. 창 아래의 모든 것을 정기적으로 전체 흐리게 하려면(더 비쌈) Xray를 끄기로 설정하세요."
+  },
+  "Xray options are in Compositor → Layout": {
+    "Xray options are in Compositor → Layout": "Xray 옵션은 컴포지터 → 레이아웃에 있습니다"
+  },
+  "Y": {
+    "Y": "Y"
+  },
+  "Y Axis": {
+    "Y Axis": "Y축"
+  },
+  "Yes": {
+    "Yes": "예"
+  },
+  "Yesterday": {
+    "Yesterday": "어제"
+  },
+  "You have unsaved changes. Save before closing this tab?": {
+    "You have unsaved changes. Save before closing this tab?": "저장하지 않은 변경 사항이 있습니다. 이 탭을 닫기 전에 저장하시겠습니까?"
+  },
+  "You have unsaved changes. Save before continuing?": {
+    "You have unsaved changes. Save before continuing?": "저장하지 않은 변경 사항이 있습니다. 계속하기 전에 저장하시겠습니까?"
+  },
+  "You have unsaved changes. Save before creating a new file?": {
+    "You have unsaved changes. Save before creating a new file?": "저장하지 않은 변경 사항이 있습니다. 새 파일을 만들기 전에 저장하시겠습니까?"
+  },
+  "You have unsaved changes. Save before opening a file?": {
+    "You have unsaved changes. Save before opening a file?": "저장하지 않은 변경 사항이 있습니다. 파일을 열기 전에 저장하시겠습니까?"
+  },
+  "You need to set either:\nQT_QPA_PLATFORMTHEME=gtk3 OR\nQT_QPA_PLATFORMTHEME=qt6ct\nas environment variables, and then restart the shell.\n\nqt6ct requires qt6ct-kde to be installed.": {
+    "You need to set either:\nQT_QPA_PLATFORMTHEME=gtk3 OR\nQT_QPA_PLATFORMTHEME=qt6ct\nas environment variables, and then restart the shell.\n\nqt6ct requires qt6ct-kde to be installed.": "환경 변수로 다음 중 하나를 설정해야 합니다:\nQT_QPA_PLATFORMTHEME=gtk3 또는\nQT_QPA_PLATFORMTHEME=qt6ct\n그런 다음 셸을 다시 시작하세요.\n\nqt6ct를 사용하려면 qt6ct-kde가 설치되어 있어야 합니다."
+  },
+  "You'll enter your password at the greeter after the next reboot.": {
+    "You'll enter your password at the greeter after the next reboot.": "다음 재부팅 후 로그인 화면에서 비밀번호를 입력하게 됩니다."
+  },
+  "You'll skip the greeter password after the next reboot. The lock screen and signing out still require your password.": {
+    "You'll skip the greeter password after the next reboot. The lock screen and signing out still require your password.": "다음 재부팅 후 로그인 화면 비밀번호를 건너뜁니다. 잠금 화면 및 로그아웃에는 여전히 비밀번호가 필요합니다."
+  },
+  "You're All Set!": {
+    "You're All Set!": "모든 준비가 끝났습니다!"
+  },
+  "Your compositor does not support background blur (ext-background-effect-v1)": {
+    "Your compositor does not support background blur (ext-background-effect-v1)": "컴포지터가 배경 블러(ext-background-effect-v1)를 지원하지 않습니다"
+  },
+  "Your system is up to date!": {
+    "Your system is up to date!": "시스템이 최신 상태입니다!"
+  },
+  "actions": {
+    "actions": "작업"
+  },
+  "admin": {
+    "admin": "관리자"
+  },
+  "attached": {
+    "attached": "연결됨"
+  },
+  "brandon": {
+    "brandon": "brandon"
+  },
+  "broken": {
+    "broken": "고장남"
+  },
+  "by %1": {
+    "by %1": "%1 제작"
+  },
+  "days": {
+    "days": "일"
+  },
+  "deprecated": {
+    "deprecated": "사용되지 않음"
+  },
+  "detached": {
+    "detached": "분리됨"
+  },
+  "device": {
+    "device": "기기"
+  },
+  "dgop not available": {
+    "dgop not available": "dgop를 사용할 수 없음"
+  },
+  "direct": {
+    "direct": "직접 연결"
+  },
+  "discuss": {
+    "discuss": "토론"
+  },
+  "dms is a highly customizable, modern desktop shell with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": {
+    "dms is a highly customizable, modern desktop shell with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": "dms는 <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3에서 영감을 받은</a> 디자인의 고도로 사용자 지정 가능한 최신 데스크톱 셸입니다.<br /><br/>데스크톱 셸 구축을 위한 QT6 프레임워크인 <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>과 정적으로 타입이 지정된 컴파일 프로그래밍 언어인 <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>로 구축되었습니다."
+  },
+  "e.g. /usr/bin/my-script --flag": {
+    "e.g. /usr/bin/my-script --flag": "예: /usr/bin/my-script --flag"
+  },
+  "e.g. My Script": {
+    "e.g. My Script": "예: 내 스크립트"
+  },
+  "e.g. alice": {
+    "e.g. alice": "예: alice"
+  },
+  "e.g., firefox, kitty --title foo": {
+    "e.g., firefox, kitty --title foo": "예: firefox, kitty --title foo"
+  },
+  "e.g., focus-workspace 3, resize-column -10": {
+    "e.g., focus-workspace 3, resize-column -10": "예: focus-workspace 3, resize-column -10"
+  },
+  "e.g., hl.dsp.focus({ workspace = \"3\" })": {
+    "e.g., hl.dsp.focus({ workspace = \"3\" })": "예: hl.dsp.focus({ workspace = \"3\" })"
+  },
+  "e.g., notify-send 'Hello' && sleep 1": {
+    "e.g., notify-send 'Hello' && sleep 1": "예: notify-send 'Hello' && sleep 1"
+  },
+  "e.g., scratch, /^tmp_.*/, build": {
+    "e.g., scratch, /^tmp_.*/, build": "예: scratch, /^tmp_.*/, build"
+  },
+  "ext": {
+    "ext": "ext"
+  },
+  "featured": {
+    "featured": "추천"
+  },
+  "khal": {
+    "khal": "khal"
+  },
+  "last seen %1": {
+    "last seen %1": "마지막 접속 %1"
+  },
+  "leave empty for default": {
+    "leave empty for default": "기본값은 비워 두세요"
+  },
+  "loginctl activate failed (exit %1)": {
+    "loginctl activate failed (exit %1)": "loginctl 활성화 실패(종료 %1)"
+  },
+  "loginctl not available - lock integration requires DMS socket connection": {
+    "loginctl not available - lock integration requires DMS socket connection": "loginctl을 사용할 수 없음 - 잠금 통합에는 DMS 소켓 연결이 필요합니다"
+  },
+  "mango: config reloaded": {
+    "mango: config reloaded": "mango: 구성이 다시 로드됨"
+  },
+  "mango: failed to reload config": {
+    "mango: failed to reload config": "mango: 구성 다시 로드 실패"
+  },
+  "mangowc Discord Server": {
+    "mangowc Discord Server": "mangowc Discord 서버"
+  },
+  "mangowc GitHub": {
+    "mangowc GitHub": "mangowc GitHub"
+  },
+  "matugen not available or disabled - cannot apply GTK colors": {
+    "matugen not available or disabled - cannot apply GTK colors": "matugen을 사용할 수 없거나 비활성화됨 - GTK 색상을 적용할 수 없음"
+  },
+  "matugen not available or disabled - cannot apply Qt colors": {
+    "matugen not available or disabled - cannot apply Qt colors": "matugen을 사용할 수 없거나 비활성화됨 - Qt 색상을 적용할 수 없음"
+  },
+  "matugen not found - install matugen package for dynamic theming": {
+    "matugen not found - install matugen package for dynamic theming": "matugen을 찾을 수 없음 - 동적 테마 지정을 위해 matugen 패키지 설치"
+  },
+  "minutes": {
+    "minutes": "분"
+  },
+  "ms": {
+    "ms": "ms"
+  },
+  "nav": {
+    "nav": "탐색"
+  },
+  "niri GitHub": {
+    "niri GitHub": "niri GitHub"
+  },
+  "niri Matrix Chat": {
+    "niri Matrix Chat": "niri Matrix 채팅"
+  },
+  "niri shortcuts config": {
+    "niri shortcuts config": "niri 바로 가기 구성"
+  },
+  "niri/dms Discord": {
+    "niri/dms Discord": "niri/dms Discord"
+  },
+  "niri: config reloaded": {
+    "niri: config reloaded": "niri: 구성 다시 로드됨"
+  },
+  "niri: failed to load config": {
+    "niri: failed to load config": "niri: 구성 로드 실패"
+  },
+  "now": {
+    "now": "지금"
+  },
+  "official": {
+    "official": "공식"
+  },
+  "on Hyprland": {
+    "on Hyprland": "Hyprland에서"
+  },
+  "on MangoWC": {
+    "on MangoWC": "MangoWC에서"
+  },
+  "on Miracle WM": {
+    "on Miracle WM": "Miracle WM에서"
+  },
+  "on Niri": {
+    "on Niri": "Niri에서"
+  },
+  "on Scroll": {
+    "on Scroll": "스크롤 시"
+  },
+  "on Sway": {
+    "on Sway": "Sway에서"
+  },
+  "open": {
+    "open": "열기"
+  },
+  "or run ": {
+    "or run ": "또는 실행"
+  },
+  "power-profiles-daemon not available": {
+    "power-profiles-daemon not available": "power-profiles-daemon을 사용할 수 없음"
+  },
+  "procs": {
+    "procs": "프로세스"
+  },
+  "r/niri Subreddit": {
+    "r/niri Subreddit": "r/niri Subreddit"
+  },
+  "relay: %1": {
+    "relay: %1": "릴레이: %1"
+  },
+  "remote": {
+    "remote": "원격"
+  },
+  "reviewed": {
+    "reviewed": "검토됨"
+  },
+  "seconds": {
+    "seconds": "초"
+  },
+  "session %1": {
+    "session %1": "세션 %1"
+  },
+  "source": {
+    "source": "소스"
+  },
+  "the Qt 6 Multimedia QML module": {
+    "the Qt 6 Multimedia QML module": "Qt 6 멀티미디어 QML 모듈"
+  },
+  "this app": {
+    "this app": "이 앱"
+  },
+  "unmaintained": {
+    "unmaintained": "유지 관리되지 않음"
+  },
+  "until %1": {
+    "until %1": "%1까지"
+  },
+  "up": {
+    "up": "가동"
+  },
+  "update dms for NM integration.": {
+    "update dms for NM integration.": "NM 통합을 위해 dms를 업데이트하세요."
+  },
+  "useradd failed (exit %1)": {
+    "useradd failed (exit %1)": "useradd 실패(종료 %1)"
+  },
+  "userdel failed (exit %1)": {
+    "userdel failed (exit %1)": "userdel 실패(종료 %1)"
+  },
+  "usermod failed (exit %1)": {
+    "usermod failed (exit %1)": "usermod 실패(종료 %1)"
+  },
+  "v%1 by %2": {
+    "v%1 by %2": "v%1(%2 제작)"
+  },
+  "• Install only from trusted sources": {
+    "• Install only from trusted sources": "• 신뢰할 수 있는 소스에서만 설치하세요"
+  },
+  "• M - Month (1-12)": {
+    "• M - Month (1-12)": "• M - 월(1-12)"
+  },
+  "• MM - Month (01-12)": {
+    "• MM - Month (01-12)": "• MM - 월(01-12)"
+  },
+  "• MMM - Month (Jan)": {
+    "• MMM - Month (Jan)": "• MMM - 월(1월)"
+  },
+  "• MMMM - Month (January)": {
+    "• MMMM - Month (January)": "• MMMM - 월(1월)"
+  },
+  "• Plugins may contain bugs or security issues": {
+    "• Plugins may contain bugs or security issues": "• 플러그인에는 버그나 보안 문제가 포함될 수 있습니다"
+  },
+  "• Review code before installation when possible": {
+    "• Review code before installation when possible": "• 가능하면 설치 전에 코드를 검토하세요"
+  },
+  "• d - Day (1-31)": {
+    "• d - Day (1-31)": "• d - 일(1-31)"
+  },
+  "• dd - Day (01-31)": {
+    "• dd - Day (01-31)": "• dd - 일(01-31)"
+  },
+  "• ddd - Day name (Mon)": {
+    "• ddd - Day name (Mon)": "• ddd - 요일 이름(월)"
+  },
+  "• dddd - Day name (Monday)": {
+    "• dddd - Day name (Monday)": "• dddd - 요일 이름(월요일)"
+  },
+  "• yy - Year (24)": {
+    "• yy - Year (24)": "• yy - 연도(24)"
+  },
+  "• yyyy - Year (2024)": {
+    "• yyyy - Year (2024)": "• yyyy - 연도(2024)"
+  },
+  "↑/↓: Nav • Space: Expand • Enter: Action/Expand • E: Text": {
+    "↑/↓: Nav • Space: Expand • Enter: Action/Expand • E: Text": "↑/↓: 탐색 • Space: 확장 • Enter: 작업/확장 • E: 텍스트"
+  },
+  "↑/↓: Navigate • Enter/Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": {
+    "↑/↓: Navigate • Enter/Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": "↑/↓: 탐색 • Enter/Ctrl+C: 복사 • Del: 삭제 • Ctrl+E: 편집 • Ctrl+S: 고정/고정 해제 • F10: 도움말"
+  },
+  "↑/↓: Navigate • Enter: Paste • Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": {
+    "↑/↓: Navigate • Enter: Paste • Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": "↑/↓: 탐색 • Enter: 붙여넣기 • Ctrl+C: 복사 • Del: 삭제 • Ctrl+E: 편집 • Ctrl+S: 고정/고정 해제 • F10: 도움말"
+  }
+}


### PR DESCRIPTION
## Summary
- Add Korean translation export as `quickshell/translations/poexports/ko.json`
- Register `ko` in the i18n sync language map

## Validation
- Parsed `ko.json` successfully
- Verified all 3,084 English source terms have Korean translation entries
- Verified placeholder tokens match
- Ran `python -m py_compile quickshell/scripts/i18nsync.py`
- Ran `git diff --check`