### PR TITLE
fix(process-list): defer IPC actions until modal is loaded

### DIFF
--- a/quickshell/DMSShellIPC.qml
+++ b/quickshell/DMSShellIPC.qml
@@ -179,8 +179,10 @@ Item {
     IpcHandler {
         function open(): string {
             root.processListModalLoader.active = true;
-            if (root.processListModalLoader.item)
-                root.processListModalLoader.item.show();
+            Qt.callLater(() => {
+                if (root.processListModalLoader.item)
+                    root.processListModalLoader.item.show();
+            });
 
             return "PROCESSLIST_OPEN_SUCCESS";
         }
@@ -194,16 +196,20 @@ Item {
 
         function toggle(): string {
             root.processListModalLoader.active = true;
-            if (root.processListModalLoader.item)
-                root.processListModalLoader.item.toggle();
+            Qt.callLater(() => {
+                if (root.processListModalLoader.item)
+                    root.processListModalLoader.item.toggle();
+            });
 
             return "PROCESSLIST_TOGGLE_SUCCESS";
         }
 
         function focusOrToggle(): string {
             root.processListModalLoader.active = true;
-            if (root.processListModalLoader.item)
-                root.processListModalLoader.item.focusOrToggle();
+            Qt.callLater(() => {
+                if (root.processListModalLoader.item)
+                    root.processListModalLoader.item.focusOrToggle();
+            });
 
             return "PROCESSLIST_FOCUS_OR_TOGGLE_SUCCESS";
         }


### PR DESCRIPTION
## Description

<!-- What does this PR do and why? -->
Defers process-list IPC actions until the lazy-loaded modal is available. Previously, IPC could report success without opening the modal.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->
Not applicable; no visual changes.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible (no new strings)
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean (not applicable)
- [x] QML changes: ran `make lint-qml` with no new warnings
- [x] I have opened a corresponding pull request in dlx-docs to document any new behaviors (not applicable; no new behavior)
