### PR TITLE
fix: use sleep_monitor/wakeup_monitor for DPMS to preserve monitor layout

### DIFF
--- a/quickshell/Services/MangoService.qml
+++ b/quickshell/Services/MangoService.qml
@@ -469,7 +469,7 @@ Singleton {
         const screens = Quickshell.screens || [];
         for (let i = 0; i < screens.length; i++) {
             if (screens[i] && screens[i].name)
-                Quickshell.execDetached(["mmsg", "dispatch", "disable_monitor," + screens[i].name]);
+                Quickshell.execDetached(["mmsg", "dispatch", "sleep_monitor," + screens[i].name]);
         }
     }
 
@@ -477,7 +477,7 @@ Singleton {
         const screens = Quickshell.screens || [];
         for (let i = 0; i < screens.length; i++) {
             if (screens[i] && screens[i].name)
-                Quickshell.execDetached(["mmsg", "dispatch", "enable_monitor," + screens[i].name]);
+                Quickshell.execDetached(["mmsg", "dispatch", "wakeup_monitor," + screens[i].name]);
         }
     }
 


### PR DESCRIPTION
## Problem

Since Mango v0.15.0, `disable_monitor` sets `only_sleep = 0`, which causes `updatemons()` to **completely remove the output from the layout** (disconnect it).

On NVIDIA (proprietary driver 610.x, wlroots 0.20), when the monitor is re-enabled via `enable_monitor`, the DRM handshake fails silently and the screen stays black. The only recovery is a TTY switch (Ctrl+Alt+F2 → F1), which forces a full DRM re-init.

This is a regression from v0.14.x, where the old `asleep` flag kept the output in the layout while powered off.

## Root cause

Commit `b0326d7` ("feat: distinguish dpms dispatch and disable dispatch in monitor") renamed `asleep` to `only_sleep` and introduced separate DPMS commands:
- `sleep_monitor` / `wakeup_monitor` → `only_sleep = 1` (output stays in layout, just powered off)
- `disable_monitor` / `enable_monitor` → `only_sleep = 0` (output removed from layout entirely)

DMS currently uses `disable_monitor`/`enable_monitor` for DPMS, which removes the output from the layout.

## Fix

Use `sleep_monitor` / `wakeup_monitor` in `MangoService.qml` instead. These commands are available since Mango v0.15.0 and keep the output in the layout while powered off, matching the pre-v0.15 behavior.

## Testing

- Before: screen goes black after idle timeout, does not wake on input, only recovers via TTY switch
- After: screen goes black after idle timeout, wakes correctly on mouse movement ✅

## Environment

- Mango 0.15.1 (also tested with 0.15.2)
- NVIDIA RTX 4050 Mobile (driver 610.x)
- wlroots 0.20
- CachyOS (Arch Linux)

## Note

Reference: PR mangowm/mango#1164 — DreamMaoMao confirmed `sleep_monitor`/`wakeup_monitor` are the correct commands for DPMS, not `disable_monitor`.