### PR TITLE
feat(media): add toggle for album art accent colors (#2831)

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -455,6 +455,7 @@ Singleton {
     property bool scrollTitleEnabled: true
     property bool mediaAdaptiveWidthEnabled: true
     property bool audioVisualizerEnabled: true
+    property bool mediaUseAlbumArtAccent: false
     property string audioScrollMode: "volume"
     property int audioWheelScrollAmount: 5
     property bool audioDeviceScrollVolumeEnabled: false

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -185,6 +185,7 @@ var SPEC = {
     scrollTitleEnabled: { def: true },
     mediaAdaptiveWidthEnabled: { def: true },
     audioVisualizerEnabled: { def: true },
+    mediaUseAlbumArtAccent: { def: false },
     audioScrollMode: { def: "volume" },
     audioWheelScrollAmount: { def: 5 },
     audioDeviceScrollVolumeEnabled: { def: false },

--- a/quickshell/Modules/Settings/MediaPlayerTab.qml
+++ b/quickshell/Modules/Settings/MediaPlayerTab.qml
@@ -67,7 +67,7 @@ Item {
 
                 SettingsToggleRow {
                     text: I18n.tr("Use album art accent")
-                    description: I18n.tr("Use colours extracted from album art instead of system theme colours")
+                    description: I18n.tr("Use colors extracted from album art instead of system theme colors")
                     checked: SettingsData.mediaUseAlbumArtAccent
                     onToggled: checked => SettingsData.set("mediaUseAlbumArtAccent", checked)
                 }

--- a/quickshell/Modules/Settings/MediaPlayerTab.qml
+++ b/quickshell/Modules/Settings/MediaPlayerTab.qml
@@ -65,6 +65,13 @@ Item {
                     onToggled: checked => SettingsData.set("mediaAdaptiveWidthEnabled", checked)
                 }
 
+                SettingsToggleRow {
+                    text: I18n.tr("Use album art accent")
+                    description: I18n.tr("Use colours extracted from album art instead of system theme colours")
+                    checked: SettingsData.mediaUseAlbumArtAccent
+                    onToggled: checked => SettingsData.set("mediaUseAlbumArtAccent", checked)
+                }
+
                 SettingsDropdownRow {
                     property var scrollOptsInternal: ["volume", "song", "nothing"]
                     property var scrollOptsDisplay: [I18n.tr("Change Volume", "media scroll wheel option"), I18n.tr("Change Song", "media scroll wheel option"), I18n.tr("Nothing", "media scroll wheel option")]

--- a/quickshell/Services/MediaAccentService.qml
+++ b/quickshell/Services/MediaAccentService.qml
@@ -6,17 +6,105 @@ import QtQuick
 import qs.Common
 import qs.Services
 
+// Accent color extracted from the current track's album art via ColorQuantizer,
+// falling back to Theme.primary when no usable accent is available.
 Singleton {
     id: root
 
-    readonly property bool hasAccent: true
-    readonly property color accent: Theme.primary
+    readonly property bool hasAccent: SettingsData.mediaUseAlbumArtAccent ? _accent !== null : true
+    readonly property color accent: SettingsData.mediaUseAlbumArtAccent && _accent !== null ? _accent : Theme.primary
 
-    readonly property color onAccent: Theme.onPrimary
+    readonly property color onAccent: SettingsData.mediaUseAlbumArtAccent && _accent !== null ? (() => {
+        const lum = 0.2126 * _accent.r + 0.7152 * _accent.g + 0.0722 * _accent.b;
+        return lum > 0.6 ? Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1);
+    })() : Theme.onPrimary
 
     readonly property color accentHover: Theme.withAlpha(accent, 0.12)
     readonly property color accentPressed: Theme.withAlpha(accent, Theme.transparentBlurLayers ? 0.24 : 0.16)
 
     readonly property color accentTrack: Theme.withAlpha(accent, 0.28)
     readonly property color accentSubtle: Theme.withAlpha(accent, 0.55)
+
+    // Prefer the validated url, but fall back to the live mpris art so quantization
+    // starts as soon as the cover exists instead of waiting on the commit pipeline.
+    readonly property string artUrl: {
+        const resolved = TrackArtService.resolvedArtUrl;
+        if (resolved !== "")
+            return resolved;
+        const p = MprisController.activePlayer;
+        if (!p)
+            return "";
+        if (p.trackArtUrl)
+            return p.trackArtUrl;
+        const m = p.metadata;
+        return m && m["mpris:artUrl"] ? m["mpris:artUrl"].toString() : "";
+    }
+
+    // Hold the last accent across the brief artUrl blank between tracks; never reset to primary.
+    property var _accent: null
+
+    ColorQuantizer {
+        id: quantizer
+        source: root.artUrl
+        depth: 4
+        rescaleSize: 64
+        onColorsChanged: {
+            // Hold last accent only across the blank-art gap; else always recompute.
+            if (!colors || colors.length === 0)
+                return;
+            root._accent = root._pickAccent(colors);
+        }
+    }
+
+    function _pickAccent(colors) {
+        if (!colors || colors.length === 0)
+            return null;
+
+        let best = null;
+        let bestScore = -1;
+        for (let i = 0; i < colors.length; i++) {
+            const c = colors[i];
+            const s = c.hsvSaturation;
+            const v = c.hsvValue;
+            if (v < 0.22 || v > 0.96 || s < 0.22)
+                continue;
+            const score = s * (1 - Math.abs(v - 0.68));
+            if (score > bestScore) {
+                bestScore = score;
+                best = c;
+            }
+        }
+
+        if (best)
+            return _normalize(best);
+
+        // Monochrome art: pick a neutral tone instead of keeping the last accent.
+        return _pickNeutral(colors);
+    }
+
+    function _pickNeutral(colors) {
+        let best = null;
+        let bestScore = -1;
+        for (let i = 0; i < colors.length; i++) {
+            const c = colors[i];
+            const v = c.hsvValue;
+            const score = (1 - Math.abs(v - 0.6)) + c.hsvSaturation * 0.5;
+            if (score > bestScore) {
+                bestScore = score;
+                best = c;
+            }
+        }
+
+        const hue = best.hsvHue < 0 ? 0 : best.hsvHue;
+        const s = Math.min(best.hsvSaturation, 0.18);
+        const v = Math.min(Math.max(best.hsvValue, 0.6), 0.82);
+        return Qt.hsva(hue, s, v, 1);
+    }
+
+    function _normalize(c) {
+        const hue = c.hsvHue < 0 ? 0 : c.hsvHue;
+        const s = Math.min(1, c.hsvSaturation * 1.05);
+        const v = Math.max(c.hsvValue, 0.62);
+        return Qt.hsva(hue, s, v, 1);
+    }
 }

--- a/quickshell/Services/MediaAccentService.qml
+++ b/quickshell/Services/MediaAccentService.qml
@@ -6,106 +6,17 @@ import QtQuick
 import qs.Common
 import qs.Services
 
-// Accent color extracted from the current track's album art via ColorQuantizer,
-// falling back to Theme.primary when no usable accent is available.
 Singleton {
     id: root
 
-    readonly property bool hasAccent: _accent !== null
-    readonly property color accent: _accent !== null ? _accent : Theme.primary
+    readonly property bool hasAccent: true
+    readonly property color accent: Theme.primary
 
-    readonly property color onAccent: {
-        const c = accent;
-        const lum = 0.2126 * c.r + 0.7152 * c.g + 0.0722 * c.b;
-        return lum > 0.6 ? Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1);
-    }
+    readonly property color onAccent: Theme.onPrimary
 
     readonly property color accentHover: Theme.withAlpha(accent, 0.12)
     readonly property color accentPressed: Theme.withAlpha(accent, Theme.transparentBlurLayers ? 0.24 : 0.16)
 
     readonly property color accentTrack: Theme.withAlpha(accent, 0.28)
     readonly property color accentSubtle: Theme.withAlpha(accent, 0.55)
-
-    // Prefer the validated url, but fall back to the live mpris art so quantization
-    // starts as soon as the cover exists instead of waiting on the commit pipeline.
-    readonly property string artUrl: {
-        const resolved = TrackArtService.resolvedArtUrl;
-        if (resolved !== "")
-            return resolved;
-        const p = MprisController.activePlayer;
-        if (!p)
-            return "";
-        if (p.trackArtUrl)
-            return p.trackArtUrl;
-        const m = p.metadata;
-        return m && m["mpris:artUrl"] ? m["mpris:artUrl"].toString() : "";
-    }
-
-    // Hold the last accent across the brief artUrl blank between tracks; never reset to primary.
-    property var _accent: null
-
-    ColorQuantizer {
-        id: quantizer
-        source: root.artUrl
-        depth: 4
-        rescaleSize: 64
-        onColorsChanged: {
-            // Hold last accent only across the blank-art gap; else always recompute.
-            if (!colors || colors.length === 0)
-                return;
-            root._accent = root._pickAccent(colors);
-        }
-    }
-
-    function _pickAccent(colors) {
-        if (!colors || colors.length === 0)
-            return null;
-
-        let best = null;
-        let bestScore = -1;
-        for (let i = 0; i < colors.length; i++) {
-            const c = colors[i];
-            const s = c.hsvSaturation;
-            const v = c.hsvValue;
-            if (v < 0.22 || v > 0.96 || s < 0.22)
-                continue;
-            const score = s * (1 - Math.abs(v - 0.68));
-            if (score > bestScore) {
-                bestScore = score;
-                best = c;
-            }
-        }
-
-        if (best)
-            return _normalize(best);
-
-        // Monochrome art: pick a neutral tone instead of keeping the last accent.
-        return _pickNeutral(colors);
-    }
-
-    function _pickNeutral(colors) {
-        let best = null;
-        let bestScore = -1;
-        for (let i = 0; i < colors.length; i++) {
-            const c = colors[i];
-            const v = c.hsvValue;
-            const score = (1 - Math.abs(v - 0.6)) + c.hsvSaturation * 0.5;
-            if (score > bestScore) {
-                bestScore = score;
-                best = c;
-            }
-        }
-
-        const hue = best.hsvHue < 0 ? 0 : best.hsvHue;
-        const s = Math.min(best.hsvSaturation, 0.18);
-        const v = Math.min(Math.max(best.hsvValue, 0.6), 0.82);
-        return Qt.hsva(hue, s, v, 1);
-    }
-
-    function _normalize(c) {
-        const hue = c.hsvHue < 0 ? 0 : c.hsvHue;
-        const s = Math.min(1, c.hsvSaturation * 1.05);
-        const v = Math.max(c.hsvValue, 0.62);
-        return Qt.hsva(hue, s, v, 1);
-    }
 }


### PR DESCRIPTION
## Description

Adds a toggle in Settings > Media Player to switch between system theme colors and album-art-extracted accent colors for the media player UI.

**Default**: Off (uses system `Theme.primary` for visual consistency with the rest of the shell).  
**When on**: Extracts accent color from the current track's album art via `ColorQuantizer` and applies it to player buttons, seekbar, album art border, and visualizer blob.

**Files changed**:
- `Services/MediaAccentService.qml` — Restored `ColorQuantizer` logic, gated behind `SettingsData.mediaUseAlbumArtAccent`. Always returns `Theme.primary` / `Theme.onPrimary` when the toggle is off.
- `Common/SettingsData.qml` — Added `mediaUseAlbumArtAccent: false`
- `Common/settings/SettingsSpec.js` — Added `mediaUseAlbumArtAccent: { def: false }`
- `Modules/Settings/MediaPlayerTab.qml` — Added `SettingsToggleRow`

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Closes #2831

## Screenshots / video

N/A

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [ ] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs