### PR TITLE
dms doctor: detect missing XDG_MENU_PREFIX when KDE apps are installed

### DIFF
--- a/core/cmd/dms/commands_doctor.go
+++ b/core/cmd/dms/commands_doctor.go
@@ -320,6 +320,7 @@ func checkEnvironmentVars() []checkResult {
 	var results []checkResult
 	results = append(results, checkEnvVar("QT_QPA_PLATFORMTHEME")...)
 	results = append(results, checkEnvVar("QS_ICON_THEME")...)
+	results = append(results, checkXDGMenuPrefix()...)
 	return results
 }
 
@@ -332,6 +333,29 @@ func checkEnvVar(name string) []checkResult {
 		return []checkResult{{catEnvironment, name, statusInfo, "Not set", "", doctorDocsURL + "#environment-variables"}}
 	}
 	return nil
+}
+
+func checkXDGMenuPrefix() []checkResult {
+	menuPrefix := os.Getenv("XDG_MENU_PREFIX")
+	if menuPrefix != "" {
+		if checkXDGMenuFile(menuPrefix) {
+			return []checkResult{{catEnvironment, "XDG_MENU_PREFIX", statusInfo, menuPrefix, "", doctorDocsURL + "#xdg-menu-prefix"}}
+		}
+		return []checkResult{{catEnvironment, "XDG_MENU_PREFIX", statusWarn, fmt.Sprintf("%s (menu file not found)", menuPrefix), "Dolphin 'Open with…' dialog may be empty. Ensure /etc/xdg/menus/%sapplications.menu exists.", doctorDocsURL + "#xdg-menu-prefix"}}
+	}
+	if _, err := exec.LookPath("keditfiletype"); err == nil {
+		return []checkResult{{catEnvironment, "XDG_MENU_PREFIX", statusWarn, "Not set", "Dolphin file associations and 'Open with…' dialog may be empty. Set XDG_MENU_PREFIX=plasma- in your compositor's environment block.", doctorDocsURL + "#xdg-menu-prefix"}}
+	}
+	if doctorVerbose {
+		return []checkResult{{catEnvironment, "XDG_MENU_PREFIX", statusInfo, "Not set", "", doctorDocsURL + "#xdg-menu-prefix"}}
+	}
+	return nil
+}
+
+func checkXDGMenuFile(prefix string) bool {
+	menuPath := fmt.Sprintf("/etc/xdg/menus/%sapplications.menu", prefix)
+	_, err := os.Stat(menuPath)
+	return err == nil
 }
 
 func readOSRelease() map[string]string {

--- a/core/cmd/dms/commands_doctor.go
+++ b/core/cmd/dms/commands_doctor.go
@@ -341,7 +341,7 @@ func checkXDGMenuPrefix() []checkResult {
 		if checkXDGMenuFile(menuPrefix) {
 			return []checkResult{{catEnvironment, "XDG_MENU_PREFIX", statusInfo, menuPrefix, "", doctorDocsURL + "#xdg-menu-prefix"}}
 		}
-		return []checkResult{{catEnvironment, "XDG_MENU_PREFIX", statusWarn, fmt.Sprintf("%s (menu file not found)", menuPrefix), "Dolphin 'Open with…' dialog may be empty. Ensure /etc/xdg/menus/%sapplications.menu exists.", doctorDocsURL + "#xdg-menu-prefix"}}
+		return []checkResult{{catEnvironment, "XDG_MENU_PREFIX", statusWarn, fmt.Sprintf("%s (menu file not found)", menuPrefix), fmt.Sprintf("Dolphin 'Open with…' dialog may be empty. Ensure /etc/xdg/menus/%sapplications.menu exists.", menuPrefix), doctorDocsURL + "#xdg-menu-prefix"}}
 	}
 	if _, err := exec.LookPath("keditfiletype"); err == nil {
 		return []checkResult{{catEnvironment, "XDG_MENU_PREFIX", statusWarn, "Not set", "Dolphin file associations and 'Open with…' dialog may be empty. Set XDG_MENU_PREFIX=plasma- in your compositor's environment block.", doctorDocsURL + "#xdg-menu-prefix"}}


### PR DESCRIPTION
## Description

`dms doctor` now checks if `XDG_MENU_PREFIX` is set.

If `kde-cli-tools` is installed but the variable is missing,
it shows a warning: Dolphin's file associations and "Open with…"
dialog won't work under non-Plasma compositors. The user gets
told to add `XDG_MENU_PREFIX=plasma-` to their compositor config.

Added `checkXDGMenuPrefix()` and `checkXDGMenuFile()` in
commands_doctor.go, called from `checkEnvironmentVars()`.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues



## Screenshots / video



## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs