### PR TITLE
fix(Modal): respect targetScreen property instead of always using focused screen

### DIFF
--- a/quickshell/Modals/Common/DankModalConnected.qml
+++ b/quickshell/Modals/Common/DankModalConnected.qml
@@ -217,7 +217,7 @@ Item {
         frozenMotionOffsetX = modalContainer ? modalContainer.offsetX : 0;
         frozenMotionOffsetY = modalContainer ? modalContainer.offsetY : animationOffset;
 
-        const focusedScreen = CompositorService.getFocusedScreen();
+        const focusedScreen = root.targetScreen ?? CompositorService.getFocusedScreen();
         if (focusedScreen) {
             contentWindow.screen = focusedScreen;
         }

--- a/quickshell/Modals/Common/DankModalStandalone.qml
+++ b/quickshell/Modals/Common/DankModalStandalone.qml
@@ -70,7 +70,7 @@ Item {
     function open() {
         closeTimer.stop();
         isClosing = false;
-        const focusedScreen = CompositorService.getFocusedScreen();
+        const focusedScreen = root.targetScreen ?? CompositorService.getFocusedScreen();
         const screenChanged = focusedScreen && contentWindow.screen !== focusedScreen;
         if (focusedScreen) {
             if (screenChanged)


### PR DESCRIPTION
## Description

The `open()` method in both `DankModalStandalone` and `DankModalConnected` unconditionally overrides `contentWindow.screen` to the focused screen, ignoring the `targetScreen` property. This means the "Modal Display Screen" setting in Quick Capture (and any other modal using this API) is silently ignored — the modal always opens on whichever display currently has focus.

Fix: use `root.targetScreen ?? CompositorService.getFocusedScreen()` so the configured screen is respected when set, with fallback to the focused screen (existing behavior).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes hthienloc/dms-quick-capture#149 — Modal Display Screen setting ignored

## Screenshots / video

N/A — runtime behavior change only (modal now opens on the configured display instead of always the focused one).

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs