### PR TITLE
feat(keep-awake): optionally block lid switch suspend while active

### DIFF
--- a/core/internal/server/loginctl/actions.go
+++ b/core/internal/server/loginctl/actions.go
@@ -99,3 +99,45 @@ func (m *Manager) SetSleepInhibitorEnabled(enabled bool) {
 		m.releaseSleepInhibitor()
 	}
 }
+
+// SetLidInhibitorEnabled acquires or releases a block-mode handle-lid-switch
+// inhibitor so logind ignores lid close while keep awake is active. logind
+// always honors handle-lid-switch locks regardless of LidSwitchIgnoreInhibited.
+func (m *Manager) SetLidInhibitorEnabled(enabled bool) error {
+	m.lidInhibitMu.Lock()
+	defer m.lidInhibitMu.Unlock()
+
+	if !enabled {
+		m.releaseLidInhibitorLocked()
+		return nil
+	}
+
+	if m.lidInhibitFile != nil {
+		return nil
+	}
+
+	if m.managerObj == nil {
+		return fmt.Errorf("manager object not available")
+	}
+
+	file, err := m.inhibit("handle-lid-switch", "DankMaterialShell", "Keep awake", "block")
+	if err != nil {
+		return fmt.Errorf("failed to acquire lid inhibitor: %w", err)
+	}
+
+	m.lidInhibitFile = file
+	return nil
+}
+
+func (m *Manager) releaseLidInhibitor() {
+	m.lidInhibitMu.Lock()
+	defer m.lidInhibitMu.Unlock()
+	m.releaseLidInhibitorLocked()
+}
+
+func (m *Manager) releaseLidInhibitorLocked() {
+	if m.lidInhibitFile != nil {
+		m.lidInhibitFile.Close()
+		m.lidInhibitFile = nil
+	}
+}

--- a/core/internal/server/loginctl/handlers.go
+++ b/core/internal/server/loginctl/handlers.go
@@ -27,6 +27,8 @@ func HandleRequest(conn net.Conn, req models.Request, manager *Manager) {
 		handleSetLockBeforeSuspend(conn, req, manager)
 	case "loginctl.setSleepInhibitorEnabled":
 		handleSetSleepInhibitorEnabled(conn, req, manager)
+	case "loginctl.setLidInhibitorEnabled":
+		handleSetLidInhibitorEnabled(conn, req, manager)
 	case "loginctl.lockerReady":
 		handleLockerReady(conn, req, manager)
 	case "loginctl.terminate":
@@ -114,6 +116,20 @@ func handleSetSleepInhibitorEnabled(conn net.Conn, req models.Request, manager *
 
 	manager.SetSleepInhibitorEnabled(enabled)
 	models.Respond(conn, req.ID, models.SuccessResult{Success: true, Message: "sleep inhibitor setting updated"})
+}
+
+func handleSetLidInhibitorEnabled(conn net.Conn, req models.Request, manager *Manager) {
+	enabled, err := params.Bool(req.Params, "enabled")
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+
+	if err := manager.SetLidInhibitorEnabled(enabled); err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+	models.Respond(conn, req.ID, models.SuccessResult{Success: true, Message: "lid inhibitor setting updated"})
 }
 
 func handleLockerReady(conn net.Conn, req models.Request, manager *Manager) {

--- a/core/internal/server/loginctl/handlers_test.go
+++ b/core/internal/server/loginctl/handlers_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"net"
+	"os"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -340,6 +342,111 @@ func TestHandleSetIdleHint(t *testing.T) {
 
 		assert.Equal(t, 123, resp.ID)
 		assert.Contains(t, resp.Error, "failed to set idle hint")
+	})
+}
+
+func TestHandleSetLidInhibitorEnabled(t *testing.T) {
+	t.Run("missing enabled parameter", func(t *testing.T) {
+		manager := &Manager{
+			state:      &SessionState{},
+			stateMutex: sync.RWMutex{},
+		}
+
+		conn := newMockNetConn()
+		req := models.Request{
+			ID:     123,
+			Method: "loginctl.setLidInhibitorEnabled",
+			Params: map[string]any{},
+		}
+
+		handleSetLidInhibitorEnabled(conn, req, manager)
+
+		var resp models.Response[any]
+		err := json.NewDecoder(conn.writeBuf).Decode(&resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, 123, resp.ID)
+		assert.Contains(t, resp.Error, "missing or invalid 'enabled' parameter")
+	})
+
+	t.Run("disable when not held succeeds", func(t *testing.T) {
+		manager := &Manager{
+			state:      &SessionState{},
+			stateMutex: sync.RWMutex{},
+		}
+
+		conn := newMockNetConn()
+		req := models.Request{
+			ID:     123,
+			Method: "loginctl.setLidInhibitorEnabled",
+			Params: map[string]any{
+				"enabled": false,
+			},
+		}
+
+		handleSetLidInhibitorEnabled(conn, req, manager)
+
+		var resp models.Response[models.SuccessResult]
+		err := json.NewDecoder(conn.writeBuf).Decode(&resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, 123, resp.ID)
+		assert.Empty(t, resp.Error)
+		require.NotNil(t, resp.Result)
+		assert.True(t, resp.Result.Success)
+	})
+
+	t.Run("enable without manager object fails", func(t *testing.T) {
+		manager := &Manager{
+			state:      &SessionState{},
+			stateMutex: sync.RWMutex{},
+		}
+
+		conn := newMockNetConn()
+		req := models.Request{
+			ID:     123,
+			Method: "loginctl.setLidInhibitorEnabled",
+			Params: map[string]any{
+				"enabled": true,
+			},
+		}
+
+		handleSetLidInhibitorEnabled(conn, req, manager)
+
+		var resp models.Response[any]
+		err := json.NewDecoder(conn.writeBuf).Decode(&resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, 123, resp.ID)
+		assert.Contains(t, resp.Error, "manager object not available")
+	})
+
+	t.Run("enable acquires inhibitor once, disable releases it", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		defer r.Close()
+		defer w.Close()
+		fd, err := syscall.Dup(int(r.Fd()))
+		require.NoError(t, err)
+
+		mockManagerObj := mockdbus.NewMockBusObject(t)
+		mockCall := &dbus.Call{Body: []any{dbus.UnixFD(fd)}}
+		mockManagerObj.EXPECT().Call(dbusManagerInterface+".Inhibit", dbus.Flags(0), "handle-lid-switch", "DankMaterialShell", "Keep awake", "block").Return(mockCall).Once()
+
+		manager := &Manager{
+			state:      &SessionState{},
+			stateMutex: sync.RWMutex{},
+			managerObj: mockManagerObj,
+		}
+
+		require.NoError(t, manager.SetLidInhibitorEnabled(true))
+		require.NotNil(t, manager.lidInhibitFile)
+
+		// Already held: no second dbus call (enforced by .Once())
+		require.NoError(t, manager.SetLidInhibitorEnabled(true))
+
+		require.NoError(t, manager.SetLidInhibitorEnabled(false))
+		assert.Nil(t, manager.lidInhibitFile)
 	})
 }
 

--- a/core/internal/server/loginctl/manager.go
+++ b/core/internal/server/loginctl/manager.go
@@ -710,6 +710,7 @@ func (m *Manager) Close() {
 	m.stopSignalPump()
 
 	m.releaseSleepInhibitor()
+	m.releaseLidInhibitor()
 
 	m.subscribers.Range(func(key string, ch chan SessionState) bool {
 		close(ch)

--- a/core/internal/server/loginctl/types.go
+++ b/core/internal/server/loginctl/types.go
@@ -59,6 +59,8 @@ type Manager struct {
 	sigWG                 sync.WaitGroup
 	inhibitMu             sync.Mutex
 	inhibitFile           *os.File
+	lidInhibitMu          sync.Mutex
+	lidInhibitFile        *os.File
 	lockBeforeSuspend     atomic.Bool
 	inSleepCycle          atomic.Bool
 	sleepCycleID          atomic.Uint64

--- a/core/internal/server/server.go
+++ b/core/internal/server/server.go
@@ -41,7 +41,7 @@ import (
 	"github.com/AvengeMedia/DankMaterialShell/core/pkg/syncmap"
 )
 
-const APIVersion = 27
+const APIVersion = 28
 
 var CLIVersion = "dev"
 
@@ -1437,6 +1437,7 @@ func Start(printDocs bool) error {
 		log.Info(" loginctl.setIdleHint        - Set idle hint (params: idle)")
 		log.Info(" loginctl.setLockBeforeSuspend - Set lock before suspend (params: enabled)")
 		log.Info(" loginctl.setSleepInhibitorEnabled - Enable/disable sleep inhibitor (params: enabled)")
+		log.Info(" loginctl.setLidInhibitorEnabled - Enable/disable lid switch inhibitor (params: enabled)")
 		log.Info(" loginctl.lockerReady        - Signal locker UI is ready (releases sleep inhibitor)")
 		log.Info(" loginctl.terminate          - Terminate session")
 		log.Info(" loginctl.subscribe          - Subscribe to session state changes (streaming)")

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -765,6 +765,7 @@ Singleton {
     property bool batteryPillPercentSign: false
     property bool lockBeforeSuspend: false
     property bool loginctlLockIntegration: true
+    property bool idleInhibitLidSwitch: false
     property bool fadeToLockEnabled: true
     property int fadeToLockGracePeriod: 5
     property bool fadeToDpmsEnabled: true

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -348,6 +348,7 @@ var SPEC = {
     batteryAutoPowerSaver: { def: false },
     lockBeforeSuspend: { def: false },
     loginctlLockIntegration: { def: true },
+    idleInhibitLidSwitch: { def: false },
     fadeToLockEnabled: { def: true },
     fadeToLockGracePeriod: { def: 5 },
     fadeToDpmsEnabled: { def: true },

--- a/quickshell/Modules/Settings/PowerSleepTab.qml
+++ b/quickshell/Modules/Settings/PowerSleepTab.qml
@@ -96,6 +96,16 @@ Item {
                     onToggled: checked => SettingsData.set("lockBeforeSuspend", checked)
                 }
 
+                SettingsToggleRow {
+                    settingKey: "idleInhibitLidSwitch"
+                    tags: ["keep", "awake", "lid", "laptop", "suspend", "inhibit"]
+                    text: I18n.tr("Keep awake blocks lid switch")
+                    description: I18n.tr("While keep awake is active, closing the laptop lid will not suspend the system")
+                    checked: SettingsData.idleInhibitLidSwitch
+                    visible: SessionService.loginctlAvailable
+                    onToggled: checked => SettingsData.set("idleInhibitLidSwitch", checked)
+                }
+
                 SettingsDropdownRow {
                     id: fadeGracePeriodDropdown
                     settingKey: "fadeToLockGracePeriod"

--- a/quickshell/Services/SessionService.qml
+++ b/quickshell/Services/SessionService.qml
@@ -410,6 +410,7 @@ Singleton {
             return;
         idleInhibited = true;
         inhibitorChanged();
+        syncLidInhibitor();
     }
 
     function disableIdleInhibit() {
@@ -417,6 +418,7 @@ Singleton {
             return;
         idleInhibited = false;
         inhibitorChanged();
+        syncLidInhibitor();
     }
 
     function toggleIdleInhibit() {
@@ -444,6 +446,7 @@ Singleton {
 
         function onCapabilitiesReceived() {
             syncSleepInhibitor();
+            syncLidInhibitor();
         }
     }
 
@@ -486,6 +489,10 @@ Singleton {
                 syncLockBeforeSuspend();
             }
             syncSleepInhibitor();
+        }
+
+        function onIdleInhibitLidSwitchChanged() {
+            syncLidInhibitor();
         }
     }
 
@@ -611,6 +618,23 @@ Singleton {
                 log.warn("Failed to sync sleep inhibitor:", response.error);
             } else {
                 log.debug("Synced sleep inhibitor:", SettingsData.loginctlLockIntegration);
+            }
+        });
+    }
+
+    function syncLidInhibitor() {
+        if (!loginctlAvailable)
+            return;
+        if (!DMSService.apiVersion || DMSService.apiVersion < 28)
+            return;
+        const enabled = idleInhibited && SettingsData.idleInhibitLidSwitch;
+        DMSService.sendRequest("loginctl.setLidInhibitorEnabled", {
+            enabled: enabled
+        }, response => {
+            if (response.error) {
+                log.warn("Failed to sync lid inhibitor:", response.error);
+            } else {
+                log.debug("Synced lid inhibitor:", enabled);
             }
         });
     }

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -6981,6 +6981,31 @@
     "description": "Gradually fade the screen before locking with a configurable grace period"
   },
   {
+    "section": "idleInhibitLidSwitch",
+    "label": "Keep awake blocks lid switch",
+    "tabIndex": 21,
+    "category": "Power & Sleep",
+    "keywords": [
+      "active",
+      "awake",
+      "blocks",
+      "closing",
+      "energy",
+      "inhibit",
+      "keep",
+      "laptop",
+      "lid",
+      "power",
+      "shutdown",
+      "sleep",
+      "suspend",
+      "switch",
+      "system",
+      "while"
+    ],
+    "description": "While keep awake is active, closing the laptop lid will not suspend the system"
+  },
+  {
     "section": "fadeToLockGracePeriod",
     "label": "Lock fade grace period",
     "tabIndex": 21,


### PR DESCRIPTION
## Problem

Keep awake only speaks the Wayland idle-inhibit protocol (an `IdleInhibitor` on the bar surface) plus gating DMS's own `IdleMonitor`s. On laptops where suspend is triggered by **closing the lid** — a logind hardware event (`HandleLidSwitch=`) — keep awake has no effect: no Wayland idle inhibitor can suppress lid handling, so the machine suspends anyway.

## Solution

New setting `idleInhibitLidSwitch` (default **off**). While keep awake is active, the DMS daemon takes a **block-mode `handle-lid-switch` logind inhibitor** via the existing `m.inhibit()` D-Bus helper, and releases it when keep awake ends or the daemon shuts down. logind always honors `handle-lid-switch` locks regardless of `LidSwitchIgnoreInhibited=`, so this works without any logind config changes.

The inhibitor is deliberately scoped to `handle-lid-switch` only (not `sleep`): a block-mode sleep inhibitor would also make explicit suspend from the power menu fail while keep awake is on.

Note: with the lid action blocked, the internal panel stays on when the lid is closed — logind's suspend was what turned it off. Users who want the panel dark can add a compositor lid-switch bind (e.g. Hyprland `bindl = , switch:on:Lid Switch, exec, hyprctl dispatch dpms off eDP-1`); that's compositor territory, so intentionally out of scope here.

## Changes

**core** (API v27 → v28):
- `loginctl.setLidInhibitorEnabled` method (params: `enabled`)
- `Manager.SetLidInhibitorEnabled()` — idempotent acquire/release under its own mutex, mirroring the sleep inhibitor
- Released in `Manager.Close()`
- Handler tests: param validation, no-op disable, missing manager object, acquire-once/release with a mocked D-Bus fd

**quickshell**:
- `idleInhibitLidSwitch` in `SettingsSpec.js` + `SettingsData.qml` (default off)
- `SessionService.syncLidInhibitor()` — sends the daemon request, gated on `loginctlAvailable` + API ≥ 28; synced on keep-awake enable/disable, setting change, and daemon reconnect (re-establishes the inhibitor if `dms` restarts while keep awake is on)
- Toggle "Keep awake blocks lid switch" in Settings → Power & Sleep, next to "Lock before suspend" (visible when loginctl is available)
- Regenerated `settings_search_index.json`

## Testing

- `go build ./...`, `go vet`, `gofmt` clean; full `loginctl` test suite passes incl. 4 new tests; all pre-commit hooks pass
- Verified end-to-end on a Hyprland laptop (NixOS, `HandleLidSwitch=suspend-then-hibernate`) running this branch:
  - keep awake on → `systemd-inhibit --list` shows `DankMaterialShell … handle-lid-switch … Keep awake … block`
  - keep awake off → lock released (only the pre-existing `sleep/delay` lock remains); re-enable re-acquires it
  - with keep awake on, physically closing the lid does **not** suspend the machine; without it, lid-close suspends as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)