### PR TITLE
Fixed bluetooth UI bug mentioned in #2627

### DIFF
--- a/quickshell/Services/BluetoothService.qml
+++ b/quickshell/Services/BluetoothService.qml
@@ -256,9 +256,8 @@ Singleton {
     function getDevicePath(device) {
         if (!device || !device.address) {
             return "";
-        }
-        const adapterPath = adapter ? "/org/bluez/hci0" : "/org/bluez/hci0";
-        return `${adapterPath}/dev_${device.address.replace(/:/g, "_")}`;
+    	}
+	return device.dbusPath ?? "";
     }
 
     function isAudioDevice(device) {


### PR DESCRIPTION
## Description

Previosly function getDevicePath assumed that if a bluetooth device exists, it's hci0, which is not always the case, leading to returning incorrect dbus paths in some cases. Changed it to use dbus path provided by the BluetoothDevice itself.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

#2627

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
