### PR TITLE
Smooth battery time remaining estimate

### DIFF
--- a/quickshell/Services/BatteryService.qml
+++ b/quickshell/Services/BatteryService.qml
@@ -184,6 +184,7 @@ Singleton {
     onIsChargingChanged: {
         // Reset average when switching states
         _smoothedChangeRate = (_hasKnownChargingState && changeRate > 0) ? changeRate : 0;
+        _lastRateSampleTime = _smoothedChangeRate > 0 ? Date.now() : 0;
 
         if (isCharging) {
             _hasNotifiedLowBattery = false;
@@ -236,22 +237,37 @@ Singleton {
         return val;
     }
 
-    // An exponential moving average based on the aggregated charge/discharge rate
+    // A time-weighted exponential moving average based on the aggregated charge/discharge rate
     property real _smoothedChangeRate: 0
-    readonly property real _rateSmoothingAlpha: 0.2
+    property real _lastRateSampleTime: 0
+    readonly property real _rateSmoothingHalfLife: 90 // in seconds
 
     function _updateSmoothedRate() {
         if (!_hasKnownChargingState || changeRate <= 0)
             return;
-        if (_smoothedChangeRate <= 0)
+
+        const now = Date.now();
+        if (_smoothedChangeRate <= 0 || _lastRateSampleTime <= 0) {
             _smoothedChangeRate = changeRate;
-        else
-            _smoothedChangeRate += _rateSmoothingAlpha * (changeRate - _smoothedChangeRate);
+            _lastRateSampleTime = now;
+            return;
+        }
+
+        const dt = (now - _lastRateSampleTime) / 1000;
+        _lastRateSampleTime = now;
+        if (dt <= 0)
+            return;
+
+        const tau = _rateSmoothingHalfLife / Math.LN2;
+        const alpha = 1 - Math.exp(-dt / tau);
+        _smoothedChangeRate += alpha * (changeRate - _smoothedChangeRate);
     }
 
     onChangeRateChanged: _updateSmoothedRate()
-    onBatteryAvailableChanged: if (!batteryAvailable)
-        _smoothedChangeRate = 0
+    onBatteryAvailableChanged: if (!batteryAvailable) {
+        _smoothedChangeRate = 0;
+        _lastRateSampleTime = 0;
+    }
 
     // Aggregated battery health
     readonly property string batteryHealth: {

--- a/quickshell/Services/BatteryService.qml
+++ b/quickshell/Services/BatteryService.qml
@@ -182,6 +182,9 @@ Singleton {
     }
 
     onIsChargingChanged: {
+        // Reset average when switching states
+        _smoothedChangeRate = (_hasKnownChargingState && changeRate > 0) ? changeRate : 0;
+
         if (isCharging) {
             _hasNotifiedLowBattery = false;
             _hasNotifiedCriticalBattery = false;
@@ -232,6 +235,23 @@ Singleton {
         _lastChangeRate = val;
         return val;
     }
+
+    // An exponential moving average based on the aggregated charge/discharge rate
+    property real _smoothedChangeRate: 0
+    readonly property real _rateSmoothingAlpha: 0.2
+
+    function _updateSmoothedRate() {
+        if (!_hasKnownChargingState || changeRate <= 0)
+            return;
+        if (_smoothedChangeRate <= 0)
+            _smoothedChangeRate = changeRate;
+        else
+            _smoothedChangeRate += _rateSmoothingAlpha * (changeRate - _smoothedChangeRate);
+    }
+
+    onChangeRateChanged: _updateSmoothedRate()
+    onBatteryAvailableChanged: if (!batteryAvailable)
+        _smoothedChangeRate = 0
 
     // Aggregated battery health
     readonly property string batteryHealth: {
@@ -341,8 +361,8 @@ Singleton {
             return "Unknown";
         }
 
-        let totalTime = 0;
-        totalTime = (isCharging) ? ((batteryCapacity - batteryEnergy) / changeRate) : (batteryEnergy / changeRate);
+        const rate = _smoothedChangeRate > 0 ? _smoothedChangeRate : changeRate;
+        const totalTime = (isCharging) ? ((batteryCapacity - batteryEnergy) / rate) : (batteryEnergy / rate);
         const avgTime = Math.abs(totalTime * 3600);
         if (!avgTime || avgTime <= 0 || avgTime > 86400)
             return "Unknown";


### PR DESCRIPTION
## Description

BatteryService uses the instantaneous rate of change of energy over time to estimate the time remaining for charge/discharge. This PR introduces an exponential moving average for this value, preventing the estimate from fluctuating under changing system load.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

None

## Screenshots / video

No visual changes

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible (N/A)
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean (N/A)
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs (N/A)