### PR TITLE
feat(ipc): add settings dump to print full live config as JSON

### DIFF
--- a/quickshell/DMSShellIPC.qml
+++ b/quickshell/DMSShellIPC.qml
@@ -997,6 +997,10 @@ Item {
             return JSON.stringify(SettingsData?.[key]);
         }
 
+        function dump(): string {
+            return SettingsData.getCurrentSettingsJson();
+        }
+
         function set(key: string, value: string): string {
             if (!(key in SettingsData)) {
                 log.warn("Cannot set property, not found:", key);


### PR DESCRIPTION
## Description

Adds a `dump` function to the `settings` IPC target:

```
dms ipc call settings dump
```

It returns the complete live configuration as pretty-printed JSON via the existing `SettingsData.getCurrentSettingsJson()` — the same serialization the read-only banner's "settings.json" copy button uses.

### Motivation

When `settings.json` is a read-only symlink (NixOS/home-manager setups), changes made through the Settings UI can't be persisted and only exist in the running shell's memory. Today the only way to retrieve that live state is the clipboard copy button in the Settings modal's read-only banner. This exposes the same full dump over IPC, so it's scriptable and works without opening the UI — e.g. to diff against or paste back into the nix-managed config.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
