### PR TITLE
fix(notifications): dismiss popups when senders close notifications

### DIFF
--- a/quickshell/Services/NotificationService.qml
+++ b/quickshell/Services/NotificationService.qml
@@ -888,6 +888,11 @@ Singleton {
                     return;
                 }
 
+                // Dismiss visible popup when sender closes the notification
+                // (e.g. YubiKey sends CloseNotification after touch).
+                // Without this, expireTimeout=0 popups stay visible forever.
+                wrapper.popup = false;
+
                 const groupKey = getGroupKey(wrapper);
                 const remainingInGroup = root.notifications.filter(n => getGroupKey(n) === groupKey);
 


### PR DESCRIPTION
## Summary

When a notification sender calls `CloseNotification` per the freedesktop spec (e.g. YubiKey touch prompts sending `expire-timeout=0` then `CloseNotification(id)` after touch), the `onDropped` handler removed the wrapper from `allWrappers` and `notifications` arrays but never dismissed the visible popup. The popup remained on screen forever for non-critical notifications.

## Root cause

`NotifWrapper.conn.onDropped()` removes the wrapper from tracking arrays but does not set `popup=false`. Since `expire-timeout=0` persistent notifications never start a timer, no other code path dismisses them. The popup stays visible until manually dismissed or another popup replaces it.

## Fix

Single-file change in `NotificationService.qml`: add `wrapper.popup = false` in `onDropped()` so the popup exits through the normal signal chain (`onPopupChanged` → `removeFromVisibleNotifications`).

This is minimal and does not:
- Change `expireTimeout` semantics or timer interval logic
- Touch queue management, persistence markers, or `releaseWrapper`
- Add new settings or IPC

## Diff

```diff
@@ -892,6 +888,11 @@ Singleton {
                     return;
                 }
 
+                // Dismiss visible popup when sender closes the notification
+                // (e.g. YubiKey sends CloseNotification after touch).
+                // Without this, expireTimeout=0 popups stay visible forever.
+                wrapper.popup = false;
+
                 const groupKey = getGroupKey(wrapper);
```

## Verification

- `dbus-monitor` capture confirms `yubikey-touch-detector` sends `Notify(expire_timeout=0)` then `CloseNotification(id)` after touch
- Brace/bracket/paren balance: 255/255, 95/95, 567/567 ✓
- No trailing whitespace, ends with newline

## Related

- #2814 — bug report with `dbus-monitor` capture
- #2760 / #2761 — related but distinct (user-initiated close race, already fixed)