### PR TITLE
workspace switcher: fix apps icon won't re focus

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
+++ b/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
@@ -1840,7 +1840,6 @@ Item {
                                                     } else if (CompositorService.isNiri) {
                                                         NiriService.focusWindow(winId);
                                                     }
-                                                    delegateRoot.updateAllData();
                                                 }
                                             }
 
@@ -2010,7 +2009,6 @@ Item {
                                                     } else if (CompositorService.isNiri) {
                                                         NiriService.focusWindow(winId);
                                                     }
-                                                    delegateRoot.updateAllData();
                                                 }
                                             }
 
@@ -2101,6 +2099,14 @@ Item {
                     enabled: CompositorService.isHyprland
                     function onValuesChanged() {
                         delegateRoot.updateAllData();
+                    }
+                }
+                Connections {
+                    target: CompositorService.isHyprland ? Hyprland : null
+                    enabled: CompositorService.isHyprland
+                    function onRawEvent(event) {
+                        if (event.name === "activewindow" || event.name === "activewindowv2")
+                            delegateRoot.updateAllData();
                     }
                 }
                 Connections {

--- a/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
+++ b/quickshell/Modules/DankBar/Widgets/WorkspaceSwitcher.qml
@@ -1840,6 +1840,7 @@ Item {
                                                     } else if (CompositorService.isNiri) {
                                                         NiriService.focusWindow(winId);
                                                     }
+                                                    delegateRoot.updateAllData();
                                                 }
                                             }
 
@@ -2009,6 +2010,7 @@ Item {
                                                     } else if (CompositorService.isNiri) {
                                                         NiriService.focusWindow(winId);
                                                     }
+                                                    delegateRoot.updateAllData();
                                                 }
                                             }
 


### PR DESCRIPTION
## Description

fix apps icon won't re focus if Show workspace apps enabled.
i use hyprland

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
