### PR TITLE
fix(dash): resolve pointer cursor hover issue in connected mode

### DIFF
--- a/quickshell/Modules/DankDash/DankDashPopout.qml
+++ b/quickshell/Modules/DankDash/DankDashPopout.qml
@@ -226,6 +226,13 @@ DankPopout {
             LayoutMirroring.enabled: I18n.isRtl
             LayoutMirroring.childrenInherit: true
 
+            MouseArea {
+                anchors.fill: parent
+                z: -1
+                enabled: root.__dropdownType !== 0
+                onClicked: root.__hideDropdowns()
+            }
+
             implicitWidth: Math.max(700, pages.implicitWidth + (Theme.spacingM * 2))
             implicitHeight: contentColumn.height + Theme.spacingM * 2
             color: "transparent"

--- a/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
+++ b/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
@@ -6,6 +6,7 @@ import qs.Widgets
 
 Item {
     id: root
+    visible: dropdownType !== 0
 
     LayoutMirroring.enabled: I18n.isRtl
     LayoutMirroring.childrenInherit: true
@@ -582,10 +583,4 @@ Item {
         }
     }
 
-    MouseArea {
-        anchors.fill: parent
-        z: -1
-        enabled: dropdownType !== 0
-        onClicked: closeRequested()
-    }
 }

--- a/quickshell/Widgets/DankPopoutConnected.qml
+++ b/quickshell/Widgets/DankPopoutConnected.qml
@@ -996,18 +996,53 @@ Item {
             height: root.renderedAlignedHeight + contentContainer.verticalConnectorExtent * 2
         }
 
-        MouseArea {
-            anchors.fill: parent
-            enabled: shouldBeVisible && backgroundInteractive
-            acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
+        Item {
+            id: backgroundClickCatcher
             z: -1
-            onClicked: mouse => {
-                const clickX = mouse.x;
-                const clickY = mouse.y;
-                const outsideContent = clickX < root.alignedX || clickX > root.alignedX + root.alignedWidth || clickY < root.renderedAlignedY || clickY > root.renderedAlignedY + root.renderedAlignedHeight;
-                if (!outsideContent)
-                    return;
-                backgroundClicked();
+            enabled: shouldBeVisible && backgroundInteractive
+            x: 0
+            y: 0
+            width: parent.width
+            height: parent.height
+
+            // Four edge strips that exclude the popup body, so cursor shapes
+            // inside the content propagate correctly (full-screen MouseAreas
+            // at z:-1 can suppress child cursorShape on Wayland).
+            MouseArea {
+                x: 0
+                y: 0
+                width: parent.width
+                height: root.renderedAlignedY
+                enabled: parent.enabled
+                acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
+                onClicked: backgroundClicked()
+            }
+            MouseArea {
+                x: 0
+                y: root.renderedAlignedY + root.renderedAlignedHeight
+                width: parent.width
+                height: Math.max(0, parent.height - root.renderedAlignedY - root.renderedAlignedHeight)
+                enabled: parent.enabled
+                acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
+                onClicked: backgroundClicked()
+            }
+            MouseArea {
+                x: 0
+                y: root.renderedAlignedY
+                width: root.alignedX
+                height: root.renderedAlignedHeight
+                enabled: parent.enabled
+                acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
+                onClicked: backgroundClicked()
+            }
+            MouseArea {
+                x: root.alignedX + root.alignedWidth
+                y: root.renderedAlignedY
+                width: Math.max(0, parent.width - root.alignedX - root.alignedWidth)
+                height: root.renderedAlignedHeight
+                enabled: parent.enabled
+                acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
+                onClicked: backgroundClicked()
             }
         }
 


### PR DESCRIPTION
## Description

This PR fixes the issue where hovering over buttons inside the Dank Dash media player tab in Connected Mode (`DankPopoutConnected`) does not change the mouse cursor to a pointer (`Qt.PointingHandCursor`).

1. **Overlay Visibility**: Binds the `visible` property of `MediaDropdownOverlay` to `dropdownType !== 0` so that it is invisible when no dropdown is active.
2. **Dismiss Handler**: 
   - Removed the full-screen dismiss handler from `MediaDropdownOverlay.qml`.
   - Added a click-dismiss `MouseArea` at `z: -1` inside the `mainContainer` of `DankDashPopout.qml`. This catches clicks inside the popout (on empty space) to close the dropdown menus, but allows the buttons (which are layered on top of it) to receive and handle clicks/hover events normally (e.g. toggle mute) without closing the dropdown.

In Connected Mode, the overlay resides inside the same `PanelWindow` stacked directly above the media player content. When inactive (`dropdownType === 0`), the transparent full-screen overlay was intercepting hover events, blocking the pointer cursor shape on the buttons underneath. When active, it also intercepted clicks on the buttons themselves. Moving the click-dismiss handler to `z: -1` in the popout layout preserves dismissals on empty space while allowing buttons to receive hover and click events.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other
## Related issues

Closes #2837

## Screenshots / video
<img width="1612" height="1080" alt="image" src="https://github.com/user-attachments/assets/c94826a1-db79-41df-9287-09c5684fc67f" />
<img width="1611" height="1057" alt="image" src="https://github.com/user-attachments/assets/e0822078-348d-442c-8795-d0b7cd572f65" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs