### PR TITLE
fix: include Hyprland in minimal install logic

### DIFF
--- a/core/internal/distros/minimal_install.go
+++ b/core/internal/distros/minimal_install.go
@@ -7,7 +7,7 @@ type minimalInstallGroup struct {
 
 func shouldPreferMinimalInstall(pkg string) bool {
 	switch pkg {
-	case "niri", "niri-git":
+	case "niri", "niri-git", "hyprland", "hyprland-git":
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Description

This PR fixes an issue where selecting Hyprland would incorrectly bypass the minimal install logic.

By adding `hyprland` and `hyprland-git` to the `shouldPreferMinimalInstall` function, we ensure that the installer correctly applies minimal installation settings. This aligns Hyprland's behavior with Niri and prevents unnecessary package bloat, as Hyprland's package specification includes several recommended utilities and dependencies, such as:

* **Core Utilities:** `uwsm`, `polkit`, `playerctl`, `brightnessctl`, and `kitty`.
* **Graphics & Frameworks:** `mesa-dri-drivers` and `qt-wayland` modules.

This change ensures a cleaner, more controlled installation process for users seeking a minimal environment.

## Type of change

- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs