### PR TITLE
fix(player): combine trackid with text identity

### DIFF
--- a/quickshell/Services/TrackArtService.qml
+++ b/quickshell/Services/TrackArtService.qml
@@ -184,11 +184,13 @@ Singleton {
         const p = activePlayer;
         if (!p)
             return "";
-        // Prefer the stable track id; title/artist/album fill in progressively (Chrome).
+        // Combine trackid with the text identity. trackid alone dedups Chrome's multi-size art
+        // re-publish, but some players (e.g. KDEconnect) expose a constant trackid across every
+        // track, so keying on it alone wedged the dedup and new-song art never loaded. Folding
+        // in title/artist/album busts the lock on a real track change while same-track art
+        // churn (stable text) stays deduped.
         const tid = p.metadata && p.metadata["mpris:trackid"] ? p.metadata["mpris:trackid"].toString() : "";
-        if (tid !== "")
-            return tid;
-        return (p.trackTitle || "") + "" + (p.trackArtist || "") + "" + (p.trackAlbum || "");
+        return tid + " " + (p.trackTitle || "") + " " + (p.trackArtist || "") + " " + (p.trackAlbum || "");
     }
 
     function _updateArtUrl() {


### PR DESCRIPTION
fixes #2807

## Description

<!-- What does this PR do and why? -->
Another mpris clients shenanigan to adapt to.  

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->
fixes #2807

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
