### PR TITLE
i18n: add Finnish translation

### DIFF
--- a/quickshell/scripts/i18nsync.py
+++ b/quickshell/scripts/i18nsync.py
@@ -25,6 +25,7 @@ LANGUAGES = {
     "he": "he.json",
     "hu": "hu.json",
     "fa": "fa.json",
+    "fi": "fi.json",
     "fr": "fr.json",
     "nl": "nl.json",
     "ru": "ru.json",

--- a/quickshell/translations/poexports/fi.json
+++ b/quickshell/translations/poexports/fi.json
@@ -1,0 +1,9014 @@
+{
+  "%1 (+%2 more)": {
+    "%1 (+%2 more)": "%1 (+%2 lisää)"
+  },
+  "%1 Animation Speed": {
+    "%1 Animation Speed": "%1 Animaationopeus"
+  },
+  "%1 Layout Overrides": {
+    "%1 Layout Overrides": "%1 asettelun ohitukset"
+  },
+  "%1 Sessions": {
+    "%1 Sessions": "%1-istunnot"
+  },
+  "%1 Startup Failed": {
+    "%1 Startup Failed": "%1 käynnistys epäonnistui"
+  },
+  "%1 active session": {
+    "%1 active session": "%1 aktiivinen istunto"
+  },
+  "%1 active sessions": {
+    "%1 active sessions": "%1 aktiiviset istunnot"
+  },
+  "%1 adapter, none connected": {
+    "%1 adapter, none connected": "%1 sovitin, ei kytketty"
+  },
+  "%1 adapters, none connected": {
+    "%1 adapters, none connected": "%1 sovittimet, ei liitetty"
+  },
+  "%1 character": {
+    "%1 character": "%1 merkki"
+  },
+  "%1 characters": {
+    "%1 characters": "%1 merkkiä"
+  },
+  "%1 connected": {
+    "%1 connected": "%1 yhdistetty"
+  },
+  "%1 copied": {
+    "%1 copied": "%1 kopioitu"
+  },
+  "%1 disconnected": {
+    "%1 disconnected": "%1 yhteys katkaistu"
+  },
+  "%1 disconnected (hidden)": {
+    "%1 disconnected (hidden)": "%1 yhteys katkaistu (piilotettu)"
+  },
+  "%1 display": {
+    "%1 display": "%1 näyttö"
+  },
+  "%1 displays": {
+    "%1 displays": "%1 -näytöt"
+  },
+  "%1 filtered": {
+    "%1 filtered": "%1 suodatettu"
+  },
+  "%1 h %2 m left": {
+    "%1 h %2 m left": "%1 h %2 m jäljellä"
+  },
+  "%1 h left": {
+    "%1 h left": "%1 h jäljellä"
+  },
+  "%1 is now included in config": {
+    "%1 is now included in config": "%1 sisältyy nyt konfiguraatioon"
+  },
+  "%1 issue found": {
+    "%1 issue found": "%1-ongelma löydetty"
+  },
+  "%1 issues found": {
+    "%1 issues found": "%1-ongelmia löydetty"
+  },
+  "%1 min left": {
+    "%1 min left": "%1 min jäljellä"
+  },
+  "%1 notifications": {
+    "%1 notifications": "%1-ilmoitukset"
+  },
+  "%1 online": {
+    "%1 online": "%1 verkossa"
+  },
+  "%1 tasks": {
+    "%1 tasks": "%1 tehtävät"
+  },
+  "%1 update": {
+    "%1 update": "%1 päivitys"
+  },
+  "%1 updates": {
+    "%1 updates": "%1 päivitykset"
+  },
+  "%1 variants": {
+    "%1 variants": "%1 versiot"
+  },
+  "%1 wallpaper  •  %2 / %3": {
+    "%1 wallpaper  •  %2 / %3": "%1 taustakuva • %2 / %3"
+  },
+  "%1 wallpapers  •  %2 / %3": {
+    "%1 wallpapers  •  %2 / %3": "%1 taustakuvat • %2 / %3"
+  },
+  "%1 widgets": {
+    "%1 widgets": "%1-widgetit"
+  },
+  "%1 window": {
+    "%1 window": "%1-ikkuna"
+  },
+  "%1 windows": {
+    "%1 windows": "%1 ikkunat"
+  },
+  "%1: %2": {
+    "%1: %2": "%1: %2"
+  },
+  "%1m ago": {
+    "%1m ago": "%1m sitten"
+  },
+  "%command%": {
+    "%command%": "%command%"
+  },
+  "'Alternative' lets the key unlock on its own. 'Second factor' requires password or fingerprint first, then the key.": {
+    "'Alternative' lets the key unlock on its own. 'Second factor' requires password or fingerprint first, then the key.": "'Vaihtoehto' antaa avaimen avata lukituksen itsestään. \"Toinen tekijä\" vaatii ensin salasanan tai sormenjäljen ja sitten avaimen."
+  },
+  "(Unnamed)": {
+    "(Unnamed)": "(Nimetön)"
+  },
+  "+ %1 more": {
+    "+ %1 more": "+ %1 lisää"
+  },
+  "/path/to/videos": {
+    "/path/to/videos": "/polku/videoihin"
+  },
+  "0 = square corners": {
+    "0 = square corners": "0 = neliömäiset kulmat"
+  },
+  "1 day": {
+    "1 day": "1 päivä"
+  },
+  "1 day before": {
+    "1 day before": "1 päivä ennen"
+  },
+  "1 hour": {
+    "1 hour": "1 tunti"
+  },
+  "1 hour 30 minutes": {
+    "1 hour 30 minutes": "1 tunti 30 minuuttia"
+  },
+  "1 hour before": {
+    "1 hour before": "1 tunti ennen"
+  },
+  "1 minute": {
+    "1 minute": "1 minuutti"
+  },
+  "1 notification": {
+    "1 notification": "1 ilmoitus"
+  },
+  "1 second": {
+    "1 second": "1 sekunti"
+  },
+  "1 task": {
+    "1 task": "1 tehtävä"
+  },
+  "10 min before": {
+    "10 min before": "10 min ennen"
+  },
+  "10 minutes": {
+    "10 minutes": "10 minuuttia"
+  },
+  "10 seconds": {
+    "10 seconds": "10 sekuntia"
+  },
+  "10-bit Color": {
+    "10-bit Color": "10-bittinen väri"
+  },
+  "12 hours": {
+    "12 hours": "12 tuntia"
+  },
+  "14 days": {
+    "14 days": "14 päivää"
+  },
+  "15 min": {
+    "15 min": "15 min"
+  },
+  "15 min before": {
+    "15 min before": "15 min ennen"
+  },
+  "15 minutes": {
+    "15 minutes": "15 minuuttia"
+  },
+  "15 seconds": {
+    "15 seconds": "15 sekuntia"
+  },
+  "180°": {
+    "180°": "180°"
+  },
+  "2 hours": {
+    "2 hours": "2 tuntia"
+  },
+  "2 minutes": {
+    "2 minutes": "2 minuuttia"
+  },
+  "2 seconds": {
+    "2 seconds": "2 sekuntia"
+  },
+  "20 minutes": {
+    "20 minutes": "20 minuuttia"
+  },
+  "20 seconds": {
+    "20 seconds": "20 sekuntia"
+  },
+  "24-Hour Format": {
+    "24-Hour Format": "24 tunnin muoto"
+  },
+  "25 seconds": {
+    "25 seconds": "25 sekuntia"
+  },
+  "250 ms": {
+    "250 ms": "250 ms"
+  },
+  "270°": {
+    "270°": "270°"
+  },
+  "3 days": {
+    "3 days": "3 päivää"
+  },
+  "3 hours": {
+    "3 hours": "3 tuntia"
+  },
+  "3 minutes": {
+    "3 minutes": "3 minuuttia"
+  },
+  "3 seconds": {
+    "3 seconds": "3 sekuntia"
+  },
+  "30 days": {
+    "30 days": "30 päivää"
+  },
+  "30 min": {
+    "30 min": "30 min"
+  },
+  "30 min before": {
+    "30 min before": "30 min ennen"
+  },
+  "30 minutes": {
+    "30 minutes": "30 minuuttia"
+  },
+  "30 seconds": {
+    "30 seconds": "30 sekuntia"
+  },
+  "35 seconds": {
+    "35 seconds": "35 sekuntia"
+  },
+  "3rd party": {
+    "3rd party": "3. osapuoli"
+  },
+  "4 hours": {
+    "4 hours": "4 tuntia"
+  },
+  "4 seconds": {
+    "4 seconds": "4 sekuntia"
+  },
+  "40 seconds": {
+    "40 seconds": "40 sekuntia"
+  },
+  "45 seconds": {
+    "45 seconds": "45 sekuntia"
+  },
+  "5 min before": {
+    "5 min before": "5 min ennen"
+  },
+  "5 minutes": {
+    "5 minutes": "5 minuuttia"
+  },
+  "5 seconds": {
+    "5 seconds": "5 sekuntia"
+  },
+  "50 seconds": {
+    "50 seconds": "50 sekuntia"
+  },
+  "500 ms": {
+    "500 ms": "500 ms"
+  },
+  "55 seconds": {
+    "55 seconds": "55 sekuntia"
+  },
+  "6 hours": {
+    "6 hours": "6 tuntia"
+  },
+  "7 days": {
+    "7 days": "7 päivää"
+  },
+  "750 ms": {
+    "750 ms": "750 ms"
+  },
+  "8 hours": {
+    "8 hours": "8 tuntia"
+  },
+  "8 seconds": {
+    "8 seconds": "8 sekuntia"
+  },
+  "90 days": {
+    "90 days": "90 päivää"
+  },
+  "90°": {
+    "90°": "90°"
+  },
+  "<a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/LICENSE\" style=\"text-decoration:none; color:%1;\">MIT License</a>": {
+    "<a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/LICENSE\" style=\"text-decoration:none; color:%1;\">MIT License</a>": "<a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/LICENSE\" style=\"text-decoration:none; color:%1;\">MIT-lisenssi</a>"
+  },
+  "A file with this name already exists. Do you want to overwrite it?": {
+    "A file with this name already exists. Do you want to overwrite it?": "Tämän niminen tiedosto on jo olemassa. Haluatko korvata sen?"
+  },
+  "A modern desktop shell for Wayland compositors": {
+    "A modern desktop shell for Wayland compositors": "Moderni työpöydän kuori Wayland-kompositoreille"
+  },
+  "A separate minimal launcher action that works in Standalone, Separate Frame Mode, and Connected Frame Mode.": {
+    "A separate minimal launcher action that works in Standalone, Separate Frame Mode, and Connected Frame Mode.": "Erillinen minimaalinen käynnistystoiminto, joka toimii itsenäisessä, erillisessä kehystilassa ja yhdistetty kehys -tilassa."
+  },
+  "A user with that name already exists.": {
+    "A user with that name already exists.": "Samanniminen käyttäjä on jo olemassa."
+  },
+  "AC Adapter (Plugged In)": {
+    "AC Adapter (Plugged In)": "Verkkolaite (kytkettynä)"
+  },
+  "AC Power": {
+    "AC Power": "AC virta"
+  },
+  "API": {
+    "API": "API"
+  },
+  "AUR helpers are interactive — see the terminal window for prompts. This popout will return to idle when the upgrade exits.": {
+    "AUR helpers are interactive — see the terminal window for prompts. This popout will return to idle when the upgrade exits.": "AUR-avustajat ovat vuorovaikutteisia – katso kehotteet pääteikkunasta. Tämä ponnahdusikkuna palaa valmiustilaan, kun päivitys lopetetaan."
+  },
+  "Aborted": {
+    "Aborted": "Keskeytetty"
+  },
+  "About": {
+    "About": "Tietoja"
+  },
+  "Accent Color": {
+    "Accent Color": "Aksenttiväri"
+  },
+  "Accept": {
+    "Accept": "Hyväksy"
+  },
+  "Accept Jobs": {
+    "Accept Jobs": "Hyväksy työt"
+  },
+  "Accepting": {
+    "Accepting": "Hyväksyminen"
+  },
+  "Access clipboard history": {
+    "Access clipboard history": "Käytä leikepöydän historiaa"
+  },
+  "Access to notifications and do not disturb": {
+    "Access to notifications and do not disturb": "Pääsy ilmoituksiin ja älä häiritse"
+  },
+  "Access to system controls and settings": {
+    "Access to system controls and settings": "Pääsy järjestelmän ohjaimiin ja asetuksiin"
+  },
+  "Action": {
+    "Action": "Toiminto"
+  },
+  "Action failed or terminal was closed.": {
+    "Action failed or terminal was closed.": "Toiminto epäonnistui tai pääte suljettiin."
+  },
+  "Action performed when scrolling horizontally on the bar": {
+    "Action performed when scrolling horizontally on the bar": "Toiminto, joka suoritetaan rullattaessa vaakasuunnassa palkkia"
+  },
+  "Action performed when scrolling vertically on the bar": {
+    "Action performed when scrolling vertically on the bar": "Toiminto, joka suoritetaan rullattaessa pystysuunnassa palkkia"
+  },
+  "Actions": {
+    "Actions": "Toiminnot"
+  },
+  "Activate": {
+    "Activate": "Aktivoi"
+  },
+  "Activate Greeter": {
+    "Activate Greeter": "Aktivoi Greeter"
+  },
+  "Activate the DMS greeter? A terminal will open for sudo authentication. Run Sync after activation to apply your settings.": {
+    "Activate the DMS greeter? A terminal will open for sudo authentication. Run Sync after activation to apply your settings.": "Aktivoidaanko DMS tervehdin? Pääte avautuu sudo-todennusta varten. Ota asetukset käyttöön suorittamalla synkronointi aktivoinnin jälkeen."
+  },
+  "Activation": {
+    "Activation": "Aktivointi"
+  },
+  "Active": {
+    "Active": "Aktiivinen"
+  },
+  "Active Color": {
+    "Active Color": "Aktiivinen väri"
+  },
+  "Active VPN": {
+    "Active VPN": "Aktiivinen VPN"
+  },
+  "Active in Column": {
+    "Active in Column": "Aktiivinen sarakkeessa"
+  },
+  "Active tile background and icon color": {
+    "Active tile background and icon color": "Aktiivinen laatan tausta ja kuvakkeen väri"
+  },
+  "Active: %1": {
+    "Active: %1": "Aktiivinen: %1"
+  },
+  "Active: %1 +%2": {
+    "Active: %1 +%2": "Aktiivinen: %1 +%2"
+  },
+  "Active: None": {
+    "Active: None": "Aktiivinen: Ei mitään"
+  },
+  "Adapters": {
+    "Adapters": "Sovittimet"
+  },
+  "Adaptive Media Width": {
+    "Adaptive Media Width": "Mukautuva median leveys"
+  },
+  "Add": {
+    "Add": "Lisää"
+  },
+  "Add \"%1\" to the %2 group?": {
+    "Add \"%1\" to the %2 group?": "Lisätäänkö \"%1\" %2-ryhmään?"
+  },
+  "Add \"%1\" to the %2 group? They must log out and back in, then run dms greeter sync --profile to publish their login-screen theme.": {
+    "Add \"%1\" to the %2 group? They must log out and back in, then run dms greeter sync --profile to publish their login-screen theme.": "Lisätäänkö \"%1\" %2-ryhmään? Heidän on kirjauduttava ulos ja takaisin sisään ja suoritettava sitten dms greeter sync --profile julkaistakseen kirjautumisnäytön teemansa."
+  },
+  "Add Bar": {
+    "Add Bar": "Lisää baari"
+  },
+  "Add Desktop Widget": {
+    "Add Desktop Widget": "Lisää työpöytäwidget"
+  },
+  "Add Entry": {
+    "Add Entry": "Lisää merkintä"
+  },
+  "Add Printer": {
+    "Add Printer": "Lisää tulostin"
+  },
+  "Add Title": {
+    "Add Title": "Lisää otsikko"
+  },
+  "Add Widget": {
+    "Add Widget": "Lisää widget"
+  },
+  "Add Widget to %1": {
+    "Add Widget to %1": "Lisää widget tiedostoon %1"
+  },
+  "Add Window Rule": {
+    "Add Window Rule": "Lisää ikkunasääntö"
+  },
+  "Add a border around the dock": {
+    "Add a border around the dock": "Lisää reuna telakan ympärille"
+  },
+  "Add a custom prefix to all application launches. This can be used for things like 'uwsm-app', 'systemd-run', or other command wrappers.": {
+    "Add a custom prefix to all application launches. This can be used for things like 'uwsm-app', 'systemd-run', or other command wrappers.": "Lisää mukautettu etuliite kaikkiin sovellusten käynnistyksiin. Tätä voidaan käyttää esimerkiksi \"uwsm-app\"-, \"systemd-run\"- tai muihin komentojen kääreisiin."
+  },
+  "Add a task...": {
+    "Add a task...": "Lisää tehtävä..."
+  },
+  "Add and configure widgets that appear on your desktop": {
+    "Add and configure widgets that appear on your desktop": "Lisää ja määritä työpöydälläsi näkyviä widgetejä"
+  },
+  "Add by Address": {
+    "Add by Address": "Lisää osoitteen mukaan"
+  },
+  "Add location": {
+    "Add location": "Lisää sijainti"
+  },
+  "Add match": {
+    "Add match": "Lisää ottelu"
+  },
+  "Add notes": {
+    "Add notes": "Lisää muistiinpanoja"
+  },
+  "Add the new user to the %1 group so they can run dms greeter sync --profile.": {
+    "Add the new user to the %1 group so they can run dms greeter sync --profile.": "Lisää uusi käyttäjä %1-ryhmään, jotta hän voi suorittaa dms greeter sync --profile."
+  },
+  "Add the new user to the %1 group so they can use sudo.": {
+    "Add the new user to the %1 group so they can use sudo.": "Lisää uusi käyttäjä %1-ryhmään, jotta hän voi käyttää sudoa."
+  },
+  "Add to Autostart": {
+    "Add to Autostart": "Lisää automaattiseen käynnistykseen"
+  },
+  "Adjust the bar height via inner padding": {
+    "Adjust the bar height via inner padding": "Säädä tangon korkeutta sisemmän pehmusteen avulla"
+  },
+  "Adjust the number of columns in grid view mode.": {
+    "Adjust the number of columns in grid view mode.": "Säädä sarakkeiden määrää ruudukkonäkymätilassa."
+  },
+  "Adjust volume per scroll indent": {
+    "Adjust volume per scroll indent": "Säädä äänenvoimakkuutta vieritys sisennystä kohti"
+  },
+  "Adjusts contrast of generated colors (-100 = minimum, 0 = standard, 100 = maximum)": {
+    "Adjusts contrast of generated colors (-100 = minimum, 0 = standard, 100 = maximum)": "Säätää luotujen värien kontrastia (-100 = minimi, 0 = vakio, 100 = maksimi)"
+  },
+  "Administrator access is required. Use the Sync button in Settings → Greeter to apply.": {
+    "Administrator access is required. Use the Sync button in Settings → Greeter to apply.": "Järjestelmänvalvojan käyttöoikeudet vaaditaan. Käytä Synkronoi-painiketta kohdassa Asetukset → Tervehdys ottaaksesi käyttöön."
+  },
+  "Administrator group:": {
+    "Administrator group:": "Ylläpitäjäryhmä:"
+  },
+  "Advanced": {
+    "Advanced": "Lisäasetukset"
+  },
+  "Afternoon": {
+    "Afternoon": "Iltapäivä"
+  },
+  "Alerts": {
+    "Alerts": "Hälytykset"
+  },
+  "All": {
+    "All": "Kaikki"
+  },
+  "All checks passed": {
+    "All checks passed": "Kaikki tarkastukset läpäisty"
+  },
+  "All day": {
+    "All day": "Koko päivän"
+  },
+  "All displays": {
+    "All displays": "Kaikki näytöt"
+  },
+  "Allow": {
+    "Allow": "Salli"
+  },
+  "Allow LAN access": {
+    "Allow LAN access": "Salli LAN-käyttö"
+  },
+  "Allow adjusting device volume by scrolling on the right half of items in the device list": {
+    "Allow adjusting device volume by scrolling on the right half of items in the device list": "Salli laitteen äänenvoimakkuuden säätäminen vierittämällä laiteluettelon kohteiden oikeaa puoliskoa"
+  },
+  "Allow clicks to pass through the widget": {
+    "Allow clicks to pass through the widget": "Salli napsautusten kulkea widgetin läpi"
+  },
+  "Allow greeter access?": {
+    "Allow greeter access?": "Sallitaanko tervehdys?"
+  },
+  "Allow greeter login access": {
+    "Allow greeter login access": "Salli tervehdyskirjautuminen"
+  },
+  "Already on that session": {
+    "Already on that session": "Jo tuossa istunnossa"
+  },
+  "Also group repeated application icons on the active workspace": {
+    "Also group repeated application icons on the active workspace": "Ryhmittele myös toistuvat sovelluskuvakkeet aktiiviseen työtilaan"
+  },
+  "Alt+←/Backspace: Back • F1/I: File Info • F10: Help • Esc: Close": {
+    "Alt+←/Backspace: Back • F1/I: File Info • F10: Help • Esc: Close": "Alt+←/askelpalautin: Takaisin • F1/I: Tiedoston tiedot • F10: Ohje • Esc: Sulje"
+  },
+  "Alternative (OR)": {
+    "Alternative (OR)": "Vaihtoehto (OR)"
+  },
+  "Always Active": {
+    "Always Active": "Aina aktiivinen"
+  },
+  "Always Show Percentage": {
+    "Always Show Percentage": "Näytä aina prosenttiosuus"
+  },
+  "Always blur against the wallpaper, even with Xray off": {
+    "Always blur against the wallpaper, even with Xray off": "Sumenna aina taustakuvaa vasten, vaikka röntgenkuvaus olisi pois päältä"
+  },
+  "Always hide the dock and reveal it when hovering near the dock area": {
+    "Always hide the dock and reveal it when hovering near the dock area": "Piilota aina telakka ja paljasta se, kun leijut lähellä telakointialuetta"
+  },
+  "Always on icons": {
+    "Always on icons": "Aina kuvakkeilla"
+  },
+  "Always show a minimum of 3 workspaces, even if fewer are available": {
+    "Always show a minimum of 3 workspaces, even if fewer are available": "Näytä aina vähintään 3 työtilaa, vaikka niitä olisi vähemmän"
+  },
+  "Always show the dock when niri's overview is open": {
+    "Always show the dock when niri's overview is open": "Näytä telakka aina, kun nirin yleiskatsaus on auki"
+  },
+  "Always show when there's only one connected display": {
+    "Always show when there's only one connected display": "Näytä aina, kun vain yksi näyttö on kytketty"
+  },
+  "Always use this app for %1": {
+    "Always use this app for %1": "Käytä aina tätä sovellusta %1:lle"
+  },
+  "Amount": {
+    "Amount": "Summa"
+  },
+  "An xray rule at %1 may conflict with the Xray settings below": {
+    "An xray rule at %1 may conflict with the Xray settings below": "%1:n röntgensääntö saattaa olla ristiriidassa alla olevien röntgenasetusten kanssa"
+  },
+  "Analog": {
+    "Analog": "Analog"
+  },
+  "Analog, digital, or stacked clock display": {
+    "Analog, digital, or stacked clock display": "Analoginen, digitaalinen tai pinottu kellonäyttö"
+  },
+  "Analyzing configuration...": {
+    "Analyzing configuration...": "Analysoidaan määritystä..."
+  },
+  "Anchor": {
+    "Anchor": "Ankkuri"
+  },
+  "Animation Duration": {
+    "Animation Duration": "Animaation kesto"
+  },
+  "Animation Speed": {
+    "Animation Speed": "Animaationopeus"
+  },
+  "Animation Style": {
+    "Animation Style": "Animaatiotyyli"
+  },
+  "Anonymous Identity": {
+    "Anonymous Identity": "Anonyymi identiteetti"
+  },
+  "Anonymous Identity (optional)": {
+    "Anonymous Identity (optional)": "Anonyymi henkilöllisyys (valinnainen)"
+  },
+  "Any window": {
+    "Any window": "Mikä tahansa ikkuna"
+  },
+  "App Customizations": {
+    "App Customizations": "Sovelluksen mukautukset"
+  },
+  "App ID": {
+    "App ID": "Sovelluksen tunnus"
+  },
+  "App ID (e.g. firefox)": {
+    "App ID (e.g. firefox)": "Sovellustunnus (esim. firefox)"
+  },
+  "App ID Substitutions": {
+    "App ID Substitutions": "Sovellustunnusten korvaukset"
+  },
+  "App ID regex": {
+    "App ID regex": "Sovellustunnuksen säännöllinen lauseke"
+  },
+  "App ID regex (e.g. ^firefox$)": {
+    "App ID regex (e.g. ^firefox$)": "Sovellustunnuksen säännöllinen lauseke (esim. ^firefox$)"
+  },
+  "App Launcher": {
+    "App Launcher": "Sovellusten käynnistysohjelma"
+  },
+  "App Names": {
+    "App Names": "Sovellusten nimet"
+  },
+  "App Theming": {
+    "App Theming": "App Theming"
+  },
+  "App name or identity (e.g., firefox)": {
+    "App name or identity (e.g., firefox)": "Sovelluksen nimi tai henkilöllisyys (esim. firefox)"
+  },
+  "Appearance": {
+    "Appearance": "Ulkoasu"
+  },
+  "Application": {
+    "Application": "Sovellus"
+  },
+  "Application Dock": {
+    "Application Dock": "Application Dock"
+  },
+  "Applications": {
+    "Applications": "Sovellukset"
+  },
+  "Applications and commands to start automatically when you log in": {
+    "Applications and commands to start automatically when you log in": "Sovellukset ja komennot käynnistyvät automaattisesti, kun kirjaudut sisään"
+  },
+  "Apply Changes": {
+    "Apply Changes": "Ota muutokset käyttöön"
+  },
+  "Apply Flatpak updates alongside system updates when running 'Update All'.": {
+    "Apply Flatpak updates alongside system updates when running 'Update All'.": "Ota Flatpak-päivitykset käyttöön järjestelmäpäivitysten rinnalla, kun suoritat Päivitä kaikki."
+  },
+  "Apply GTK Colors": {
+    "Apply GTK Colors": "Käytä GTK-värejä"
+  },
+  "Apply Qt Colors": {
+    "Apply Qt Colors": "Käytä Qt-värejä"
+  },
+  "Apply compositor blur behind the frame border": {
+    "Apply compositor blur behind the frame border": "Lisää kompositorisumutus kehyksen reunan taakse"
+  },
+  "Apply inverse concave corner cutouts to the bar": {
+    "Apply inverse concave corner cutouts to the bar": "Kiinnitä tankoon käänteiset koverat kulman leikkaukset"
+  },
+  "Apply to Hardware": {
+    "Apply to Hardware": "Käytä laitteistoon"
+  },
+  "Apply warm color temperature to reduce eye strain. Use automation settings below to control when it activates.": {
+    "Apply warm color temperature to reduce eye strain. Use automation settings below to control when it activates.": "Käytä lämmintä värilämpötilaa vähentääksesi silmien rasitusta. Käytä alla olevia automaatioasetuksia määrittääksesi, milloin se aktivoituu."
+  },
+  "Applying authentication changes...": {
+    "Applying authentication changes...": "Otetaan käyttöön todennusmuutoksia..."
+  },
+  "Applying auto-login on startup...": {
+    "Applying auto-login on startup...": "Otetaan automaattista sisäänkirjautumista käyttöön käynnistyksen yhteydessä..."
+  },
+  "Apps": {
+    "Apps": "Sovellukset"
+  },
+  "Apps Dock": {
+    "Apps Dock": "Apps Dock"
+  },
+  "Apps Dock Settings": {
+    "Apps Dock Settings": "Apps Dockin asetukset"
+  },
+  "Apps Icon": {
+    "Apps Icon": "Sovellusten kuvake"
+  },
+  "Apps are ordered by usage frequency, then last used, then alphabetically.": {
+    "Apps are ordered by usage frequency, then last used, then alphabetically.": "Sovellukset on järjestetty käyttötiheyden mukaan, sitten viimeksi käytettyjen ja sitten aakkosjärjestyksessä."
+  },
+  "Apps with custom display name, icon, or launch options. Right-click an app and select 'Edit App' to customize.": {
+    "Apps with custom display name, icon, or launch options. Right-click an app and select 'Edit App' to customize.": "Sovellukset, joissa on mukautettu näyttönimi, kuvake tai käynnistysasetukset. Napsauta sovellusta hiiren kakkospainikkeella ja muokkaa sovellusta valitsemalla Muokkaa sovellusta."
+  },
+  "Apps with notification popups muted. Unmute or delete to remove.": {
+    "Apps with notification popups muted. Unmute or delete to remove.": "Sovellukset, joiden ilmoitusponnahdusikkunat on mykistetty. Poista mykistys tai poista se."
+  },
+  "Arc Extender": {
+    "Arc Extender": "Kaaren jatke"
+  },
+  "Architecture": {
+    "Architecture": "Arkkitehtuuri"
+  },
+  "Are you sure you want to kill session \"%1\"?": {
+    "Are you sure you want to kill session \"%1\"?": "Haluatko varmasti lopettaa istunnon \"%1\"?"
+  },
+  "Arrange displays and configure resolution, refresh rate, and VRR": {
+    "Arrange displays and configure resolution, refresh rate, and VRR": "Järjestä näytöt ja määritä resoluutio, virkistystaajuus ja VRR"
+  },
+  "At Startup": {
+    "At Startup": "Käynnistyksen yhteydessä"
+  },
+  "At least one output must remain enabled": {
+    "At least one output must remain enabled": "Vähintään yhden lähdön on oltava käytössä"
+  },
+  "At start": {
+    "At start": "Alussa"
+  },
+  "Attach": {
+    "Attach": "Kiinnitä"
+  },
+  "Audio": {
+    "Audio": "Ääni"
+  },
+  "Audio Codec": {
+    "Audio Codec": "Äänikoodekki"
+  },
+  "Audio Codec Selection": {
+    "Audio Codec Selection": "Äänikoodekkien valinta"
+  },
+  "Audio Devices": {
+    "Audio Devices": "Äänilaitteet"
+  },
+  "Audio Input": {
+    "Audio Input": "Äänitulo"
+  },
+  "Audio Output": {
+    "Audio Output": "Äänilähtö"
+  },
+  "Audio Output Devices (": {
+    "Audio Output Devices (": "Äänen ulostulolaitteet ("
+  },
+  "Audio Output Switch": {
+    "Audio Output Switch": "Äänilähdön kytkin"
+  },
+  "Audio Visualizer": {
+    "Audio Visualizer": "Audiovisualisoija"
+  },
+  "Audio system restarted": {
+    "Audio system restarted": "Äänijärjestelmä käynnistettiin uudelleen"
+  },
+  "Audio volume control": {
+    "Audio volume control": "Äänenvoimakkuuden säätö"
+  },
+  "Auth": {
+    "Auth": "Tod"
+  },
+  "Auth Type": {
+    "Auth Type": "Todennustyyppi"
+  },
+  "Authenticate": {
+    "Authenticate": "Todentaa"
+  },
+  "Authenticated!": {
+    "Authenticated!": "Todennettu!"
+  },
+  "Authenticating...": {
+    "Authenticating...": "Todennetaan..."
+  },
+  "Authentication": {
+    "Authentication": "Todennus"
+  },
+  "Authentication Required": {
+    "Authentication Required": "Todennus vaaditaan"
+  },
+  "Authentication Source": {
+    "Authentication Source": "Todennuksen lähde"
+  },
+  "Authentication changes applied.": {
+    "Authentication changes applied.": "Todennusmuutokset otettu käyttöön."
+  },
+  "Authentication changes apply automatically.": {
+    "Authentication changes apply automatically.": "Todennusmuutokset tulevat voimaan automaattisesti."
+  },
+  "Authentication changes need sudo. Opening terminal so you can use password or fingerprint.": {
+    "Authentication changes need sudo. Opening terminal so you can use password or fingerprint.": "Todennusmuutokset vaativat sudon. Avaa pääte, jotta voit käyttää salasanaa tai sormenjälkeä."
+  },
+  "Authentication error - try again": {
+    "Authentication error - try again": "Todennusvirhe - yritä uudelleen"
+  },
+  "Authentication failed - attempt %1 of %2": {
+    "Authentication failed - attempt %1 of %2": "Todennus epäonnistui – %1/%2 yritys"
+  },
+  "Authentication failed - lockout can occur": {
+    "Authentication failed - lockout can occur": "Todennus epäonnistui – voi tapahtua lukitus"
+  },
+  "Authentication failed - try again": {
+    "Authentication failed - try again": "Todennus epäonnistui - yritä uudelleen"
+  },
+  "Authorize": {
+    "Authorize": "Valtuuta"
+  },
+  "Authorize pairing with ": {
+    "Authorize pairing with ": "Valtuuta pariliitos"
+  },
+  "Authorize service for ": {
+    "Authorize service for ": "Valtuuta palvelu kohteelle"
+  },
+  "Auto": {
+    "Auto": "Auto"
+  },
+  "Auto (Bar-aware)": {
+    "Auto (Bar-aware)": "Auto (baaritietoinen)"
+  },
+  "Auto (Wide)": {
+    "Auto (Wide)": "Automaattinen (leveä)"
+  },
+  "Auto Compositor Gaps": {
+    "Auto Compositor Gaps": "Automaattinen kompositorin aukot"
+  },
+  "Auto Location": {
+    "Auto Location": "Automaattinen sijainti"
+  },
+  "Auto Overflow": {
+    "Auto Overflow": "Automaattinen ylivuoto"
+  },
+  "Auto Popup Gaps": {
+    "Auto Popup Gaps": "Automaattiset ponnahdusikkunat"
+  },
+  "Auto Power Saver": {
+    "Auto Power Saver": "Automaattinen virransäästö"
+  },
+  "Auto matches bar spacing; Off leaves gaps to your %1 config": {
+    "Auto matches bar spacing; Off leaves gaps to your %1 config": "Automaattinen vastaa palkin välistystä; Pois jättää välit %1-asetustesi mukaisiksi"
+  },
+  "Auto mode is on. Manual profile selection is disabled.": {
+    "Auto mode is on. Manual profile selection is disabled.": "Automaattinen tila on päällä. Manuaalinen profiilin valinta on poistettu käytöstä."
+  },
+  "Auto saved": {
+    "Auto saved": "Automaattisesti tallennettu"
+  },
+  "Auto uses an installed or bundled key-only service.": {
+    "Auto uses an installed or bundled key-only service.": "Automaattinen käyttää asennettua tai mukana toimitettua vain avaimen hyväksyvää palvelua."
+  },
+  "Auto-Clear After": {
+    "Auto-Clear After": "Automaattinen tyhjennys jälkeen"
+  },
+  "Auto-Hide Timeout": {
+    "Auto-Hide Timeout": "Automaattisen piilotuksen aikakatkaisu"
+  },
+  "Auto-close Niri overview when launching apps.": {
+    "Auto-close Niri overview when launching apps.": "Sulje automaattisesti Niri yleiskatsaus sovelluksia käynnistettäessä."
+  },
+  "Auto-delete notifications older than this": {
+    "Auto-delete notifications older than this": "Poista tätä vanhemmat ilmoitukset automaattisesti"
+  },
+  "Auto-hide": {
+    "Auto-hide": "Piilota automaattisesti"
+  },
+  "Auto-hide Dock": {
+    "Auto-hide Dock": "Piilota telakka automaattisesti"
+  },
+  "Auto-login": {
+    "Auto-login": "Automaattinen kirjautuminen"
+  },
+  "Auto-login change needs a sync": {
+    "Auto-login change needs a sync": "Automaattisen kirjautumisen muutos vaatii synkronoinnin"
+  },
+  "Auto-login disabled": {
+    "Auto-login disabled": "Automaattinen kirjautuminen pois käytöstä"
+  },
+  "Auto-login enabled": {
+    "Auto-login enabled": "Automaattinen sisäänkirjautuminen käytössä"
+  },
+  "Auto-login on startup": {
+    "Auto-login on startup": "Automaattinen sisäänkirjautuminen käynnistyksen yhteydessä"
+  },
+  "Auto-save to disk": {
+    "Auto-save to disk": "Automaattinen tallennus levylle"
+  },
+  "Autoconnect": {
+    "Autoconnect": "Automaattinen yhteys"
+  },
+  "Autoconnect disabled": {
+    "Autoconnect disabled": "Automaattinen yhteys pois käytöstä"
+  },
+  "Autoconnect enabled": {
+    "Autoconnect enabled": "Automaattinen yhteys käytössä"
+  },
+  "Autofill last remembered query when opened": {
+    "Autofill last remembered query when opened": "Automaattinen täyttö viimeinen muistettu kysely avattaessa"
+  },
+  "Automatic Color Mode": {
+    "Automatic Color Mode": "Automaattinen väritila"
+  },
+  "Automatic Control": {
+    "Automatic Control": "Automaattinen ohjaus"
+  },
+  "Automatic Cycling": {
+    "Automatic Cycling": "Automaattinen Pyöräily"
+  },
+  "Automatically calculate popup gap based on bar spacing": {
+    "Automatically calculate popup gap based on bar spacing": "Laske ponnahdusikkunoiden väli automaattisesti palkkien välin perusteella"
+  },
+  "Automatically cycle through wallpapers in the same folder": {
+    "Automatically cycle through wallpapers in the same folder": "Selaa automaattisesti saman kansion taustakuvia"
+  },
+  "Automatically delete entries older than this": {
+    "Automatically delete entries older than this": "Poista tätä vanhemmat merkinnät automaattisesti"
+  },
+  "Automatically detect location based on IP address": {
+    "Automatically detect location based on IP address": "Tunnista sijainti automaattisesti IP-osoitteen perusteella"
+  },
+  "Automatically determine your location using your IP address": {
+    "Automatically determine your location using your IP address": "Määritä sijaintisi automaattisesti IP-osoitteesi avulla"
+  },
+  "Automatically hide the bar when the pointer moves away": {
+    "Automatically hide the bar when the pointer moves away": "Piilota palkki automaattisesti, kun osoitin siirtyy poispäin"
+  },
+  "Automatically lock after": {
+    "Automatically lock after": "Automaattinen lukitus jälkeen"
+  },
+  "Automatically lock the screen when DMS starts": {
+    "Automatically lock the screen when DMS starts": "Lukitse näyttö automaattisesti, kun DMS käynnistyy"
+  },
+  "Automatically lock the screen when the system prepares to suspend": {
+    "Automatically lock the screen when the system prepares to suspend": "Lukitse näyttö automaattisesti, kun järjestelmä valmistautuu keskeytykseen"
+  },
+  "Automatically save changes to opened files as you type": {
+    "Automatically save changes to opened files as you type": "Tallenna muutokset avattuihin tiedostoihin automaattisesti kirjoittaessasi"
+  },
+  "Automatically turn on Power Saver profile when battery is low.": {
+    "Automatically turn on Power Saver profile when battery is low.": "Ota virransäästöprofiili automaattisesti käyttöön, kun akku on vähissä."
+  },
+  "Automation": {
+    "Automation": "Automaatio"
+  },
+  "Autostart Apps": {
+    "Autostart Apps": "Autostart Apps"
+  },
+  "Autostart Entries": {
+    "Autostart Entries": "Autostart merkinnät"
+  },
+  "Available": {
+    "Available": "Saatavilla"
+  },
+  "Available Layouts": {
+    "Available Layouts": "Käytettävissä olevat asettelut"
+  },
+  "Available Networks": {
+    "Available Networks": "Käytettävissä olevat verkot"
+  },
+  "Available Plugins": {
+    "Available Plugins": "Saatavilla olevat laajennukset"
+  },
+  "Available Screens (%1)": {
+    "Available Screens (%1)": "Käytettävissä olevat näytöt (%1)"
+  },
+  "Available Updates (%1)": {
+    "Available Updates (%1)": "Saatavilla olevat päivitykset (%1)"
+  },
+  "Available in Detailed and Forecast view modes": {
+    "Available in Detailed and Forecast view modes": "Saatavilla Yksityiskohtainen- ja Ennuste-näkymässä"
+  },
+  "Awaiting fingerprint authentication": {
+    "Awaiting fingerprint authentication": "Odotetaan sormenjälkitunnistusta"
+  },
+  "Awaiting fingerprint or security key authentication": {
+    "Awaiting fingerprint or security key authentication": "Odottaa sormenjäljen tai suojausavaimen todennusta"
+  },
+  "Awaiting security key authentication": {
+    "Awaiting security key authentication": "Odotetaan suojausavaimen todennusta"
+  },
+  "BSSID": {
+    "BSSID": "BSSID"
+  },
+  "Back": {
+    "Back": "Takaisin"
+  },
+  "Back to user list": {
+    "Back to user list": "Takaisin käyttäjäluetteloon"
+  },
+  "Backend": {
+    "Backend": "Taustapalvelu"
+  },
+  "Background": {
+    "Background": "Tausta"
+  },
+  "Background Blur": {
+    "Background Blur": "Taustan sumennus"
+  },
+  "Background Color": {
+    "Background Color": "Taustaväri"
+  },
+  "Background Effect": {
+    "Background Effect": "Taustatehoste"
+  },
+  "Background Opacity": {
+    "Background Opacity": "Taustan läpinäkyvyys"
+  },
+  "Background authentication sync failed. Trying terminal mode.": {
+    "Background authentication sync failed. Trying terminal mode.": "Taustatodennuksen synkronointi epäonnistui. Yritetään päätetilaa."
+  },
+  "Background image": {
+    "Background image": "Taustakuva"
+  },
+  "Backlight device": {
+    "Backlight device": "Taustavalo laite"
+  },
+  "Balance power and performance": {
+    "Balance power and performance": "Tasapainottaa teho ja suorituskyky"
+  },
+  "Balanced": {
+    "Balanced": "Tasapainoinen"
+  },
+  "Balanced palette with focused accents (default).": {
+    "Balanced palette with focused accents (default).": "Tasapainoinen paletti kohdistetuilla aksenteilla (oletus)."
+  },
+  "Bar": {
+    "Bar": "Baari"
+  },
+  "Bar %1": {
+    "Bar %1": "Tanko %1"
+  },
+  "Bar Inset Padding": {
+    "Bar Inset Padding": "Palkin upotettu pehmuste"
+  },
+  "Bar Opacity": {
+    "Bar Opacity": "Palkin opasiteetti"
+  },
+  "Bar Shadows": {
+    "Bar Shadows": "Baarivarjot"
+  },
+  "Bar Spacing": {
+    "Bar Spacing": "Palkkivälit"
+  },
+  "Bar corners and background": {
+    "Bar corners and background": "Baarien kulmat ja tausta"
+  },
+  "Bar shadow, border, and corners": {
+    "Bar shadow, border, and corners": "Palkin varjo, reunus ja kulmat"
+  },
+  "Base color for shadows (opacity is applied automatically)": {
+    "Base color for shadows (opacity is applied automatically)": "Varjojen perusväri (opasiteetti lisätään automaattisesti)"
+  },
+  "Base duration for animations (drag to use Custom)": {
+    "Base duration for animations (drag to use Custom)": "Animaatioiden peruskesto (muokattuun käyttöön vetämällä)"
+  },
+  "Battery": {
+    "Battery": "Akku"
+  },
+  "Battery %1": {
+    "Battery %1": "Akku %1"
+  },
+  "Battery Charge Limit": {
+    "Battery Charge Limit": "Akun latausraja"
+  },
+  "Battery Health": {
+    "Battery Health": "Akun kunto"
+  },
+  "Battery Power": {
+    "Battery Power": "Akun teho"
+  },
+  "Battery and power management": {
+    "Battery and power management": "Akun ja virranhallinta"
+  },
+  "Battery has charged to your set limit of %1%": {
+    "Battery has charged to your set limit of %1%": "Akku on latautunut asettamasi %1 % rajaan"
+  },
+  "Battery is at %1% - Connect charger immediately!": {
+    "Battery is at %1% - Connect charger immediately!": "Akku on %1% - Liitä laturi välittömästi!"
+  },
+  "Battery is at %1% - Consider charging soon": {
+    "Battery is at %1% - Consider charging soon": "Akun varaustaso on %1 % – Harkitse lataamista pian"
+  },
+  "Battery percentage to trigger a critical alert.": {
+    "Battery percentage to trigger a critical alert.": "Akun prosenttiosuus kriittisen hälytyksen laukaisemiseksi."
+  },
+  "Behavior": {
+    "Behavior": "Käyttäytyminen"
+  },
+  "Bind lock screen to dbus signals from loginctl. Disable if using an external lock screen": {
+    "Bind lock screen to dbus signals from loginctl. Disable if using an external lock screen": "Sido lukitusnäyttö dbus-signaaleihin loginctl:stä. Poista käytöstä, jos käytät ulkoista lukitusnäyttöä"
+  },
+  "Bind the %1 IPC action in your compositor config.": {
+    "Bind the %1 IPC action in your compositor config.": "Määritä %1-IPC-toiminnolle pikanäppäin ikkunanhallinnan asetuksissa."
+  },
+  "Binds include added": {
+    "Binds include added": "Sidot sisältävät lisätyt"
+  },
+  "Bit Depth": {
+    "Bit Depth": "Bittisyvyys"
+  },
+  "Black": {
+    "Black": "Musta"
+  },
+  "Blend between Surface High and the selected custom color": {
+    "Blend between Surface High and the selected custom color": "Sekoita Surface Highin ja valitun mukautetun värin välillä"
+  },
+  "Block Out": {
+    "Block Out": "Estä pois"
+  },
+  "Block Out From": {
+    "Block Out From": "Estä pois"
+  },
+  "Block notifications": {
+    "Block notifications": "Estä ilmoitukset"
+  },
+  "Blocked": {
+    "Blocked": "Estetty"
+  },
+  "Blue light filter": {
+    "Blue light filter": "Sinisen valon suodatin"
+  },
+  "Bluetooth": {
+    "Bluetooth": "Bluetooth"
+  },
+  "Bluetooth Settings": {
+    "Bluetooth Settings": "Bluetooth-asetukset"
+  },
+  "Bluetooth not available": {
+    "Bluetooth not available": "Bluetooth ei ole käytettävissä"
+  },
+  "Blur": {
+    "Blur": "Sumennus"
+  },
+  "Blur Wallpaper Layer": {
+    "Blur Wallpaper Layer": "Sumennuksen taustakuvakerros"
+  },
+  "Blur on Overview": {
+    "Blur on Overview": "Sumennus yleiskatsauksessa"
+  },
+  "Blur the background behind bars, popouts, modals, and notifications. Requires compositor support. Adjust Opacity accordingly.": {
+    "Blur the background behind bars, popouts, modals, and notifications. Requires compositor support. Adjust Opacity accordingly.": "Sumenna tausta kaltereiden, ponnahdusikkunoiden, modaalien ja ilmoitusten takana. Vaatii kompositorituen. Säädä Opacity vastaavasti."
+  },
+  "Blur wallpaper when niri overview is open": {
+    "Blur wallpaper when niri overview is open": "Sumenna taustakuva, kun niri-katsaus on auki"
+  },
+  "Blurred surfaces show the wallpaper instead of the content beneath": {
+    "Blurred surfaces show the wallpaper instead of the content beneath": "Epäselvillä pinnoilla näkyy taustakuva alla olevan sisällön sijaan"
+  },
+  "Body": {
+    "Body": "Runko"
+  },
+  "Body Font Size": {
+    "Body Font Size": "Tekstin kirjasinkoko"
+  },
+  "Bold": {
+    "Bold": "Lihavoitu"
+  },
+  "Border": {
+    "Border": "Raja"
+  },
+  "Border Color": {
+    "Border Color": "Reunuksen väri"
+  },
+  "Border Off": {
+    "Border Off": "Raja pois"
+  },
+  "Border Opacity": {
+    "Border Opacity": "Reunan läpinäkyvyys"
+  },
+  "Border Radius": {
+    "Border Radius": "Reunan säde"
+  },
+  "Border Size": {
+    "Border Size": "Reunuksen koko"
+  },
+  "Border Thickness": {
+    "Border Thickness": "Reunan paksuus"
+  },
+  "Border Width": {
+    "Border Width": "Reunan leveys"
+  },
+  "Border color around popouts, modals, and other shell surfaces": {
+    "Border color around popouts, modals, and other shell surfaces": "Reunuksen väri ponnahdusikkunoiden, modaalien ja muiden kuoripintojen ympärillä"
+  },
+  "Border w/ Bg": {
+    "Border w/ Bg": "Reunus Bg"
+  },
+  "Border with Background": {
+    "Border with Background": "Reunus taustalla"
+  },
+  "Bottom": {
+    "Bottom": "Pohja"
+  },
+  "Bottom Center": {
+    "Bottom Center": "Alakeskus"
+  },
+  "Bottom Left": {
+    "Bottom Left": "Vasemmalla alhaalla"
+  },
+  "Bottom Right": {
+    "Bottom Right": "Alhaalla oikealla"
+  },
+  "Bottom Section": {
+    "Bottom Section": "Alaosa"
+  },
+  "Bottom dock for pinned and running applications": {
+    "Bottom dock for pinned and running applications": "Pohjatelakka kiinnitetyille ja käynnissä oleville sovelluksille"
+  },
+  "Brightness": {
+    "Brightness": "Kirkkaus"
+  },
+  "Brightness Slider": {
+    "Brightness Slider": "Kirkkauden liukusäädin"
+  },
+  "Brightness Value": {
+    "Brightness Value": "Kirkkauden arvo"
+  },
+  "Brightness control not available": {
+    "Brightness control not available": "Kirkkauden säätö ei ole käytettävissä"
+  },
+  "Browse": {
+    "Browse": "Selaa"
+  },
+  "Browse Files": {
+    "Browse Files": "Selaa tiedostoja"
+  },
+  "Browse Plugins": {
+    "Browse Plugins": "Selaa laajennuksia"
+  },
+  "Browse Themes": {
+    "Browse Themes": "Selaa teemoja"
+  },
+  "Browse and set wallpapers": {
+    "Browse and set wallpapers": "Selaa ja aseta taustakuvia"
+  },
+  "Browse or search plugins": {
+    "Browse or search plugins": "Selaa tai etsi laajennuksia"
+  },
+  "Button Color": {
+    "Button Color": "Painikkeen väri"
+  },
+  "CPU": {
+    "CPU": "CPU"
+  },
+  "CPU Graph": {
+    "CPU Graph": "CPU-kaavio"
+  },
+  "CPU Temperature": {
+    "CPU Temperature": "CPU:n lämpötila"
+  },
+  "CPU Usage": {
+    "CPU Usage": "CPU:n käyttö"
+  },
+  "CPU temperature display": {
+    "CPU temperature display": "CPU:n lämpötilan näyttö"
+  },
+  "CPU usage indicator": {
+    "CPU usage indicator": "Prosessorin käytön ilmaisin"
+  },
+  "CPU, memory, network, and disk monitoring": {
+    "CPU, memory, network, and disk monitoring": "Suorittimen, muistin, verkon ja levyn valvonta"
+  },
+  "CUPS Insecure Filter Warning": {
+    "CUPS Insecure Filter Warning": "CUPS:n suojaamaton suodatin Varoitus"
+  },
+  "CUPS Missing Filter Warning": {
+    "CUPS Missing Filter Warning": "CUPS-varoitus puuttuvasta suodattimesta"
+  },
+  "CUPS Print Server": {
+    "CUPS Print Server": "CUPS-tulostuspalvelin"
+  },
+  "CUPS not available": {
+    "CUPS not available": "CUPS ei ole saatavilla"
+  },
+  "Calendar": {
+    "Calendar": "Kalenteri"
+  },
+  "Calendar Backend": {
+    "Calendar Backend": "Kalenterin taustaohjelma"
+  },
+  "Camera": {
+    "Camera": "Kamera"
+  },
+  "Cancel": {
+    "Cancel": "Peruuta"
+  },
+  "Cancel all jobs for \"%1\"?": {
+    "Cancel all jobs for \"%1\"?": "Perutaanko kaikki työt kohteelle \"%1\"?"
+  },
+  "Canceled": {
+    "Canceled": "Peruutettu"
+  },
+  "Cannot delete the only administrator": {
+    "Cannot delete the only administrator": "Ainoaa järjestelmänvalvojaa ei voi poistaa"
+  },
+  "Cannot disable the only output": {
+    "Cannot disable the only output": "Ainoa lähtöä ei voi poistaa käytöstä"
+  },
+  "Cannot open trash: '%1' is not installed": {
+    "Cannot open trash: '%1' is not installed": "Roskakoria ei voi avata: \"%1\" ei ole asennettu"
+  },
+  "Cannot open trash: no custom command set": {
+    "Cannot open trash: no custom command set": "Roskakoria ei voi avata: mukautettua komentoa ei ole asetettu"
+  },
+  "Cannot pair": {
+    "Cannot pair": "Ei voi muodostaa paria"
+  },
+  "Cannot remove the only administrator": {
+    "Cannot remove the only administrator": "Ainoaa järjestelmänvalvojaa ei voi poistaa"
+  },
+  "Capabilities": {
+    "Capabilities": "Ominaisuudet"
+  },
+  "Capacity": {
+    "Capacity": "Kapasiteetti"
+  },
+  "Caps Lock": {
+    "Caps Lock": "Caps Lock"
+  },
+  "Caps Lock Indicator": {
+    "Caps Lock Indicator": "Caps Lock -ilmaisin"
+  },
+  "Caps Lock is on": {
+    "Caps Lock is on": "Caps Lock on päällä"
+  },
+  "Cast Target": {
+    "Cast Target": "Cast Target"
+  },
+  "Category": {
+    "Category": "Luokka"
+  },
+  "Center Section": {
+    "Center Section": "Keskiosa"
+  },
+  "Center Single Column": {
+    "Center Single Column": "Yksi sarake keskellä"
+  },
+  "Center Tiling": {
+    "Center Tiling": "Keskuksen laatoitus"
+  },
+  "Certificate Password": {
+    "Certificate Password": "Sertifikaatin salasana"
+  },
+  "Change Song": {
+    "Change Song": "Vaihda kappale"
+  },
+  "Change Volume": {
+    "Change Volume": "Muuta äänenvoimakkuutta"
+  },
+  "Change the locale used by the DMS interface.": {
+    "Change the locale used by the DMS interface.": "Vaihda DMS-käyttöliittymän kieli."
+  },
+  "Change the locale used for date and time formatting, independent of the interface language.": {
+    "Change the locale used for date and time formatting, independent of the interface language.": "Vaihda päivämäärien ja kellonaikojen muotoilussa käytettävä alueasetus käyttöliittymän kielestä riippumatta."
+  },
+  "Channel": {
+    "Channel": "kanava"
+  },
+  "Charge Level": {
+    "Charge Level": "Lataustaso"
+  },
+  "Charge Limit Reached": {
+    "Charge Limit Reached": "Latausraja saavutettu"
+  },
+  "Charge limit applied successfully": {
+    "Charge limit applied successfully": "Veloitusrajan käyttöönotto onnistui"
+  },
+  "Charging": {
+    "Charging": "Lataus"
+  },
+  "Check for system updates": {
+    "Check for system updates": "Tarkista järjestelmäpäivitykset"
+  },
+  "Check interval": {
+    "Check interval": "Tarkista intervalli"
+  },
+  "Check on startup": {
+    "Check on startup": "Tarkista käynnistyksen yhteydessä"
+  },
+  "Check your custom command in Settings → Dock → Trash.": {
+    "Check your custom command in Settings → Dock → Trash.": "Tarkista mukautettu komento kohdasta Asetukset → Dock → Roskakori."
+  },
+  "Checking for updates...": {
+    "Checking for updates...": "Tarkistetaan päivityksiä..."
+  },
+  "Checking whether sudo authentication is needed...": {
+    "Checking whether sudo authentication is needed...": "Tarkistetaan, tarvitaanko sudo-todennusta..."
+  },
+  "Checking...": {
+    "Checking...": "Tarkistetaan..."
+  },
+  "Choose Color": {
+    "Choose Color": "Valitse Väri"
+  },
+  "Choose Dark Mode Color": {
+    "Choose Dark Mode Color": "Valitse Tumman tilan väri"
+  },
+  "Choose Launcher Logo Color": {
+    "Choose Launcher Logo Color": "Valitse Launcherin logon väri"
+  },
+  "Choose Light Mode Color": {
+    "Choose Light Mode Color": "Valitse Light Mode Color"
+  },
+  "Choose Wallpaper Color": {
+    "Choose Wallpaper Color": "Valitse taustakuvan väri"
+  },
+  "Choose a color": {
+    "Choose a color": "Valitse väri"
+  },
+  "Choose a power profile": {
+    "Choose a power profile": "Valitse tehoprofiili"
+  },
+  "Choose colors from palette": {
+    "Choose colors from palette": "Valitse värit paletista"
+  },
+  "Choose how the weather widget is displayed": {
+    "Choose how the weather widget is displayed": "Valitse, miten sää-widget näytetään"
+  },
+  "Choose how this bar resolves shadow direction": {
+    "Choose how this bar resolves shadow direction": "Valitse, kuinka tämä palkki määrittää varjon suunnan"
+  },
+  "Choose how to be notified about critical battery alerts.": {
+    "Choose how to be notified about critical battery alerts.": "Valitse, miten saat ilmoituksen kriittisistä akkuhälytyksistä."
+  },
+  "Choose how to be notified about low battery alerts.": {
+    "Choose how to be notified about low battery alerts.": "Valitse, miten saat ilmoituksen akun heikentymisestä."
+  },
+  "Choose how to be notified when charge limit is reached.": {
+    "Choose how to be notified when charge limit is reached.": "Valitse, miten saat ilmoituksen, kun latausraja on saavutettu."
+  },
+  "Choose icon": {
+    "Choose icon": "Valitse kuvake"
+  },
+  "Choose monochrome or a theme color tint for system tray icons": {
+    "Choose monochrome or a theme color tint for system tray icons": "Valitse ilmaisinalueen kuvakkeille yksivärinen tai teemavärisävy"
+  },
+  "Choose neutral or accent-colored widget text": {
+    "Choose neutral or accent-colored widget text": "Valitse neutraali tai korostusvärinen widget-teksti"
+  },
+  "Choose the logo displayed on the launcher button in DankBar": {
+    "Choose the logo displayed on the launcher button in DankBar": "Valitse DankBarin käynnistyspainikkeessa näkyvä logo"
+  },
+  "Choose wallpaper folder": {
+    "Choose wallpaper folder": "Valitse taustakuvakansio"
+  },
+  "Choose where notification popups appear on screen": {
+    "Choose where notification popups appear on screen": "Valitse, missä ilmoitusponnahdusikkunat näkyvät näytöllä"
+  },
+  "Choose where on-screen displays appear on screen": {
+    "Choose where on-screen displays appear on screen": "Valitse, missä näytöllä näkyvät näytöt"
+  },
+  "Choose whether to launch a desktop app or a command": {
+    "Choose whether to launch a desktop app or a command": "Valitse, käynnistetäänkö työpöytäsovellus vai komento"
+  },
+  "Choose which action buttons appear on clipboard entries": {
+    "Choose which action buttons appear on clipboard entries": "Valitse, mitkä toimintopainikkeet näkyvät leikepöydän merkinnöissä"
+  },
+  "Choose which displays show this widget": {
+    "Choose which displays show this widget": "Valitse, millä näytöillä tämä widget näytetään"
+  },
+  "Choose which monitors show the lock screen interface. Other monitors will display a solid color for OLED burn-in protection.": {
+    "Choose which monitors show the lock screen interface. Other monitors will display a solid color for OLED burn-in protection.": "Valitse, mitkä näytöt näyttävät lukitusnäytön käyttöliittymän. Muut näytöt näyttävät yhtenäisen värin OLED-suojausta varten."
+  },
+  "Chroma Style": {
+    "Chroma Style": "Chroma tyyli"
+  },
+  "Cipher": {
+    "Cipher": "Salaus"
+  },
+  "Circle": {
+    "Circle": "Ympyrä"
+  },
+  "Class regex": {
+    "Class regex": "Luokan säännöllinen lauseke"
+  },
+  "Class regex (e.g. ^firefox$)": {
+    "Class regex (e.g. ^firefox$)": "Luokan regex (esim. ^firefox$)"
+  },
+  "Clear": {
+    "Clear": "Selkeä"
+  },
+  "Clear All": {
+    "Clear All": "Tyhjennä kaikki"
+  },
+  "Clear All Jobs": {
+    "Clear All Jobs": "Tyhjennä kaikki työt"
+  },
+  "Clear History?": {
+    "Clear History?": "Tyhjennä historia?"
+  },
+  "Clear Sky": {
+    "Clear Sky": "Kirkas taivas"
+  },
+  "Clear all history when server starts": {
+    "Clear all history when server starts": "Tyhjennä kaikki historia, kun palvelin käynnistyy"
+  },
+  "Clear at Startup": {
+    "Clear at Startup": "Tyhjennä käynnistyksen yhteydessä"
+  },
+  "Click 'Setup' to create %1 and add include to your compositor config.": {
+    "Click 'Setup' to create %1 and add include to your compositor config.": "Napsauta \"Asetukset\" luodaksesi %1 ja lisäät sisällyttämisen kokoonpanoasi."
+  },
+  "Click Import to add a .ovpn or .conf": {
+    "Click Import to add a .ovpn or .conf": "Napsauta Tuo lisätäksesi .ovpn- tai .conf-tiedoston"
+  },
+  "Click Refresh to check status.": {
+    "Click Refresh to check status.": "Tarkista tila napsauttamalla Päivitä."
+  },
+  "Click Through": {
+    "Click Through": "Napsauta läpi"
+  },
+  "Click an entry to paste directly instead of copying": {
+    "Click an entry to paste directly instead of copying": "Napsauta merkintää liittääksesi sen suoraan kopioimisen sijaan"
+  },
+  "Click any shortcut to edit. Changes save to %1": {
+    "Click any shortcut to edit. Changes save to %1": "Napsauta mitä tahansa pikakuvaketta muokataksesi. Muutokset tallennetaan tiedostoon %1"
+  },
+  "Click to Paste": {
+    "Click to Paste": "Liitä napsauttamalla"
+  },
+  "Click to capture": {
+    "Click to capture": "Tallenna napsauttamalla"
+  },
+  "Click to select a custom theme JSON file": {
+    "Click to select a custom theme JSON file": "Napsauta valitaksesi mukautetun teeman JSON-tiedosto"
+  },
+  "Clip": {
+    "Clip": "Leike"
+  },
+  "Clip to Geometry": {
+    "Clip to Geometry": "Leikkaa geometriaan"
+  },
+  "Clipboard": {
+    "Clipboard": "Leikepöytä"
+  },
+  "Clipboard History": {
+    "Clipboard History": "Leikepöydän historia"
+  },
+  "Clipboard Manager": {
+    "Clipboard Manager": "Leikepöydän hallinta"
+  },
+  "Clipboard Saved": {
+    "Clipboard Saved": "Leikepöytä tallennettu"
+  },
+  "Clipboard sent": {
+    "Clipboard sent": "Leikepöytä lähetetty"
+  },
+  "Clipboard works but nothing saved to disk": {
+    "Clipboard works but nothing saved to disk": "Leikepöytä toimii, mutta mitään ei ole tallennettu levylle"
+  },
+  "Clock": {
+    "Clock": "Kello"
+  },
+  "Clock Style": {
+    "Clock Style": "Kellon tyyli"
+  },
+  "Clock, calendar, system info and profile": {
+    "Clock, calendar, system info and profile": "Kello, kalenteri, järjestelmätiedot ja profiili"
+  },
+  "Close": {
+    "Close": "Sulje"
+  },
+  "Close All Windows": {
+    "Close All Windows": "Sulje kaikki ikkunat"
+  },
+  "Close Overview on Launch": {
+    "Close Overview on Launch": "Sulje Yleiskatsaus käynnistettäessä"
+  },
+  "Close Window": {
+    "Close Window": "Sulje ikkuna"
+  },
+  "Codec switching is unavailable because pactl was not found": {
+    "Codec switching is unavailable because pactl was not found": "Koodekin vaihto ei ole käytettävissä, koska pactl ei löytynyt"
+  },
+  "Color": {
+    "Color": "Väri"
+  },
+  "Color %1 copied": {
+    "Color %1 copied": "Väri %1 kopioitu"
+  },
+  "Color Gamut": {
+    "Color Gamut": "Värivalikoima"
+  },
+  "Color Management": {
+    "Color Management": "Värinhallinta"
+  },
+  "Color Mode": {
+    "Color Mode": "Väritila"
+  },
+  "Color Override": {
+    "Color Override": "Värien ohitus"
+  },
+  "Color Picker": {
+    "Color Picker": "Värinvalitsin"
+  },
+  "Color Temperature": {
+    "Color Temperature": "Värilämpötila"
+  },
+  "Color displayed on monitors without the lock screen": {
+    "Color displayed on monitors without the lock screen": "Värit näkyvät näytöissä ilman lukitusnäyttöä"
+  },
+  "Color for primary action buttons": {
+    "Color for primary action buttons": "Päätoimintopainikkeiden väri"
+  },
+  "Color shown for areas not covered by wallpaper": {
+    "Color shown for areas not covered by wallpaper": "Väri näkyy alueilla, joita tapetti ei peitä"
+  },
+  "Color temperature for night mode": {
+    "Color temperature for night mode": "Värilämpötila yötilassa"
+  },
+  "Color theme for syntax highlighting.": {
+    "Color theme for syntax highlighting.": "Väriteema syntaksin korostamiseen."
+  },
+  "Color theme for syntax highlighting. %1 themes available.": {
+    "Color theme for syntax highlighting. %1 themes available.": "Väriteema syntaksin korostamiseen. %1-teemat saatavilla."
+  },
+  "Color theme from DMS registry": {
+    "Color theme from DMS registry": "Väriteema DMS-rekisteristä"
+  },
+  "Colorful": {
+    "Colorful": "Värikäs"
+  },
+  "Colorful mix of bright contrasting accents.": {
+    "Colorful mix of bright contrasting accents.": "Värikäs sekoitus kirkkaita kontrastisia aksentteja."
+  },
+  "Colorize Active": {
+    "Colorize Active": "Väritä aktiivinen"
+  },
+  "Colors from wallpaper": {
+    "Colors from wallpaper": "Värit tapetista"
+  },
+  "Column": {
+    "Column": "Sarake"
+  },
+  "Column Display": {
+    "Column Display": "Sarake näyttö"
+  },
+  "Column Width": {
+    "Column Width": "Sarakkeen leveys"
+  },
+  "Comma-separated list of session names to hide. Wrap in slashes for regex (e.g., /^_.*/).": {
+    "Comma-separated list of session names to hide. Wrap in slashes for regex (e.g., /^_.*/).": "Pilkuilla eroteltu luettelo piilotettavista istuntojen nimistä. Kääri vinoviivalla säännöllinen lauseke (esim. /^_.*/)."
+  },
+  "Command": {
+    "Command": "komento"
+  },
+  "Command Line": {
+    "Command Line": "Komentorivi"
+  },
+  "Commands": {
+    "Commands": "komennot"
+  },
+  "Communication": {
+    "Communication": "Viestintä"
+  },
+  "Community themes": {
+    "Community themes": "yhteisön teemoja"
+  },
+  "Compact": {
+    "Compact": "Kompakti"
+  },
+  "Compact Mode": {
+    "Compact Mode": "Kompakti tila"
+  },
+  "Completed": {
+    "Completed": "Valmis"
+  },
+  "Compositor": {
+    "Compositor": "Säveltäjä"
+  },
+  "Compositor Settings": {
+    "Compositor Settings": "Kompositorin asetukset"
+  },
+  "Config Format": {
+    "Config Format": "Määritysmuoto"
+  },
+  "Config action: %1": {
+    "Config action: %1": "Määritystoiminto: %1"
+  },
+  "Config validation failed": {
+    "Config validation failed": "Määritysten tarkistus epäonnistui"
+  },
+  "Configuration": {
+    "Configuration": "Kokoonpano"
+  },
+  "Configuration activated": {
+    "Configuration activated": "Kokoonpano aktivoitu"
+  },
+  "Configuration will be preserved when this display reconnects": {
+    "Configuration will be preserved when this display reconnects": "Määritykset säilyvät, kun tämä näyttö muodostaa yhteyden uudelleen"
+  },
+  "Configurations": {
+    "Configurations": "Määritykset"
+  },
+  "Configure": {
+    "Configure": "Määritä"
+  },
+  "Configure Keybinds": {
+    "Configure Keybinds": "Määritä näppäinsidokset"
+  },
+  "Configure a new printer": {
+    "Configure a new printer": "Määritä uusi tulostin"
+  },
+  "Configure icons for named workspaces. Icons take priority over numbers when both are enabled.": {
+    "Configure icons for named workspaces. Icons take priority over numbers when both are enabled.": "Määritä kuvakkeet nimetyille työtiloille. Kuvakkeet ovat etusijalla numeroihin nähden, kun molemmat ovat käytössä."
+  },
+  "Configure match criteria and actions": {
+    "Configure match criteria and actions": "Määritä hakukriteerit ja -toiminnot"
+  },
+  "Configure one in Settings → Dock → Trash.": {
+    "Configure one in Settings → Dock → Trash.": "Määritä yksi kohdassa Asetukset → Dock → Roskakori."
+  },
+  "Configure which displays show \"%1\"": {
+    "Configure which displays show \"%1\"": "Määritä, mitkä näytöt näyttävät \"%1\""
+  },
+  "Configure which displays show shell components": {
+    "Configure which displays show shell components": "Määritä, mitkä näytöt näyttävät kuorikomponentit"
+  },
+  "Confirm": {
+    "Confirm": "Vahvista"
+  },
+  "Confirm Delete": {
+    "Confirm Delete": "Vahvista Poista"
+  },
+  "Confirm Display Changes": {
+    "Confirm Display Changes": "Vahvista näytön muutokset"
+  },
+  "Confirm passkey for ": {
+    "Confirm passkey for ": "Vahvista salasana kohteelle"
+  },
+  "Confirm password": {
+    "Confirm password": "Vahvista salasana"
+  },
+  "Conflicts with: %1": {
+    "Conflicts with: %1": "Ristiriidat: %1"
+  },
+  "Connect": {
+    "Connect": "Yhdistä"
+  },
+  "Connect to Hidden Network": {
+    "Connect to Hidden Network": "Yhdistä piiloverkkoon"
+  },
+  "Connect to VPN": {
+    "Connect to VPN": "Yhdistä VPN:ään"
+  },
+  "Connect to Wi-Fi": {
+    "Connect to Wi-Fi": "Yhdistä Wi-Fi-verkkoon"
+  },
+  "Connected": {
+    "Connected": "Yhdistetty"
+  },
+  "Connected Device": {
+    "Connected Device": "Yhdistetty laite"
+  },
+  "Connected Displays": {
+    "Connected Displays": "Yhdistetyt näytöt"
+  },
+  "Connected Frame Mode uses the connected launcher for default launcher shortcuts.": {
+    "Connected Frame Mode uses the connected launcher for default launcher shortcuts.": "Connected Frame Mode käyttää yhdistettyä käynnistysohjelmaa oletusarvoisena käynnistysohjelman pikanäppäimenä."
+  },
+  "Connected Options": {
+    "Connected Options": "Yhdistetyt vaihtoehdot"
+  },
+  "Connected to %1": {
+    "Connected to %1": "Yhdistetty %1:ään"
+  },
+  "Connecting to Device": {
+    "Connecting to Device": "Yhdistetään laitteeseen"
+  },
+  "Connecting to clipboard service...": {
+    "Connecting to clipboard service...": "Yhdistetään leikepöytäpalveluun..."
+  },
+  "Connecting...": {
+    "Connecting...": "Yhdistetään..."
+  },
+  "Connection failed": {
+    "Connection failed": "Yhteys epäonnistui"
+  },
+  "Contains": {
+    "Contains": "Sisältää"
+  },
+  "Content": {
+    "Content": "Sisältö"
+  },
+  "Content copied": {
+    "Content copied": "Sisältö kopioitu"
+  },
+  "Contrast": {
+    "Contrast": "Kontrasti"
+  },
+  "Contributor": {
+    "Contributor": "Osallistuja"
+  },
+  "Control Center": {
+    "Control Center": "Ohjauskeskus"
+  },
+  "Control Center Tile Color": {
+    "Control Center Tile Color": "Ohjauskeskuksen laattojen väri"
+  },
+  "Control animation duration for notification popups and history": {
+    "Control animation duration for notification popups and history": "Hallitse ilmoitusten ponnahdusikkunoiden ja historian animaation kestoa"
+  },
+  "Control currently playing media": {
+    "Control currently playing media": "Hallitse parhaillaan toistettavaa mediaa"
+  },
+  "Control what notification information is shown on the lock screen": {
+    "Control what notification information is shown on the lock screen": "Hallitse, mitä ilmoitustietoja lukitusnäytössä näytetään"
+  },
+  "Control which plugins appear in 'All' mode without requiring a trigger prefix. Drag to reorder.": {
+    "Control which plugins appear in 'All' mode without requiring a trigger prefix. Drag to reorder.": "Hallitse, mitkä laajennukset näkyvät \"Kaikki\"-tilassa ilman liipaisimen etuliitettä. Järjestä uudelleen vetämällä."
+  },
+  "Control workspaces and columns by scrolling on the bar": {
+    "Control workspaces and columns by scrolling on the bar": "Hallitse työtiloja ja sarakkeita vierittämällä palkkia"
+  },
+  "Controls how much original icon color is removed before applying tint": {
+    "Controls how much original icon color is removed before applying tint": "Määrittää, kuinka paljon alkuperäistä kuvakkeen väriä poistetaan ennen sävyn lisäämistä"
+  },
+  "Controls how strongly the selected tint color is applied": {
+    "Controls how strongly the selected tint color is applied": "Määrittää, kuinka voimakkaasti valittua sävyä käytetään"
+  },
+  "Controls opacity of shell surfaces, popouts, and modals": {
+    "Controls opacity of shell surfaces, popouts, and modals": "Ohjaa kuoren pintojen, ponnahdusikkunoiden ja modaalien peittävyyttä"
+  },
+  "Controls outlines around foreground cards, pills, and notification cards": {
+    "Controls outlines around foreground cards, pills, and notification cards": "Ohjaa etualan korttien, pillerien ja ilmoituskorttien ääriviivoja"
+  },
+  "Controls shadow cast direction for elevation layers": {
+    "Controls shadow cast direction for elevation layers": "Ohjaa korkeustasojen varjon suuntaa"
+  },
+  "Controls the base blur radius and offset of shadows": {
+    "Controls the base blur radius and offset of shadows": "Ohjaa perussumennussädettä ja varjojen siirtymää"
+  },
+  "Controls the outline of popouts, modals, and other shell surfaces": {
+    "Controls the outline of popouts, modals, and other shell surfaces": "Ohjaa ponnahdusikkunoiden, modaalien ja muiden kuoripintojen ääriviivoja"
+  },
+  "Convenience options for the login screen. Sync to apply.": {
+    "Convenience options for the login screen. Sync to apply.": "Kirjautumisnäytön mukavuusvaihtoehdot. Synkronoi ottaaksesi käyttöön."
+  },
+  "Convert to DMS": {
+    "Convert to DMS": "Muunna muotoon DMS"
+  },
+  "Cooldown": {
+    "Cooldown": "Jäähdytys"
+  },
+  "Copied GIF": {
+    "Copied GIF": "Kopioitu GIF"
+  },
+  "Copied MP4": {
+    "Copied MP4": "Kopioitu MP4"
+  },
+  "Copied WebP": {
+    "Copied WebP": "Kopioitu WebP"
+  },
+  "Copied to clipboard": {
+    "Copied to clipboard": "Kopioitu leikepöydälle"
+  },
+  "Copied!": {
+    "Copied!": "Kopioitu!"
+  },
+  "Copy": {
+    "Copy": "Kopioi"
+  },
+  "Copy Content": {
+    "Copy Content": "Kopioi sisältö"
+  },
+  "Copy Full Command": {
+    "Copy Full Command": "Kopioi koko komento"
+  },
+  "Copy HTML": {
+    "Copy HTML": "Kopioi HTML"
+  },
+  "Copy Name": {
+    "Copy Name": "Kopioi nimi"
+  },
+  "Copy PID": {
+    "Copy PID": "Kopioi PID"
+  },
+  "Copy Text": {
+    "Copy Text": "Kopioi teksti"
+  },
+  "Copy path": {
+    "Copy path": "Kopioi polku"
+  },
+  "Corner Radius": {
+    "Corner Radius": "Kulman säde"
+  },
+  "Corner Radius Override": {
+    "Corner Radius Override": "Kulman säteen ohitus"
+  },
+  "Corners & Background": {
+    "Corners & Background": "Kulmat ja tausta"
+  },
+  "Count Only": {
+    "Count Only": "Vain laskea"
+  },
+  "Cover Open": {
+    "Cover Open": "Kansi auki"
+  },
+  "Create": {
+    "Create": "Luo"
+  },
+  "Create Dir": {
+    "Create Dir": "Luo Dir"
+  },
+  "Create Printer": {
+    "Create Printer": "Luo tulostin"
+  },
+  "Create User": {
+    "Create User": "Luo käyttäjä"
+  },
+  "Create Window Rule": {
+    "Create Window Rule": "Luo ikkunasääntö"
+  },
+  "Create a new %1 session (^N)": {
+    "Create a new %1 session (^N)": "Luo uusi %1-istunto (^N)"
+  },
+  "Create rule for:": {
+    "Create rule for:": "Luo sääntö kohteelle:"
+  },
+  "Create rules to mute, ignore, hide from history, or override notification priority. Default only overrides priority; notifications still show normally.": {
+    "Create rules to mute, ignore, hide from history, or override notification priority. Default only overrides priority; notifications still show normally.": "Luo sääntöjä mykistääksesi, ohittaaksesi, piilottaaksesi historiasta tai ohittaaksesi ilmoitusten prioriteetin. Oletusarvo ohittaa vain prioriteetin; ilmoitukset näkyvät edelleen normaalisti."
+  },
+  "Created plugin directory: %1": {
+    "Created plugin directory: %1": "Luotu laajennushakemisto: %1"
+  },
+  "Creating...": {
+    "Creating...": "Luodaan..."
+  },
+  "Credentials": {
+    "Credentials": "Valtuustiedot"
+  },
+  "Critical Battery": {
+    "Critical Battery": "Kriittinen akku"
+  },
+  "Critical Battery Alert": {
+    "Critical Battery Alert": "Kriittisen akun varoitus"
+  },
+  "Critical Battery Notifications": {
+    "Critical Battery Notifications": "Kriittiset akun ilmoitukset"
+  },
+  "Critical Priority": {
+    "Critical Priority": "Kriittinen prioriteetti"
+  },
+  "Critical Threshold": {
+    "Critical Threshold": "Kriittinen kynnys"
+  },
+  "Ctrl+A: Select All • Ctrl+P: Preview • Enter/Shift+Enter: Find Next/Previous • Esc: Close": {
+    "Ctrl+A: Select All • Ctrl+P: Preview • Enter/Shift+Enter: Find Next/Previous • Esc: Close": "Ctrl+A: Valitse kaikki • Ctrl+P: Esikatselu • Enter/Shift+Enter: Etsi seuraava/edellinen • Esc: Sulje"
+  },
+  "Ctrl+S: Save • Ctrl+O: Open • Ctrl+N: New • Ctrl+F: Find": {
+    "Ctrl+S: Save • Ctrl+O: Open • Ctrl+N: New • Ctrl+F: Find": "Ctrl+S: Tallenna • Ctrl+O: Avaa • Ctrl+N: Uusi • Ctrl+F: Etsi"
+  },
+  "Ctrl+Tab: Switch Tab • Ctrl+S: Pin/Unpin • Shift+Del: Clear All • Esc: Close": {
+    "Ctrl+Tab: Switch Tab • Ctrl+S: Pin/Unpin • Shift+Del: Clear All • Esc: Close": "Ctrl+Sarkain: Vaihda välilehteä • Ctrl+S: Kiinnitä/Poista kiinnitys • Vaihto+Del: Tyhjennä kaikki • Esc: Sulje"
+  },
+  "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Copy • Shift+Del: Clear All • F10: Help • Esc: Close": {
+    "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Copy • Shift+Del: Clear All • F10: Help • Esc: Close": "Ctrl+Sarkain: Vaihda välilehtiä • Ctrl+S: Kiinnitä/Poista kiinnitys • Vaihto+Enter: Kopioi • Vaihto+Del: Tyhjennä kaikki • F10: Ohje • Esc: Sulje"
+  },
+  "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Paste • Shift+Del: Clear All • F10: Help • Esc: Close": {
+    "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Paste • Shift+Del: Clear All • F10: Help • Esc: Close": "Ctrl+Sarkain: Vaihda välilehtiä • Ctrl+S: Kiinnitä/Poista kiinnitys • Vaihto+Enter: Liitä • Vaihto+Del: Tyhjennä kaikki • F10: Ohje • Esc: Sulje"
+  },
+  "Current": {
+    "Current": "Nykyinen"
+  },
+  "Current Items": {
+    "Current Items": "Nykyiset kohteet"
+  },
+  "Current Locale": {
+    "Current Locale": "Käyttöliittymän kieli"
+  },
+  "Current Monitor": {
+    "Current Monitor": "Nykyinen näyttö"
+  },
+  "Current Period": {
+    "Current Period": "Nykyinen kausi"
+  },
+  "Current Status": {
+    "Current Status": "Nykyinen tila"
+  },
+  "Current Temp": {
+    "Current Temp": "Nykyinen lämpötila"
+  },
+  "Current Theme: %1": {
+    "Current Theme: %1": "Nykyinen teema: %1"
+  },
+  "Current Weather": {
+    "Current Weather": "Nykyinen sää"
+  },
+  "Current Workspace": {
+    "Current Workspace": "Nykyinen työtila"
+  },
+  "Current time and date display": {
+    "Current time and date display": "Nykyisen ajan ja päivämäärän näyttö"
+  },
+  "Current weather conditions and temperature": {
+    "Current weather conditions and temperature": "Nykyiset sääolosuhteet ja lämpötila"
+  },
+  "Current: %1": {
+    "Current: %1": "Nykyinen: %1"
+  },
+  "Cursor Size": {
+    "Cursor Size": "Kohdistimen koko"
+  },
+  "Cursor Theme": {
+    "Cursor Theme": "Kohdistimen teema"
+  },
+  "Curve": {
+    "Curve": "Käyrä"
+  },
+  "Curve: curve rasterizer.": {
+    "Curve: curve rasterizer.": "Käyrä: käyrärasterointi."
+  },
+  "Custom": {
+    "Custom": "Mukautettu"
+  },
+  "Custom Blend": {
+    "Custom Blend": "Mukautettu sekoitus"
+  },
+  "Custom Color": {
+    "Custom Color": "Mukautettu väri"
+  },
+  "Custom Duration": {
+    "Custom Duration": "Mukautettu kesto"
+  },
+  "Custom Hibernate Command": {
+    "Custom Hibernate Command": "Mukautettu horroskomento"
+  },
+  "Custom Location": {
+    "Custom Location": "Mukautettu sijainti"
+  },
+  "Custom Lock Command": {
+    "Custom Lock Command": "Mukautettu lukituskomento"
+  },
+  "Custom Logout Command": {
+    "Custom Logout Command": "Mukautettu uloskirjautumiskomento"
+  },
+  "Custom Name": {
+    "Custom Name": "Mukautettu nimi"
+  },
+  "Custom Power Actions": {
+    "Custom Power Actions": "Mukautetut tehotoiminnot"
+  },
+  "Custom Power Off Command": {
+    "Custom Power Off Command": "Mukautettu sammutuskomento"
+  },
+  "Custom Reboot Command": {
+    "Custom Reboot Command": "Mukautettu uudelleenkäynnistyskomento"
+  },
+  "Custom Shadow Color": {
+    "Custom Shadow Color": "Mukautettu varjon väri"
+  },
+  "Custom Shadow Override": {
+    "Custom Shadow Override": "Mukautettu varjon ohitus"
+  },
+  "Custom Suspend Command": {
+    "Custom Suspend Command": "Mukautettu keskeytyskomento"
+  },
+  "Custom command and terminal params are split on whitespace; paths with spaces will break.": {
+    "Custom command and terminal params are split on whitespace; paths with spaces will break.": "Mukautetut komento- ja pääteparametrit on jaettu välilyönnillä; välilyöntejä sisältävät polut katkeavat."
+  },
+  "Custom interval in minutes (minimum 5)": {
+    "Custom interval in minutes (minimum 5)": "Mukautettu aika minuutteina (vähintään 5)"
+  },
+  "Custom open-trash command": {
+    "Custom open-trash command": "Mukautettu open-trash-komento"
+  },
+  "Custom power profile": {
+    "Custom power profile": "Mukautettu tehoprofiili"
+  },
+  "Custom theme loaded from JSON file": {
+    "Custom theme loaded from JSON file": "Mukautettu teema ladattu JSON-tiedostosta"
+  },
+  "Custom update command": {
+    "Custom update command": "Mukautettu päivityskomento"
+  },
+  "Custom...": {
+    "Custom...": "Mukautettu..."
+  },
+  "Customizable empty space": {
+    "Customizable empty space": "Muokattava tyhjä tila"
+  },
+  "Customize the font and background of the lock screen, or leave empty to use your theme font and desktop wallpaper. Changes apply instantly.": {
+    "Customize the font and background of the lock screen, or leave empty to use your theme font and desktop wallpaper. Changes apply instantly.": "Mukauta lukitusnäytön fonttia ja taustaa tai jätä se tyhjäksi, jos haluat käyttää teemafonttiasi ja työpöydän taustakuvaa. Muutokset tulevat voimaan välittömästi."
+  },
+  "Customize which actions appear in the power menu": {
+    "Customize which actions appear in the power menu": "Mukauta, mitkä toiminnot näkyvät virtavalikossa"
+  },
+  "DDC/CI monitor": {
+    "DDC/CI monitor": "DDC/CI-näyttö"
+  },
+  "DEMO MODE - Click anywhere to exit": {
+    "DEMO MODE - Click anywhere to exit": "DEMOTILA - Poistu napsauttamalla mitä tahansa"
+  },
+  "DMS Chooser": {
+    "DMS Chooser": "DMS Valitsija"
+  },
+  "DMS Plugin Manager Unavailable": {
+    "DMS Plugin Manager Unavailable": "DMS Plugin Manager ei ole saatavilla"
+  },
+  "DMS Settings": {
+    "DMS Settings": "DMS Asetukset"
+  },
+  "DMS Settings writes Lua keybinds. Add the DMS include so edits apply.": {
+    "DMS Settings writes Lua keybinds. Add the DMS include so edits apply.": "DMS Asetukset kirjoittaa Lua-näppäinsidoksia. Lisää DMS-sisältö, jotta muutokset ovat voimassa."
+  },
+  "DMS Shortcuts": {
+    "DMS Shortcuts": "DMS pikanäppäimet"
+  },
+  "DMS out of date": {
+    "DMS out of date": "DMS vanhentunut"
+  },
+  "DMS removes its managed block from /etc/pam.d/greetd and stops writing to it": {
+    "DMS removes its managed block from /etc/pam.d/greetd and stops writing to it": "DMS poistaa hallitsemansa lohkon tiedostosta /etc/pam.d/greetd eikä enää kirjoita siihen"
+  },
+  "DMS server is outdated (API v%1, expected v%2)": {
+    "DMS server is outdated (API v%1, expected v%2)": "DMS-palvelin on vanhentunut (API v%1, odotettavissa v%2)"
+  },
+  "DMS service is not connected. Clipboard settings are unavailable.": {
+    "DMS service is not connected. Clipboard settings are unavailable.": "DMS-palvelua ei ole yhdistetty. Leikepöydän asetukset eivät ole käytettävissä."
+  },
+  "DMS shell actions (launcher, clipboard, etc.)": {
+    "DMS shell actions (launcher, clipboard, etc.)": "DMS komentotulkkitoiminnot (käynnistysohjelma, leikepöytä jne.)"
+  },
+  "DMS_SOCKET not available": {
+    "DMS_SOCKET not available": "DMS_SOCKET ei ole saatavilla"
+  },
+  "Daily": {
+    "Daily": "Päivittäin"
+  },
+  "Daily at:": {
+    "Daily at:": "Päivittäin klo:"
+  },
+  "Dank": {
+    "Dank": "Dank"
+  },
+  "Dank Bar": {
+    "Dank Bar": "Dank Baari"
+  },
+  "Dank Bar Xray": {
+    "Dank Bar Xray": "Dank Bar Xray"
+  },
+  "Dank Dash": {
+    "Dank Dash": "Dank Dash"
+  },
+  "DankBar": {
+    "DankBar": "DankBar"
+  },
+  "DankCalendar": {
+    "DankCalendar": "DankCalendar"
+  },
+  "DankCalendar isn't installed": {
+    "DankCalendar isn't installed": "DankCalendaria ei ole asennettu"
+  },
+  "DankCalendar isn't running": {
+    "DankCalendar isn't running": "DankCalendar ei ole käynnissä"
+  },
+  "DankMaterialShell is ready to use": {
+    "DankMaterialShell is ready to use": "DankMaterialShell on käyttövalmis"
+  },
+  "DankShell & System Icons (requires restart)": {
+    "DankShell & System Icons (requires restart)": "DankShell & System Icons (vaatii uudelleenkäynnistyksen)"
+  },
+  "Dark Mode": {
+    "Dark Mode": "Tumma tila"
+  },
+  "Dark Mode Icon Theme": {
+    "Dark Mode Icon Theme": "Tumman tilan kuvaketeema"
+  },
+  "Dark mode base": {
+    "Dark mode base": "Tumman tilan pohja"
+  },
+  "Dark mode harmony": {
+    "Dark mode harmony": "Tumman tilan harmonia"
+  },
+  "Darken Modal Background": {
+    "Darken Modal Background": "Tummentaa modaalista taustaa"
+  },
+  "Date Format": {
+    "Date Format": "Päivämäärän muoto"
+  },
+  "Date format on greeter": {
+    "Date format on greeter": "Päivämäärän muoto tervehtimässä"
+  },
+  "Dawn (Astronomical Twilight)": {
+    "Dawn (Astronomical Twilight)": "Dawn (astronominen hämärä)"
+  },
+  "Dawn (Civil Twilight)": {
+    "Dawn (Civil Twilight)": "Dawn (Civil Twilight)"
+  },
+  "Dawn (Nautical Twilight)": {
+    "Dawn (Nautical Twilight)": "Dawn (meren iltahämärä)"
+  },
+  "Day Date": {
+    "Day Date": "Päivä Päivämäärä"
+  },
+  "Day Month Date": {
+    "Day Month Date": "Päivä Kuukausi Päivämäärä"
+  },
+  "Day Temperature": {
+    "Day Temperature": "Päivän lämpötila"
+  },
+  "Daytime": {
+    "Daytime": "Päivällä"
+  },
+  "Deck": {
+    "Deck": "Kansi"
+  },
+  "Default": {
+    "Default": "Oletus"
+  },
+  "Default (Black)": {
+    "Default (Black)": "Oletus (musta)"
+  },
+  "Default (Global)": {
+    "Default (Global)": "Oletus (maailmanlaajuinen)"
+  },
+  "Default Apps": {
+    "Default Apps": "Oletussovellukset"
+  },
+  "Default Launcher": {
+    "Default Launcher": "Oletuskäynnistysohjelma"
+  },
+  "Default Launcher Shortcut": {
+    "Default Launcher Shortcut": "Käynnistysohjelman oletuspikakuvake"
+  },
+  "Default Mode": {
+    "Default Mode": "Oletustila"
+  },
+  "Default Opens": {
+    "Default Opens": "Oletus Avautuu"
+  },
+  "Default Width (%)": {
+    "Default Width (%)": "Oletusleveys (%)"
+  },
+  "Default launcher shortcuts open the full launcher with mode tabs, grid view, and action panel.": {
+    "Default launcher shortcuts open the full launcher with mode tabs, grid view, and action panel.": "Käynnistysohjelman oletuspikanäppäimet avaavat koko käynnistysohjelman tilavälilehdillä, ruudukkonäkymällä ja toimintopaneelilla."
+  },
+  "Default launcher shortcuts open the minimal Spotlight Bar. The dedicated Spotlight Bar shortcut below stays independent.": {
+    "Default launcher shortcuts open the minimal Spotlight Bar. The dedicated Spotlight Bar shortcut below stays independent.": "Käynnistysohjelman oletuspikakuvakkeet avaavat minimaalisen Spotlight-palkin. Alla oleva Spotlight Bar -pikakuvake pysyy itsenäisenä."
+  },
+  "Default selected action": {
+    "Default selected action": "Oletusvalintatoiminto"
+  },
+  "Defaults": {
+    "Defaults": "Oletukset"
+  },
+  "Define rules for window behavior. Saves to %1": {
+    "Define rules for window behavior. Saves to %1": "Määritä säännöt ikkunan käyttäytymiselle. Tallentaa tiedostoon %1"
+  },
+  "Del: Clear • Shift+Del: Clear All • 1-9: Actions • F10: Help • Esc: Close": {
+    "Del: Clear • Shift+Del: Clear All • 1-9: Actions • F10: Help • Esc: Close": "Del: Tyhjennä • Vaihto+Del: Tyhjennä kaikki • 1-9: Toiminnot • F10: Ohje • Esc: Sulje"
+  },
+  "Delete": {
+    "Delete": "Poista"
+  },
+  "Delete \"%1\" and remove the home directory? This cannot be undone.": {
+    "Delete \"%1\" and remove the home directory? This cannot be undone.": "Poistetaanko \"%1\" ja kotihakemisto? Tätä ei voi kumota."
+  },
+  "Delete \"%1\"?": {
+    "Delete \"%1\"?": "Poistetaanko \"%1\"?"
+  },
+  "Delete Class": {
+    "Delete Class": "Poista luokka"
+  },
+  "Delete Printer": {
+    "Delete Printer": "Poista tulostin"
+  },
+  "Delete Rule": {
+    "Delete Rule": "Poista sääntö"
+  },
+  "Delete Saved Item?": {
+    "Delete Saved Item?": "Poistetaanko tallennettu kohde?"
+  },
+  "Delete VPN": {
+    "Delete VPN": "Poista VPN"
+  },
+  "Delete class \"%1\"?": {
+    "Delete class \"%1\"?": "Poistetaanko luokka \"%1\"?"
+  },
+  "Delete profile \"%1\"?": {
+    "Delete profile \"%1\"?": "Poistetaanko profiili \"%1\"?"
+  },
+  "Delete user": {
+    "Delete user": "Poista käyttäjä"
+  },
+  "Demi Bold": {
+    "Demi Bold": "Demi Bold"
+  },
+  "Dependencies & documentation": {
+    "Dependencies & documentation": "Riippuvuudet ja dokumentaatio"
+  },
+  "Depth": {
+    "Depth": "Syvyys"
+  },
+  "Depth: Panels scale up from small as they slide in — a dramatic pop-forward depth effect.": {
+    "Depth: Panels scale up from small as they slide in — a dramatic pop-forward depth effect.": "Syvyys: Paneelit skaalautuvat pienestä, kun ne liukuvat sisään – dramaattinen ponnahdussyvyysvaikutelma."
+  },
+  "Derives colors that closely match the underlying image.": {
+    "Derives colors that closely match the underlying image.": "Saat värit, jotka vastaavat läheisesti taustakuvaa."
+  },
+  "Description": {
+    "Description": "Kuvaus"
+  },
+  "Desktop": {
+    "Desktop": "Työpöytä"
+  },
+  "Desktop Application": {
+    "Desktop Application": "Työpöytäsovellus"
+  },
+  "Desktop Clock": {
+    "Desktop Clock": "Työpöytäkello"
+  },
+  "Desktop Entry": {
+    "Desktop Entry": "Työpöytämerkintä"
+  },
+  "Desktop Widget": {
+    "Desktop Widget": "Työpöytäwidget"
+  },
+  "Desktop Widgets": {
+    "Desktop Widgets": "Työpöytäwidgetit"
+  },
+  "Desktop background images": {
+    "Desktop background images": "Työpöydän taustakuvat"
+  },
+  "Detailed": {
+    "Detailed": "Yksityiskohtainen"
+  },
+  "Details for \"%1\"": {
+    "Details for \"%1\"": "\"%1\":n tiedot"
+  },
+  "Detected backends: %1": {
+    "Detected backends: %1": "Havaitut taustaohjelmat: %1"
+  },
+  "Development": {
+    "Development": "Kehitys"
+  },
+  "Device": {
+    "Device": "Laite"
+  },
+  "Device connections": {
+    "Device connections": "Laitteiden liitännät"
+  },
+  "Device list scroll volume": {
+    "Device list scroll volume": "Laiteluettelon vierityksen äänenvoimakkuus"
+  },
+  "Device names updated": {
+    "Device names updated": "Laitteiden nimet päivitetty"
+  },
+  "Device paired": {
+    "Device paired": "Laite paritettu"
+  },
+  "Device unpaired": {
+    "Device unpaired": "Laite on paritettu"
+  },
+  "Diff": {
+    "Diff": "Diff"
+  },
+  "Digital": {
+    "Digital": "Digitaalinen"
+  },
+  "Direction Source": {
+    "Direction Source": "Suuntalähde"
+  },
+  "Directional": {
+    "Directional": "Suuntaava"
+  },
+  "Directional: Panels glide in from a larger distance at full size — no scale change, pure clean motion.": {
+    "Directional: Panels glide in from a larger distance at full size — no scale change, pure clean motion.": "Suuntaus: Paneelit liukuvat sisään suuremmalta etäisyydeltä täysikokoisina – ei mittakaavan muutosta, puhdasta liikettä."
+  },
+  "Disable Autoconnect": {
+    "Disable Autoconnect": "Poista automaattinen yhteys käytöstä"
+  },
+  "Disable Built-in Wallpapers": {
+    "Disable Built-in Wallpapers": "Poista sisäänrakennetut taustakuvat käytöstä"
+  },
+  "Disable History Persistence": {
+    "Disable History Persistence": "Poista historian pysyvyys käytöstä"
+  },
+  "Disable Output": {
+    "Disable Output": "Poista lähtö käytöstä"
+  },
+  "Disabled": {
+    "Disabled": "Pois käytöstä"
+  },
+  "Disabled by Frame Mode": {
+    "Disabled by Frame Mode": "Poistettu kehystilasta"
+  },
+  "Disabling WiFi...": {
+    "Disabling WiFi...": "Poistetaan WiFi käytöstä..."
+  },
+  "Disabling auto-login on startup...": {
+    "Disabling auto-login on startup...": "Poistetaan automaattinen sisäänkirjautuminen käynnistettäessä..."
+  },
+  "Disc": {
+    "Disc": "Disc"
+  },
+  "Discard": {
+    "Discard": "Hävitä"
+  },
+  "Discharging": {
+    "Discharging": "Purkautuminen"
+  },
+  "Disconnect": {
+    "Disconnect": "Katkaise yhteys"
+  },
+  "Disconnected": {
+    "Disconnected": "Yhteys katkaistu"
+  },
+  "Disconnected from WiFi": {
+    "Disconnected from WiFi": "Wi-Fi-yhteys katkaistu"
+  },
+  "Discover Devices": {
+    "Discover Devices": "Löydä laitteet"
+  },
+  "Disk": {
+    "Disk": "Levy"
+  },
+  "Disk I/O": {
+    "Disk I/O": "Levyn I/O"
+  },
+  "Disk Usage": {
+    "Disk Usage": "Levyn käyttö"
+  },
+  "Disk Usage Display": {
+    "Disk Usage Display": "Levyn käyttönäyttö"
+  },
+  "Disks": {
+    "Disks": "Levyt"
+  },
+  "Dismiss": {
+    "Dismiss": "Hylkää"
+  },
+  "Display": {
+    "Display": "Näyttö"
+  },
+  "Display Assignment": {
+    "Display Assignment": "Näyttötehtävä"
+  },
+  "Display Control": {
+    "Display Control": "Näytön ohjaus"
+  },
+  "Display Name Format": {
+    "Display Name Format": "Näyttönimen muoto"
+  },
+  "Display Profiles": {
+    "Display Profiles": "Näytä profiilit"
+  },
+  "Display Settings": {
+    "Display Settings": "Näyttöasetukset"
+  },
+  "Display a dock with pinned and running applications": {
+    "Display a dock with pinned and running applications": "Näytä telakka kiinnitetyillä ja käynnissä olevilla sovelluksilla"
+  },
+  "Display all priorities over fullscreen apps": {
+    "Display all priorities over fullscreen apps": "Näytä kaikki prioriteetit koko näytön sovelluksiin verrattuna"
+  },
+  "Display and switch MangoWC layouts": {
+    "Display and switch MangoWC layouts": "Näytä ja vaihda MangoWC-asetteluja"
+  },
+  "Display application icons in workspace indicators": {
+    "Display application icons in workspace indicators": "Näytä sovelluskuvakkeet työtilan ilmaisimissa"
+  },
+  "Display brightness control": {
+    "Display brightness control": "Näytön kirkkauden säätö"
+  },
+  "Display configuration is not available. WLR output management protocol not supported.": {
+    "Display configuration is not available. WLR output management protocol not supported.": "Näytön kokoonpano ei ole käytettävissä. WLR-lähdönhallintaprotokollaa ei tueta."
+  },
+  "Display currently focused application title": {
+    "Display currently focused application title": "Näytä tällä hetkellä kohdistetun sovelluksen otsikko"
+  },
+  "Display hourly weather predictions": {
+    "Display hourly weather predictions": "Näytä tunnin sääennusteet"
+  },
+  "Display line numbers in editor": {
+    "Display line numbers in editor": "Näytä rivinumerot editorissa"
+  },
+  "Display name for this entry": {
+    "Display name for this entry": "Tämän merkinnän näyttönimi"
+  },
+  "Display only workspaces that contain windows": {
+    "Display only workspaces that contain windows": "Näytä vain ikkunoita sisältävät työtilat"
+  },
+  "Display power menu actions in a grid instead of a list": {
+    "Display power menu actions in a grid instead of a list": "Näytä tehovalikon toiminnot ruudukossa luettelon sijaan"
+  },
+  "Display setup failed": {
+    "Display setup failed": "Näytön asennus epäonnistui"
+  },
+  "Display the power system menu": {
+    "Display the power system menu": "Näytä virtajärjestelmän valikko"
+  },
+  "Display volume and brightness percentage values in OSD popups": {
+    "Display volume and brightness percentage values in OSD popups": "Näytä äänenvoimakkuuden ja kirkkauden prosenttiarvot OSD-ponnahdusikkunoissa"
+  },
+  "Displays": {
+    "Displays": "Näytöt"
+  },
+  "Displays the active keyboard layout and allows switching": {
+    "Displays the active keyboard layout and allows switching": "Näyttää aktiivisen näppäimistöasettelun ja sallii vaihtamisen"
+  },
+  "Distribution": {
+    "Distribution": "Jakelu"
+  },
+  "Diverse palette spanning the full spectrum.": {
+    "Diverse palette spanning the full spectrum.": "Monipuolinen paletti, joka kattaa koko spektrin."
+  },
+  "Do Not Disturb": {
+    "Do Not Disturb": "Älä häiritse"
+  },
+  "Dock": {
+    "Dock": "Telakka"
+  },
+  "Dock & Launcher": {
+    "Dock & Launcher": "Telakka & Launcher"
+  },
+  "Dock Opacity": {
+    "Dock Opacity": "Telakan läpinäkyvyys"
+  },
+  "Dock margin, opacity, and border": {
+    "Dock margin, opacity, and border": "Telakan marginaali, peittävyys ja reunus"
+  },
+  "Dock window": {
+    "Dock window": "Telakka ikkuna"
+  },
+  "Docs": {
+    "Docs": "Asiakirjat"
+  },
+  "Documents": {
+    "Documents": "Asiakirjat"
+  },
+  "Domain (optional)": {
+    "Domain (optional)": "Verkkotunnus (valinnainen)"
+  },
+  "Don't Change": {
+    "Don't Change": "Älä muuta"
+  },
+  "Don't Save": {
+    "Don't Save": "Älä Tallenna"
+  },
+  "Door Open": {
+    "Door Open": "Ovi auki"
+  },
+  "Downloads": {
+    "Downloads": "Lataukset"
+  },
+  "Drag a widget by its handle here to reorder it or drop it into another group": {
+    "Drag a widget by its handle here to reorder it or drop it into another group": "Vedä widget sen kahvasta tähän, jos haluat järjestää sen uudelleen tai pudota se toiseen ryhmään"
+  },
+  "Drag to Reorder": {
+    "Drag to Reorder": "Vedä Järjestä uudelleen"
+  },
+  "Drag to reorder or click to hide tabs. Use ↑/↓ to highlight a tab and Ctrl+↑/↓ to move it.": {
+    "Drag to reorder or click to hide tabs. Use ↑/↓ to highlight a tab and Ctrl+↑/↓ to move it.": "Järjestä uudelleen vetämällä tai piilota välilehdet napsauttamalla. Käytä ↑/↓ korostaaksesi välilehteä ja Ctrl+↑/↓ siirtääksesi sitä."
+  },
+  "Drag widgets to reorder within sections. Use the eye icon to hide/show widgets (maintains spacing), or X to remove them completely.": {
+    "Drag widgets to reorder within sections. Use the eye icon to hide/show widgets (maintains spacing), or X to remove them completely.": "Järjestä widgetit uudelleen osioiden sisällä vetämällä. Käytä silmäkuvaketta piilottaaksesi/näytäksesi widgetit (säilyttääksesi välit) tai X-kuvaketta poistaaksesi ne kokonaan."
+  },
+  "Drag workspace indicators to reorder them": {
+    "Drag workspace indicators to reorder them": "Järjestä ne uudelleen vetämällä työtilan ilmaisimia"
+  },
+  "Draw a connected picture-frame border around the entire display": {
+    "Draw a connected picture-frame border around the entire display": "Piirrä yhdistetty kuvakehyksen reunus koko näytön ympärille"
+  },
+  "Driver": {
+    "Driver": "Kuljettaja"
+  },
+  "Drizzle": {
+    "Drizzle": "Tihkusadetta"
+  },
+  "Drop here": {
+    "Drop here": "Pudota tänne"
+  },
+  "Drop your override for %1 so the DMS default action re-applies?": {
+    "Drop your override for %1 so the DMS default action re-applies?": "Luovutetaanko %1:n ohitus, jotta DMS-oletustoiminto otetaan uudelleen käyttöön?"
+  },
+  "Duplicate": {
+    "Duplicate": "Kopioi"
+  },
+  "Duplicate Wallpaper with Blur": {
+    "Duplicate Wallpaper with Blur": "Kopioi taustakuva, jossa on sumeus"
+  },
+  "Duration": {
+    "Duration": "Kesto"
+  },
+  "Dusk (Astronomical Twilight)": {
+    "Dusk (Astronomical Twilight)": "Hämärä (astronominen hämärä)"
+  },
+  "Dusk (Civil Twighlight)": {
+    "Dusk (Civil Twighlight)": "Hämärä (Civil Twighlight)"
+  },
+  "Dusk (Nautical Twilight)": {
+    "Dusk (Nautical Twilight)": "Hämärä (meren iltahämärä)"
+  },
+  "Dynamic": {
+    "Dynamic": "Dynaaminen"
+  },
+  "Dynamic Properties": {
+    "Dynamic Properties": "Dynaamiset ominaisuudet"
+  },
+  "Dynamic Theming": {
+    "Dynamic Theming": "Dynaaminen teema"
+  },
+  "Dynamic Width": {
+    "Dynamic Width": "Dynaaminen leveys"
+  },
+  "Dynamic colors from wallpaper": {
+    "Dynamic colors from wallpaper": "Dynaamiset värit tapetista"
+  },
+  "Dynamic colors parse error: %1": {
+    "Dynamic colors parse error: %1": "Dynaamisten värien jäsennysvirhe: %1"
+  },
+  "Dynamic colors, presets": {
+    "Dynamic colors, presets": "Dynaamiset värit, esiasetukset"
+  },
+  "Dynamic: Spring bezier with overshoot — entry briefly exceeds its target then settles. Expressive and alive.": {
+    "Dynamic: Spring bezier with overshoot — entry briefly exceeds its target then settles. Expressive and alive.": "Dynaaminen: Spring Bezier ylityksellä – tulo ylittää hetkeksi tavoitteensa ja asettuu. Ilmeikäs ja elävä."
+  },
+  "Edge Hover Reveal": {
+    "Edge Hover Reveal": "Edge Hover paljastaa"
+  },
+  "Edge Spacing": {
+    "Edge Spacing": "Reunavälit"
+  },
+  "Edge spacing, exclusive zone, and popup gaps are managed by Frame": {
+    "Edge spacing, exclusive zone, and popup gaps are managed by Frame": "Frame hallitsee reunaväliä, yksinomaista vyöhykettä ja ponnahdusikkunoiden aukkoja"
+  },
+  "Edge the launcher slides from": {
+    "Edge the launcher slides from": "Reunaa kantoraketti liukuu"
+  },
+  "Edit": {
+    "Edit": "Muokkaa"
+  },
+  "Edit App": {
+    "Edit App": "Muokkaa sovellusta"
+  },
+  "Edit Clipboard": {
+    "Edit Clipboard": "Muokkaa leikepöytää"
+  },
+  "Edit Rule": {
+    "Edit Rule": "Muokkaa sääntöä"
+  },
+  "Edit Window Rule": {
+    "Edit Window Rule": "Muokkaa ikkunasääntöä"
+  },
+  "Edit clipboard text": {
+    "Edit clipboard text": "Muokkaa leikepöydän tekstiä"
+  },
+  "Edit event": {
+    "Edit event": "Muokkaa tapahtumaa"
+  },
+  "Editing changes on %1": {
+    "Editing changes on %1": "%1:n muutosten muokkaaminen"
+  },
+  "Education": {
+    "Education": "koulutus"
+  },
+  "Empty": {
+    "Empty": "Tyhjä"
+  },
+  "Empty Trash": {
+    "Empty Trash": "Tyhjennä roskakori"
+  },
+  "Empty Trash (%1)": {
+    "Empty Trash (%1)": "Tyhjennä roskakori (%1)"
+  },
+  "Enable 10-bit color depth for wider color gamut and HDR support": {
+    "Enable 10-bit color depth for wider color gamut and HDR support": "Ota käyttöön 10-bittinen värisyvyys laajentaaksesi värivalikoimaa ja HDR-tukea"
+  },
+  "Enable Autoconnect": {
+    "Enable Autoconnect": "Ota automaattinen yhteys käyttöön"
+  },
+  "Enable Bar": {
+    "Enable Bar": "Ota palkki käyttöön"
+  },
+  "Enable Do Not Disturb": {
+    "Enable Do Not Disturb": "Ota Älä häiritse käyttöön"
+  },
+  "Enable Frame": {
+    "Enable Frame": "Ota kehys käyttöön"
+  },
+  "Enable History": {
+    "Enable History": "Ota historia käyttöön"
+  },
+  "Enable Overview Overlay": {
+    "Enable Overview Overlay": "Ota yleiskuvaus käyttöön"
+  },
+  "Enable Ripple Effects": {
+    "Enable Ripple Effects": "Ota Ripple Effects käyttöön"
+  },
+  "Enable System Sounds": {
+    "Enable System Sounds": "Ota järjestelmääänet käyttöön"
+  },
+  "Enable Video Screensaver": {
+    "Enable Video Screensaver": "Ota Video Screensaver käyttöön"
+  },
+  "Enable Weather": {
+    "Enable Weather": "Ota Sää käyttöön"
+  },
+  "Enable WiFi": {
+    "Enable WiFi": "Ota WiFi käyttöön"
+  },
+  "Enable a custom override below to set per-bar shadow intensity, opacity, and color.": {
+    "Enable a custom override below to set per-bar shadow intensity, opacity, and color.": "Ota mukautettu ohitus käyttöön alta asettaaksesi palkkikohtaisen varjon voimakkuuden, peittävyyden ja värin."
+  },
+  "Enable compositor-targetable blur layer (namespace: dms:blurwallpaper). Requires manual niri configuration.": {
+    "Enable compositor-targetable blur layer (namespace: dms:blurwallpaper). Requires manual niri configuration.": "Ota käyttöön kompositoriin kohdistettava sumennuskerros (nimiavaruus: dms:blurwallpaper). Vaatii manuaalisen niri-konfiguroinnin."
+  },
+  "Enable fingerprint at login": {
+    "Enable fingerprint at login": "Ota sormenjälki käyttöön kirjautumisen yhteydessä"
+  },
+  "Enable fingerprint authentication": {
+    "Enable fingerprint authentication": "Ota käyttöön sormenjälkitunnistus"
+  },
+  "Enable fingerprint or security key for DMS Greeter. Authentication changes apply automatically.": {
+    "Enable fingerprint or security key for DMS Greeter. Authentication changes apply automatically.": "Ota käyttöön sormenjälki tai suojausavain DMS Greeterille. Todennusmuutokset tulevat voimaan automaattisesti."
+  },
+  "Enable loginctl lock integration": {
+    "Enable loginctl lock integration": "Ota loginctl-lukon integrointi käyttöön"
+  },
+  "Enable security key at login": {
+    "Enable security key at login": "Ota suojausavain käyttöön kirjautumisen yhteydessä"
+  },
+  "Enable security key authentication": {
+    "Enable security key authentication": "Ota suojausavaimen todennus käyttöön"
+  },
+  "Enabled": {
+    "Enabled": "Käytössä"
+  },
+  "Enabling WiFi...": {
+    "Enabling WiFi...": "Otetaan WiFi käyttöön..."
+  },
+  "End": {
+    "End": "Loppu"
+  },
+  "End must be after start": {
+    "End must be after start": "Lopun on oltava alkamisen jälkeen"
+  },
+  "Enlarge on Hover": {
+    "Enlarge on Hover": "Suurenna Hoverissa"
+  },
+  "Enlargement %": {
+    "Enlargement %": "Laajennus %"
+  },
+  "Enter 6-digit passkey": {
+    "Enter 6-digit passkey": "Anna 6-numeroinen salasana"
+  },
+  "Enter PIN": {
+    "Enter PIN": "Anna PIN-koodi"
+  },
+  "Enter PIN for ": {
+    "Enter PIN for ": "Anna PIN:"
+  },
+  "Enter URI or text to share": {
+    "Enter URI or text to share": "Kirjoita URI tai teksti jaettavaksi"
+  },
+  "Enter a new name for session \"%1\"": {
+    "Enter a new name for session \"%1\"": "Anna istunnolle uusi nimi \"%1\""
+  },
+  "Enter a new name for this workspace": {
+    "Enter a new name for this workspace": "Anna tälle työtilalle uusi nimi"
+  },
+  "Enter command or script path": {
+    "Enter command or script path": "Anna komento- tai komentosarjapolku"
+  },
+  "Enter credentials for ": {
+    "Enter credentials for ": "Syötä tunnistetiedot kohteelle"
+  },
+  "Enter custom lock screen format (e.g., dddd, MMMM d)": {
+    "Enter custom lock screen format (e.g., dddd, MMMM d)": "Anna mukautettu lukitusnäytön muoto (esim. dddd, MMMM d)"
+  },
+  "Enter custom top bar format (e.g., ddd MMM d)": {
+    "Enter custom top bar format (e.g., ddd MMM d)": "Anna mukautettu yläpalkin muoto (esim. ddd MMM d)"
+  },
+  "Enter device name...": {
+    "Enter device name...": "Anna laitteen nimi..."
+  },
+  "Enter filename...": {
+    "Enter filename...": "Anna tiedostonimi..."
+  },
+  "Enter launch prefix (e.g., 'uwsm-app')": {
+    "Enter launch prefix (e.g., 'uwsm-app')": "Anna käynnistyksen etuliite (esim. \"uwsm-app\")"
+  },
+  "Enter network name and password": {
+    "Enter network name and password": "Anna verkon nimi ja salasana"
+  },
+  "Enter passkey for ": {
+    "Enter passkey for ": "Anna salasana kohteelle"
+  },
+  "Enter password for ": {
+    "Enter password for ": "Anna salasana kohteelle"
+  },
+  "Enter this passkey on ": {
+    "Enter this passkey on ": "Syötä tämä salasana päälle"
+  },
+  "Enter to Paste": {
+    "Enter to Paste": "Anna Liitä"
+  },
+  "Enterprise": {
+    "Enterprise": "Yritys"
+  },
+  "Entry Type": {
+    "Entry Type": "Sisääntulotyyppi"
+  },
+  "Entry pinned": {
+    "Entry pinned": "Sisäänkirjaus kiinnitetty"
+  },
+  "Entry unpinned": {
+    "Entry unpinned": "Merkintä irrotettu"
+  },
+  "Environment Variables": {
+    "Environment Variables": "Ympäristömuuttujat"
+  },
+  "Error": {
+    "Error": "Virhe"
+  },
+  "Errors": {
+    "Errors": "Virheet"
+  },
+  "Estimated Time": {
+    "Estimated Time": "Arvioitu aika"
+  },
+  "Ethernet": {
+    "Ethernet": "Ethernet"
+  },
+  "Event title": {
+    "Event title": "Tapahtuman otsikko"
+  },
+  "Every 15 minutes": {
+    "Every 15 minutes": "15 minuutin välein"
+  },
+  "Every 30 minutes": {
+    "Every 30 minutes": "30 minuutin välein"
+  },
+  "Every 4 hours": {
+    "Every 4 hours": "4 tunnin välein"
+  },
+  "Every hour": {
+    "Every hour": "Joka tunti"
+  },
+  "Exact": {
+    "Exact": "Tarkka"
+  },
+  "Excluded Players": {
+    "Excluded Players": "Ohitetut mediasoittimet"
+  },
+  "Exclusive Zone Offset": {
+    "Exclusive Zone Offset": "Exclusive Zone Offset"
+  },
+  "Existing Users": {
+    "Existing Users": "Nykyiset käyttäjät"
+  },
+  "Exit node": {
+    "Exit node": "Poistu solmusta"
+  },
+  "Experimental Feature": {
+    "Experimental Feature": "Kokeellinen ominaisuus"
+  },
+  "Explore": {
+    "Explore": "Tutki"
+  },
+  "Exponential": {
+    "Exponential": "Eksponentiaalinen"
+  },
+  "Expose the Arcs": {
+    "Expose the Arcs": "Paljasta kaaret"
+  },
+  "Expressive": {
+    "Expressive": "Ilmeikäs"
+  },
+  "Extend battery life": {
+    "Extend battery life": "Pidennä akun käyttöikää"
+  },
+  "Extensible architecture": {
+    "Extensible architecture": "Laajennettava arkkitehtuuri"
+  },
+  "External Wallpaper Management": {
+    "External Wallpaper Management": "Ulkoisen taustakuvan hallinta"
+  },
+  "Extra Arguments": {
+    "Extra Arguments": "Ylimääräisiä argumentteja"
+  },
+  "Extra Bold": {
+    "Extra Bold": "Erittäin lihavoitu"
+  },
+  "Extra Light": {
+    "Extra Light": "Extra Light"
+  },
+  "F1/I: Toggle • F10: Help": {
+    "F1/I: Toggle • F10: Help": "F1/I: Vaihda • F10: Ohje"
+  },
+  "Fade": {
+    "Fade": "Häivyttää"
+  },
+  "Fade to lock screen": {
+    "Fade to lock screen": "Häivytä lukitusnäyttöön"
+  },
+  "Fade to monitor off": {
+    "Fade to monitor off": "Häivytä näytön sammuttamiseksi"
+  },
+  "Failed to accept pairing": {
+    "Failed to accept pairing": "Pariliitoksen hyväksyminen epäonnistui"
+  },
+  "Failed to activate configuration": {
+    "Failed to activate configuration": "Määrityksen aktivointi epäonnistui"
+  },
+  "Failed to add binds include": {
+    "Failed to add binds include": "Sidosten lisääminen epäonnistui"
+  },
+  "Failed to add printer to class": {
+    "Failed to add printer to class": "Tulostimen lisääminen luokkaan epäonnistui"
+  },
+  "Failed to apply %1 colors": {
+    "Failed to apply %1 colors": "%1-värien käyttöönotto epäonnistui"
+  },
+  "Failed to apply charge limit to system": {
+    "Failed to apply charge limit to system": "Maksurajan soveltaminen järjestelmään epäonnistui"
+  },
+  "Failed to apply profile": {
+    "Failed to apply profile": "Profiilin käyttäminen epäonnistui"
+  },
+  "Failed to browse device": {
+    "Failed to browse device": "Laitteen selaaminen epäonnistui"
+  },
+  "Failed to cancel all jobs": {
+    "Failed to cancel all jobs": "Kaikkien töiden peruuttaminen epäonnistui"
+  },
+  "Failed to cancel selected job": {
+    "Failed to cancel selected job": "Valitun työn peruuttaminen epäonnistui"
+  },
+  "Failed to check pin limit": {
+    "Failed to check pin limit": "Pin-rajan tarkistaminen epäonnistui"
+  },
+  "Failed to connect VPN": {
+    "Failed to connect VPN": "VPN-yhteyden muodostaminen epäonnistui"
+  },
+  "Failed to connect to %1": {
+    "Failed to connect to %1": "Yhteyden muodostaminen kohteeseen %1 epäonnistui"
+  },
+  "Failed to copy entry": {
+    "Failed to copy entry": "Tiedon kopioiminen epäonnistui"
+  },
+  "Failed to create printer": {
+    "Failed to create printer": "Tulostimen luominen epäonnistui"
+  },
+  "Failed to delete VPN": {
+    "Failed to delete VPN": "VPN:n poistaminen epäonnistui"
+  },
+  "Failed to delete class": {
+    "Failed to delete class": "Kurssin poistaminen epäonnistui"
+  },
+  "Failed to delete printer": {
+    "Failed to delete printer": "Tulostimen poistaminen epäonnistui"
+  },
+  "Failed to disable job acceptance": {
+    "Failed to disable job acceptance": "Työn vastaanottamisen estäminen epäonnistui"
+  },
+  "Failed to disable night mode": {
+    "Failed to disable night mode": "Yötilan poistaminen käytöstä epäonnistui"
+  },
+  "Failed to disable plugin: %1": {
+    "Failed to disable plugin: %1": "Laajennuksen poistaminen käytöstä epäonnistui: %1"
+  },
+  "Failed to disconnect VPN": {
+    "Failed to disconnect VPN": "VPN-yhteyden katkaiseminen epäonnistui"
+  },
+  "Failed to disconnect VPNs": {
+    "Failed to disconnect VPNs": "VPN-yhteyksien katkaiseminen epäonnistui"
+  },
+  "Failed to disconnect WiFi": {
+    "Failed to disconnect WiFi": "Wi-Fi-yhteyden katkaiseminen epäonnistui"
+  },
+  "Failed to empty trash": {
+    "Failed to empty trash": "Roskakorin tyhjennys epäonnistui"
+  },
+  "Failed to enable IP location": {
+    "Failed to enable IP location": "IP-sijainnin käyttöönotto epäonnistui"
+  },
+  "Failed to enable WiFi": {
+    "Failed to enable WiFi": "Wi-Fi:n käyttöönotto epäonnistui"
+  },
+  "Failed to enable job acceptance": {
+    "Failed to enable job acceptance": "Työn hyväksyminen epäonnistui"
+  },
+  "Failed to enable night mode": {
+    "Failed to enable night mode": "Yötilan käyttöönotto epäonnistui"
+  },
+  "Failed to fetch network QR code: %1": {
+    "Failed to fetch network QR code: %1": "Verkon QR-koodin nouto epäonnistui: %1"
+  },
+  "Failed to generate systemd override": {
+    "Failed to generate systemd override": "Järjestelmän ohituksen luominen epäonnistui"
+  },
+  "Failed to hold job": {
+    "Failed to hold job": "Työn pitäminen epäonnistui"
+  },
+  "Failed to import VPN": {
+    "Failed to import VPN": "VPN:n tuonti epäonnistui"
+  },
+  "Failed to launch SMS app": {
+    "Failed to launch SMS app": "SMS-sovelluksen käynnistäminen epäonnistui"
+  },
+  "Failed to load VPN config": {
+    "Failed to load VPN config": "VPN-määrityksen lataaminen epäonnistui"
+  },
+  "Failed to load clipboard configuration.": {
+    "Failed to load clipboard configuration.": "Leikepöydän asetusten lataaminen epäonnistui."
+  },
+  "Failed to move job": {
+    "Failed to move job": "Työpaikan siirtäminen epäonnistui"
+  },
+  "Failed to move to trash": {
+    "Failed to move to trash": "Roskakoriin siirtäminen epäonnistui"
+  },
+  "Failed to parse %1": {
+    "Failed to parse %1": "Kohteen %1 jäsentäminen epäonnistui"
+  },
+  "Failed to pause printer": {
+    "Failed to pause printer": "Tulostimen keskeyttäminen epäonnistui"
+  },
+  "Failed to pin entry": {
+    "Failed to pin entry": "Tiedon kiinnittäminen epäonnistui"
+  },
+  "Failed to print test page": {
+    "Failed to print test page": "Testisivun tulostaminen epäonnistui"
+  },
+  "Failed to read theme file: %1": {
+    "Failed to read theme file: %1": "Teematiedoston lukeminen epäonnistui: %1"
+  },
+  "Failed to reject pairing": {
+    "Failed to reject pairing": "Pariliitoksen hylkääminen epäonnistui"
+  },
+  "Failed to reload plugin: %1": {
+    "Failed to reload plugin: %1": "Plugin uudelleenlataus epäonnistui: %1"
+  },
+  "Failed to remove QR code at %1: %2": {
+    "Failed to remove QR code at %1: %2": "QR-koodin poistaminen epäonnistui osoitteessa %1: %2"
+  },
+  "Failed to remove device": {
+    "Failed to remove device": "Laitteen poistaminen epäonnistui"
+  },
+  "Failed to remove keybind": {
+    "Failed to remove keybind": "Näppäimistön poistaminen epäonnistui"
+  },
+  "Failed to remove printer from class": {
+    "Failed to remove printer from class": "Tulostimen poistaminen luokasta epäonnistui"
+  },
+  "Failed to restart audio system": {
+    "Failed to restart audio system": "Äänijärjestelmän uudelleenkäynnistys epäonnistui"
+  },
+  "Failed to restart job": {
+    "Failed to restart job": "Työn uudelleenkäynnistys epäonnistui"
+  },
+  "Failed to resume printer": {
+    "Failed to resume printer": "Tulostimen jatkaminen epäonnistui"
+  },
+  "Failed to ring device": {
+    "Failed to ring device": "Laitteen soittaminen epäonnistui"
+  },
+  "Failed to run 'dms greeter status'. Ensure DMS is installed and dms is in PATH.": {
+    "Failed to run 'dms greeter status'. Ensure DMS is installed and dms is in PATH.": "\"dms greeter status\" -komentoa ei voitu suorittaa. Varmista, että DMS on asennettu ja dms on kohdassa PATH."
+  },
+  "Failed to save VPN credentials": {
+    "Failed to save VPN credentials": "VPN-kirjautumistietojen tallentaminen epäonnistui"
+  },
+  "Failed to save audio config": {
+    "Failed to save audio config": "Äänimäärityksen tallentaminen epäonnistui"
+  },
+  "Failed to save clipboard setting": {
+    "Failed to save clipboard setting": "Leikepöydän asetuksen tallentaminen epäonnistui"
+  },
+  "Failed to save keybind": {
+    "Failed to save keybind": "Näppäimistön tallentaminen epäonnistui"
+  },
+  "Failed to save profile": {
+    "Failed to save profile": "Profiilin tallennus epäonnistui"
+  },
+  "Failed to send SMS": {
+    "Failed to send SMS": "Tekstiviestin lähettäminen epäonnistui"
+  },
+  "Failed to send clipboard": {
+    "Failed to send clipboard": "Leikepöydän lähettäminen epäonnistui"
+  },
+  "Failed to send file": {
+    "Failed to send file": "Tiedoston lähettäminen epäonnistui"
+  },
+  "Failed to send ping": {
+    "Failed to send ping": "Pingin lähettäminen epäonnistui"
+  },
+  "Failed to set brightness": {
+    "Failed to set brightness": "Kirkkauden asettaminen epäonnistui"
+  },
+  "Failed to set night mode location": {
+    "Failed to set night mode location": "Yötilan sijainnin asettaminen epäonnistui"
+  },
+  "Failed to set night mode schedule": {
+    "Failed to set night mode schedule": "Yötilan aikataulun asettaminen epäonnistui"
+  },
+  "Failed to set night mode temperature": {
+    "Failed to set night mode temperature": "Yötilan lämpötilan asettaminen epäonnistui"
+  },
+  "Failed to set power profile": {
+    "Failed to set power profile": "Tehoprofiilin asettaminen epäonnistui"
+  },
+  "Failed to set profile image": {
+    "Failed to set profile image": "Profiilikuvan asettaminen epäonnistui"
+  },
+  "Failed to set profile image: %1": {
+    "Failed to set profile image: %1": "Profiilikuvan asettaminen epäonnistui: %1"
+  },
+  "Failed to share": {
+    "Failed to share": "Jakaminen epäonnistui"
+  },
+  "Failed to start connection to %1": {
+    "Failed to start connection to %1": "Yhteyden aloittaminen kohteeseen %1 epäonnistui"
+  },
+  "Failed to unpin entry": {
+    "Failed to unpin entry": "Tiedon irrottaminen epäonnistui"
+  },
+  "Failed to update %1: %2": {
+    "Failed to update %1: %2": "%1:n päivitys epäonnistui: %2"
+  },
+  "Failed to update VPN": {
+    "Failed to update VPN": "VPN:n päivittäminen epäonnistui"
+  },
+  "Failed to update autoconnect": {
+    "Failed to update autoconnect": "Automaattisen yhteyden päivittäminen epäonnistui"
+  },
+  "Failed to update clipboard": {
+    "Failed to update clipboard": "Leikepöydän päivittäminen epäonnistui"
+  },
+  "Failed to update description": {
+    "Failed to update description": "Kuvauksen päivittäminen epäonnistui"
+  },
+  "Failed to update location": {
+    "Failed to update location": "Sijainnin päivittäminen epäonnistui"
+  },
+  "Failed to update sharing": {
+    "Failed to update sharing": "Jakamisen päivittäminen epäonnistui"
+  },
+  "Failed to write autostart entry": {
+    "Failed to write autostart entry": "Autostart-merkinnän kirjoittaminen epäonnistui"
+  },
+  "Failed to write outputs config.": {
+    "Failed to write outputs config.": "Lähtöasetusten kirjoittaminen epäonnistui."
+  },
+  "Failed to write temp file for validation": {
+    "Failed to write temp file for validation": "Temp-tiedoston kirjoittaminen vahvistusta varten epäonnistui"
+  },
+  "Failed: %1": {
+    "Failed: %1": "Epäonnistui: %1"
+  },
+  "Features": {
+    "Features": "Ominaisuudet"
+  },
+  "Feels": {
+    "Feels": "Tuntuu"
+  },
+  "Feels Like": {
+    "Feels Like": "Tuntuu"
+  },
+  "Feels Like %1°": {
+    "Feels Like %1°": "Tuntuu kuin %1°"
+  },
+  "Fidelity": {
+    "Fidelity": "Uskollisuus"
+  },
+  "Field": {
+    "Field": "Kenttä"
+  },
+  "File": {
+    "File": "Tiedosto"
+  },
+  "File Already Exists": {
+    "File Already Exists": "Tiedosto on jo olemassa"
+  },
+  "File Information": {
+    "File Information": "Tiedoston tiedot"
+  },
+  "File Manager": {
+    "File Manager": "Tiedostonhallinta"
+  },
+  "File changed on disk": {
+    "File changed on disk": "Tiedosto vaihdettu levylle"
+  },
+  "File manager used to open the trash. Pick \"custom\" to enter your own command.": {
+    "File manager used to open the trash. Pick \"custom\" to enter your own command.": "Tiedostonhallinta, jota käytettiin roskakorin avaamiseen. Valitse \"mukautettu\" syöttääksesi oman komennon."
+  },
+  "File received from %1": {
+    "File received from %1": "Tiedosto vastaanotettu laitteelta %1"
+  },
+  "File search requires dsearch\nInstall from github.com/AvengeMedia/danksearch": {
+    "File search requires dsearch\nInstall from github.com/AvengeMedia/danksearch": "Tiedostohaku vaatii dsearchin\nAsenna osoitteesta github.com/AvengeMedia/danksearch"
+  },
+  "File search unavailable": {
+    "File search unavailable": "Tiedostohaku ei ole käytettävissä"
+  },
+  "Files": {
+    "Files": "Tiedostot"
+  },
+  "Filesystem usage monitoring": {
+    "Filesystem usage monitoring": "Tiedostojärjestelmän käytön seuranta"
+  },
+  "Fill": {
+    "Fill": "Täytä"
+  },
+  "Fill Mode": {
+    "Fill Mode": "Täyttötila"
+  },
+  "Filter": {
+    "Filter": "Suodata"
+  },
+  "Filter by type": {
+    "Filter by type": "Suodata tyypin mukaan"
+  },
+  "Find in Text": {
+    "Find in Text": "Etsi tekstistä"
+  },
+  "Find in note...": {
+    "Find in note...": "Hae muistiinpanosta..."
+  },
+  "Fine-tune the space reserved for the bar from the screen edge": {
+    "Fine-tune the space reserved for the bar from the screen edge": "Hienosäädä palkille varattu tila näytön reunasta"
+  },
+  "Fingerprint availability could not be confirmed.": {
+    "Fingerprint availability could not be confirmed.": "Sormenjälkien saatavuutta ei voitu vahvistaa."
+  },
+  "Fingerprint error": {
+    "Fingerprint error": "Sormenjälkivirhe"
+  },
+  "Fingerprint not recognized (%1/%2). Please try again or use password.": {
+    "Fingerprint not recognized (%1/%2). Please try again or use password.": "Sormenjälkeä ei tunnisteta (%1/%2). Yritä uudelleen tai käytä salasanaa."
+  },
+  "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and enroll later.": {
+    "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and enroll later.": "Sormenjälkitunnistin havaittu, mutta tulosteita ei ole vielä rekisteröity. Voit ottaa tämän käyttöön nyt ja ilmoittautua myöhemmin."
+  },
+  "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and run Sync later.": {
+    "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and run Sync later.": "Sormenjälkitunnistin havaittu, mutta tulosteita ei ole vielä rekisteröity. Voit ottaa tämän käyttöön nyt ja suorittaa synkronoinnin myöhemmin."
+  },
+  "Finish": {
+    "Finish": "Valmis"
+  },
+  "First Day of Week": {
+    "First Day of Week": "Viikon ensimmäinen päivä"
+  },
+  "First Time Setup": {
+    "First Time Setup": "Ensimmäinen asennuskerta"
+  },
+  "Fit": {
+    "Fit": "Sopiva"
+  },
+  "Flags": {
+    "Flags": "Liput"
+  },
+  "Flatpak": {
+    "Flatpak": "Flatpak"
+  },
+  "Flipped": {
+    "Flipped": "Käännetty"
+  },
+  "Flipped 180°": {
+    "Flipped 180°": "Käännetty 180°"
+  },
+  "Flipped 270°": {
+    "Flipped 270°": "Käännetty 270°"
+  },
+  "Flipped 90°": {
+    "Flipped 90°": "Käännetty 90°"
+  },
+  "Float": {
+    "Float": "Kelluu"
+  },
+  "Float Anchor": {
+    "Float Anchor": "Kelluva ankkuri"
+  },
+  "Float X": {
+    "Float X": "Kelluu X"
+  },
+  "Float Y": {
+    "Float Y": "Kelluu Y"
+  },
+  "Floating": {
+    "Floating": "Kelluva"
+  },
+  "Floating Position": {
+    "Floating Position": "Kelluva asento"
+  },
+  "Fluent": {
+    "Fluent": "Sujuva"
+  },
+  "Fluent: Smooth cubic deceleration in, quick snap out — clean, elegant curves.": {
+    "Fluent: Smooth cubic deceleration in, quick snap out — clean, elegant curves.": "Sujuva: Tasainen kuutioinen hidastus sisään, nopea irrotus – puhtaat, tyylikkäät kaarteet."
+  },
+  "Focus": {
+    "Focus": "Keskity"
+  },
+  "Focus Ring Color": {
+    "Focus Ring Color": "Tarkennusrenkaan väri"
+  },
+  "Focus Ring Off": {
+    "Focus Ring Off": "Tarkennusrengas pois päältä"
+  },
+  "Focus at Startup": {
+    "Focus at Startup": "Keskity käynnistykseen"
+  },
+  "Focused": {
+    "Focused": "Keskittynyt"
+  },
+  "Focused Border": {
+    "Focused Border": "Kohdistettu raja"
+  },
+  "Focused Color": {
+    "Focused Color": "Keskitetty väri"
+  },
+  "Focused Display": {
+    "Focused Display": "Tarkennettu näyttö"
+  },
+  "Focused Monitor Only": {
+    "Focused Monitor Only": "Vain fokusoitu näyttö"
+  },
+  "Focused Window": {
+    "Focused Window": "Tarkennettu ikkuna"
+  },
+  "Fog": {
+    "Fog": "Sumua"
+  },
+  "Folder": {
+    "Folder": "Kansio"
+  },
+  "Folders": {
+    "Folders": "Kansiot"
+  },
+  "Follow DMS background color": {
+    "Follow DMS background color": "Follow DMS background color"
+  },
+  "Follow Monitor Focus": {
+    "Follow Monitor Focus": "Seuraa Monitor Focus -toimintoa"
+  },
+  "Follow focus": {
+    "Follow focus": "Seuraa keskittymistä"
+  },
+  "Follows the default launcher choice selected above.": {
+    "Follows the default launcher choice selected above.": "Noudattaa yllä valittua oletuskäynnistysohjelmaa."
+  },
+  "Font": {
+    "Font": "Fontti"
+  },
+  "Font Family": {
+    "Font Family": "Fonttiperhe"
+  },
+  "Font Scale": {
+    "Font Scale": "Fonttimittakaava"
+  },
+  "Font Size": {
+    "Font Size": "Fontin koko"
+  },
+  "Font Weight": {
+    "Font Weight": "Fontin paino"
+  },
+  "Font used for the clock and date on the lock screen": {
+    "Font used for the clock and date on the lock screen": "Kellon ja päivämäärän kirjasin lukitusnäytössä"
+  },
+  "Font used on the login screen": {
+    "Font used on the login screen": "Font used on the login screen"
+  },
+  "For 1 hour": {
+    "For 1 hour": "1 tunnin ajan"
+  },
+  "For 15 minutes": {
+    "For 15 minutes": "15 minuutiksi"
+  },
+  "For 3 hours": {
+    "For 3 hours": "3 tunnin ajan"
+  },
+  "For 30 minutes": {
+    "For 30 minutes": "30 minuutiksi"
+  },
+  "For 8 hours": {
+    "For 8 hours": "8 tunnin ajan"
+  },
+  "For editing plain text files": {
+    "For editing plain text files": "For editing plain text files"
+  },
+  "Force HDR": {
+    "Force HDR": "Pakota HDR"
+  },
+  "Force Kill (SIGKILL)": {
+    "Force Kill (SIGKILL)": "Force Kill (SIGKILL)"
+  },
+  "Force Padding": {
+    "Force Padding": "Force Padding"
+  },
+  "Force RGBX": {
+    "Force RGBX": "Pakota RGBX"
+  },
+  "Force Wide Color": {
+    "Force Wide Color": "Force Wide Color"
+  },
+  "Force terminal applications to always use dark color schemes": {
+    "Force terminal applications to always use dark color schemes": "Pakota päätesovellukset käyttämään aina tummia väriteemoja"
+  },
+  "Forecast": {
+    "Forecast": "Ennuste"
+  },
+  "Forecast Days": {
+    "Forecast Days": "Ennuste päivät"
+  },
+  "Forecast Not Available": {
+    "Forecast Not Available": "Ennuste ei saatavilla"
+  },
+  "Forecast and conditions": {
+    "Forecast and conditions": "Ennuste ja ehdot"
+  },
+  "Foreground Layers": {
+    "Foreground Layers": "Etualan tasot"
+  },
+  "Forever": {
+    "Forever": "Ikuisesti"
+  },
+  "Forget": {
+    "Forget": "Unohda"
+  },
+  "Forget \"%1\"?": {
+    "Forget \"%1\"?": "Unohditko \"%1\"?"
+  },
+  "Forget Device": {
+    "Forget Device": "Unohda laite"
+  },
+  "Forget Network": {
+    "Forget Network": "Unohda verkko"
+  },
+  "Forgot network %1": {
+    "Forgot network %1": "Unohtunut verkko %1"
+  },
+  "Format Legend": {
+    "Format Legend": "Muotoile legenda"
+  },
+  "Forward 10s": {
+    "Forward 10s": "Eteenpäin 10s"
+  },
+  "Frame": {
+    "Frame": "Kehys"
+  },
+  "Frame Blur": {
+    "Frame Blur": "Kehyksen sumennus"
+  },
+  "Frame Blur follows Background Blur in Theme & Colors": {
+    "Frame Blur follows Background Blur in Theme & Colors": "Kehyksen sumennus seuraa taustan sumennusta teemassa ja väreissä"
+  },
+  "Frame Border Color": {
+    "Frame Border Color": "Kehyksen reunan väri"
+  },
+  "Frame Xray": {
+    "Frame Xray": "Runko röntgen"
+  },
+  "Free VRAM/memory when the launcher is closed. May cause a slight delay when reopening.": {
+    "Free VRAM/memory when the launcher is closed. May cause a slight delay when reopening.": "Vapaa VRAM/muisti, kun kantoraketti on suljettu. Saattaa aiheuttaa pienen viiveen uudelleen avaamisessa."
+  },
+  "Freezing Drizzle": {
+    "Freezing Drizzle": "Jäätävää tihkusadetta"
+  },
+  "Frequency": {
+    "Frequency": "Taajuus"
+  },
+  "Fruit Salad": {
+    "Fruit Salad": "Hedelmäsalaatti"
+  },
+  "Full": {
+    "Full": "Täysi"
+  },
+  "Full Command:": {
+    "Full Command:": "Täysi komento:"
+  },
+  "Full Content": {
+    "Full Content": "Täysi sisältö"
+  },
+  "Full Day & Month": {
+    "Full Day & Month": "Koko päivä & kuukausi"
+  },
+  "Full Size": {
+    "Full Size": "Täysi koko"
+  },
+  "Full command to execute": {
+    "Full command to execute": "Täysi komento suoritettavaksi"
+  },
+  "Full with Year": {
+    "Full with Year": "Täynnä vuosi"
+  },
+  "Fullscreen": {
+    "Fullscreen": "Koko näyttö"
+  },
+  "Fullscreen Only": {
+    "Fullscreen Only": "Vain koko näyttö"
+  },
+  "Fully Charged": {
+    "Fully Charged": "Täysin ladattu"
+  },
+  "Fun": {
+    "Fun": "Hauskaa"
+  },
+  "G: grid • Z/X: size": {
+    "G: grid • Z/X: size": "G: ruudukko • Z/X: koko"
+  },
+  "GPU": {
+    "GPU": "GPU"
+  },
+  "GPU Monitoring": {
+    "GPU Monitoring": "GPU-valvonta"
+  },
+  "GPU Temperature": {
+    "GPU Temperature": "GPU:n lämpötila"
+  },
+  "GPU temperature display": {
+    "GPU temperature display": "GPU-lämpötilan näyttö"
+  },
+  "GTK colors applied successfully": {
+    "GTK colors applied successfully": "GTK-värien käyttö onnistui"
+  },
+  "GTK, Qt, IDEs, more": {
+    "GTK, Qt, IDEs, more": "GTK, Qt, IDEs ja paljon muuta"
+  },
+  "Games": {
+    "Games": "Pelit"
+  },
+  "Gamma Control": {
+    "Gamma Control": "Gamma ohjaus"
+  },
+  "Gamma control not available. Requires DMS API v6+.": {
+    "Gamma control not available. Requires DMS API v6+.": "Gammaohjaus ei ole käytettävissä. Vaatii DMS API v6+."
+  },
+  "Gap between the end widgets and the bar ends (0 = edge-to-edge)": {
+    "Gap between the end widgets and the bar ends (0 = edge-to-edge)": "Rako päätywidgetien ja palkin päiden välillä (0 = reunasta reunaan)"
+  },
+  "Gaps": {
+    "Gaps": "aukkoja"
+  },
+  "General": {
+    "General": "Yleiset"
+  },
+  "Generate Override": {
+    "Generate Override": "Luo ohitus"
+  },
+  "Generate baseline GTK3/4 or QT5/QT6 (requires qt6ct-kde) configurations to follow DMS colors. Only needed once.<br /><br />It is recommended to configure <a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/README.md#Theming\" style=\"text-decoration:none; color:%1;\">adw-gtk3</a> prior to applying GTK themes.": {
+    "Generate baseline GTK3/4 or QT5/QT6 (requires qt6ct-kde) configurations to follow DMS colors. Only needed once.<br /><br />It is recommended to configure <a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/README.md#Theming\" style=\"text-decoration:none; color:%1;\">adw-gtk3</a> prior to applying GTK themes.": "Luo perustason GTK3/4- tai QT5/QT6 (vaatii qt6ct-kde) -kokoonpanot noudattamaan DMS-värejä. Tarvitaan vain kerran.<br /><br />IOn suositeltavaa määrittää <a href=\"https://github.com/AvengeMedia/DankMaterialShell/blob/master/README.md#Theming\" style=\"text-decoration:none; color:%1;\">adw-gtk3</a> ennen GTK-teemojen käyttämistä."
+  },
+  "Generic": {
+    "Generic": "Yleinen"
+  },
+  "Geometric Centering": {
+    "Geometric Centering": "Geometrinen keskitys"
+  },
+  "Get Started": {
+    "Get Started": "Aloita"
+  },
+  "GitHub": {
+    "GitHub": "GitHub"
+  },
+  "Global fonts can be configured in Settings → Personalization": {
+    "Global fonts can be configured in Settings → Personalization": "Yleiset fontit voidaan määrittää kohdassa Asetukset → Mukauttaminen"
+  },
+  "Globally scale all animation durations": {
+    "Globally scale all animation durations": "Skaalaa maailmanlaajuisesti kaikki animaation kestoajat"
+  },
+  "Golden Hour": {
+    "Golden Hour": "Kultainen tunti"
+  },
+  "Good": {
+    "Good": "Hyvä"
+  },
+  "Goth Corner Radius": {
+    "Goth Corner Radius": "Goth Corner Radius"
+  },
+  "Goth Corners": {
+    "Goth Corners": "Goth Corners"
+  },
+  "Gradually fade the screen before locking with a configurable grace period": {
+    "Gradually fade the screen before locking with a configurable grace period": "Häivytä näyttöä asteittain ennen lukitsemista määritettävällä lisäajalla"
+  },
+  "Gradually fade the screen before turning off monitors with a configurable grace period": {
+    "Gradually fade the screen before turning off monitors with a configurable grace period": "Häivytä näyttöä vähitellen ennen kuin sammutat näytöt määritettävällä lisäajalla"
+  },
+  "Grant": {
+    "Grant": "Grant"
+  },
+  "Grant administrator privileges": {
+    "Grant administrator privileges": "Myönnä järjestelmänvalvojan oikeudet"
+  },
+  "Granted administrator privileges": {
+    "Granted administrator privileges": "Myönnetty järjestelmänvalvojan oikeudet"
+  },
+  "Granted greeter login access": {
+    "Granted greeter login access": "Myönnetty tervehdyskirjautumisoikeus"
+  },
+  "Graph Time Range": {
+    "Graph Time Range": "Kaavion aikaväli"
+  },
+  "Graphics": {
+    "Graphics": "Grafiikka"
+  },
+  "Greeter": {
+    "Greeter": "Tervehdys"
+  },
+  "Greeter activated. greetd is now enabled.": {
+    "Greeter activated. greetd is now enabled.": "Tervehdys aktivoitu. tervehdys on nyt käytössä."
+  },
+  "Greeter font": {
+    "Greeter font": "Tervehdys fontti"
+  },
+  "Greeter group members can sync their login-screen theme with dms greeter sync --profile after logging out and back in.": {
+    "Greeter group members can sync their login-screen theme with dms greeter sync --profile after logging out and back in.": "Tervehdysryhmän jäsenet voivat synkronoida sisäänkirjautumisnäytön teemansa dms greeter sync --profiilin kanssa kirjautuessaan ulos ja takaisin sisään."
+  },
+  "Greeter group:": {
+    "Greeter group:": "Tervehdysryhmä:"
+  },
+  "Greeter only — format for the date on the login screen": {
+    "Greeter only — format for the date on the login screen": "Vain tervehdys — kirjautumisnäytön päivämäärän muoto"
+  },
+  "Greeter sync complete": {
+    "Greeter sync complete": "Tervehdyssynkronointi valmis"
+  },
+  "Grid": {
+    "Grid": "Ruudukko"
+  },
+  "Grid Columns": {
+    "Grid Columns": "Ruudukon sarakkeet"
+  },
+  "Grid: OFF": {
+    "Grid: OFF": "Ristikko: POIS"
+  },
+  "Grid: ON": {
+    "Grid: ON": "Ristikko: PÄÄLLÄ"
+  },
+  "Group": {
+    "Group": "ryhmä"
+  },
+  "Group Active Workspace": {
+    "Group Active Workspace": "Ryhmän aktiivinen työtila"
+  },
+  "Group Workspace Apps": {
+    "Group Workspace Apps": "Ryhmätyötilasovellukset"
+  },
+  "Group by App": {
+    "Group by App": "Ryhmittele sovelluksen mukaan"
+  },
+  "Group multiple windows of the same app together with a window count indicator": {
+    "Group multiple windows of the same app together with a window count indicator": "Ryhmittele saman sovelluksen useita ikkunoita yhteen ikkunoiden määrän ilmaisimen avulla"
+  },
+  "Group removed": {
+    "Group removed": "Ryhmä poistettu"
+  },
+  "Group repeated application icons in unfocused workspaces": {
+    "Group repeated application icons in unfocused workspaces": "Ryhmittele toistuvat sovelluskuvakkeet tarkentamattomiin työtiloihin"
+  },
+  "Groups": {
+    "Groups": "ryhmät"
+  },
+  "H": {
+    "H": "H"
+  },
+  "HDR (EDID)": {
+    "HDR (EDID)": "HDR (EDID)"
+  },
+  "HDR Tone Mapping": {
+    "HDR Tone Mapping": "HDR Tone Mapping"
+  },
+  "HDR mode is experimental. Verify your monitor supports HDR before enabling.": {
+    "HDR mode is experimental. Verify your monitor supports HDR before enabling.": "HDR-tila on kokeellinen. Varmista, että näyttösi tukee HDR:ää, ennen kuin otat sen käyttöön."
+  },
+  "HSV": {
+    "HSV": "HSV"
+  },
+  "HSV %1 copied": {
+    "HSV %1 copied": "HSV %1 kopioitu"
+  },
+  "HTML copied to clipboard": {
+    "HTML copied to clipboard": "HTML kopioitu leikepöydälle"
+  },
+  "Handles geo: location links": {
+    "Handles geo: location links": "Käsittelee geo: sijaintilinkkejä"
+  },
+  "Handles links and opens HTML files": {
+    "Handles links and opens HTML files": "Käsittelee linkkejä ja avaa HTML-tiedostoja"
+  },
+  "Handles mailto links": {
+    "Handles mailto links": "Käsittelee mailto-linkkejä"
+  },
+  "Health": {
+    "Health": "Terveys"
+  },
+  "Heavy Rain": {
+    "Heavy Rain": "Voimakas sade"
+  },
+  "Heavy Snow": {
+    "Heavy Snow": "Raskasta lunta"
+  },
+  "Heavy Snow Showers": {
+    "Heavy Snow Showers": "Kovia lumisateita"
+  },
+  "Height": {
+    "Height": "Korkeus"
+  },
+  "Held": {
+    "Held": "Pidetty"
+  },
+  "Help": {
+    "Help": "Ohje"
+  },
+  "Hex": {
+    "Hex": "Hex"
+  },
+  "Hibernate": {
+    "Hibernate": "Lepotila"
+  },
+  "Hibernate failed": {
+    "Hibernate failed": "Lepotila epäonnistui"
+  },
+  "Hidden": {
+    "Hidden": "Piilotettu"
+  },
+  "Hidden (%1)": {
+    "Hidden (%1)": "Piilotettu (%1)"
+  },
+  "Hidden Apps": {
+    "Hidden Apps": "Piilotetut sovellukset"
+  },
+  "Hidden apps won't appear in the launcher. Right-click an app and select 'Hide App' to hide it.": {
+    "Hidden apps won't appear in the launcher. Right-click an app and select 'Hide App' to hide it.": "Piilotetut sovellukset eivät näy käynnistysohjelmassa. Napsauta sovellusta hiiren kakkospainikkeella ja piilota se valitsemalla Piilota sovellus."
+  },
+  "Hidden until weather is enabled": {
+    "Hidden until weather is enabled": "Piilotettu, kunnes sää otetaan käyttöön"
+  },
+  "Hide": {
+    "Hide": "Piilota"
+  },
+  "Hide 3rd Party": {
+    "Hide 3rd Party": "Piilota kolmas osapuoli"
+  },
+  "Hide App": {
+    "Hide App": "Piilota sovellus"
+  },
+  "Hide Delay": {
+    "Hide Delay": "Piilota viive"
+  },
+  "Hide Indicators": {
+    "Hide Indicators": "Piilota ilmaisimet"
+  },
+  "Hide When Typing": {
+    "Hide When Typing": "Piilota kirjoittaessasi"
+  },
+  "Hide When Windows Open": {
+    "Hide When Windows Open": "Piilota Windowsin avautuessa"
+  },
+  "Hide cursor after inactivity (0 = disabled)": {
+    "Hide cursor after inactivity (0 = disabled)": "Piilota kohdistin käyttämättömyyden jälkeen (0 = pois käytöstä)"
+  },
+  "Hide cursor when pressing keyboard keys": {
+    "Hide cursor when pressing keyboard keys": "Piilota kohdistin, kun painat näppäimistön näppäimiä"
+  },
+  "Hide cursor when using touch input": {
+    "Hide cursor when using touch input": "Piilota kohdistin kosketussyöttöä käytettäessä"
+  },
+  "Hide device": {
+    "Hide device": "Piilota laite"
+  },
+  "Hide installed": {
+    "Hide installed": "Piilota asennettu"
+  },
+  "Hide notification content until expanded": {
+    "Hide notification content until expanded": "Piilota ilmoitusten sisältö, kunnes se laajennetaan"
+  },
+  "Hide notification content until expanded; popups show collapsed by default": {
+    "Hide notification content until expanded; popups show collapsed by default": "Piilota ilmoitusten sisältö, kunnes se laajennetaan; ponnahdusikkunat näkyvät oletuksena kutistettuina"
+  },
+  "Hide on Touch": {
+    "Hide on Touch": "Piilota kosketuksessa"
+  },
+  "Hide the bar when the pointer leaves even if a popout is still open": {
+    "Hide the bar when the pointer leaves even if a popout is still open": "Piilota palkki, kun osoitin poistuu, vaikka ponnahdusikkuna olisi edelleen auki"
+  },
+  "Hide when no updates: OFF": {
+    "Hide when no updates: OFF": "Piilota, kun ei päivityksiä: POIS"
+  },
+  "Hide when no updates: ON": {
+    "Hide when no updates: ON": "Piilota, kun ei päivityksiä: PÄÄLLÄ"
+  },
+  "High": {
+    "High": "Korkea"
+  },
+  "High-fidelity palette that preserves source hues.": {
+    "High-fidelity palette that preserves source hues.": "Korkealaatuinen paletti, joka säilyttää lähdesävyt."
+  },
+  "Highlight Active Workspace App": {
+    "Highlight Active Workspace App": "Korosta Active Workspace -sovellus"
+  },
+  "Highlight the currently focused app inside workspace indicators": {
+    "Highlight the currently focused app inside workspace indicators": "Korosta tällä hetkellä kohdistettu sovellus työtilan ilmaisimissa"
+  },
+  "History": {
+    "History": "Historia"
+  },
+  "History Retention": {
+    "History Retention": "Historian säilyttäminen"
+  },
+  "History Settings": {
+    "History Settings": "Historia-asetukset"
+  },
+  "History cleared. %1 pinned entries kept.": {
+    "History cleared. %1 pinned entries kept.": "Historia tyhjennetty. %1 kiinnitetyt merkinnät säilytetään."
+  },
+  "Hold Duration": {
+    "Hold Duration": "Pidon kesto"
+  },
+  "Hold longer to confirm": {
+    "Hold longer to confirm": "Vahvista pitämällä pidempään"
+  },
+  "Hold to Confirm Power Actions": {
+    "Hold to Confirm Power Actions": "Pidä painettuna vahvistaaksesi tehotoiminnot"
+  },
+  "Hold to confirm (%1 ms)": {
+    "Hold to confirm (%1 ms)": "Vahvista pitämällä painettuna (%1 ms)"
+  },
+  "Hold to confirm (%1s)": {
+    "Hold to confirm (%1s)": "Vahvista painamalla (%1s)"
+  },
+  "Home": {
+    "Home": "Kotiin"
+  },
+  "Horizontal and vertical bar thickness": {
+    "Horizontal and vertical bar thickness": "Vaaka- ja pystysuoran tangon paksuus"
+  },
+  "Host": {
+    "Host": "Isäntä"
+  },
+  "Hostname": {
+    "Hostname": "Isäntänimi"
+  },
+  "Hot Corners": {
+    "Hot Corners": "Kuumat kulmat"
+  },
+  "Hotkey overlay title (optional)": {
+    "Hotkey overlay title (optional)": "Pikanäppäinpeittokuvan otsikko (valinnainen)"
+  },
+  "Hour": {
+    "Hour": "Tunti"
+  },
+  "Hourly": {
+    "Hourly": "Tunneittain"
+  },
+  "Hourly Forecast Count": {
+    "Hourly Forecast Count": "Tuntiennuste Count"
+  },
+  "Hover Popouts": {
+    "Hover Popouts": "Vie hiiri ponnahdusikkunat"
+  },
+  "How often the server polls for new updates.": {
+    "How often the server polls for new updates.": "Kuinka usein palvelin kyselee uusia päivityksiä."
+  },
+  "How often to change wallpaper": {
+    "How often to change wallpaper": "Kuinka usein vaihtaa taustakuvaa"
+  },
+  "How the background image is scaled": {
+    "How the background image is scaled": "Miten taustakuva skaalataan"
+  },
+  "How the wallpaper is scaled to fit the screen": {
+    "How the wallpaper is scaled to fit the screen": "Kuinka taustakuva skaalataan näytölle sopivaksi"
+  },
+  "Humidity": {
+    "Humidity": "Kosteus"
+  },
+  "Hyprland Discord Server": {
+    "Hyprland Discord Server": "Hyprland Discord-palvelin"
+  },
+  "Hyprland Options": {
+    "Hyprland Options": "Hyprland Vaihtoehdot"
+  },
+  "Hyprland Website": {
+    "Hyprland Website": "Hyprland-verkkosivusto"
+  },
+  "Hyprland conf mode": {
+    "Hyprland conf mode": "Hyprland neuvottelutila"
+  },
+  "Hyprland conf mode is read-only in Settings": {
+    "Hyprland conf mode is read-only in Settings": "Hyprland conf-tila on vain luku -tilassa asetuksissa"
+  },
+  "Hyprland config include missing": {
+    "Hyprland config include missing": "Hyprland-kokoonpano puuttuu"
+  },
+  "I Understand": {
+    "I Understand": "Ymmärrän"
+  },
+  "IP": {
+    "IP": "IP"
+  },
+  "IP Address:": {
+    "IP Address:": "IP-osoite:"
+  },
+  "IP address or hostname": {
+    "IP address or hostname": "IP-osoite tai isäntänimi"
+  },
+  "ISO Date": {
+    "ISO Date": "ISO-päivämäärä"
+  },
+  "Icon": {
+    "Icon": "Kuvake"
+  },
+  "Icon Scale": {
+    "Icon Scale": "Ikoni mittakaava"
+  },
+  "Icon Size": {
+    "Icon Size": "Kuvakkeen koko"
+  },
+  "Icon Size %": {
+    "Icon Size %": "Kuvakkeen koko %"
+  },
+  "Icon Theme": {
+    "Icon Theme": "Ikoni teema"
+  },
+  "Icon theme changed outside DMS; switched to System Default": {
+    "Icon theme changed outside DMS; switched to System Default": "Kuvaketeema muutettu DMS:n ulkopuolella; vaihdettu järjestelmän oletustilaan"
+  },
+  "Identical alerts show as one popup instead of stacking": {
+    "Identical alerts show as one popup instead of stacking": "Identtiset hälytykset näkyvät yhtenä ponnahdusikkunana pinoamisen sijaan"
+  },
+  "Identical alerts stack as separate notification cards": {
+    "Identical alerts stack as separate notification cards": "Samat hälytykset pinoavat erillisinä ilmoituskorteina"
+  },
+  "Identify": {
+    "Identify": "Tunnista"
+  },
+  "Idle": {
+    "Idle": "Tyhjäkäynti"
+  },
+  "Idle Inhibit": {
+    "Idle Inhibit": "Tyhjäkäynnin esto"
+  },
+  "Idle Inhibitor": {
+    "Idle Inhibitor": "Tyhjäkäynnin estäjä"
+  },
+  "Idle Settings": {
+    "Idle Settings": "Idle Settings"
+  },
+  "If autostart app icons don't appear in the system tray, generate a systemd override to ensure DMS starts before autostart apps": {
+    "If autostart app icons don't appear in the system tray, generate a systemd override to ensure DMS starts before autostart apps": "Jos automaattisen käynnistyksen sovellusten kuvakkeet eivät näy ilmaisinalueella, luo järjestelmän ohitus varmistaaksesi, että DMS käynnistyy ennen kuin sovelluksia käynnistyy automaattisesti."
+  },
+  "If the field is hidden, it will appear as soon as a key is pressed.": {
+    "If the field is hidden, it will appear as soon as a key is pressed.": "Jos kenttä on piilotettu, se tulee näkyviin heti, kun näppäintä painetaan."
+  },
+  "Ignore Completely": {
+    "Ignore Completely": "Ohita kokonaan"
+  },
+  "Ignore package": {
+    "Ignore package": "Ohita paketti"
+  },
+  "Ignore this package": {
+    "Ignore this package": "Ohita tämä paketti"
+  },
+  "Ignored (%1)": {
+    "Ignored (%1)": "Ohitettu (%1)"
+  },
+  "Ignored Packages": {
+    "Ignored Packages": "Ohitetut paketit"
+  },
+  "Ignored packages are hidden from the updater and skipped by 'Update All'.": {
+    "Ignored packages are hidden from the updater and skipped by 'Update All'.": "Ohitetut paketit piilotetaan päivitykseltä ja ohitetaan \"Päivitä kaikki\" -toiminnolla."
+  },
+  "Ignored packages only apply to the built-in updater. Your custom command controls its own exclusions.": {
+    "Ignored packages only apply to the built-in updater. Your custom command controls its own exclusions.": "Ohitetut paketit koskevat vain sisäänrakennettua päivitysohjelmaa. Mukautettu komentosi hallitsee omia poissulkemisiaan."
+  },
+  "Image": {
+    "Image": "Kuva"
+  },
+  "Image Viewer": {
+    "Image Viewer": "Kuvankatseluohjelma"
+  },
+  "Image copied to clipboard": {
+    "Image copied to clipboard": "Kuva kopioitu leikepöydälle"
+  },
+  "Import": {
+    "Import": "Tuo"
+  },
+  "Import VPN": {
+    "Import VPN": "Tuo VPN"
+  },
+  "Inactive Monitor Color": {
+    "Inactive Monitor Color": "Ei-aktiivinen näytön väri"
+  },
+  "Include AUR updates": {
+    "Include AUR updates": "Sisällytä AUR-päivitykset"
+  },
+  "Include Files in All Tab": {
+    "Include Files in All Tab": "Sisällytä tiedostot Kaikki-välilehteen"
+  },
+  "Include Flatpak updates": {
+    "Include Flatpak updates": "Sisällytä Flatpak-päivitykset"
+  },
+  "Include Folders in All Tab": {
+    "Include Folders in All Tab": "Sisällytä kansiot Kaikki-välilehteen"
+  },
+  "Include Transitions": {
+    "Include Transitions": "Sisällytä siirtymät"
+  },
+  "Include desktop actions (shortcuts) in search results.": {
+    "Include desktop actions (shortcuts) in search results.": "Sisällytä hakutuloksiin työpöytätoiminnot (pikakuvakkeet)."
+  },
+  "Incompatible Plugins Loaded": {
+    "Incompatible Plugins Loaded": "Yhteensopimattomat laajennukset ladattu"
+  },
+  "Incorrect password": {
+    "Incorrect password": "Väärä salasana"
+  },
+  "Incorrect password - try again": {
+    "Incorrect password - try again": "Väärä salasana - yritä uudelleen"
+  },
+  "Index Centering": {
+    "Index Centering": "Hakemiston keskitys"
+  },
+  "Indicator Style": {
+    "Indicator Style": "Ilmaisimen tyyli"
+  },
+  "Individual Batteries": {
+    "Individual Batteries": "Yksittäiset akut"
+  },
+  "Individual bar configuration": {
+    "Individual bar configuration": "Yksilöllinen baarikokoonpano"
+  },
+  "Info": {
+    "Info": "Tietoja"
+  },
+  "Inherit": {
+    "Inherit": "Peri"
+  },
+  "Inherit Global (Default)": {
+    "Inherit Global (Default)": "Peri globaali (oletus)"
+  },
+  "Inhibitable": {
+    "Inhibitable": "Estettävä"
+  },
+  "Initial position for floating windows. Set both X and Y; anchor controls which corner/edge they're relative to.": {
+    "Initial position for floating windows. Set both X and Y; anchor controls which corner/edge they're relative to.": "Alkuasento kelluville ikkunoille. Aseta sekä X että Y; ankkuri ohjaa mihin kulmaan/reunaan ne ovat suhteessa."
+  },
+  "Initialised": {
+    "Initialised": "Alustettu"
+  },
+  "Inner Gaps": {
+    "Inner Gaps": "Sisäiset aukot"
+  },
+  "Inner padding applied to each widget": {
+    "Inner padding applied to each widget": "Jokaisessa widgetissä on sisäpehmuste"
+  },
+  "Input Devices": {
+    "Input Devices": "Syöttölaitteet"
+  },
+  "Input Volume Slider": {
+    "Input Volume Slider": "Tuloäänenvoimakkuuden liukusäädin"
+  },
+  "Insert your security key...": {
+    "Insert your security key...": "Aseta suojausavain..."
+  },
+  "Inset the Notepad from screen edges using the compositor's configured gaps": {
+    "Inset the Notepad from screen edges using the compositor's configured gaps": "Aseta muistilehtiö näytön reunoista käyttämällä kompositorin määritettyjä rakoja"
+  },
+  "Install": {
+    "Install": "Asenna"
+  },
+  "Install Greeter": {
+    "Install Greeter": "Asenna Greeter"
+  },
+  "Install Plugin": {
+    "Install Plugin": "Asenna Plugin"
+  },
+  "Install Theme": {
+    "Install Theme": "Asenna teema"
+  },
+  "Install color themes from the DMS theme registry": {
+    "Install color themes from the DMS theme registry": "Asenna väriteemat DMS-teemarekisteristä"
+  },
+  "Install complete. Greeter has been installed.": {
+    "Install complete. Greeter has been installed.": "Asennus valmis. Greeter on asennettu."
+  },
+  "Install dsearch to search files.": {
+    "Install dsearch to search files.": "Asenna dsearch etsiäksesi tiedostoja."
+  },
+  "Install failed: %1": {
+    "Install failed: %1": "Asennus epäonnistui: %1"
+  },
+  "Install matugen package for dynamic theming": {
+    "Install matugen package for dynamic theming": "Asenna matugen-paketti dynaamista teemaa varten"
+  },
+  "Install plugin '%1' from the DMS registry?": {
+    "Install plugin '%1' from the DMS registry?": "Asennetaanko laajennus %1 DMS-rekisteristä?"
+  },
+  "Install plugins from the DMS plugin registry": {
+    "Install plugins from the DMS plugin registry": "Asenna laajennukset DMS-laajennusrekisteristä"
+  },
+  "Install the DMS greeter? A terminal will open for sudo authentication.": {
+    "Install the DMS greeter? A terminal will open for sudo authentication.": "Asennetaanko DMS tervehdin? Pääte avautuu sudo-todennusta varten."
+  },
+  "Install theme '%1' from the DMS registry?": {
+    "Install theme '%1' from the DMS registry?": "Asennetaanko teema \"%1\" DMS-rekisteristä?"
+  },
+  "Installation and PAM setup: see the ": {
+    "Installation and PAM setup: see the ": "Asennus ja PAM-asetukset: katso"
+  },
+  "Installed": {
+    "Installed": "Asennettu"
+  },
+  "Installed first": {
+    "Installed first": "Asennettu ensin"
+  },
+  "Installed: %1": {
+    "Installed: %1": "Asennettu: %1"
+  },
+  "Installing: %1": {
+    "Installing: %1": "Asennus: %1"
+  },
+  "Integrations": {
+    "Integrations": "Integraatiot"
+  },
+  "Intelligent Auto-hide": {
+    "Intelligent Auto-hide": "Älykäs automaattinen piilotus"
+  },
+  "Intensity": {
+    "Intensity": "Intensiteetti"
+  },
+  "Interface:": {
+    "Interface:": "Käyttöliittymä:"
+  },
+  "Interlock Open": {
+    "Interlock Open": "Lukitus auki"
+  },
+  "Internet": {
+    "Internet": "Internet"
+  },
+  "Interval": {
+    "Interval": "Intervalli"
+  },
+  "Invalid JSON format: %1": {
+    "Invalid JSON format: %1": "Virheellinen JSON-muoto: %1"
+  },
+  "Invalid configuration": {
+    "Invalid configuration": "Virheellinen määritys"
+  },
+  "Invalid package name — letters, digits and @._+:- only.": {
+    "Invalid package name — letters, digits and @._+:- only.": "Virheellinen paketin nimi – vain kirjaimet, numerot ja @._+:-."
+  },
+  "Invalid password for %1": {
+    "Invalid password for %1": "Virheellinen salasana %1:lle"
+  },
+  "Invalid username": {
+    "Invalid username": "Virheellinen käyttäjätunnus"
+  },
+  "Invert on mode change": {
+    "Invert on mode change": "Käänteinen tilan vaihto"
+  },
+  "Invert touchpad scroll direction": {
+    "Invert touchpad scroll direction": "Käännä kosketuslevyn vierityssuunta"
+  },
+  "Iris Bloom": {
+    "Iris Bloom": "Iris Bloom"
+  },
+  "Isolate Displays": {
+    "Isolate Displays": "Eristä näytöt"
+  },
+  "Jobs": {
+    "Jobs": "Työpaikat"
+  },
+  "Join video call": {
+    "Join video call": "Liity videopuheluun"
+  },
+  "Jump to page": {
+    "Jump to page": "Siirry sivulle"
+  },
+  "Jump to page (1 - %1)": {
+    "Jump to page (1 - %1)": "Siirry sivulle (1 - %1)"
+  },
+  "Keep Awake": {
+    "Keep Awake": "Pysy hereillä"
+  },
+  "Keep Changes": {
+    "Keep Changes": "Säilytä muutokset"
+  },
+  "Keep My Edits": {
+    "Keep My Edits": "Säilytä muokkaukset"
+  },
+  "Keep in Bar": {
+    "Keep in Bar": "Säilytä baarissa"
+  },
+  "Keep the clipboard type filter when reopening history": {
+    "Keep the clipboard type filter when reopening history": "Säilytä leikepöydän tyyppisuodatin, kun avaat historian uudelleen"
+  },
+  "Keep typing": {
+    "Keep typing": "Jatka kirjoittamista"
+  },
+  "Keeping Awake": {
+    "Keeping Awake": "Pidetään hereillä"
+  },
+  "Kernel": {
+    "Kernel": "Ydin"
+  },
+  "Key": {
+    "Key": "Avain"
+  },
+  "Keybind Sources": {
+    "Keybind Sources": "Näppäimistön lähteet"
+  },
+  "Keybinds": {
+    "Keybinds": "Näppäimet"
+  },
+  "Keybinds Search Settings": {
+    "Keybinds Search Settings": "Keybinds-hakuasetukset"
+  },
+  "Keybinds shown alongside regular search results": {
+    "Keybinds shown alongside regular search results": "Näppäinyhdistelmät näytetään tavallisten hakutulosten yhteydessä"
+  },
+  "Keyboard Layout Name": {
+    "Keyboard Layout Name": "Näppäimistön asettelun nimi"
+  },
+  "Keyboard Shortcuts": {
+    "Keyboard Shortcuts": "Pikanäppäimet"
+  },
+  "Keys": {
+    "Keys": "Avaimet"
+  },
+  "Kill": {
+    "Kill": "Tapa"
+  },
+  "Kill Process": {
+    "Kill Process": "Tappoprosessi"
+  },
+  "Kill Session": {
+    "Kill Session": "Tapa istunto"
+  },
+  "Ko-fi": {
+    "Ko-fi": "Ko-fi"
+  },
+  "LED device": {
+    "LED device": "LED laite"
+  },
+  "LabWC IRC Channel": {
+    "LabWC IRC Channel": "LabWC IRC-kanava"
+  },
+  "LabWC Website": {
+    "LabWC Website": "LabWC:n verkkosivusto"
+  },
+  "Large": {
+    "Large": "Suuri"
+  },
+  "Largest": {
+    "Largest": "Suurin"
+  },
+  "Last hour": {
+    "Last hour": "Viimeinen tunti"
+  },
+  "Last launched %1": {
+    "Last launched %1": "Viimeksi käynnistetty %1"
+  },
+  "Last launched %1 day ago": {
+    "Last launched %1 day ago": "Julkaistu viimeksi %1 päivä sitten"
+  },
+  "Last launched %1 days ago": {
+    "Last launched %1 days ago": "Julkaistu viimeksi %1 päivää sitten"
+  },
+  "Last launched %1 hour ago": {
+    "Last launched %1 hour ago": "Julkaistu viimeksi %1 tunti sitten"
+  },
+  "Last launched %1 hours ago": {
+    "Last launched %1 hours ago": "Julkaistu viimeksi %1 tuntia sitten"
+  },
+  "Last launched %1 minute ago": {
+    "Last launched %1 minute ago": "Viimeksi käynnistetty %1 minuutti sitten"
+  },
+  "Last launched %1 minutes ago": {
+    "Last launched %1 minutes ago": "Julkaistu viimeksi %1 minuuttia sitten"
+  },
+  "Last launched just now": {
+    "Last launched just now": "Viimeksi käynnistetty juuri nyt"
+  },
+  "Latitude": {
+    "Latitude": "Leveysaste"
+  },
+  "Launch": {
+    "Launch": "Käynnistä"
+  },
+  "Launch Prefix": {
+    "Launch Prefix": "Käynnistä etuliite"
+  },
+  "Launch on dGPU": {
+    "Launch on dGPU": "Käynnistä dGPU:ssa"
+  },
+  "Launcher": {
+    "Launcher": "Käynnistysohjelma"
+  },
+  "Launcher Button": {
+    "Launcher Button": "Käynnistyspainike"
+  },
+  "Launcher Button Logo": {
+    "Launcher Button Logo": "Käynnistyspainikkeen logo"
+  },
+  "Launcher Emerge Side": {
+    "Launcher Emerge Side": "Kantoraketti Emerge Side"
+  },
+  "Layer Outline Opacity": {
+    "Layer Outline Opacity": "Layer Outline Opacity"
+  },
+  "Layout": {
+    "Layout": "Asettelu"
+  },
+  "Layout Overrides": {
+    "Layout Overrides": "Asettelun ohitukset"
+  },
+  "Left": {
+    "Left": "Vasen"
+  },
+  "Left Center": {
+    "Left Center": "Vasen keskusta"
+  },
+  "Left Section": {
+    "Left Section": "Vasen osio"
+  },
+  "Light": {
+    "Light": "Kevyt"
+  },
+  "Light Direction": {
+    "Light Direction": "Valon suunta"
+  },
+  "Light Mode": {
+    "Light Mode": "Valotila"
+  },
+  "Light Mode Icon Theme": {
+    "Light Mode Icon Theme": "Valotilan kuvaketeema"
+  },
+  "Light Rain": {
+    "Light Rain": "Kevyt sade"
+  },
+  "Light Snow": {
+    "Light Snow": "Kevyttä lunta"
+  },
+  "Light Snow Showers": {
+    "Light Snow Showers": "Kevyitä lumisateita"
+  },
+  "Light mode base": {
+    "Light mode base": "Valotilan pohja"
+  },
+  "Light mode harmony": {
+    "Light mode harmony": "Valotilan harmonia"
+  },
+  "Limit set to %1%": {
+    "Limit set to %1%": "Rajaksi asetettu %1 %"
+  },
+  "Limit the maximum battery charge level to extend lifespan.": {
+    "Limit the maximum battery charge level to extend lifespan.": "Rajoita akun enimmäislataustasoa pidentääksesi käyttöikää."
+  },
+  "Line": {
+    "Line": "rivi"
+  },
+  "Line: %1": {
+    "Line: %1": "Rivi: %1"
+  },
+  "Linear": {
+    "Linear": "Lineaarinen"
+  },
+  "Lines: %1": {
+    "Lines: %1": "Rivit: %1"
+  },
+  "List": {
+    "List": "Luettelo"
+  },
+  "Lively palette with saturated accents.": {
+    "Lively palette with saturated accents.": "Eloisa paletti kylläisillä aksenteilla."
+  },
+  "Load Average": {
+    "Load Average": "Keskimääräinen kuormitus"
+  },
+  "Loading codecs...": {
+    "Loading codecs...": "Ladataan koodekkeja..."
+  },
+  "Loading keybinds...": {
+    "Loading keybinds...": "Ladataan näppäinsidoksia..."
+  },
+  "Loading trending...": {
+    "Loading trending...": "Ladataan trendejä..."
+  },
+  "Loading...": {
+    "Loading...": "Ladataan..."
+  },
+  "Local": {
+    "Local": "Paikallinen"
+  },
+  "Local Weather": {
+    "Local Weather": "Paikallinen sää"
+  },
+  "Locale": {
+    "Locale": "Alue"
+  },
+  "Location": {
+    "Location": "Sijainti"
+  },
+  "Location Search": {
+    "Location Search": "Sijaintihaku"
+  },
+  "Lock": {
+    "Lock": "Lukko"
+  },
+  "Lock Screen": {
+    "Lock Screen": "Lukitusnäyttö"
+  },
+  "Lock Screen Format": {
+    "Lock Screen Format": "Lukitusnäytön muoto"
+  },
+  "Lock at startup": {
+    "Lock at startup": "Lukitse käynnistyksen yhteydessä"
+  },
+  "Lock before suspend": {
+    "Lock before suspend": "Lukitse ennen keskeytystä"
+  },
+  "Lock fade grace period": {
+    "Lock fade grace period": "Lukon häivytyksen lisäaika"
+  },
+  "Lock screen font": {
+    "Lock screen font": "Lukitusnäytön fontti"
+  },
+  "Locked": {
+    "Locked": "Lukittu"
+  },
+  "Log Out": {
+    "Log Out": "Kirjaudu ulos"
+  },
+  "Logging in...": {
+    "Logging in...": "Kirjaudutaan sisään..."
+  },
+  "Login": {
+    "Login": "Kirjaudu sisään"
+  },
+  "Long": {
+    "Long": "Pitkä"
+  },
+  "Long Text": {
+    "Long Text": "Pitkä teksti"
+  },
+  "Long press": {
+    "Long press": "Pitkä painallus"
+  },
+  "Longitude": {
+    "Longitude": "Pituusaste"
+  },
+  "Low": {
+    "Low": "Matala"
+  },
+  "Low Battery": {
+    "Low Battery": "Alhainen akku"
+  },
+  "Low Battery Notifications": {
+    "Low Battery Notifications": "Alhaisen akun ilmoitukset"
+  },
+  "Low Battery Threshold": {
+    "Low Battery Threshold": "Alhainen akun kynnys"
+  },
+  "Low Priority": {
+    "Low Priority": "Matala prioriteetti"
+  },
+  "MAC": {
+    "MAC": "MAC"
+  },
+  "MTU": {
+    "MTU": "MTU"
+  },
+  "Mail": {
+    "Mail": "Mail"
+  },
+  "Make admin": {
+    "Make admin": "Tee järjestelmänvalvojaksi"
+  },
+  "Make sure KDE Connect or Valent is running on your other devices": {
+    "Make sure KDE Connect or Valent is running on your other devices": "Varmista, että KDE Connect tai Valent ovat käynnissä muissa laitteissasi"
+  },
+  "Make the bar background fully transparent": {
+    "Make the bar background fully transparent": "Tee palkin taustasta täysin läpinäkyvä"
+  },
+  "Manage and configure plugins for extending DMS functionality": {
+    "Manage and configure plugins for extending DMS functionality": "Hallinnoi ja määritä laajennuksia DMS-toiminnallisuuden laajentamiseksi"
+  },
+  "Manage up to 4 independent bar configurations. Each bar has its own position, widgets, styling, and display assignment.": {
+    "Manage up to 4 independent bar configurations. Each bar has its own position, widgets, styling, and display assignment.": "Hallitse jopa 4 erillistä baarikokoonpanoa. Jokaisella palkilla on oma sijainti, widgetit, tyyli ja näyttötehtävä."
+  },
+  "Managed by Frame": {
+    "Managed by Frame": "Hallinnoi Frame"
+  },
+  "Managed by Frame in Connected Mode": {
+    "Managed by Frame in Connected Mode": "Yhdistetty tilassa Frame hallinnoi"
+  },
+  "Managed by the primary PAM source.": {
+    "Managed by the primary PAM source.": "Ensisijainen PAM-lähde hallitsee tätä."
+  },
+  "Management": {
+    "Management": "Hallinto"
+  },
+  "Manages files and directories": {
+    "Manages files and directories": "Hallitsee tiedostoja ja hakemistoja"
+  },
+  "Mango Options": {
+    "Mango Options": "Mango-vaihtoehdot"
+  },
+  "Mango service not available": {
+    "Mango service not available": "Mango-palvelu ei ole saatavilla"
+  },
+  "Manual": {
+    "Manual": "Manuaalinen"
+  },
+  "Manual Coordinates": {
+    "Manual Coordinates": "Manuaaliset koordinaatit"
+  },
+  "Manual Direction": {
+    "Manual Direction": "Manuaalinen suunta"
+  },
+  "Manual Gap Size": {
+    "Manual Gap Size": "Manuaalinen aukon koko"
+  },
+  "Manual Gaps": {
+    "Manual Gaps": "Manuaaliset aukot"
+  },
+  "Manual Show/Hide": {
+    "Manual Show/Hide": "Manuaalinen Näytä/Piilota"
+  },
+  "Manual config": {
+    "Manual config": "Manuaalinen konfigurointi"
+  },
+  "Map window class names to icon names for proper icon display": {
+    "Map window class names to icon names for proper icon display": "Yhdistä ikkunoiden luokkien nimet kuvakkeiden nimiin oikean kuvakkeen näyttämiseksi"
+  },
+  "Maps": {
+    "Maps": "Kartat"
+  },
+  "Margin": {
+    "Margin": "Marginaali"
+  },
+  "Marker Supply Empty": {
+    "Marker Supply Empty": "Merkintarvike tyhjä"
+  },
+  "Marker Supply Low": {
+    "Marker Supply Low": "Marker Supply Low"
+  },
+  "Marker Waste Almost Full": {
+    "Marker Waste Almost Full": "Merkinjäte melkein täynnä"
+  },
+  "Marker Waste Full": {
+    "Marker Waste Full": "Merkkijäte täynnä"
+  },
+  "Match (%1)": {
+    "Match (%1)": "Ottelu (%1)"
+  },
+  "Match Conditions": {
+    "Match Conditions": "Otteluehdot"
+  },
+  "Match Criteria": {
+    "Match Criteria": "Vastaavuuskriteerit"
+  },
+  "Material": {
+    "Material": "Materiaali"
+  },
+  "Material Battery Style": {
+    "Material Battery Style": "Materiaali Akun tyyli"
+  },
+  "Material Colors": {
+    "Material Colors": "Materiaalin värit"
+  },
+  "Material Design inspired color themes": {
+    "Material Design inspired color themes": "Materiaalisuunnittelun inspiroimia väriteemoja"
+  },
+  "Material colors generated from wallpaper": {
+    "Material colors generated from wallpaper": "Tapetista luodut materiaalivärit"
+  },
+  "Material inspired shadows and elevation on modals, popouts, and dialogs": {
+    "Material inspired shadows and elevation on modals, popouts, and dialogs": "Materiaalin inspiroimia varjoja ja korkeuksia modaaleissa, ponnahdusikkunoissa ja valintaikkunoissa"
+  },
+  "Material: Material Design 3 Expressive bezier curves. The DMS default feel.": {
+    "Material: Material Design 3 Expressive bezier curves. The DMS default feel.": "Materiaali: Materiaali Design 3 ilmeikkäät bezier-käyrät. DMS oletustuntuma."
+  },
+  "Matugen Contrast": {
+    "Matugen Contrast": "Matugenin kontrasti"
+  },
+  "Matugen Missing": {
+    "Matugen Missing": "Matugen puuttuu"
+  },
+  "Matugen Palette": {
+    "Matugen Palette": "Matugen paletti"
+  },
+  "Matugen Target Monitor": {
+    "Matugen Target Monitor": "Matugen Target Monitor"
+  },
+  "Matugen Templates": {
+    "Matugen Templates": "Matugen mallit"
+  },
+  "Max Edges": {
+    "Max Edges": "Max reunat"
+  },
+  "Max H": {
+    "Max H": "Max H"
+  },
+  "Max Pinned Apps": {
+    "Max Pinned Apps": "Maksimi kiinnitetyt sovellukset"
+  },
+  "Max Pinned Apps (0 = Unlimited)": {
+    "Max Pinned Apps (0 = Unlimited)": "Kiinnitettyjen sovellusten enimmäismäärä (0 = rajoittamaton)"
+  },
+  "Max Running Apps": {
+    "Max Running Apps": "Max käynnissä olevia sovelluksia"
+  },
+  "Max Running Apps (0 = Unlimited)": {
+    "Max Running Apps (0 = Unlimited)": "Käynnissä olevien sovellusten enimmäismäärä (0 = rajoittamaton)"
+  },
+  "Max Visible": {
+    "Max Visible": "Näkyvä maksimi"
+  },
+  "Max Volume": {
+    "Max Volume": "Suurin äänenvoimakkuus"
+  },
+  "Max W": {
+    "Max W": "Max W"
+  },
+  "Max apps to show": {
+    "Max apps to show": "Näytettävien sovellusten enimmäismäärä"
+  },
+  "Max to Edges": {
+    "Max to Edges": "Max Edgesiin"
+  },
+  "Maximize": {
+    "Maximize": "Maksimoi"
+  },
+  "Maximize Detection": {
+    "Maximize Detection": "Maksimoi tunnistus"
+  },
+  "Maximize Widget Icons": {
+    "Maximize Widget Icons": "Maksimoi widget-kuvakkeet"
+  },
+  "Maximize Widget Text": {
+    "Maximize Widget Text": "Maksimoi Widget-teksti"
+  },
+  "Maximum Entry Size": {
+    "Maximum Entry Size": "Suurin sisääntulokoko"
+  },
+  "Maximum History": {
+    "Maximum History": "Suurin historia"
+  },
+  "Maximum Pinned Entries": {
+    "Maximum Pinned Entries": "Kiinnitettyjen merkintöjen enimmäismäärä"
+  },
+  "Maximum fingerprint attempts reached. Please use password.": {
+    "Maximum fingerprint attempts reached. Please use password.": "Sormenjälkiyritysten enimmäismäärä saavutettu. Käytä salasanaa."
+  },
+  "Maximum number of clipboard entries to keep": {
+    "Maximum number of clipboard entries to keep": "Säilytettävien leikepöydän merkintöjen enimmäismäärä"
+  },
+  "Maximum number of entries that can be saved": {
+    "Maximum number of entries that can be saved": "Tallennettavien merkintöjen enimmäismäärä"
+  },
+  "Maximum number of notifications to keep": {
+    "Maximum number of notifications to keep": "Säilytettävien ilmoitusten enimmäismäärä"
+  },
+  "Maximum pinned entries reached": {
+    "Maximum pinned entries reached": "Kiinnitettyjen merkintöjen enimmäismäärä saavutettu"
+  },
+  "Media": {
+    "Media": "Media"
+  },
+  "Media Controls": {
+    "Media Controls": "Mediaohjaimet"
+  },
+  "Media Empty": {
+    "Media Empty": "Media tyhjä"
+  },
+  "Media Jam": {
+    "Media Jam": "Media Jam"
+  },
+  "Media Low": {
+    "Media Low": "Media alhainen"
+  },
+  "Media Needed": {
+    "Media Needed": "Mediaa tarvitaan"
+  },
+  "Media Playback": {
+    "Media Playback": "Median toisto"
+  },
+  "Media Player": {
+    "Media Player": "Mediasoitin"
+  },
+  "Media Players (": {
+    "Media Players (": "Mediasoittimet ("
+  },
+  "Media Volume": {
+    "Media Volume": "Media Volume"
+  },
+  "Medium": {
+    "Medium": "Keskikokoinen"
+  },
+  "Memory": {
+    "Memory": "Muisti"
+  },
+  "Memory Graph": {
+    "Memory Graph": "Muistikaavio"
+  },
+  "Memory Usage": {
+    "Memory Usage": "Muistin käyttö"
+  },
+  "Memory usage indicator": {
+    "Memory usage indicator": "Muistin käytön ilmaisin"
+  },
+  "Merge indexed file results into the All tab (requires dsearch).": {
+    "Merge indexed file results into the All tab (requires dsearch).": "Yhdistä indeksoidun tiedoston tulokset Kaikki-välilehteen (vaatii dsearchin)."
+  },
+  "Merge indexed folder results into the All tab (requires dsearch).": {
+    "Merge indexed folder results into the All tab (requires dsearch).": "Yhdistä indeksoidun kansion tulokset Kaikki-välilehteen (vaatii d-haun)."
+  },
+  "Message": {
+    "Message": "Viesti"
+  },
+  "Message Content": {
+    "Message Content": "Viestin sisältö"
+  },
+  "Microphone": {
+    "Microphone": "Mikrofoni"
+  },
+  "Microphone Mute": {
+    "Microphone Mute": "Mikrofonin mykistys"
+  },
+  "Microphone Volume": {
+    "Microphone Volume": "Mikrofonin äänenvoimakkuus"
+  },
+  "Microphone settings": {
+    "Microphone settings": "Mikrofonin asetukset"
+  },
+  "Microphone volume control": {
+    "Microphone volume control": "Mikrofonin äänenvoimakkuuden säätö"
+  },
+  "Middle Section": {
+    "Middle Section": "Keskiosa"
+  },
+  "Min H": {
+    "Min H": "Min H"
+  },
+  "Min W": {
+    "Min W": "Min W"
+  },
+  "Minimal palette built around a single hue.": {
+    "Minimal palette built around a single hue.": "Minimaalinen paletti, joka on rakennettu yhden sävyn ympärille."
+  },
+  "Minute": {
+    "Minute": "Minuutti"
+  },
+  "Mirror Display": {
+    "Mirror Display": "Peilin näyttö"
+  },
+  "Missing Environment Variables": {
+    "Missing Environment Variables": "Puuttuvat ympäristömuuttujat"
+  },
+  "Modal Background": {
+    "Modal Background": "Modaalinen tausta"
+  },
+  "Modal Shadows": {
+    "Modal Shadows": "Modaaliset varjot"
+  },
+  "Modals": {
+    "Modals": "Modaalit"
+  },
+  "Mode": {
+    "Mode": "tila"
+  },
+  "Model": {
+    "Model": "Malli"
+  },
+  "Modified": {
+    "Modified": "Muokattu"
+  },
+  "Modular widget bar": {
+    "Modular widget bar": "Modulaarinen widget-palkki"
+  },
+  "Monitor": {
+    "Monitor": "Monitor"
+  },
+  "Monitor Configuration": {
+    "Monitor Configuration": "Näytön kokoonpano"
+  },
+  "Monitor fade grace period": {
+    "Monitor fade grace period": "Monitor fade lisäaika"
+  },
+  "Monitor whose wallpaper drives dynamic theming colors": {
+    "Monitor whose wallpaper drives dynamic theming colors": "Näyttö, jonka taustakuva ohjaa dynaamisia teemavärejä"
+  },
+  "Monitors in \"%1\":": {
+    "Monitors in \"%1\":": "Näytöt \"%1\":ssä:"
+  },
+  "Monochrome": {
+    "Monochrome": "Yksivärinen"
+  },
+  "Monocle": {
+    "Monocle": "Monocle"
+  },
+  "Monospace Font": {
+    "Monospace Font": "Monospace fontti"
+  },
+  "Month Date": {
+    "Month Date": "Kuukauden päivämäärä"
+  },
+  "Morning": {
+    "Morning": "Huomenta"
+  },
+  "Motion Effects": {
+    "Motion Effects": "Liiketehosteet"
+  },
+  "Mount Points": {
+    "Mount Points": "Mount Points"
+  },
+  "Mouse clicks pass through the bar to windows behind it": {
+    "Mouse clicks pass through the bar to windows behind it": "Hiiren napsautukset kulkevat palkin läpi sen takana oleviin ikkunoihin"
+  },
+  "Mouse pointer appearance": {
+    "Mouse pointer appearance": "Hiiren osoittimen ulkonäkö"
+  },
+  "Mouse pointer size in pixels": {
+    "Mouse pointer size in pixels": "Hiiren osoittimen koko pikseleinä"
+  },
+  "Move Widget": {
+    "Move Widget": "Siirrä widgetiä"
+  },
+  "Move to Trash": {
+    "Move to Trash": "Siirrä roskakoriin"
+  },
+  "Moving to Paused": {
+    "Moving to Paused": "Siirtyminen keskeytettyyn"
+  },
+  "Multi-Monitor": {
+    "Multi-Monitor": "Moninäyttö"
+  },
+  "Multimedia": {
+    "Multimedia": "Multimedia"
+  },
+  "Multiplexer Type": {
+    "Multiplexer Type": "Multiplekserin tyyppi"
+  },
+  "Multiplexers": {
+    "Multiplexers": "Multiplekserit"
+  },
+  "Music": {
+    "Music": "Musiikki"
+  },
+  "Music Player": {
+    "Music Player": "Musiikkisoitin"
+  },
+  "Mute During Playback": {
+    "Mute During Playback": "Mykistys toiston aikana"
+  },
+  "Mute Popups": {
+    "Mute Popups": "Mykistä ponnahdusikkunat"
+  },
+  "Mute popups for %1": {
+    "Mute popups for %1": "Mykistä %1:n ponnahdusikkunat"
+  },
+  "Muted": {
+    "Muted": "Mykistetty"
+  },
+  "Muted Apps": {
+    "Muted Apps": "Mykistetut sovellukset"
+  },
+  "Muted palette with subdued, calming tones.": {
+    "Muted palette with subdued, calming tones.": "Mykistetty paletti hillityillä, rauhoittavilla sävyillä."
+  },
+  "My Online": {
+    "My Online": "Oma Online"
+  },
+  "NM not supported": {
+    "NM not supported": "NM ei tueta"
+  },
+  "Name": {
+    "Name": "Nimi"
+  },
+  "Named Workspace Icons": {
+    "Named Workspace Icons": "Nimetyt työtilan kuvakkeet"
+  },
+  "Native": {
+    "Native": "Alkuperäinen"
+  },
+  "Native: platform renderer (FreeType).": {
+    "Native: platform renderer (FreeType).": "Alkuperäinen: alustan renderöija (FreeType)."
+  },
+  "Natural Touchpad Scrolling": {
+    "Natural Touchpad Scrolling": "Luonnollinen kosketuslevyn vieritys"
+  },
+  "Navigate": {
+    "Navigate": "Navigoi"
+  },
+  "Navigation": {
+    "Navigation": "Navigointi"
+  },
+  "Network": {
+    "Network": "Verkko"
+  },
+  "Network Graph": {
+    "Network Graph": "Verkkokaavio"
+  },
+  "Network Info": {
+    "Network Info": "Verkkotiedot"
+  },
+  "Network Information": {
+    "Network Information": "Verkkotiedot"
+  },
+  "Network Name (SSID)": {
+    "Network Name (SSID)": "Verkon nimi (SSID)"
+  },
+  "Network Speed Monitor": {
+    "Network Speed Monitor": "Verkon nopeusvalvonta"
+  },
+  "Network Type": {
+    "Network Type": "Verkkotyyppi"
+  },
+  "Network download and upload speed display": {
+    "Network download and upload speed display": "Verkon lataus- ja latausnopeuden näyttö"
+  },
+  "Network not found": {
+    "Network not found": "Verkkoa ei löydy"
+  },
+  "Neutral": {
+    "Neutral": "Neutraali"
+  },
+  "Never": {
+    "Never": "Ei koskaan"
+  },
+  "Never used": {
+    "Never used": "Ei koskaan käytetty"
+  },
+  "New": {
+    "New": "Uusi"
+  },
+  "New Key": {
+    "New Key": "Uusi avain"
+  },
+  "New Keybind": {
+    "New Keybind": "Uusi Keybind"
+  },
+  "New Notification": {
+    "New Notification": "Uusi ilmoitus"
+  },
+  "New Session": {
+    "New Session": "Uusi istunto"
+  },
+  "New Window Rule": {
+    "New Window Rule": "Uusi ikkunasääntö"
+  },
+  "New York, NY": {
+    "New York, NY": "New York, NY"
+  },
+  "New event": {
+    "New event": "Uusi tapahtuma"
+  },
+  "New group name...": {
+    "New group name...": "Ryhmän uusi nimi..."
+  },
+  "Next": {
+    "Next": "Seuraava"
+  },
+  "Next Transition": {
+    "Next Transition": "Seuraava siirto"
+  },
+  "Next page": {
+    "Next page": "Seuraava sivu"
+  },
+  "Night": {
+    "Night": "Yö"
+  },
+  "Night Mode": {
+    "Night Mode": "Yötila"
+  },
+  "Night Temperature": {
+    "Night Temperature": "Yölämpötila"
+  },
+  "Night mode & gamma": {
+    "Night mode & gamma": "Yötila & gamma"
+  },
+  "Night mode failed: DMS gamma control not available": {
+    "Night mode failed: DMS gamma control not available": "Yötila epäonnistui: DMS gammaohjaus ei ole käytettävissä"
+  },
+  "Niri Integration": {
+    "Niri Integration": "Niri-integrointi"
+  },
+  "Niri compositor actions (focus, move, etc.)": {
+    "Niri compositor actions (focus, move, etc.)": "Niri kokoonpanotoiminnot (tarkenna, siirrä jne.)"
+  },
+  "No": {
+    "No": "Ei"
+  },
+  "No Active Players": {
+    "No Active Players": "Ei aktiivisia pelaajia"
+  },
+  "No Anim": {
+    "No Anim": "Ei Anim"
+  },
+  "No Background": {
+    "No Background": "Ei taustaa"
+  },
+  "No Bluetooth adapter found": {
+    "No Bluetooth adapter found": "Bluetooth-sovitinta ei löydy"
+  },
+  "No Blur": {
+    "No Blur": "Ei sumennusta"
+  },
+  "No Border": {
+    "No Border": "Ei rajaa"
+  },
+  "No DMS shortcuts configured": {
+    "No DMS shortcuts configured": "DMS-pikakuvakkeita ei ole määritetty"
+  },
+  "No Dim": {
+    "No Dim": "Ei Dim"
+  },
+  "No Focus": {
+    "No Focus": "Ei tarkennusta"
+  },
+  "No GPU detected": {
+    "No GPU detected": "GPU:ta ei havaittu"
+  },
+  "No GPUs detected": {
+    "No GPUs detected": "Grafiikkasuorittimia ei havaittu"
+  },
+  "No History": {
+    "No History": "Ei historiaa"
+  },
+  "No Media": {
+    "No Media": "Ei mediaa"
+  },
+  "No Round": {
+    "No Round": "Ei kierrosta"
+  },
+  "No Rounding": {
+    "No Rounding": "Ei pyöristystä"
+  },
+  "No Shadow": {
+    "No Shadow": "Ei varjoa"
+  },
+  "No VPN profiles": {
+    "No VPN profiles": "Ei VPN-profiileja"
+  },
+  "No Weather": {
+    "No Weather": "Ei säätä"
+  },
+  "No Weather Data": {
+    "No Weather Data": "Ei säätietoja"
+  },
+  "No Weather Data Available": {
+    "No Weather Data Available": "Säätietoja ei ole saatavilla"
+  },
+  "No action": {
+    "No action": "Ei toimintaa"
+  },
+  "No active %1 sessions": {
+    "No active %1 sessions": "Ei aktiivisia %1-istuntoja"
+  },
+  "No active session found for %1": {
+    "No active session found for %1": "Aktiivista istuntoa ei löytynyt kohteelle %1"
+  },
+  "No adapter": {
+    "No adapter": "Ei sovitinta"
+  },
+  "No adapters": {
+    "No adapters": "Ei sovittimia"
+  },
+  "No app customizations.": {
+    "No app customizations.": "Ei sovellusten mukautuksia."
+  },
+  "No application selected": {
+    "No application selected": "Sovellusta ei ole valittu"
+  },
+  "No apps found": {
+    "No apps found": "Sovelluksia ei löytynyt"
+  },
+  "No apps have been launched yet.": {
+    "No apps have been launched yet.": "Sovelluksia ei ole vielä julkaistu."
+  },
+  "No apps muted. Right-click a notification and choose \"Mute popups\" to add one here.": {
+    "No apps muted. Right-click a notification and choose \"Mute popups\" to add one here.": "Ei sovelluksia mykistetty. Napsauta ilmoitusta hiiren kakkospainikkeella ja lisää ilmoitus tähän valitsemalla Mykistä ponnahdusikkunat."
+  },
+  "No autostart entries": {
+    "No autostart entries": "Ei automaattisen käynnistyksen merkintöjä"
+  },
+  "No battery": {
+    "No battery": "Ei akkua"
+  },
+  "No brightness devices available": {
+    "No brightness devices available": "Kirkkauslaitteita ei ole saatavilla"
+  },
+  "No calendar source available": {
+    "No calendar source available": "Kalenterilähdettä ei ole saatavilla"
+  },
+  "No changes": {
+    "No changes": "Ei muutoksia"
+  },
+  "No checks passed": {
+    "No checks passed": "Ei läpäissyt tarkastuksia"
+  },
+  "No codecs found": {
+    "No codecs found": "Ei löytynyt koodekkeja"
+  },
+  "No custom theme file": {
+    "No custom theme file": "Ei mukautettua teematiedostoa"
+  },
+  "No devices": {
+    "No devices": "Ei laitteita"
+  },
+  "No devices found": {
+    "No devices found": "Laitteita ei löytynyt"
+  },
+  "No disk data": {
+    "No disk data": "Ei levytietoja"
+  },
+  "No disk data available": {
+    "No disk data available": "Levytietoja ei ole saatavilla"
+  },
+  "No display profiles found. Create them in Settings > Displays.": {
+    "No display profiles found. Create them in Settings > Displays.": "Näyttöprofiileja ei löytynyt. Luo ne kohdassa Asetukset > Näytöt."
+  },
+  "No drivers found": {
+    "No drivers found": "Ajureita ei löytynyt"
+  },
+  "No errors": {
+    "No errors": "Ei virheitä"
+  },
+  "No excluded players configured": {
+    "No excluded players configured": "Poissuljettuja pelaajia ei ole määritetty"
+  },
+  "No features enabled": {
+    "No features enabled": "Ei ominaisuuksia käytössä"
+  },
+  "No files found": {
+    "No files found": "Tiedostoja ei löytynyt"
+  },
+  "No fingerprint reader detected.": {
+    "No fingerprint reader detected.": "Sormenjälkilukijaa ei havaittu."
+  },
+  "No folders found": {
+    "No folders found": "Kansioita ei löytynyt"
+  },
+  "No hidden apps.": {
+    "No hidden apps.": "Ei piilotettuja sovelluksia."
+  },
+  "No human user accounts found.": {
+    "No human user accounts found.": "Ihmisten käyttäjätilejä ei löytynyt."
+  },
+  "No images found": {
+    "No images found": "Kuvia ei löytynyt"
+  },
+  "No info items": {
+    "No info items": "Ei tietokohteita"
+  },
+  "No information available": {
+    "No information available": "Tietoja ei ole saatavilla"
+  },
+  "No input device": {
+    "No input device": "Ei syöttölaitetta"
+  },
+  "No input devices found": {
+    "No input devices found": "Syöttölaitteita ei löytynyt"
+  },
+  "No items added yet": {
+    "No items added yet": "Kohteita ei ole vielä lisätty"
+  },
+  "No keybinds found": {
+    "No keybinds found": "Näppäimiä ei löytynyt"
+  },
+  "No launcher plugins installed.": {
+    "No launcher plugins installed.": "Käynnistyslaajennuksia ei ole asennettu."
+  },
+  "No match criteria": {
+    "No match criteria": "Ei vastaavuusehtoja"
+  },
+  "No matches": {
+    "No matches": "Ei osumia"
+  },
+  "No matching devices": {
+    "No matching devices": "Ei vastaavia laitteita"
+  },
+  "No matching processes": {
+    "No matching processes": "Ei vastaavia prosesseja"
+  },
+  "No monitors": {
+    "No monitors": "Ei näyttöjä"
+  },
+  "No mount points found": {
+    "No mount points found": "Kiinnityspisteitä ei löytynyt"
+  },
+  "No other active sessions on this seat": {
+    "No other active sessions on this seat": "Ei muita aktiivisia istuntoja tällä istuimella"
+  },
+  "No output device": {
+    "No output device": "Ei tulostuslaitetta"
+  },
+  "No output devices found": {
+    "No output devices found": "Tulostuslaitteita ei löytynyt"
+  },
+  "No packages ignored. Add one here or hover an update in the popout and click the hide button.": {
+    "No packages ignored. Add one here or hover an update in the popout and click the hide button.": "Yhtään pakettia ei huomioitu. Lisää yksi tähän tai vie päivitys ponnahdusikkunaan ja napsauta Piilota-painiketta."
+  },
+  "No peers found": {
+    "No peers found": "Vertaisia ei löytynyt"
+  },
+  "No plugin results": {
+    "No plugin results": "Ei liitännäisiä tuloksia"
+  },
+  "No plugins found": {
+    "No plugins found": "Laajennuksia ei löytynyt"
+  },
+  "No printer found": {
+    "No printer found": "Tulostinta ei löytynyt"
+  },
+  "No printers configured": {
+    "No printers configured": "Tulostimia ei ole määritetty"
+  },
+  "No printers found": {
+    "No printers found": "Tulostimia ei löytynyt"
+  },
+  "No profiles": {
+    "No profiles": "Ei profiileja"
+  },
+  "No recent clipboard entries found": {
+    "No recent clipboard entries found": "Viimeaikaisia leikepöydän merkintöjä ei löytynyt"
+  },
+  "No reminder": {
+    "No reminder": "Ei muistutusta"
+  },
+  "No results": {
+    "No results": "Ei tuloksia"
+  },
+  "No results found": {
+    "No results found": "Tuloksia ei löytynyt"
+  },
+  "No saved clipboard entries": {
+    "No saved clipboard entries": "Ei tallennettuja leikepöydän merkintöjä"
+  },
+  "No screenshot provided": {
+    "No screenshot provided": "Kuvakaappausta ei toimitettu"
+  },
+  "No session selected": {
+    "No session selected": "Istuntoa ei ole valittu"
+  },
+  "No sessions found": {
+    "No sessions found": "Istuntoja ei löytynyt"
+  },
+  "No status output.": {
+    "No status output.": "Ei tilatulostusta."
+  },
+  "No supported package manager found.": {
+    "No supported package manager found.": "Tuettua paketinhallintaa ei löydy."
+  },
+  "No terminal configured": {
+    "No terminal configured": "Päätettä ei ole määritetty"
+  },
+  "No themes found": {
+    "No themes found": "Teemoja ei löytynyt"
+  },
+  "No themes installed. Browse themes to install from the registry.": {
+    "No themes installed. Browse themes to install from the registry.": "Teemoja ei ole asennettu. Selaa rekisteristä asennettavia teemoja."
+  },
+  "No trigger": {
+    "No trigger": "Ei laukaisinta"
+  },
+  "No updates available.": {
+    "No updates available.": "Päivityksiä ei ole saatavilla."
+  },
+  "No user specified": {
+    "No user specified": "Ei määritettyä käyttäjää"
+  },
+  "No video found in folder": {
+    "No video found in folder": "Kansiosta ei löytynyt videota"
+  },
+  "No wallpaper selected": {
+    "No wallpaper selected": "Taustakuvaa ei ole valittu"
+  },
+  "No wallpapers": {
+    "No wallpapers": "Ei taustakuvia"
+  },
+  "No wallpapers found\n\nClick the folder icon below to browse": {
+    "No wallpapers found\n\nClick the folder icon below to browse": "Taustakuvia ei löytynyt\n\nNapsauta alla olevaa kansiokuvaketta selataksesi"
+  },
+  "No warnings": {
+    "No warnings": "Ei varoituksia"
+  },
+  "No widgets added. Click \"Add Widget\" to get started.": {
+    "No widgets added. Click \"Add Widget\" to get started.": "Widgetejä ei ole lisätty. Napsauta \"Lisää widget\" aloittaaksesi."
+  },
+  "No widgets available": {
+    "No widgets available": "Ei widgetejä saatavilla"
+  },
+  "No widgets match your search": {
+    "No widgets match your search": "No widgets match your search"
+  },
+  "No window rules configured": {
+    "No window rules configured": "No window rules configured"
+  },
+  "No writable calendar available": {
+    "No writable calendar available": "No writable calendar available"
+  },
+  "Noise": {
+    "Noise": "Melu"
+  },
+  "None": {
+    "None": "Ei mitään"
+  },
+  "None active": {
+    "None active": "Ei yhtään aktiivista"
+  },
+  "Normal": {
+    "Normal": "Normaali"
+  },
+  "Normal Font": {
+    "Normal Font": "Normaali fontti"
+  },
+  "Normal Priority": {
+    "Normal Priority": "Normaali prioriteetti"
+  },
+  "Not available": {
+    "Not available": "Ei saatavilla"
+  },
+  "Not available — install fprintd and pam_fprintd, or configure greetd PAM.": {
+    "Not available — install fprintd and pam_fprintd, or configure greetd PAM.": "Ei saatavilla — asenna fprintd ja pam_fprintd tai määritä tervehdys PAM."
+  },
+  "Not available — install fprintd and pam_fprintd.": {
+    "Not available — install fprintd and pam_fprintd.": "Ei saatavilla – asenna fprintd ja pam_fprintd."
+  },
+  "Not available — install or configure pam_u2f, or configure greetd PAM.": {
+    "Not available — install or configure pam_u2f, or configure greetd PAM.": "Ei saatavilla — asenna tai määritä pam_u2f tai määritä tervehdys PAM."
+  },
+  "Not available — install or configure pam_u2f.": {
+    "Not available — install or configure pam_u2f.": "Not available — install or configure pam_u2f."
+  },
+  "Not bound": {
+    "Not bound": "Ei sidottu"
+  },
+  "Not connected": {
+    "Not connected": "Ei yhdistetty"
+  },
+  "Not detected": {
+    "Not detected": "Ei havaittu"
+  },
+  "Not listed?": {
+    "Not listed?": "Ei listattu?"
+  },
+  "Not paired": {
+    "Not paired": "Ei pariksi"
+  },
+  "Not set": {
+    "Not set": "Ei asetettu"
+  },
+  "Notepad": {
+    "Notepad": "Muistilehtiö"
+  },
+  "Notepad Settings": {
+    "Notepad Settings": "Muistioasetukset"
+  },
+  "Notepad Slideout": {
+    "Notepad Slideout": "Muistio Slideout"
+  },
+  "Notes": {
+    "Notes": "Huomautuksia"
+  },
+  "Nothing": {
+    "Nothing": "Ei mitään"
+  },
+  "Nothing to see here": {
+    "Nothing to see here": "Täällä ei ole mitään nähtävää"
+  },
+  "Notification": {
+    "Notification": "Ilmoitus"
+  },
+  "Notification Center": {
+    "Notification Center": "Ilmoituskeskus"
+  },
+  "Notification Display": {
+    "Notification Display": "Ilmoitusnäyttö"
+  },
+  "Notification Overlay": {
+    "Notification Overlay": "Ilmoituspeitto"
+  },
+  "Notification Popups": {
+    "Notification Popups": "Ponnahdusikkunat"
+  },
+  "Notification Settings": {
+    "Notification Settings": "Ilmoitusasetukset"
+  },
+  "Notification Type": {
+    "Notification Type": "Ilmoituksen tyyppi"
+  },
+  "Notification toast popups": {
+    "Notification toast popups": "Ilmoituspaahtoleipä ponnahdusikkunat"
+  },
+  "Notifications": {
+    "Notifications": "Ilmoitukset"
+  },
+  "Notify when limit is reached": {
+    "Notify when limit is reached": "Ilmoita kun raja saavutetaan"
+  },
+  "Now playing and media controls": {
+    "Now playing and media controls": "Nyt toisto ja mediaohjaimet"
+  },
+  "Numbers": {
+    "Numbers": "Numerot"
+  },
+  "Numeric (D/M)": {
+    "Numeric (D/M)": "Numeerinen (D/M)"
+  },
+  "Numeric (M/D)": {
+    "Numeric (M/D)": "Numeerinen (M/D)"
+  },
+  "OK": {
+    "OK": "OK"
+  },
+  "OS Logo": {
+    "OS Logo": "OS-logo"
+  },
+  "OSD Position": {
+    "OSD Position": "OSD-sijainti"
+  },
+  "Occupied Color": {
+    "Occupied Color": "Varattu väri"
+  },
+  "Off": {
+    "Off": "Pois päältä"
+  },
+  "Office": {
+    "Office": "Toimisto"
+  },
+  "Offline": {
+    "Offline": "Offline-tilassa"
+  },
+  "Offline Report": {
+    "Offline Report": "Offline-raportti"
+  },
+  "Older": {
+    "Older": "Vanhempi"
+  },
+  "On": {
+    "On": "Päällä"
+  },
+  "On indefinitely": {
+    "On indefinitely": "Päällä toistaiseksi"
+  },
+  "On-Demand": {
+    "On-Demand": "On-demand"
+  },
+  "On-screen Displays": {
+    "On-screen Displays": "Ruudun näytöt"
+  },
+  "Once a day": {
+    "Once a day": "Kerran päivässä"
+  },
+  "Online": {
+    "Online": "verkossa"
+  },
+  "Only adjust gamma based on time or location rules.": {
+    "Only adjust gamma based on time or location rules.": "Säädä gammaa vain aika- tai sijaintisääntöjen perusteella."
+  },
+  "Only on Battery": {
+    "Only on Battery": "Vain akulla"
+  },
+  "Only show windows from the current monitor on each dock": {
+    "Only show windows from the current monitor on each dock": "Näytä vain kunkin telakointiaseman nykyisen näytön ikkunat"
+  },
+  "Only visible if hibernate is supported by your system": {
+    "Only visible if hibernate is supported by your system": "Näkyy vain, jos järjestelmäsi tukee horrostilaa"
+  },
+  "Opacity": {
+    "Opacity": "Peittävyys"
+  },
+  "Opaque": {
+    "Opaque": "Läpinäkymätön"
+  },
+  "Open": {
+    "Open": "Avaa"
+  },
+  "Open App": {
+    "Open App": "Avaa App"
+  },
+  "Open Delay": {
+    "Open Delay": "Avaa viive"
+  },
+  "Open Dir": {
+    "Open Dir": "Avaa Dir"
+  },
+  "Open Frame": {
+    "Open Frame": "Avaa kehys"
+  },
+  "Open From": {
+    "Open From": "Avaa alkaen"
+  },
+  "Open Notepad File": {
+    "Open Notepad File": "Avaa Muistiotiedosto"
+  },
+  "Open Trash": {
+    "Open Trash": "Avaa Roskakori"
+  },
+  "Open Trash With": {
+    "Open Trash With": "Avaa Roskakori"
+  },
+  "Open a new note": {
+    "Open a new note": "Avaa uusi muistiinpano"
+  },
+  "Open a terminal and run a custom command instead of the in-shell upgrade flow.": {
+    "Open a terminal and run a custom command instead of the in-shell upgrade flow.": "Avaa pääte ja suorita mukautettu komento shellin sisäisen päivityksen sijaan."
+  },
+  "Open as window": {
+    "Open as window": "Avaa ikkunana"
+  },
+  "Open folder": {
+    "Open folder": "Avaa kansio"
+  },
+  "Open in Browser": {
+    "Open in Browser": "Avaa selaimessa"
+  },
+  "Open in terminal": {
+    "Open in terminal": "Avaa terminaalissa"
+  },
+  "Open search bar to find text": {
+    "Open search bar to find text": "Avaa hakupalkki löytääksesi tekstiä"
+  },
+  "Open the launcher by hovering the emerge edge (when free of bar and dock)": {
+    "Open the launcher by hovering the emerge edge (when free of bar and dock)": "Avaa kantoraketti viemällä esiin nousevaa reunaa (kun vapaa tanko ja telakka)"
+  },
+  "Open widget popouts by hovering over the bar. Moving to another widget switches the popout.": {
+    "Open widget popouts by hovering over the bar. Moving to another widget switches the popout.": "Avaa widgetien ponnahdusikkunat viemällä hiiren osoitin palkin päälle. Siirtyminen toiseen widgetiin vaihtaa ponnahdusikkunaa."
+  },
+  "Open with...": {
+    "Open with...": "Avaa..."
+  },
+  "Opening SMS app": {
+    "Opening SMS app": "SMS-sovelluksen avaaminen"
+  },
+  "Opening file browser": {
+    "Opening file browser": "Tiedostoselaimen avaaminen"
+  },
+  "Opening terminal: ": {
+    "Opening terminal: ": "Terminaalin avaus:"
+  },
+  "Opens a picker of other active sessions on this seat": {
+    "Opens a picker of other active sessions on this seat": "Avaa valitsimen tämän istuimen muista aktiivisista istunnoista"
+  },
+  "Opens the connected launcher in Connected Frame Mode.": {
+    "Opens the connected launcher in Connected Frame Mode.": "Avaa yhdistetyn käynnistysohjelman Connected Frame -tilassa."
+  },
+  "Optional description": {
+    "Optional description": "Valinnainen kuvaus"
+  },
+  "Optional location": {
+    "Optional location": "Valinnainen sijainti"
+  },
+  "Optional state-based conditions applied to the first match.": {
+    "Optional state-based conditions applied to the first match.": "Valinnaiset tilaperusteiset ehdot sovellettiin ensimmäiseen otteluun."
+  },
+  "Options": {
+    "Options": "Vaihtoehdot"
+  },
+  "Organize widgets into collapsible groups": {
+    "Organize widgets into collapsible groups": "Järjestä widgetit kokoontaitettaviin ryhmiin"
+  },
+  "Original: %1": {
+    "Original: %1": "Alkuperäinen: %1"
+  },
+  "Other": {
+    "Other": "muu"
+  },
+  "Outer Gaps": {
+    "Outer Gaps": "Ulkoiset aukot"
+  },
+  "Outline": {
+    "Outline": "Outline"
+  },
+  "Output": {
+    "Output": "Lähtö"
+  },
+  "Output Area Almost Full": {
+    "Output Area Almost Full": "Lähtöalue lähes täynnä"
+  },
+  "Output Area Full": {
+    "Output Area Full": "Lähtöalue täynnä"
+  },
+  "Output Devices": {
+    "Output Devices": "Tulostuslaitteet"
+  },
+  "Output Tray Missing": {
+    "Output Tray Missing": "Tulostelokero puuttuu"
+  },
+  "Overcast": {
+    "Overcast": "Pilvistä"
+  },
+  "Overflow": {
+    "Overflow": "Overflow"
+  },
+  "Overlay": {
+    "Overlay": "Peittokuva"
+  },
+  "Overridden by config": {
+    "Overridden by config": "Konfig ohittaa"
+  },
+  "Override": {
+    "Override": "Ohita"
+  },
+  "Override Border Size": {
+    "Override Border Size": "Ohita reunan koko"
+  },
+  "Override Corner Radius": {
+    "Override Corner Radius": "Ohita kulman säde"
+  },
+  "Override global layout settings for this output": {
+    "Override global layout settings for this output": "Ohita tämän lähdön yleiset asetteluasetukset"
+  },
+  "Override global transparency for Notepad": {
+    "Override global transparency for Notepad": "Ohita Notepadin yleinen läpinäkyvyys"
+  },
+  "Override terminal with a custom command or script": {
+    "Override terminal with a custom command or script": "Ohita pääte mukautetulla komennolla tai komentosarjalla"
+  },
+  "Override the global shadow with per-bar settings": {
+    "Override the global shadow with per-bar settings": "Override the global shadow with per-bar settings"
+  },
+  "Override the popup gap size when auto is disabled": {
+    "Override the popup gap size when auto is disabled": "Ohita ponnahdusikkunan välikoko, kun automaattinen toiminto on poistettu käytöstä"
+  },
+  "Overrides": {
+    "Overrides": "Ohitus"
+  },
+  "Overview": {
+    "Overview": "Yleisnäkymä"
+  },
+  "Overview of your network connections": {
+    "Overview of your network connections": "Yleiskatsaus verkkoyhteyksistäsi"
+  },
+  "Overwrite": {
+    "Overwrite": "Korvaa"
+  },
+  "Owner: %1": {
+    "Owner: %1": "Omistaja: %1"
+  },
+  "PAM already provides fingerprint auth. Enable this to show it at login.": {
+    "PAM already provides fingerprint auth. Enable this to show it at login.": "PAM tarjoaa jo sormenjälkitunnistuksen. Ota tämä käyttöön näyttääksesi sen sisäänkirjautumisen yhteydessä."
+  },
+  "PAM already provides security-key auth. Enable this to show it at login.": {
+    "PAM already provides security-key auth. Enable this to show it at login.": "PAM tarjoaa jo suojausavaimen todennuksen. Enable this to show it at login."
+  },
+  "PDF Reader": {
+    "PDF Reader": "PDF-lukija"
+  },
+  "PIN": {
+    "PIN": "PIN-koodi"
+  },
+  "Package name (e.g., docker)": {
+    "Package name (e.g., docker)": "Paketin nimi (esim. telakka)"
+  },
+  "Pad": {
+    "Pad": "Pad"
+  },
+  "Pad Hours": {
+    "Pad Hours": "Pad-tunnit"
+  },
+  "Padding": {
+    "Padding": "Pehmuste"
+  },
+  "Pair": {
+    "Pair": "Pari"
+  },
+  "Pair Bluetooth Device": {
+    "Pair Bluetooth Device": "Yhdistä Bluetooth-laite"
+  },
+  "Paired": {
+    "Paired": "Paritettu"
+  },
+  "Pairing failed": {
+    "Pairing failed": "Pariliitos epäonnistui"
+  },
+  "Pairing request from %1": {
+    "Pairing request from %1": "Pariliitospyyntö laitteelta %1"
+  },
+  "Pairing request sent": {
+    "Pairing request sent": "Pariliitospyyntö lähetetty"
+  },
+  "Pairing requested": {
+    "Pairing requested": "Pariliitos pyydetty"
+  },
+  "Pairing...": {
+    "Pairing...": "Muodostetaan laiteparia..."
+  },
+  "Partly Cloudy": {
+    "Partly Cloudy": "Puolipilvistä"
+  },
+  "Passkey:": {
+    "Passkey:": "Salasana:"
+  },
+  "Password": {
+    "Password": "Salasana"
+  },
+  "Password cannot be empty": {
+    "Password cannot be empty": "Salasana ei voi olla tyhjä"
+  },
+  "Password change failed (exit %1)": {
+    "Password change failed (exit %1)": "Salasanan vaihto epäonnistui (poistu %1)"
+  },
+  "Password set": {
+    "Password set": "Salasana asetettu"
+  },
+  "Password updated": {
+    "Password updated": "Salasana päivitetty"
+  },
+  "Password...": {
+    "Password...": "Salasana..."
+  },
+  "Passwords do not match.": {
+    "Passwords do not match.": "Passwords do not match."
+  },
+  "Paste": {
+    "Paste": "Liitä"
+  },
+  "Paste failed: %1": {
+    "Paste failed: %1": "Liitäminen epäonnistui: %1"
+  },
+  "Path copied to clipboard": {
+    "Path copied to clipboard": "Polku kopioitu leikepöydälle"
+  },
+  "Path to a video file or folder containing videos": {
+    "Path to a video file or folder containing videos": "Polku videotiedostoon tai -kansioon, joka sisältää videoita"
+  },
+  "Pattern": {
+    "Pattern": "kuvio"
+  },
+  "Pause": {
+    "Pause": "Tauko"
+  },
+  "Paused": {
+    "Paused": "Keskeytetty"
+  },
+  "Pending": {
+    "Pending": "Pending"
+  },
+  "Pending Charge": {
+    "Pending Charge": "Odottaa maksua"
+  },
+  "Pending Discharge": {
+    "Pending Discharge": "Odottaa vastuuvapautta"
+  },
+  "Per-Mode Wallpapers": {
+    "Per-Mode Wallpapers": "Tilakohtaiset taustakuvat"
+  },
+  "Per-Monitor Wallpapers": {
+    "Per-Monitor Wallpapers": "Monitorikohtaiset taustakuvat"
+  },
+  "Per-screen config": {
+    "Per-screen config": "Per-screen config"
+  },
+  "Percentage": {
+    "Percentage": "Prosenttiosuus"
+  },
+  "Performance": {
+    "Performance": "Suorituskyky"
+  },
+  "Permanently delete %1 item(s)? This cannot be undone.": {
+    "Permanently delete %1 item(s)? This cannot be undone.": "Poistetaanko %1-kohteet pysyvästi? Tätä ei voi kumota."
+  },
+  "Permission denied to set profile image.": {
+    "Permission denied to set profile image.": "Lupa profiilikuvan asettamiseen evätty."
+  },
+  "Personalization": {
+    "Personalization": "Personointi"
+  },
+  "Phone Connect Not Available": {
+    "Phone Connect Not Available": "Puhelinyhteys ei ole käytettävissä"
+  },
+  "Phone number": {
+    "Phone number": "Puhelinnumero"
+  },
+  "Pick a different file manager in Settings → Dock → Trash.": {
+    "Pick a different file manager in Settings → Dock → Trash.": "Pick a different file manager in Settings → Dock → Trash."
+  },
+  "Pick a different random video each time from the same folder": {
+    "Pick a different random video each time from the same folder": "Valitse joka kerta eri satunnainen video samasta kansiosta"
+  },
+  "Pick a terminal in Settings → Launcher (or set $TERMINAL).": {
+    "Pick a terminal in Settings → Launcher (or set $TERMINAL).": "Valitse pääte kohdasta Asetukset → Launcher (tai aseta $TERMINAL)."
+  },
+  "Pick how long to pause notifications": {
+    "Pick how long to pause notifications": "Valitse, kuinka kauan ilmoitukset keskeytetään"
+  },
+  "Pictures": {
+    "Pictures": "Kuvia"
+  },
+  "Pin": {
+    "Pin": "Pin"
+  },
+  "Pin to Dock": {
+    "Pin to Dock": "Kiinnitä Dockiin"
+  },
+  "Ping": {
+    "Ping": "Ping"
+  },
+  "Ping sent to %1": {
+    "Ping sent to %1": "Ping lähetetty laitteelle %1"
+  },
+  "Pinned": {
+    "Pinned": "Kiinnitetty"
+  },
+  "Pinned and running apps with drag-and-drop": {
+    "Pinned and running apps with drag-and-drop": "Kiinnitetyt ja käynnissä olevat sovellukset vetämällä ja pudottamalla"
+  },
+  "Pixelate": {
+    "Pixelate": "Pixelate"
+  },
+  "Place a trash bin at the end of the dock": {
+    "Place a trash bin at the end of the dock": "Aseta roskakori telakan päähän"
+  },
+  "Place plugin directories here. Each plugin should have a plugin.json manifest file.": {
+    "Place plugin directories here. Each plugin should have a plugin.json manifest file.": "Sijoita laajennushakemistot tähän. Jokaisella laajennuksella tulee olla plugin.json-luettelotiedosto."
+  },
+  "Place plugins in %1": {
+    "Place plugins in %1": "Aseta laajennukset tiedostoon %1"
+  },
+  "Place the bar on the Wayland overlay layer": {
+    "Place the bar on the Wayland overlay layer": "Place the bar on the Wayland overlay layer"
+  },
+  "Place the dock on the Wayland overlay layer": {
+    "Place the dock on the Wayland overlay layer": "Aseta telakka Wayland-peittokerroksen päälle"
+  },
+  "Play": {
+    "Play": "Pelaa"
+  },
+  "Play a video when the screen locks.": {
+    "Play a video when the screen locks.": "Toista video, kun näyttö lukittuu."
+  },
+  "Play sound after logging in": {
+    "Play sound after logging in": "Toista ääni sisäänkirjautumisen jälkeen"
+  },
+  "Play sound when new notification arrives": {
+    "Play sound when new notification arrives": "Toista ääni, kun uusi ilmoitus saapuu"
+  },
+  "Play sound when power cable is connected": {
+    "Play sound when power cable is connected": "Toista ääni, kun virtajohto on kytketty"
+  },
+  "Play sound when volume is adjusted": {
+    "Play sound when volume is adjusted": "Toista ääni, kun äänenvoimakkuutta säädetään"
+  },
+  "Playback": {
+    "Playback": "Toisto"
+  },
+  "Playback error: ": {
+    "Playback error: ": "Toistovirhe:"
+  },
+  "Plays audio files": {
+    "Plays audio files": "Toistaa äänitiedostoja"
+  },
+  "Please wait...": {
+    "Please wait...": "Odota..."
+  },
+  "Please write a name for your new %1 session": {
+    "Please write a name for your new %1 session": "Please write a name for your new %1 session"
+  },
+  "Plugged In": {
+    "Plugged In": "Kytketty verkkoon"
+  },
+  "Plugin": {
+    "Plugin": "Plugin"
+  },
+  "Plugin Directory": {
+    "Plugin Directory": "Plugin-hakemisto"
+  },
+  "Plugin Management": {
+    "Plugin Management": "Plugin Management"
+  },
+  "Plugin Visibility": {
+    "Plugin Visibility": "Plugin näkyvyys"
+  },
+  "Plugin dependency missing": {
+    "Plugin dependency missing": "Liitännäisriippuvuus puuttuu"
+  },
+  "Plugin disabled: %1": {
+    "Plugin disabled: %1": "Plugin pois käytöstä: %1"
+  },
+  "Plugin enabled: %1": {
+    "Plugin enabled: %1": "Plugin käytössä: %1"
+  },
+  "Plugin is disabled - enable in Plugins settings to use": {
+    "Plugin is disabled - enable in Plugins settings to use": "Plugin on poistettu käytöstä - ota käyttöön Plugins-asetuksissa"
+  },
+  "Plugin reloaded: %1": {
+    "Plugin reloaded: %1": "Plugin ladattu uudelleen: %1"
+  },
+  "Plugin uninstalled: %1": {
+    "Plugin uninstalled: %1": "Laajennus poistettu: %1"
+  },
+  "Plugin updated: %1": {
+    "Plugin updated: %1": "Plugin päivitetty: %1"
+  },
+  "Plugins": {
+    "Plugins": "Liitännäiset"
+  },
+  "Pointer": {
+    "Pointer": "Osoitin"
+  },
+  "Polkit integration is disabled. User management requires Polkit to elevate privileges.": {
+    "Polkit integration is disabled. User management requires Polkit to elevate privileges.": "Polkit-integrointi on poistettu käytöstä. Käyttäjien hallinta edellyttää, että Polkit lisää käyttöoikeuksia."
+  },
+  "Popout": {
+    "Popout": "Ponnahdusikkuna"
+  },
+  "Popout Shadows": {
+    "Popout Shadows": "Popout Shadows"
+  },
+  "Popouts": {
+    "Popouts": "Ponnahdusikkunat"
+  },
+  "Popouts and Modals follow global Animation Speed (disable to customize independently)": {
+    "Popouts and Modals follow global Animation Speed (disable to customize independently)": "Ponnahdusikkunat ja modaalit noudattavat maailmanlaajuista animaationopeutta (poista käytöstä, jotta voit muokata itsenäisesti)"
+  },
+  "Popup Only": {
+    "Popup Only": "Vain ponnahdusikkuna"
+  },
+  "Popup Position": {
+    "Popup Position": "Ponnahdusikkunan sijainti"
+  },
+  "Popup Shadow": {
+    "Popup Shadow": "Popup Shadow"
+  },
+  "Popup behavior, position": {
+    "Popup behavior, position": "Ponnahdusikkunoiden käyttäytyminen, asema"
+  },
+  "Popups": {
+    "Popups": "Ponnahdusikkunat"
+  },
+  "Port": {
+    "Port": "Portti"
+  },
+  "Portal": {
+    "Portal": "Portaali"
+  },
+  "Position": {
+    "Position": "asema"
+  },
+  "Position, pinned apps": {
+    "Position, pinned apps": "Sijainti, kiinnitetyt sovellukset"
+  },
+  "Possible Override Conflicts": {
+    "Possible Override Conflicts": "Mahdolliset ohitusristiriidat"
+  },
+  "Power": {
+    "Power": "Virta"
+  },
+  "Power & Security": {
+    "Power & Security": "Virta ja turvallisuus"
+  },
+  "Power & Sleep": {
+    "Power & Sleep": "Virta ja uni"
+  },
+  "Power Action Confirmation": {
+    "Power Action Confirmation": "Virtatoiminnon vahvistus"
+  },
+  "Power Menu Customization": {
+    "Power Menu Customization": "Virta-valikon mukauttaminen"
+  },
+  "Power Mode": {
+    "Power Mode": "Virtatila"
+  },
+  "Power Off": {
+    "Power Off": "Virta pois päältä"
+  },
+  "Power Options": {
+    "Power Options": "Virta-asetukset"
+  },
+  "Power Profile": {
+    "Power Profile": "Tehoprofiili"
+  },
+  "Power Profile Degradation": {
+    "Power Profile Degradation": "Tehoprofiilin heikkeneminen"
+  },
+  "Power Profiles & Saving": {
+    "Power Profiles & Saving": "Virtaprofiilit ja säästö"
+  },
+  "Power Saver": {
+    "Power Saver": "Virransäästö"
+  },
+  "Power off monitors on lock": {
+    "Power off monitors on lock": "Sammuta monitorit lukossa"
+  },
+  "Power profile management available": {
+    "Power profile management available": "Tehoprofiilin hallinta saatavilla"
+  },
+  "Power source": {
+    "Power source": "Virtalähde"
+  },
+  "Pre-fill the last successful username on the greeter": {
+    "Pre-fill the last successful username on the greeter": "Esitäytä viimeinen onnistunut käyttäjätunnus tervehtimään"
+  },
+  "Pre-select the last used session on the greeter": {
+    "Pre-select the last used session on the greeter": "Esivalitse viimeksi käytetty istunto tervehdyksessä"
+  },
+  "Precip": {
+    "Precip": "Sade"
+  },
+  "Precipitation": {
+    "Precipitation": "Sademäärä"
+  },
+  "Precipitation Chance": {
+    "Precipitation Chance": "Sateen mahdollisuus"
+  },
+  "Preference": {
+    "Preference": "etusija"
+  },
+  "Preset Widths (%)": {
+    "Preset Widths (%)": "Esiasetetut leveydet (%)"
+  },
+  "Press Ctrl+N or click 'New Session' to create one": {
+    "Press Ctrl+N or click 'New Session' to create one": "Luo se painamalla Ctrl+N tai napsauttamalla Uusi istunto"
+  },
+  "Press Enter and the audio system will restart to apply the change": {
+    "Press Enter and the audio system will restart to apply the change": "Paina Enter, niin äänijärjestelmä käynnistyy uudelleen ja ottaa muutoksen käyttöön"
+  },
+  "Press Enter to paste, Shift+Enter to copy": {
+    "Press Enter to paste, Shift+Enter to copy": "Paina Enter liittääksesi, Shift+Enter kopioidaksesi"
+  },
+  "Press key...": {
+    "Press key...": "Paina näppäintä..."
+  },
+  "Pressure": {
+    "Pressure": "Paine"
+  },
+  "Prevent screen timeout": {
+    "Prevent screen timeout": "Estä näytön aikakatkaisu"
+  },
+  "Prevent specific applications from displaying in the media controllers (e.g., browser audio streams, background tools). Matches player identity or desktop file name case-insensitively.": {
+    "Prevent specific applications from displaying in the media controllers (e.g., browser audio streams, background tools). Matches player identity or desktop file name case-insensitively.": "Estä tiettyjen sovellusten näyttäminen mediaohjaimissa (esim. selaimen äänivirrat, taustatyökalut). Vastaa soittimen identiteettiä tai työpöydän tiedostonimeä kirjainkoolla."
+  },
+  "Preview": {
+    "Preview": "Esikatselu"
+  },
+  "Preview: %1": {
+    "Preview: %1": "Esikatselu: %1"
+  },
+  "Previous": {
+    "Previous": "Edellinen"
+  },
+  "Previous page": {
+    "Previous page": "Edellinen sivu"
+  },
+  "Primary": {
+    "Primary": "Ensisijainen"
+  },
+  "Primary Container": {
+    "Primary Container": "Ensisijainen säiliö"
+  },
+  "Print Server Management": {
+    "Print Server Management": "Tulostuspalvelimen hallinta"
+  },
+  "Print Server not available": {
+    "Print Server not available": "Tulostuspalvelin ei ole käytettävissä"
+  },
+  "Printer": {
+    "Printer": "Tulostin"
+  },
+  "Printer Classes": {
+    "Printer Classes": "Tulostinluokat"
+  },
+  "Printer created successfully": {
+    "Printer created successfully": "Tulostimen luominen onnistui"
+  },
+  "Printer deleted": {
+    "Printer deleted": "Tulostin poistettu"
+  },
+  "Printer name (no spaces)": {
+    "Printer name (no spaces)": "Tulostimen nimi (ei välilyöntejä)"
+  },
+  "Printer reachable": {
+    "Printer reachable": "Tulostin tavoitettavissa"
+  },
+  "Printers": {
+    "Printers": "Tulostimet"
+  },
+  "Prioritize performance": {
+    "Prioritize performance": "Priorisoi suorituskyky"
+  },
+  "Priority": {
+    "Priority": "Prioriteetti"
+  },
+  "Privacy Indicator": {
+    "Privacy Indicator": "Yksityisyyden ilmaisin"
+  },
+  "Privacy Mode": {
+    "Privacy Mode": "Yksityisyystila"
+  },
+  "Private Key Password": {
+    "Private Key Password": "Yksityisen avaimen salasana"
+  },
+  "Process Count": {
+    "Process Count": "Prosessin määrä"
+  },
+  "Process exited with code %1": {
+    "Process exited with code %1": "Prosessi lopetettiin koodilla %1"
+  },
+  "Processes": {
+    "Processes": "Prosessit"
+  },
+  "Processing": {
+    "Processing": "Käsittely"
+  },
+  "Profile Image Error": {
+    "Profile Image Error": "Profiilikuvavirhe"
+  },
+  "Profile activated: %1": {
+    "Profile activated: %1": "Profiili aktivoitu: %1"
+  },
+  "Profile deleted": {
+    "Profile deleted": "Profiili poistettu"
+  },
+  "Profile error": {
+    "Profile error": "Profiilivirhe"
+  },
+  "Profile image is too large. Please use a smaller image.": {
+    "Profile image is too large. Please use a smaller image.": "Profiilikuva on liian suuri. Käytä pienempää kuvaa."
+  },
+  "Profile name": {
+    "Profile name": "Profiilin nimi"
+  },
+  "Profile not found": {
+    "Profile not found": "Profiilia ei löydy"
+  },
+  "Profile not found in monitors.json": {
+    "Profile not found in monitors.json": "Profiilia ei löydy tiedostosta monitors.json"
+  },
+  "Profile saved: %1": {
+    "Profile saved: %1": "Profiili tallennettu: %1"
+  },
+  "Profile when Plugged In (AC)": {
+    "Profile when Plugged In (AC)": "Profiili kytkettynä (AC)"
+  },
+  "Profile when on Battery": {
+    "Profile when on Battery": "Profiili akun ollessa päällä"
+  },
+  "Protection": {
+    "Protection": "Suojaus"
+  },
+  "Protocol": {
+    "Protocol": "pöytäkirja"
+  },
+  "Qt": {
+    "Qt": "Qt"
+  },
+  "Qt colors applied successfully": {
+    "Qt colors applied successfully": "Qt-värien käyttöönotto onnistui"
+  },
+  "Qt: distance-field renderer.": {
+    "Qt: distance-field renderer.": "Qt: etäisyyskentän renderöijä."
+  },
+  "QtMultimedia is not available": {
+    "QtMultimedia is not available": "QtMultimedia is not available"
+  },
+  "QtMultimedia is not available - video screensaver requires qt multimedia services": {
+    "QtMultimedia is not available - video screensaver requires qt multimedia services": "QtMultimedia ei ole käytettävissä - videon näytönsäästäjä vaatii qt-multimediapalveluita"
+  },
+  "Quality": {
+    "Quality": "Laatu"
+  },
+  "Quick Access": {
+    "Quick Access": "Nopea pääsy"
+  },
+  "Quick access to application launcher": {
+    "Quick access to application launcher": "Quick access to application launcher"
+  },
+  "Quick access to color picker": {
+    "Quick access to color picker": "Quick access to color picker"
+  },
+  "Quick access to notepad": {
+    "Quick access to notepad": "Nopea pääsy muistilehtiöön"
+  },
+  "Quick note-taking slideout panel": {
+    "Quick note-taking slideout panel": "Quick note-taking slideout panel"
+  },
+  "Quick system toggles": {
+    "Quick system toggles": "Nopeat järjestelmän vaihdot"
+  },
+  "RGB": {
+    "RGB": "RGB"
+  },
+  "Radius": {
+    "Radius": "Säde"
+  },
+  "Rain": {
+    "Rain": "Sade"
+  },
+  "Rain Chance": {
+    "Rain Chance": "Sateen mahdollisuus"
+  },
+  "Rainbow": {
+    "Rainbow": "Sateenkaari"
+  },
+  "Random": {
+    "Random": "Satunnainen"
+  },
+  "Rate": {
+    "Rate": "Rate"
+  },
+  "Re-enter password": {
+    "Re-enter password": "Re-enter password"
+  },
+  "Reach local network devices while using an exit node": {
+    "Reach local network devices while using an exit node": "Tavoita paikallisen verkon laitteet poistumissolmun avulla"
+  },
+  "Read-only legacy config": {
+    "Read-only legacy config": "Vain luku -vanha kokoonpano"
+  },
+  "Read:": {
+    "Read:": "Lue:"
+  },
+  "Reason": {
+    "Reason": "Syy"
+  },
+  "Reboot": {
+    "Reboot": "Käynnistä uudelleen"
+  },
+  "Recent": {
+    "Recent": "Viimeaikaiset"
+  },
+  "Recent Colors": {
+    "Recent Colors": "Viimeaikaiset värit"
+  },
+  "Recent Images": {
+    "Recent Images": "Viimeisimmät kuvat"
+  },
+  "Recently Used Apps": {
+    "Recently Used Apps": "Äskettäin käytetyt sovellukset"
+  },
+  "Recommended available": {
+    "Recommended available": "Suositeltu saatavilla"
+  },
+  "Refresh": {
+    "Refresh": "Päivitä"
+  },
+  "Refresh Weather": {
+    "Refresh Weather": "Päivitä sää"
+  },
+  "Refreshing...": {
+    "Refreshing...": "Virkistävää..."
+  },
+  "Regex": {
+    "Regex": "Regex"
+  },
+  "Regular": {
+    "Regular": "Säännöllinen"
+  },
+  "Reject": {
+    "Reject": "Hylkää"
+  },
+  "Reject Jobs": {
+    "Reject Jobs": "Hylkää työt"
+  },
+  "Related: %1": {
+    "Related: %1": "Aiheeseen liittyvä: %1"
+  },
+  "Release": {
+    "Release": "Vapauta"
+  },
+  "Reload From Disk": {
+    "Reload From Disk": "Lataa uudelleen levyltä"
+  },
+  "Reload Plugin": {
+    "Reload Plugin": "Lataa Plugin uudelleen"
+  },
+  "Remaining": {
+    "Remaining": "Jäljellä"
+  },
+  "Remaining / Total": {
+    "Remaining / Total": "Jäljellä / yhteensä"
+  },
+  "Remember Last Mode": {
+    "Remember Last Mode": "Muista viimeinen tila"
+  },
+  "Remember Last Query": {
+    "Remember Last Query": "Muista viimeinen kysely"
+  },
+  "Remember Type Filter": {
+    "Remember Type Filter": "Muista tyyppisuodatin"
+  },
+  "Remember last session": {
+    "Remember last session": "Muista viimeinen istunto"
+  },
+  "Remember last user": {
+    "Remember last user": "Muista viimeinen käyttäjä"
+  },
+  "Reminder": {
+    "Reminder": "Muistutus"
+  },
+  "Remove": {
+    "Remove": "Poista"
+  },
+  "Remove \"%1\" from the %2 group?": {
+    "Remove \"%1\" from the %2 group?": "Poistetaanko \"%1\" %2-ryhmästä?"
+  },
+  "Remove Shortcut?": {
+    "Remove Shortcut?": "Poistetaanko pikakuvake?"
+  },
+  "Remove Widget Padding": {
+    "Remove Widget Padding": "Poista widget-täyte"
+  },
+  "Remove admin": {
+    "Remove admin": "Poista järjestelmänvalvoja"
+  },
+  "Remove corner rounding from the bar": {
+    "Remove corner rounding from the bar": "Poista kulman pyöristys tangosta"
+  },
+  "Remove gaps and border when windows are maximized": {
+    "Remove gaps and border when windows are maximized": "Poista aukot ja reunat, kun ikkunat ovat maksimoituja"
+  },
+  "Remove greeter access?": {
+    "Remove greeter access?": "Poistetaanko tervehdys?"
+  },
+  "Remove greeter login access": {
+    "Remove greeter login access": "Poista tervehdyskirjautumisoikeudet"
+  },
+  "Remove inner padding from all widgets": {
+    "Remove inner padding from all widgets": "Poista sisäpehmusteet kaikista widgeteistä"
+  },
+  "Remove match": {
+    "Remove match": "Poista ottelu"
+  },
+  "Remove the shortcut %1?": {
+    "Remove the shortcut %1?": "Poistetaanko pikakuvake %1?"
+  },
+  "Remove the shortcut %1? An unbind entry will be saved to dms/binds-user.lua so it stays removed across DMS updates.": {
+    "Remove the shortcut %1? An unbind entry will be saved to dms/binds-user.lua so it stays removed across DMS updates.": "Poistetaanko pikakuvake %1? Sidonnan purkaminen tallennetaan tiedostoon dms/binds-user.lua, joten se pysyy poistettuna DMS-päivitysten aikana."
+  },
+  "Removed administrator privileges": {
+    "Removed administrator privileges": "Järjestelmänvalvojan oikeudet poistettu"
+  },
+  "Removed greeter login access": {
+    "Removed greeter login access": "Poistettu tervehdyskirjautumisoikeus"
+  },
+  "Rename": {
+    "Rename": "Nimeä uudelleen"
+  },
+  "Rename Session": {
+    "Rename Session": "Nimeä istunto uudelleen"
+  },
+  "Rename Workspace": {
+    "Rename Workspace": "Nimeä työtila uudelleen"
+  },
+  "Reorder & Group": {
+    "Reorder & Group": "Järjestä uudelleen ja ryhmittele"
+  },
+  "Repeat": {
+    "Repeat": "Toista"
+  },
+  "Replacement": {
+    "Replacement": "Vaihto"
+  },
+  "Report": {
+    "Report": "Raportoi"
+  },
+  "Request Pairing": {
+    "Request Pairing": "Pyydä pariliitosta"
+  },
+  "Require holding button/key to confirm power off, restart, suspend, hibernate and logout": {
+    "Require holding button/key to confirm power off, restart, suspend, hibernate and logout": "Vaadi painikkeen/näppäimen pitämistä painettuna vahvistaaksesi virran katkaisemisen, uudelleenkäynnistyksen, keskeytyksen, lepotilan ja uloskirjautumisen"
+  },
+  "Required plugin: ": {
+    "Required plugin: ": "Vaadittu laajennus:"
+  },
+  "Requires %1": {
+    "Requires %1": "Vaatii %1"
+  },
+  "Requires 'dgop' tool": {
+    "Requires 'dgop' tool": "Vaatii \"dgop\"-työkalun"
+  },
+  "Requires DMS %1": {
+    "Requires DMS %1": "Vaatii DMS %1"
+  },
+  "Requires DMS server with sysupdate capability": {
+    "Requires DMS server with sysupdate capability": "Vaatii DMS-palvelimen, jossa on sysupdate-ominaisuus"
+  },
+  "Requires MangoWC compositor": {
+    "Requires MangoWC compositor": "Vaatii MangoWC-kompositorin"
+  },
+  "Requires a newer version of Quickshell": {
+    "Requires a newer version of Quickshell": "Vaatii uudemman version Quickshell:stä"
+  },
+  "Requires greetd, dms-greeter, and your user in the greeter group (plus fprintd/pam_fprintd for fingerprint, pam_u2f for security keys). Auth changes apply automatically and may open a terminal for sudo.": {
+    "Requires greetd, dms-greeter, and your user in the greeter group (plus fprintd/pam_fprintd for fingerprint, pam_u2f for security keys). Auth changes apply automatically and may open a terminal for sudo.": "Vaatii tervehdyksen, dms-greeterin ja käyttäjän tervehdysryhmässä (sekä fprintd/pam_fprintd sormenjäljelle, pam_u2f suojausavaimelle). Todennusmuutokset tulevat voimaan automaattisesti ja voivat avata sudo-päätteen."
+  },
+  "Requires night mode support": {
+    "Requires night mode support": "Vaatii yötilan tuen"
+  },
+  "Requires remembering the last user and session. Enable those options first.": {
+    "Requires remembering the last user and session. Enable those options first.": "Edellyttää viimeisen käyttäjän ja istunnon muistamista. Ota nämä asetukset käyttöön ensin."
+  },
+  "Reset": {
+    "Reset": "Palauta"
+  },
+  "Reset Position": {
+    "Reset Position": "Palauta sijainti"
+  },
+  "Reset Size": {
+    "Reset Size": "Palauta koko"
+  },
+  "Reset to default": {
+    "Reset to default": "Palauta oletusarvo"
+  },
+  "Reset to default name": {
+    "Reset to default name": "Palauta oletusnimi"
+  },
+  "Resize Widget": {
+    "Resize Widget": "Muuta widgetin kokoa"
+  },
+  "Resize on Border": {
+    "Resize on Border": "Muuta kokoa reunassa"
+  },
+  "Resize windows by dragging their edges with the mouse": {
+    "Resize windows by dragging their edges with the mouse": "Muuta ikkunoiden kokoa vetämällä niiden reunoja hiirellä"
+  },
+  "Resolution & Refresh": {
+    "Resolution & Refresh": "Resoluutio & Päivitä"
+  },
+  "Resolution, position, scale": {
+    "Resolution, position, scale": "Resoluutio, sijainti, mittakaava"
+  },
+  "Restart DMS": {
+    "Restart DMS": "Käynnistä DMS uudelleen"
+  },
+  "Restart the DankMaterialShell": {
+    "Restart the DankMaterialShell": "Käynnistä DankMaterialShell uudelleen"
+  },
+  "Restarting audio system...": {
+    "Restarting audio system...": "Äänijärjestelmää käynnistetään uudelleen..."
+  },
+  "Restore Special Workspace Windows": {
+    "Restore Special Workspace Windows": "Palauta Special Workspace Windows"
+  },
+  "Restore the last selected mode (tab) when the launcher is opened": {
+    "Restore the last selected mode (tab) when the launcher is opened": "Palauta viimeksi valittu tila (välilehti), kun käynnistysohjelma avataan"
+  },
+  "Resume": {
+    "Resume": "Jatka"
+  },
+  "Reveal the arcs where surfaces meet the frame": {
+    "Reveal the arcs where surfaces meet the frame": "Paljasta kaaret, joissa pinnat kohtaavat kehyksen"
+  },
+  "Reverse Scrolling Direction": {
+    "Reverse Scrolling Direction": "Käänteinen vierityssuunta"
+  },
+  "Reverse workspace switch direction when scrolling over the bar": {
+    "Reverse workspace switch direction when scrolling over the bar": "Käännä työtilan vaihtimen suunta, kun vierität palkin yli"
+  },
+  "Revert": {
+    "Revert": "Palauta"
+  },
+  "Rewind 10s": {
+    "Rewind 10s": "Kelaa 10s taaksepäin"
+  },
+  "Right": {
+    "Right": "Oikein"
+  },
+  "Right Center": {
+    "Right Center": "Oikea keskusta"
+  },
+  "Right Section": {
+    "Right Section": "Oikea osasto"
+  },
+  "Right Tiling": {
+    "Right Tiling": "Oikea laatoitus"
+  },
+  "Right-click and drag anywhere on the widget": {
+    "Right-click and drag anywhere on the widget": "Napsauta hiiren kakkospainikkeella ja vedä mitä tahansa widgetin kohtaa"
+  },
+  "Right-click and drag the bottom-right corner": {
+    "Right-click and drag the bottom-right corner": "Napsauta hiiren kakkospainikkeella ja vedä oikeaa alakulmaa"
+  },
+  "Right-click bar widget to cycle": {
+    "Right-click bar widget to cycle": "Napsauta hiiren kakkospainikkeella palkki-widgetiä vaihtaaksesi"
+  },
+  "Ring": {
+    "Ring": "Sormus"
+  },
+  "Ringing %1...": {
+    "Ringing %1...": "Soitetaan laitteeseen %1…"
+  },
+  "Ripple Effects": {
+    "Ripple Effects": "Ripple-efektit"
+  },
+  "Root Filesystem": {
+    "Root Filesystem": "Juuritiedostojärjestelmä"
+  },
+  "Rounded corners for windows": {
+    "Rounded corners for windows": "Pyöristetyt kulmat ikkunoihin"
+  },
+  "Rule": {
+    "Rule": "Sääntö"
+  },
+  "Rule %1": {
+    "Rule %1": "Sääntö %1"
+  },
+  "Rule Name": {
+    "Rule Name": "Säännön nimi"
+  },
+  "Rules": {
+    "Rules": "Säännöt"
+  },
+  "Rules (%1)": {
+    "Rules (%1)": "Säännöt (%1)"
+  },
+  "Rules found in your compositor config. These are read-only here, use Convert to DMS to make an editable copy.": {
+    "Rules found in your compositor config. These are read-only here, use Convert to DMS to make an editable copy.": "Säännöt löytyvät kokoonpanon kokoonpanosta. Nämä ovat vain luku -tilassa. Käytä Convert to DMS luodaksesi muokattavan kopion."
+  },
+  "Run Again": {
+    "Run Again": "Juokse uudelleen"
+  },
+  "Run DMS Templates": {
+    "Run DMS Templates": "Suorita DMS-malleja"
+  },
+  "Run User Templates": {
+    "Run User Templates": "Suorita käyttäjämalleja"
+  },
+  "Run a program (e.g., firefox, kitty)": {
+    "Run a program (e.g., firefox, kitty)": "Suorita ohjelma (esim. firefox, kitty)"
+  },
+  "Run a shell command (e.g., notify-send)": {
+    "Run a shell command (e.g., notify-send)": "Suorita komentotulkkikomento (esim. notify-send)"
+  },
+  "Run paru/yay with AUR enabled when 'Update All' is clicked.": {
+    "Run paru/yay with AUR enabled when 'Update All' is clicked.": "Suorita paru/yay AUR ollessa käytössä, kun 'Päivitä kaikki' napsautetaan."
+  },
+  "Running Apps": {
+    "Running Apps": "Käynnissä olevat sovellukset"
+  },
+  "Running Apps Settings": {
+    "Running Apps Settings": "Sovellusten asetukset"
+  },
+  "Running greeter sync...": {
+    "Running greeter sync...": "Käynnissä tervehdyssynkronointia..."
+  },
+  "Running in terminal": {
+    "Running in terminal": "Käynnissä terminaalissa"
+  },
+  "SDR Brightness": {
+    "SDR Brightness": "SDR-kirkkaus"
+  },
+  "SDR Saturation": {
+    "SDR Saturation": "SDR-kylläisyys"
+  },
+  "SMS": {
+    "SMS": "SMS"
+  },
+  "SMS sent successfully": {
+    "SMS sent successfully": "Tekstiviesti lähetetty onnistuneesti"
+  },
+  "Saturation": {
+    "Saturation": "Kylläisyys"
+  },
+  "Save": {
+    "Save": "Tallenna"
+  },
+  "Save Notepad File": {
+    "Save Notepad File": "Tallenna Notepad-tiedosto"
+  },
+  "Save QR Code": {
+    "Save QR Code": "Tallenna QR-koodi"
+  },
+  "Save and close": {
+    "Save and close": "Tallenna ja sulje"
+  },
+  "Save and paste": {
+    "Save and paste": "Tallenna ja liitä"
+  },
+  "Save and switch between display configurations": {
+    "Save and switch between display configurations": "Tallenna ja vaihda näyttökokoonpanojen välillä"
+  },
+  "Save credentials": {
+    "Save credentials": "Tallenna tunnistetiedot"
+  },
+  "Save critical priority notifications to history": {
+    "Save critical priority notifications to history": "Tallenna tärkeät prioriteettiilmoitukset historiaan"
+  },
+  "Save dismissed notifications to history": {
+    "Save dismissed notifications to history": "Tallenna hylätyt ilmoitukset historiaan"
+  },
+  "Save low priority notifications to history": {
+    "Save low priority notifications to history": "Tallenna alhaisen prioriteetin ilmoitukset historiaan"
+  },
+  "Save normal priority notifications to history": {
+    "Save normal priority notifications to history": "Tallenna normaalit prioriteettiilmoitukset historiaan"
+  },
+  "Save password": {
+    "Save password": "Tallenna salasana"
+  },
+  "Saved": {
+    "Saved": "Tallennettu"
+  },
+  "Saved Configurations": {
+    "Saved Configurations": "Tallennetut asetukset"
+  },
+  "Saved Networks": {
+    "Saved Networks": "Tallennetut verkot"
+  },
+  "Saved Note": {
+    "Saved Note": "Tallennettu muistiinpano"
+  },
+  "Saved item deleted": {
+    "Saved item deleted": "Tallennettu kohde poistettu"
+  },
+  "Saving...": {
+    "Saving...": "Tallennetaan..."
+  },
+  "Scale": {
+    "Scale": "Mittakaava"
+  },
+  "Scale DankBar font sizes independently": {
+    "Scale DankBar font sizes independently": "Skaalaa DankBarin fonttikoot itsenäisesti"
+  },
+  "Scale DankBar icon sizes independently": {
+    "Scale DankBar icon sizes independently": "Skaalaa DankBar-kuvakkeen kokoa itsenäisesti"
+  },
+  "Scale all font sizes throughout the shell": {
+    "Scale all font sizes throughout the shell": "Skaalaa kaikki kirjasinkoot läpi kuoren"
+  },
+  "Scan": {
+    "Scan": "Skannaa"
+  },
+  "Scanning...": {
+    "Scanning...": "Skannataan..."
+  },
+  "Science": {
+    "Science": "Tiede"
+  },
+  "Score": {
+    "Score": "Pisteet"
+  },
+  "Screen sharing": {
+    "Screen sharing": "Näytön jakaminen"
+  },
+  "Screenshot unavailable": {
+    "Screenshot unavailable": "Kuvakaappaus ei ole saatavilla"
+  },
+  "Scroll": {
+    "Scroll": "Selaa"
+  },
+  "Scroll Factor": {
+    "Scroll Factor": "Vieritystekijä"
+  },
+  "Scroll GitHub": {
+    "Scroll GitHub": "Vieritä GitHub"
+  },
+  "Scroll Wheel": {
+    "Scroll Wheel": "Vierityspyörä"
+  },
+  "Scroll song title": {
+    "Scroll song title": "Vieritä kappaleen otsikkoa"
+  },
+  "Scroll title if it doesn't fit in widget": {
+    "Scroll title if it doesn't fit in widget": "Vieritä otsikkoa, jos se ei mahdu widgetiin"
+  },
+  "Scroll wheel behavior on media widget": {
+    "Scroll wheel behavior on media widget": "Vierityspyörän toiminta media-widgetissä"
+  },
+  "Scrolling": {
+    "Scrolling": "Vieritys"
+  },
+  "Search App Actions": {
+    "Search App Actions": "Hae sovellustoimintoja"
+  },
+  "Search Options": {
+    "Search Options": "Hakuasetukset"
+  },
+  "Search applications...": {
+    "Search applications...": "Hae sovelluksia..."
+  },
+  "Search by key combo, description, or action name.\n\nDefault action copies the keybind to clipboard.\nRight-click or press Right Arrow to pin frequently used keybinds - they'll appear at the top when not searching.": {
+    "Search by key combo, description, or action name.\n\nDefault action copies the keybind to clipboard.\nRight-click or press Right Arrow to pin frequently used keybinds - they'll appear at the top when not searching.": "Hae näppäinyhdistelmän, kuvauksen tai toiminnon nimen perusteella.\n\nOletustoiminto kopioi näppäimistön leikepöydälle.\nNapsauta hiiren kakkospainikkeella tai paina oikeaa nuolta kiinnittääksesi usein käytetyt näppäinsidokset – ne näkyvät yläreunassa, kun et etsi."
+  },
+  "Search devices...": {
+    "Search devices...": "Hae laitteita..."
+  },
+  "Search for a location...": {
+    "Search for a location...": "Hae sijaintia..."
+  },
+  "Search installed plugins...": {
+    "Search installed plugins...": "Hae asennettuja laajennuksia..."
+  },
+  "Search keybinds...": {
+    "Search keybinds...": "Hae näppäinsidoksia..."
+  },
+  "Search keyboard shortcuts from your compositor and applications": {
+    "Search keyboard shortcuts from your compositor and applications": "Hae pikanäppäimiä kompositoristasi ja sovelluksistasi"
+  },
+  "Search plugins...": {
+    "Search plugins...": "Hae laajennuksia..."
+  },
+  "Search processes...": {
+    "Search processes...": "Hakuprosessit..."
+  },
+  "Search sessions...": {
+    "Search sessions...": "Hae istuntoja..."
+  },
+  "Search themes...": {
+    "Search themes...": "Hae teemoja..."
+  },
+  "Search widgets...": {
+    "Search widgets...": "Hae widgetejä..."
+  },
+  "Search...": {
+    "Search...": "Hae…"
+  },
+  "Searching...": {
+    "Searching...": "Haetaan..."
+  },
+  "Second Factor (AND)": {
+    "Second Factor (AND)": "Toinen tekijä (JA)"
+  },
+  "Secondary": {
+    "Secondary": "Toissijainen"
+  },
+  "Secondary Container": {
+    "Secondary Container": "Toissijainen säiliö"
+  },
+  "Secured": {
+    "Secured": "Turvattu"
+  },
+  "Security": {
+    "Security": "Turvallisuus"
+  },
+  "Security & privacy": {
+    "Security & privacy": "Turvallisuus ja yksityisyys"
+  },
+  "Security Key PAM Source": {
+    "Security Key PAM Source": "Suojausavaimen PAM-lähde"
+  },
+  "Security key mode": {
+    "Security key mode": "Suojausavaintila"
+  },
+  "Security-key availability could not be confirmed.": {
+    "Security-key availability could not be confirmed.": "Suojausavaimen saatavuutta ei voitu vahvistaa."
+  },
+  "Security-key support was detected, but no registered key was found yet. You can enable this now and register one later.": {
+    "Security-key support was detected, but no registered key was found yet. You can enable this now and register one later.": "Suojausavaimen tuki havaittiin, mutta rekisteröityä avainta ei vielä löytynyt. Voit ottaa tämän käyttöön nyt ja rekisteröidä sen myöhemmin."
+  },
+  "Select": {
+    "Select": "Valitse"
+  },
+  "Select Application": {
+    "Select Application": "Valitse Sovellus"
+  },
+  "Select Bar": {
+    "Select Bar": "Valitse Palkki"
+  },
+  "Select Custom Theme": {
+    "Select Custom Theme": "Valitse mukautettu teema"
+  },
+  "Select Dock Launcher Logo": {
+    "Select Dock Launcher Logo": "Valitse Dock Launcher -logo"
+  },
+  "Select File to Send": {
+    "Select File to Send": "Valitse lähetettävä tiedosto"
+  },
+  "Select Launcher Logo": {
+    "Select Launcher Logo": "Valitse Launcher Logo"
+  },
+  "Select Profile Image": {
+    "Select Profile Image": "Valitse Profiilikuva"
+  },
+  "Select Video or Folder": {
+    "Select Video or Folder": "Valitse Video tai Kansio"
+  },
+  "Select Wallpaper": {
+    "Select Wallpaper": "Valitse Taustakuva"
+  },
+  "Select Wallpaper Directory": {
+    "Select Wallpaper Directory": "Valitse Taustakuvahakemisto"
+  },
+  "Select a color from the palette or use custom sliders": {
+    "Select a color from the palette or use custom sliders": "Valitse väri paletista tai käytä mukautettuja liukusäätimiä"
+  },
+  "Select a desktop application": {
+    "Select a desktop application": "Valitse työpöytäsovellus"
+  },
+  "Select a widget to add to your desktop. Each widget is a separate instance with its own settings.": {
+    "Select a widget to add to your desktop. Each widget is a separate instance with its own settings.": "Valitse työpöydällesi lisättävä widget. Jokainen widget on erillinen esiintymä, jolla on omat asetukset."
+  },
+  "Select a widget to add. You can add multiple instances of the same widget if needed.": {
+    "Select a widget to add. You can add multiple instances of the same widget if needed.": "Valitse lisättävä widget. Voit tarvittaessa lisätä useita esiintymiä samasta widgetistä."
+  },
+  "Select a window...": {
+    "Select a window...": "Valitse ikkuna..."
+  },
+  "Select an active session to switch to. The current session stays running in the background.": {
+    "Select an active session to switch to. The current session stays running in the background.": "Valitse aktiivinen istunto, johon haluat vaihtaa. Nykyinen istunto pysyy käynnissä taustalla."
+  },
+  "Select an image file...": {
+    "Select an image file...": "Valitse kuvatiedosto..."
+  },
+  "Select at least one provider": {
+    "Select at least one provider": "Valitse vähintään yksi palveluntarjoaja"
+  },
+  "Select background image": {
+    "Select background image": "Valitse taustakuva"
+  },
+  "Select device": {
+    "Select device": "Valitse laite"
+  },
+  "Select device...": {
+    "Select device...": "Valitse laite..."
+  },
+  "Select driver...": {
+    "Select driver...": "Valitse ohjain..."
+  },
+  "Select font weight for UI text": {
+    "Select font weight for UI text": "Valitse käyttöliittymätekstin fontin paino"
+  },
+  "Select greeter background image": {
+    "Select greeter background image": "Valitse tervehdys taustakuva"
+  },
+  "Select lock screen background image": {
+    "Select lock screen background image": "Valitse lukitusnäytön taustakuva"
+  },
+  "Select monospace font for process list and technical displays": {
+    "Select monospace font for process list and technical displays": "Valitse monospace-fontti prosessiluetteloa ja teknisiä näyttöjä varten"
+  },
+  "Select network": {
+    "Select network": "Valitse verkko"
+  },
+  "Select the font family for UI text": {
+    "Select the font family for UI text": "Valitse käyttöliittymätekstin kirjasinperhe"
+  },
+  "Select the palette algorithm used for wallpaper-based colors": {
+    "Select the palette algorithm used for wallpaper-based colors": "Valitse taustakuvapohjaisille väreille käytettävä palettialgoritmi"
+  },
+  "Select user...": {
+    "Select user...": "Valitse käyttäjä..."
+  },
+  "Select which keybind providers to include": {
+    "Select which keybind providers to include": "Valitse sisällytettävät näppäinten toimittajat"
+  },
+  "Select which transitions to include in randomization": {
+    "Select which transitions to include in randomization": "Valitse, mitkä siirtymät sisällytetään satunnaistukseen"
+  },
+  "Select...": {
+    "Select...": "Valitse..."
+  },
+  "Selected image file not found.": {
+    "Selected image file not found.": "Valittua kuvatiedostoa ei löydy."
+  },
+  "Send": {
+    "Send": "Lähetä"
+  },
+  "Send Clipboard": {
+    "Send Clipboard": "Lähetä leikepöytä"
+  },
+  "Send SMS": {
+    "Send SMS": "Lähetä SMS"
+  },
+  "Sending %1...": {
+    "Sending %1...": "Lähetetään laitteelle %1…"
+  },
+  "Separate": {
+    "Separate": "Erillinen"
+  },
+  "Separate Appearance for Unfocused Display(s)": {
+    "Separate Appearance for Unfocused Display(s)": "Erillinen ulkoasu tarkentamattomille näytöille"
+  },
+  "Separate Light & Dark Themes": {
+    "Separate Light & Dark Themes": "Erilliset vaaleat ja tummat teemat"
+  },
+  "Separate appearance for unfocused displays is not supported on this compositor.": {
+    "Separate appearance for unfocused displays is not supported on this compositor.": "Tämä kompositori ei tue erillistä ulkoasua tarkentamattomille näytöille."
+  },
+  "Separator": {
+    "Separator": "Erotin"
+  },
+  "Server": {
+    "Server": "Palvelin"
+  },
+  "Session Filter": {
+    "Session Filter": "Istuntosuodatin"
+  },
+  "Set Custom Device Name": {
+    "Set Custom Device Name": "Aseta mukautettu laitenimi"
+  },
+  "Set custom name": {
+    "Set custom name": "Aseta mukautettu nimi"
+  },
+  "Set custom names for your audio input devices": {
+    "Set custom names for your audio input devices": "Aseta mukautetut nimet äänensyöttölaitteillesi"
+  },
+  "Set custom names for your audio output devices": {
+    "Set custom names for your audio output devices": "Aseta mukautetut nimet äänentoistolaitteillesi"
+  },
+  "Set different wallpapers for each connected monitor": {
+    "Set different wallpapers for each connected monitor": "Aseta eri taustakuvat jokaiselle liitetylle näytölle"
+  },
+  "Set different wallpapers for light and dark mode": {
+    "Set different wallpapers for light and dark mode": "Aseta erilaisia taustakuvia vaalealle ja tummalle tilaan"
+  },
+  "Set initial password": {
+    "Set initial password": "Aseta alkuperäinen salasana"
+  },
+  "Set key and action to save": {
+    "Set key and action to save": "Aseta avain ja toiminto tallennettavaksi"
+  },
+  "Set notification rules": {
+    "Set notification rules": "Aseta ilmoitussäännöt"
+  },
+  "Set the font size for notification body text (htmlBody)": {
+    "Set the font size for notification body text (htmlBody)": "Ilmoituksen tekstin (htmlBody) fontin koon asettaminen"
+  },
+  "Set the percentage at which the battery is considered low.": {
+    "Set the percentage at which the battery is considered low.": "Aseta prosenttiosuus, jolla akun katsotaan olevan alhainen."
+  },
+  "Setting": {
+    "Setting": "Asetus"
+  },
+  "Setting up...": {
+    "Setting up...": "Määritetään..."
+  },
+  "Settings": {
+    "Settings": "Asetukset"
+  },
+  "Settings Search": {
+    "Settings Search": "Asetukset Haku"
+  },
+  "Settings are read-only. Changes will not persist.": {
+    "Settings are read-only. Changes will not persist.": "Asetukset ovat vain luku -tilassa. Muutokset eivät säily."
+  },
+  "Setup": {
+    "Setup": "Asennus"
+  },
+  "Shadow Color": {
+    "Shadow Color": "Varjon väri"
+  },
+  "Shadow Intensity": {
+    "Shadow Intensity": "Varjon intensiteetti"
+  },
+  "Shadow Opacity": {
+    "Shadow Opacity": "Varjon opasiteetti"
+  },
+  "Shadow Override": {
+    "Shadow Override": "Shadow Override"
+  },
+  "Shadow blur radius in pixels": {
+    "Shadow blur radius in pixels": "Varjon sumennuksen säde pikseleinä"
+  },
+  "Shadow elevation on bars and panels": {
+    "Shadow elevation on bars and panels": "Varjon korkeus palkkeissa ja paneeleissa"
+  },
+  "Shadow elevation on modals and dialogs": {
+    "Shadow elevation on modals and dialogs": "Varjon korkeus modaaleissa ja dialogeissa"
+  },
+  "Shadow elevation on popouts, OSDs, and dropdowns": {
+    "Shadow elevation on popouts, OSDs, and dropdowns": "Varjon korkeus ponnahdusikkunoissa, OSD:issä ja pudotusvalikoissa"
+  },
+  "Shadows": {
+    "Shadows": "Varjot"
+  },
+  "Share": {
+    "Share": "Jaa"
+  },
+  "Share Gamma Control Settings": {
+    "Share Gamma Control Settings": "Jaa Gamma Control -asetukset"
+  },
+  "Shared": {
+    "Shared": "Jaettu"
+  },
+  "Shell": {
+    "Shell": "Shell"
+  },
+  "Shift+Enter to copy": {
+    "Shift+Enter to copy": "Vaihto+Enter kopioidaksesi"
+  },
+  "Shift+Enter to paste": {
+    "Shift+Enter to paste": "Vaihto+Enter liittääksesi"
+  },
+  "Short": {
+    "Short": "Lyhyt"
+  },
+  "Shortcut (%1)": {
+    "Shortcut (%1)": "Pikanäppäin (%1)"
+  },
+  "Shortcut that opens this settings window": {
+    "Shortcut that opens this settings window": "Pikakuvake, joka avaa tämän asetusikkunan"
+  },
+  "Shortcuts": {
+    "Shortcuts": "Pikanäppäimet"
+  },
+  "Shortcuts (%1)": {
+    "Shortcuts (%1)": "Pikanäppäimet (%1)"
+  },
+  "Show": {
+    "Show": "Näytä"
+  },
+  "Show 3rd Party": {
+    "Show 3rd Party": "Näytä kolmas osapuoli"
+  },
+  "Show All Tags": {
+    "Show All Tags": "Näytä kaikki tunnisteet"
+  },
+  "Show All, Apps, Files, and Plugins chips beside the Spotlight Bar input.": {
+    "Show All, Apps, Files, and Plugins chips beside the Spotlight Bar input.": "Näytä kaikki, sovellukset, tiedostot ja lisäosat -sirut Spotlight Bar -syötteen vieressä."
+  },
+  "Show Badge": {
+    "Show Badge": "Näytä merkki"
+  },
+  "Show CPU": {
+    "Show CPU": "Näytä CPU"
+  },
+  "Show CPU Graph": {
+    "Show CPU Graph": "Näytä CPU Graph"
+  },
+  "Show CPU Temp": {
+    "Show CPU Temp": "Näytä CPU Temp"
+  },
+  "Show Date": {
+    "Show Date": "Näytä päivämäärä"
+  },
+  "Show Disk": {
+    "Show Disk": "Näytä levy"
+  },
+  "Show Dock": {
+    "Show Dock": "Näytä Dock"
+  },
+  "Show Feels Like Temperature": {
+    "Show Feels Like Temperature": "Esitys tuntuu lämpötilalta"
+  },
+  "Show Flatpak, Snap, AppImage, or Nix badge icons on launcher items.": {
+    "Show Flatpak, Snap, AppImage, or Nix badge icons on launcher items.": "Näytä Flatpak-, Snap-, AppImage- tai Nix-merkkikuvakkeet käynnistyskohteissa."
+  },
+  "Show Footer": {
+    "Show Footer": "Näytä alatunniste"
+  },
+  "Show Forecast": {
+    "Show Forecast": "Näytä ennuste"
+  },
+  "Show GPU Temperature": {
+    "Show GPU Temperature": "Näytä GPU:n lämpötila"
+  },
+  "Show Header": {
+    "Show Header": "Näytä otsikko"
+  },
+  "Show Hibernate": {
+    "Show Hibernate": "Näytä Hibernate"
+  },
+  "Show Hour Numbers": {
+    "Show Hour Numbers": "Näytä tuntinumerot"
+  },
+  "Show Hourly Forecast": {
+    "Show Hourly Forecast": "Näytä tuntiennuste"
+  },
+  "Show Humidity": {
+    "Show Humidity": "Näytä Kosteus"
+  },
+  "Show Icon": {
+    "Show Icon": "Näytä kuvake"
+  },
+  "Show Launcher Button": {
+    "Show Launcher Button": "Näytä käynnistyspainike"
+  },
+  "Show Line Numbers": {
+    "Show Line Numbers": "Näytä rivinumerot"
+  },
+  "Show Location": {
+    "Show Location": "Näytä sijainti"
+  },
+  "Show Lock": {
+    "Show Lock": "Näytä lukko"
+  },
+  "Show Log Out": {
+    "Show Log Out": "Näytä Kirjaudu ulos"
+  },
+  "Show Material Design ripple animations on interactive elements": {
+    "Show Material Design ripple animations on interactive elements": "Näytä materiaalisuunnittelun aaltoiluanimaatioita interaktiivisissa elementeissä"
+  },
+  "Show Media Player": {
+    "Show Media Player": "Näytä mediasoitin"
+  },
+  "Show Memory": {
+    "Show Memory": "Näytä muisti"
+  },
+  "Show Memory Graph": {
+    "Show Memory Graph": "Näytä muistikaavio"
+  },
+  "Show Memory in GB": {
+    "Show Memory in GB": "Näytä muisti gigatavuina"
+  },
+  "Show Mode Chips": {
+    "Show Mode Chips": "Näytä tilasirut"
+  },
+  "Show Network": {
+    "Show Network": "Näytä verkko"
+  },
+  "Show Network Graph": {
+    "Show Network Graph": "Näytä verkkokaavio"
+  },
+  "Show Occupied Workspaces Only": {
+    "Show Occupied Workspaces Only": "Näytä vain varatut työtilat"
+  },
+  "Show Overflow Badge Count": {
+    "Show Overflow Badge Count": "Näytä ylivuotomerkkien määrä"
+  },
+  "Show Package Source Badges": {
+    "Show Package Source Badges": "Näytä paketin lähdemerkit"
+  },
+  "Show Password Field": {
+    "Show Password Field": "Näytä salasanakenttä"
+  },
+  "Show Percentage": {
+    "Show Percentage": "Näytä prosenttiosuus"
+  },
+  "Show Power Actions": {
+    "Show Power Actions": "Näytä tehotoiminnot"
+  },
+  "Show Power Off": {
+    "Show Power Off": "Näytä Virta pois"
+  },
+  "Show Precipitation Probability": {
+    "Show Precipitation Probability": "Näytä sateen todennäköisyys"
+  },
+  "Show Pressure": {
+    "Show Pressure": "Näytä paine"
+  },
+  "Show Profile Image": {
+    "Show Profile Image": "Näytä profiilikuva"
+  },
+  "Show Reboot": {
+    "Show Reboot": "Näytä uudelleenkäynnistys"
+  },
+  "Show Remaining Time": {
+    "Show Remaining Time": "Näytä jäljellä oleva aika"
+  },
+  "Show Restart DMS": {
+    "Show Restart DMS": "Näytä Käynnistä uudelleen DMS"
+  },
+  "Show Saved Items": {
+    "Show Saved Items": "Näytä tallennetut kohteet"
+  },
+  "Show Seconds": {
+    "Show Seconds": "Näytä sekunnit"
+  },
+  "Show Sunrise/Sunset": {
+    "Show Sunrise/Sunset": "Näytä auringonnousu/auringonlasku"
+  },
+  "Show Suspend": {
+    "Show Suspend": "Näytä keskeytys"
+  },
+  "Show Swap": {
+    "Show Swap": "Näytä Swap"
+  },
+  "Show Switch User": {
+    "Show Switch User": "Näytä Vaihda käyttäjää"
+  },
+  "Show System Date": {
+    "Show System Date": "Näytä järjestelmän päivämäärä"
+  },
+  "Show System Icons": {
+    "Show System Icons": "Näytä järjestelmäkuvakkeet"
+  },
+  "Show System Time": {
+    "Show System Time": "Näytä järjestelmän aika"
+  },
+  "Show Top Processes": {
+    "Show Top Processes": "Näytä suosituimmat prosessit"
+  },
+  "Show Trash in Dock": {
+    "Show Trash in Dock": "Näytä Roskakori Dockissa"
+  },
+  "Show Weather Condition": {
+    "Show Weather Condition": "Näytä sääolosuhteet"
+  },
+  "Show Week Number": {
+    "Show Week Number": "Näytä viikon numero"
+  },
+  "Show Welcome": {
+    "Show Welcome": "Näytä tervetuloikkuna"
+  },
+  "Show Wind Speed": {
+    "Show Wind Speed": "Näytä Tuulen nopeus"
+  },
+  "Show Workspace Apps": {
+    "Show Workspace Apps": "Näytä työtilasovellukset"
+  },
+  "Show a bar that drains as the popup's auto-dismiss timer runs": {
+    "Show a bar that drains as the popup's auto-dismiss timer runs": "Näytä palkki, joka tyhjenee, kun ponnahdusikkunan automaattisen hylkäämisen ajastin toimii"
+  },
+  "Show a notification when battery reaches the charge limit.": {
+    "Show a notification when battery reaches the charge limit.": "Näytä ilmoitus, kun akku saavuttaa latausrajan."
+  },
+  "Show a warning popup when battery is running low.": {
+    "Show a warning popup when battery is running low.": "Näytä varoitusponnahdusikkuna, kun akku on vähissä."
+  },
+  "Show all 9 tags instead of only occupied tags": {
+    "Show all 9 tags instead of only occupied tags": "Näytä kaikki 9 tunnistetta vain varattujen tunnisteiden sijaan"
+  },
+  "Show an outline ring around the focused workspace indicator": {
+    "Show an outline ring around the focused workspace indicator": "Näytä ääriviivarengas kohdistetun työtilan ilmaisimen ympärillä"
+  },
+  "Show an urgent alert when battery reaches critical level.": {
+    "Show an urgent alert when battery reaches critical level.": "Näytä kiireellinen hälytys, kun akku saavuttaa kriittisen tason."
+  },
+  "Show cava audio visualizer in media widget": {
+    "Show cava audio visualizer in media widget": "Näytä cava-äänivisualisoija mediawidgetissä"
+  },
+  "Show darkened overlay behind modal dialogs": {
+    "Show darkened overlay behind modal dialogs": "Näytä tummennettu peittokuva modaalisten valintaikkunoiden takana"
+  },
+  "Show device": {
+    "Show device": "Näytä laite"
+  },
+  "Show dock when floating windows don't overlap its area": {
+    "Show dock when floating windows don't overlap its area": "Näytä telakka, kun kelluvat ikkunat eivät mene päällekkäin sen alueen kanssa"
+  },
+  "Show drop shadow on notification popups. Requires M3 Elevation to be enabled in Theme & Colors.": {
+    "Show drop shadow on notification popups. Requires M3 Elevation to be enabled in Theme & Colors.": "Näytä varjo ilmoitusten ponnahdusikkunoissa. Edellyttää, että M3 Elevation on käytössä Teema ja värit -kohdassa."
+  },
+  "Show during Niri overview": {
+    "Show during Niri overview": "Näytä Niri-katsauksen aikana"
+  },
+  "Show foreground surfaces on panels for stronger contrast": {
+    "Show foreground surfaces on panels for stronger contrast": "Näytä etualan pinnat paneeleissa vahvistaaksesi kontrastia"
+  },
+  "Show in GB": {
+    "Show in GB": "Näytä GB"
+  },
+  "Show launcher overlay when typing in Niri overview. Disable to use another launcher.": {
+    "Show launcher overlay when typing in Niri overview. Disable to use another launcher.": "Näytä käynnistysohjelman peitto, kun kirjoitat Niri-yleiskatsausta. Poista käytöstä toisen käynnistysohjelman käyttö."
+  },
+  "Show mode tabs and keyboard hints at the bottom.": {
+    "Show mode tabs and keyboard hints at the bottom.": "Näytä tilavälilehdet ja näppäimistövihjeet alareunassa."
+  },
+  "Show mount path": {
+    "Show mount path": "Näytä asennuspolku"
+  },
+  "Show on Last Display": {
+    "Show on Last Display": "Näytä viimeisellä näytöllä"
+  },
+  "Show on Overlay": {
+    "Show on Overlay": "Näytä peittokuvassa"
+  },
+  "Show on Overview": {
+    "Show on Overview": "Näytä yleiskatsauksessa"
+  },
+  "Show on Overview Only": {
+    "Show on Overview Only": "Näytä vain yleiskatsauksessa"
+  },
+  "Show on screens:": {
+    "Show on screens:": "Näytä näytöillä:"
+  },
+  "Show the bar only when no windows are open": {
+    "Show the bar only when no windows are open": "Näytä palkki vain, kun yksikään ikkuna ei ole auki"
+  },
+  "Show the bar when niri overview is active": {
+    "Show the bar when niri overview is active": "Näytä palkki, kun niri-katsaus on aktiivinen"
+  },
+  "Show weather information in top bar and control center": {
+    "Show weather information in top bar and control center": "Näytä säätiedot yläpalkissa ja ohjauskeskuksessa"
+  },
+  "Show workspace index numbers in the top bar workspace switcher": {
+    "Show workspace index numbers in the top bar workspace switcher": "Näytä työtilan indeksinumerot yläpalkin työtilan vaihtajassa"
+  },
+  "Show workspace name on horizontal bars, and first letter on vertical bars": {
+    "Show workspace name on horizontal bars, and first letter on vertical bars": "Näytä työtilan nimi vaakapalkeissa ja ensimmäinen kirjain pystypalkeissa"
+  },
+  "Show workspaces of the currently focused monitor": {
+    "Show workspaces of the currently focused monitor": "Näytä tällä hetkellä fokusoidun näytön työtilat"
+  },
+  "Shows all running applications with focus indication": {
+    "Shows all running applications with focus indication": "Näyttää kaikki käynnissä olevat sovellukset tarkennuksen ilmauksella"
+  },
+  "Shows current workspace and allows switching": {
+    "Shows current workspace and allows switching": "Näyttää nykyisen työtilan ja sallii vaihdon"
+  },
+  "Shows when caps lock is active": {
+    "Shows when caps lock is active": "Näyttää, kun caps lock on aktiivinen"
+  },
+  "Shows when microphone, camera, or screen sharing is active": {
+    "Shows when microphone, camera, or screen sharing is active": "Näyttää, kun mikrofoni, kamera tai näytön jakaminen on aktiivinen"
+  },
+  "Shrink the media widget to fit shorter song titles while still respecting the configured maximum size": {
+    "Shrink the media widget to fit shorter song titles while still respecting the configured maximum size": "Pienennä mediawidgetiä niin, että se sopisi lyhyempiin kappaleiden nimiin, mutta noudata silti määritettyä enimmäiskokoa"
+  },
+  "Shutdown": {
+    "Shutdown": "Sammutus"
+  },
+  "Signal": {
+    "Signal": "Signaali"
+  },
+  "Signal Strength": {
+    "Signal Strength": "Signaalin voimakkuus"
+  },
+  "Silence for a while": {
+    "Silence for a while": "Hiljaisuus hetken"
+  },
+  "Silence notifications": {
+    "Silence notifications": "Hiljennä ilmoitukset"
+  },
+  "Silence system sounds while media is playing": {
+    "Silence system sounds while media is playing": "Hiljennä järjestelmän äänet median toiston aikana"
+  },
+  "Single-Line Popup": {
+    "Single-Line Popup": "Yksirivinen ponnahdusikkuna"
+  },
+  "Size": {
+    "Size": "Koko"
+  },
+  "Size Constraints": {
+    "Size Constraints": "Kokorajoitukset"
+  },
+  "Size Offset": {
+    "Size Offset": "Kokopoikkeama"
+  },
+  "Sizing": {
+    "Sizing": "Mitoitus"
+  },
+  "Skip": {
+    "Skip": "Ohita"
+  },
+  "Skip confirmation": {
+    "Skip confirmation": "Ohita vahvistus"
+  },
+  "Skip setup": {
+    "Skip setup": "Ohita asetukset"
+  },
+  "Skip the greeter password after boot until you sign out. Lock screen unlock is unchanged. Takes effect on the next reboot after sync.": {
+    "Skip the greeter password after boot until you sign out. Lock screen unlock is unchanged. Takes effect on the next reboot after sync.": "Ohita tervehdyssalasana käynnistyksen jälkeen, kunnes kirjaudut ulos. Lukitusnäytön lukituksen avaus ei ole muuttunut. Tulee voimaan seuraavan uudelleenkäynnistyksen yhteydessä synkronoinnin jälkeen."
+  },
+  "Slideout": {
+    "Slideout": "Slideout"
+  },
+  "Small": {
+    "Small": "Pieni"
+  },
+  "Smartcard Authentication": {
+    "Smartcard Authentication": "Älykortin todennus"
+  },
+  "Snap": {
+    "Snap": "Snap"
+  },
+  "Snow": {
+    "Snow": "Lunta"
+  },
+  "Some plugins require a newer version of DMS:": {
+    "Some plugins require a newer version of DMS:": "Jotkut laajennukset vaativat uudemman version DMS:stä:"
+  },
+  "Sort Alphabetically": {
+    "Sort Alphabetically": "Lajittele aakkosjärjestyksessä"
+  },
+  "Sort By": {
+    "Sort By": "Lajitteluperuste"
+  },
+  "Sort wallpapers": {
+    "Sort wallpapers": "Lajittele taustakuvat"
+  },
+  "Sorting & Layout": {
+    "Sorting & Layout": "Lajittelu ja asettelu"
+  },
+  "Sound Theme": {
+    "Sound Theme": "Ääniteema"
+  },
+  "Sounds": {
+    "Sounds": "Äänet"
+  },
+  "Source: %1": {
+    "Source: %1": "Lähde: %1"
+  },
+  "Space between the bar and screen edges": {
+    "Space between the bar and screen edges": "Palkin ja näytön reunojen välissä oleva tila"
+  },
+  "Space between windows": {
+    "Space between windows": "Ikkunoiden välissä tilaa"
+  },
+  "Space between windows and screen edges": {
+    "Space between windows and screen edges": "Ikkunoiden ja näytön reunojen välinen tila"
+  },
+  "Spacer": {
+    "Spacer": "Välikappale"
+  },
+  "Spacing": {
+    "Spacing": "Välit"
+  },
+  "Speaker settings": {
+    "Speaker settings": "Kaiutinasetukset"
+  },
+  "Speed": {
+    "Speed": "Nopeus"
+  },
+  "Spool Area Full": {
+    "Spool Area Full": "Kela-alue täynnä"
+  },
+  "Spotlight": {
+    "Spotlight": "Valokeila"
+  },
+  "Spotlight Bar": {
+    "Spotlight Bar": "Spotlight Bar"
+  },
+  "Spotlight Bar Shortcut": {
+    "Spotlight Bar Shortcut": "Spotlight-palkin pikakuvake"
+  },
+  "Spotlight Search": {
+    "Spotlight Search": "Spotlight-haku"
+  },
+  "Square Corners": {
+    "Square Corners": "Neliön kulmat"
+  },
+  "Stacked": {
+    "Stacked": "Pinottu"
+  },
+  "Standard": {
+    "Standard": "Vakio"
+  },
+  "Standard: Classic Material Design 3 — panels rise from below with a subtle scale. The DMS default.": {
+    "Standard: Classic Material Design 3 — panels rise from below with a subtle scale. The DMS default.": "Vakio: Classic Material Design 3 — paneelit nousevat alhaalta hienovaraisesti. DMS oletusarvo."
+  },
+  "Start": {
+    "Start": "Aloita"
+  },
+  "Start KDE Connect or Valent to use this plugin": {
+    "Start KDE Connect or Valent to use this plugin": "Käynnistä KDE Connect tai Valen käyttääksesi tätä laajennusta"
+  },
+  "Start typing your notes here...": {
+    "Start typing your notes here...": "Aloita muistiinpanojen kirjoittaminen tästä..."
+  },
+  "State": {
+    "State": "osavaltio"
+  },
+  "Status": {
+    "Status": "Tila"
+  },
+  "Stop ignoring %1": {
+    "Stop ignoring %1": "Älä ohita %1"
+  },
+  "Stopped": {
+    "Stopped": "Pysähtynyt"
+  },
+  "Stopped Partly": {
+    "Stopped Partly": "Pysäytyi osittain"
+  },
+  "Stopping": {
+    "Stopping": "Pysähtyminen"
+  },
+  "Stretch": {
+    "Stretch": "Venytä"
+  },
+  "Stretch widget icons to fill the available bar height": {
+    "Stretch widget icons to fill the available bar height": "Venytä widget-kuvakkeet täyttämään käytettävissä oleva palkin korkeus"
+  },
+  "Stretch widget text to fill the available bar height": {
+    "Stretch widget text to fill the available bar height": "Venytä widgetin tekstiä täyttämään käytettävissä oleva palkin korkeus"
+  },
+  "Strict auto-hide": {
+    "Strict auto-hide": "Tiukka automaattinen piilotus"
+  },
+  "Stripes": {
+    "Stripes": "Raidat"
+  },
+  "Summary": {
+    "Summary": "Yhteenveto"
+  },
+  "Summary Font Size": {
+    "Summary Font Size": "Yhteenveto fonttikoko"
+  },
+  "Sunrise": {
+    "Sunrise": "Auringonnousu"
+  },
+  "Sunset": {
+    "Sunset": "Auringonlasku"
+  },
+  "Suppress Duplicate Notifications": {
+    "Suppress Duplicate Notifications": "Estä päällekkäiset ilmoitukset"
+  },
+  "Suppress notification popups while enabled": {
+    "Suppress notification popups while enabled": "Estä ilmoitusten ponnahdusikkunat, kun se on käytössä"
+  },
+  "Surface": {
+    "Surface": "Pinta"
+  },
+  "Surface Behavior": {
+    "Surface Behavior": "Pinnan käyttäytyminen"
+  },
+  "Surface Border Color": {
+    "Surface Border Color": "Pintareunuksen väri"
+  },
+  "Surface Border Opacity": {
+    "Surface Border Opacity": "Pintareunan peittävyys"
+  },
+  "Surface Container": {
+    "Surface Container": "Pintasäiliö"
+  },
+  "Surface High": {
+    "Surface High": "Pinta korkea"
+  },
+  "Surface Highest": {
+    "Surface Highest": "Pinta korkein"
+  },
+  "Surface Opacity": {
+    "Surface Opacity": "Pinnan peittävyys"
+  },
+  "Surface Text": {
+    "Surface Text": "Pintateksti"
+  },
+  "Surface Variant": {
+    "Surface Variant": "Pintavariantti"
+  },
+  "Surfaces emerge flush from the bar": {
+    "Surfaces emerge flush from the bar": "Pinnat tulevat esiin tangosta tasaisesti"
+  },
+  "Surfaces float independently of the frame": {
+    "Surfaces float independently of the frame": "Pinnat kelluvat kehyksestä riippumatta"
+  },
+  "Suspend": {
+    "Suspend": "Keskeytä"
+  },
+  "Suspend behavior": {
+    "Suspend behavior": "Keskeytä käyttäytyminen"
+  },
+  "Suspend system after": {
+    "Suspend system after": "Keskeytä järjestelmä sen jälkeen"
+  },
+  "Suspend then Hibernate": {
+    "Suspend then Hibernate": "Keskeytä ja sitten lepotila"
+  },
+  "Sway Website": {
+    "Sway Website": "Sway-verkkosivusto"
+  },
+  "Switch User": {
+    "Switch User": "Vaihda käyttäjää"
+  },
+  "Switch between display configurations": {
+    "Switch between display configurations": "Vaihda näyttökokoonpanojen välillä"
+  },
+  "Switch to power profile": {
+    "Switch to power profile": "Vaihda tehoprofiiliin"
+  },
+  "Sync": {
+    "Sync": "Synkronoi"
+  },
+  "Sync Bar Inset Padding": {
+    "Sync Bar Inset Padding": "Synkronointipalkin täyttö"
+  },
+  "Sync Mode with Portal": {
+    "Sync Mode with Portal": "Synkronointitila portaalin kanssa"
+  },
+  "Sync Popouts & Modals": {
+    "Sync Popouts & Modals": "Synkronoi ponnahdusikkunat ja modaalit"
+  },
+  "Sync Position Across Screens": {
+    "Sync Position Across Screens": "Synkronoi sijainti eri näyttöjen välillä"
+  },
+  "Sync applies your theme and settings to the login screen. Other users should run dms greeter sync --profile instead of a full sync. Authentication changes apply automatically.": {
+    "Sync applies your theme and settings to the login screen. Other users should run dms greeter sync --profile instead of a full sync. Authentication changes apply automatically.": "Synkronointi käyttää teemaasi ja asetuksiasi kirjautumisnäytössä. Muiden käyttäjien tulee suorittaa dms greeter sync --profile täyden synkronoinnin sijaan. Todennusmuutokset tulevat voimaan automaattisesti."
+  },
+  "Sync completed successfully.": {
+    "Sync completed successfully.": "Synkronointi onnistui."
+  },
+  "Sync dark mode with settings portals for system-wide theme hints": {
+    "Sync dark mode with settings portals for system-wide theme hints": "Synkronoi tumma tila asetusportaalien kanssa saadaksesi järjestelmän laajuisia teemavinkkejä"
+  },
+  "Sync failed in background mode. Trying terminal mode so you can authenticate interactively.": {
+    "Sync failed in background mode. Trying terminal mode so you can authenticate interactively.": "Synkronointi epäonnistui taustatilassa. Kokeile päätetilaa, jotta voit todentaa interaktiivisesti."
+  },
+  "Sync needs sudo authentication. Opening terminal so you can use password or fingerprint.": {
+    "Sync needs sudo authentication. Opening terminal so you can use password or fingerprint.": "Synkronointi vaatii sudo-todennuksen. Avaa pääte, jotta voit käyttää salasanaa tai sormenjälkeä."
+  },
+  "Sync to apply": {
+    "Sync to apply": "Synkronoi ottaaksesi käyttöön"
+  },
+  "Syncing...": {
+    "Syncing...": "Synkronoidaan..."
+  },
+  "System": {
+    "System": "Järjestelmä"
+  },
+  "System App Theming": {
+    "System App Theming": "Järjestelmäsovellusteema"
+  },
+  "System Check": {
+    "System Check": "Järjestelmän tarkistus"
+  },
+  "System Default": {
+    "System Default": "Järjestelmän oletus"
+  },
+  "System Information": {
+    "System Information": "Järjestelmätiedot"
+  },
+  "System Monitor": {
+    "System Monitor": "Järjestelmän valvonta"
+  },
+  "System Monitor Unavailable": {
+    "System Monitor Unavailable": "Järjestelmän valvonta ei ole käytettävissä"
+  },
+  "System Sounds": {
+    "System Sounds": "Järjestelmän äänet"
+  },
+  "System Tray": {
+    "System Tray": "Järjestelmälokero"
+  },
+  "System Tray Icon Tint": {
+    "System Tray Icon Tint": "Järjestelmäpalkin kuvakkeen sävy"
+  },
+  "System Update": {
+    "System Update": "Järjestelmän päivitys"
+  },
+  "System Updater": {
+    "System Updater": "Järjestelmän päivitys"
+  },
+  "System Updates": {
+    "System Updates": "Järjestelmäpäivitykset"
+  },
+  "System notification area icons": {
+    "System notification area icons": "Järjestelmän ilmoitusalueen kuvakkeet"
+  },
+  "System sounds are not available. Install %1 for sound support.": {
+    "System sounds are not available. Install %1 for sound support.": "Järjestelmän äänet eivät ole käytettävissä. Asenna %1 saadaksesi äänen tuen."
+  },
+  "System theme toggle": {
+    "System theme toggle": "Järjestelmäteeman vaihto"
+  },
+  "System toast notifications": {
+    "System toast notifications": "Järjestelmän paahtoleipäilmoitukset"
+  },
+  "Systemd Override generated": {
+    "Systemd Override generated": "Järjestelmän ohitus luotu"
+  },
+  "Tab": {
+    "Tab": "Tab"
+  },
+  "Tab/Shift+Tab: Nav • ←→↑↓: Grid Nav • Enter/Space: Select": {
+    "Tab/Shift+Tab: Nav • ←→↑↓: Grid Nav • Enter/Space: Select": "Sarkain/Vaihto+Sarkain: Nav • ←→↑↓: Ruudukkonavigointi • Enter/välilyönti: Valitse"
+  },
+  "Tags": {
+    "Tags": "Tunnisteet"
+  },
+  "Tags: %1": {
+    "Tags: %1": "Tunnisteet: %1"
+  },
+  "Tailscale": {
+    "Tailscale": "Tailscale"
+  },
+  "Tailscale Network": {
+    "Tailscale Network": "Tailscale-verkko"
+  },
+  "Tailscale action failed": {
+    "Tailscale action failed": "Tailscale-toiminto epäonnistui"
+  },
+  "Tailscale not available": {
+    "Tailscale not available": "Tailscale ei saatavilla"
+  },
+  "Terminal": {
+    "Terminal": "Terminaali"
+  },
+  "Terminal additional parameters": {
+    "Terminal additional parameters": "Päätteen lisäparametrit"
+  },
+  "Terminal fallback failed. Install a supported terminal emulator or run 'dms auth sync' manually.": {
+    "Terminal fallback failed. Install a supported terminal emulator or run 'dms auth sync' manually.": "Terminaalin varmistus epäonnistui. Asenna tuettu pääteemulaattori tai suorita \"dms auth sync\" manuaalisesti."
+  },
+  "Terminal fallback failed. Install one of the supported terminal emulators or run 'dms greeter sync' manually.": {
+    "Terminal fallback failed. Install one of the supported terminal emulators or run 'dms greeter sync' manually.": "Terminaalin varmistus epäonnistui. Asenna jokin tuetuista pääteemulaattoreista tai suorita \"dms greeter sync\" manuaalisesti."
+  },
+  "Terminal fallback opened. Complete authentication there; it will close automatically when done.": {
+    "Terminal fallback opened. Complete authentication there; it will close automatically when done.": "Varapääte avattiin. Viimeistele todennus siinä; se sulkeutuu automaattisesti valmistuttuaan."
+  },
+  "Terminal opened. Complete authentication there; it will close automatically when done.": {
+    "Terminal opened. Complete authentication there; it will close automatically when done.": "Pääte avattiin. Viimeistele todennus siinä; se sulkeutuu automaattisesti valmistuttuaan."
+  },
+  "Terminals - Always use Dark Theme": {
+    "Terminals - Always use Dark Theme": "Päätteet - Käytä aina tummaa teemaa"
+  },
+  "Tertiary": {
+    "Tertiary": "Kolmannen asteen"
+  },
+  "Tertiary Container": {
+    "Tertiary Container": "Kolmannen asteen kontti"
+  },
+  "Test Connection": {
+    "Test Connection": "Testaa yhteys"
+  },
+  "Test Page": {
+    "Test Page": "Testisivu"
+  },
+  "Test page sent to printer": {
+    "Test page sent to printer": "Testisivu lähetetty tulostimelle"
+  },
+  "Testing...": {
+    "Testing...": "Testataan..."
+  },
+  "Text": {
+    "Text": "Teksti"
+  },
+  "Text Color": {
+    "Text Color": "Tekstin väri"
+  },
+  "Text Editor": {
+    "Text Editor": "Tekstieditori"
+  },
+  "Text Rendering": {
+    "Text Rendering": "Tekstin renderöinti"
+  },
+  "The 'dgop' tool is required for system monitoring.\nPlease install dgop to use this feature.": {
+    "The 'dgop' tool is required for system monitoring.\nPlease install dgop to use this feature.": "Järjestelmän valvontaan tarvitaan dgop-työkalu.\nAsenna dgop käyttääksesi tätä ominaisuutta."
+  },
+  "The DMS_SOCKET environment variable is not set or the socket is unavailable. Automated plugin management requires the DMS_SOCKET.": {
+    "The DMS_SOCKET environment variable is not set or the socket is unavailable. Automated plugin management requires the DMS_SOCKET.": "DMS_SOCKET-ympäristömuuttujaa ei ole asetettu tai socket ei ole käytettävissä. Automaattinen laajennusten hallinta vaatii DMS_SOCKETin."
+  },
+  "The below settings will modify your GTK and Qt settings. If you wish to preserve your current configurations, please back them up (qt5ct.conf|qt6ct.conf and ~/.config/gtk-3.0|gtk-4.0).": {
+    "The below settings will modify your GTK and Qt settings. If you wish to preserve your current configurations, please back them up (qt5ct.conf|qt6ct.conf and ~/.config/gtk-3.0|gtk-4.0).": "Alla olevat asetukset muokkaavat GTK- ja Qt-asetuksiasi. Jos haluat säilyttää nykyiset kokoonpanosi, varmuuskopioi ne (qt5ct.conf|qt6ct.conf ja ~/.config/gtk-3.0|gtk-4.0)."
+  },
+  "The custom command used when attaching to sessions (receives the session name as the first argument)": {
+    "The custom command used when attaching to sessions (receives the session name as the first argument)": "Mukautettu komento, jota käytetään istuntoihin liitettäessä (saa istunnon nimen ensimmäisenä argumenttina)"
+  },
+  "The job queue of this printer is empty": {
+    "The job queue of this printer is empty": "Tämän tulostimen työjono on tyhjä"
+  },
+  "The rule applies to any window matching one of these.": {
+    "The rule applies to any window matching one of these.": "Sääntö koskee kaikkia ikkunoita, jotka vastaavat jotakin näistä."
+  },
+  "Theme & Colors": {
+    "Theme & Colors": "Teema ja värit"
+  },
+  "Theme Color": {
+    "Theme Color": "Teeman väri"
+  },
+  "Theme Registry": {
+    "Theme Registry": "Teeman rekisteri"
+  },
+  "Theme color used for the border": {
+    "Theme color used for the border": "Reunuksessa käytetty teemaväri"
+  },
+  "Theme color used for the widget outline": {
+    "Theme color used for the widget outline": "Widgetin ääriviivassa käytetty teemaväri"
+  },
+  "Theme worker failed (%1)": {
+    "Theme worker failed (%1)": "Teematyöntekijä epäonnistui (%1)"
+  },
+  "Themes": {
+    "Themes": "Teemat"
+  },
+  "These add entries to the XDG autostart directory (~/.config/autostart/*.desktop)": {
+    "These add entries to the XDG autostart directory (~/.config/autostart/*.desktop)": "Nämä lisäävät merkintöjä XDG:n automaattisen käynnistyksen hakemistoon (~/.config/autostart/*.desktop)"
+  },
+  "Thickness": {
+    "Thickness": "Paksuus"
+  },
+  "Thin": {
+    "Thin": "Ohut"
+  },
+  "Third-Party Plugin Warning": {
+    "Third-Party Plugin Warning": "Varoitus kolmannen osapuolen laajennuksista"
+  },
+  "Third-party plugins are created by the community and are not officially supported by DankMaterialShell.\n\nThese plugins may pose security and privacy risks - install at your own risk.": {
+    "Third-party plugins are created by the community and are not officially supported by DankMaterialShell.\n\nThese plugins may pose security and privacy risks - install at your own risk.": "Kolmannen osapuolen laajennukset ovat yhteisön luomia, eikä DankMaterialShell tue niitä virallisesti.\n\nNämä laajennukset voivat aiheuttaa turvallisuus- ja tietosuojariskejä – asenna omalla vastuullasi."
+  },
+  "This bind is overridden by config.kdl": {
+    "This bind is overridden by config.kdl": "Tämän sidoksen ohittaa config.kdl"
+  },
+  "This device": {
+    "This device": "Tämä laite"
+  },
+  "This install is still using hyprland.conf. Run dms setup to migrate before changing these settings.": {
+    "This install is still using hyprland.conf. Run dms setup to migrate before changing these settings.": "Tämä asennus käyttää yhä hyprland.conf-tiedostoa. Suorita dms setup siirtymistä varten ennen näiden asetusten muuttamista."
+  },
+  "This may take a few seconds": {
+    "This may take a few seconds": "Tämä voi kestää muutaman sekunnin"
+  },
+  "This output is disabled in the current profile": {
+    "This output is disabled in the current profile": "Tämä lähtö on poistettu käytöstä nykyisessä profiilissa"
+  },
+  "This plugin does not have 'settings_write' permission.\n\nAdd \"permissions\": [\"settings_read\", \"settings_write\"] to plugin.json": {
+    "This plugin does not have 'settings_write' permission.\n\nAdd \"permissions\": [\"settings_read\", \"settings_write\"] to plugin.json": "Tällä laajennuksella ei ole asetusten_kirjoitusoikeutta.\n\nLisää \"oikeudet\": [\"settings_read\", \"settings_write\"] tiedostoon plugin.json"
+  },
+  "This widget prevents GPU power off states, which can significantly impact battery life on laptops. It is not recommended to use this on laptops with hybrid graphics.": {
+    "This widget prevents GPU power off states, which can significantly impact battery life on laptops. It is not recommended to use this on laptops with hybrid graphics.": "Tämä widget estää GPU:n virrankatkaisutilat, jotka voivat vaikuttaa merkittävästi kannettavien tietokoneiden akun käyttöikään. Tätä ei suositella käytettäväksi kannettavissa tietokoneissa, joissa on hybridigrafiikka."
+  },
+  "This will delete all unpinned entries. %1 pinned entries will be kept.": {
+    "This will delete all unpinned entries. %1 pinned entries will be kept.": "Tämä poistaa kaikki kiinnittämättömät merkinnät. %1 kiinnitetyt merkinnät säilytetään."
+  },
+  "This will permanently delete all clipboard history.": {
+    "This will permanently delete all clipboard history.": "Tämä poistaa pysyvästi koko leikepöydän historian."
+  },
+  "This will permanently remove this saved clipboard item. This action cannot be undone.": {
+    "This will permanently remove this saved clipboard item. This action cannot be undone.": "Tämä poistaa tämän tallennetun leikepöydän kohteen pysyvästi. Tätä toimintoa ei voi kumota."
+  },
+  "Thunderstorm": {
+    "Thunderstorm": "Ukkosmyrsky"
+  },
+  "Thunderstorm with Hail": {
+    "Thunderstorm with Hail": "Ukkosmyrsky ja rakeita"
+  },
+  "Tile": {
+    "Tile": "Laatta"
+  },
+  "Tile Horizontally": {
+    "Tile Horizontally": "Laatta vaakatasossa"
+  },
+  "Tile Vertically": {
+    "Tile Vertically": "Laatta pystysuoraan"
+  },
+  "Tiled": {
+    "Tiled": "Laatoitettu"
+  },
+  "Tiled State": {
+    "Tiled State": "Laatoitettu tila"
+  },
+  "Tiling": {
+    "Tiling": "Laatoitus"
+  },
+  "Time": {
+    "Time": "Aika"
+  },
+  "Time & Date Locale": {
+    "Time & Date Locale": "Ajan ja päivämäärän alueasetus"
+  },
+  "Time & Weather": {
+    "Time & Weather": "Aika & Sää"
+  },
+  "Time Format": {
+    "Time Format": "Ajan esitysmuoto"
+  },
+  "Time remaining: %1": {
+    "Time remaining: %1": "Jäljellä oleva aika: %1"
+  },
+  "Time to rest on a widget before its popout opens": {
+    "Time to rest on a widget before its popout opens": "Aika levätä widgetin parissa ennen kuin sen ponnahdusikkuna avautuu"
+  },
+  "Time to wait before hiding after the pointer leaves": {
+    "Time to wait before hiding after the pointer leaves": "Aika odottaa ennen kuin piiloudut osoittimen poistumisen jälkeen"
+  },
+  "Time until full: %1": {
+    "Time until full: %1": "Aika täyteen: %1"
+  },
+  "Timed Out": {
+    "Timed Out": "Aikakatkaisu"
+  },
+  "Timeout Progress Bar": {
+    "Timeout Progress Bar": "Aikakatkaisun etenemispalkki"
+  },
+  "Timeouts": {
+    "Timeouts": "Aikakatkaisut"
+  },
+  "Tint Saturation": {
+    "Tint Saturation": "Värikylläisyys"
+  },
+  "Tint Strength": {
+    "Tint Strength": "Sävyn vahvuus"
+  },
+  "Title": {
+    "Title": "Otsikko"
+  },
+  "Title (optional)": {
+    "Title (optional)": "Otsikko (valinnainen)"
+  },
+  "Title is required": {
+    "Title is required": "Otsikko vaaditaan"
+  },
+  "Title regex (optional)": {
+    "Title regex (optional)": "Otsikon säännöllinen lauseke (valinnainen)"
+  },
+  "To Full": {
+    "To Full": "Täyteen"
+  },
+  "To sign in as a different user, log out and pick the account from the greeter. Creating a fresh session in parallel needs a multi-session greeter (greetd-flexiserver / GDM / LightDM).": {
+    "To sign in as a different user, log out and pick the account from the greeter. Creating a fresh session in parallel needs a multi-session greeter (greetd-flexiserver / GDM / LightDM).": "Jos haluat kirjautua sisään toisena käyttäjänä, kirjaudu ulos ja valitse tili tervehdyspalkista. Uuden istunnon luominen rinnakkain vaatii usean istunnon tervehdin (greetd-flexiserver / GDM / LightDM)."
+  },
+  "To update, run the following command:": {
+    "To update, run the following command:": "Päivitä suorittamalla seuraava komento:"
+  },
+  "To use this DMS bind, remove or change the keybind in your config.kdl": {
+    "To use this DMS bind, remove or change the keybind in your config.kdl": "Jos haluat käyttää tätä DMS-sidontaa, poista tai vaihda näppäinsidonta config.kdl-tiedostossa"
+  },
+  "Toast": {
+    "Toast": "Paahtoleipää"
+  },
+  "Toast Messages": {
+    "Toast Messages": "Toast Viestit"
+  },
+  "Today": {
+    "Today": "Tänään"
+  },
+  "Toggle bar visibility manually via IPC": {
+    "Toggle bar visibility manually via IPC": "Vaihda palkin näkyvyys manuaalisesti IPC:n kautta"
+  },
+  "Toggle fonts": {
+    "Toggle fonts": "Vaihda fontit"
+  },
+  "Toggle visibility of this bar configuration": {
+    "Toggle visibility of this bar configuration": "Vaihda tämän palkkikokoonpanon näkyvyyttä"
+  },
+  "Toggling...": {
+    "Toggling...": "Vaihdetaan..."
+  },
+  "Tomorrow": {
+    "Tomorrow": "Huomenna"
+  },
+  "Tonal Spot": {
+    "Tonal Spot": "Tonaalinen piste"
+  },
+  "Toner Empty": {
+    "Toner Empty": "Väriaine tyhjä"
+  },
+  "Toner Low": {
+    "Toner Low": "Väriaine vähissä"
+  },
+  "Too many attempts - locked out": {
+    "Too many attempts - locked out": "Liian monta yritystä - lukittu"
+  },
+  "Too many failed attempts - account may be locked": {
+    "Too many failed attempts - account may be locked": "Liian monta epäonnistunutta yritystä - tili voi olla lukittu"
+  },
+  "Tools": {
+    "Tools": "Työkalut"
+  },
+  "Top": {
+    "Top": "Yläosa"
+  },
+  "Top (Default)": {
+    "Top (Default)": "Yläosa (oletus)"
+  },
+  "Top Bar Format": {
+    "Top Bar Format": "Yläpalkin muoto"
+  },
+  "Top Center": {
+    "Top Center": "Yläkeskus"
+  },
+  "Top Left": {
+    "Top Left": "Ylävasen"
+  },
+  "Top Processes": {
+    "Top Processes": "Huippuprosessit"
+  },
+  "Top Right": {
+    "Top Right": "Ylhäällä oikea"
+  },
+  "Top Section": {
+    "Top Section": "Yläosio"
+  },
+  "Total": {
+    "Total": "Yhteensä"
+  },
+  "Total Jobs": {
+    "Total Jobs": "Työpaikkoja yhteensä"
+  },
+  "Touch your security key...": {
+    "Touch your security key...": "Kosketa suojausavainta..."
+  },
+  "Transform": {
+    "Transform": "Muunna"
+  },
+  "Transition Effect": {
+    "Transition Effect": "Siirtymävaikutus"
+  },
+  "Transparency": {
+    "Transparency": "Läpinäkyvyys"
+  },
+  "Trash": {
+    "Trash": "Roskakori"
+  },
+  "Trash command failed (exit %1)": {
+    "Trash command failed (exit %1)": "Roskakorikomento epäonnistui (poistu %1)"
+  },
+  "Tray Icon Fix": {
+    "Tray Icon Fix": "Lokerokuvakkeen korjaus"
+  },
+  "Trending GIFs": {
+    "Trending GIFs": "Trendaavat GIF-kuvat"
+  },
+  "Trending Stickers": {
+    "Trending Stickers": "Trendaavat tarrat"
+  },
+  "Trigger": {
+    "Trigger": "Liipaisin"
+  },
+  "Trigger Prefix": {
+    "Trigger Prefix": "Liipaisimen etuliite"
+  },
+  "Trigger: %1": {
+    "Trigger: %1": "Liipaisin: %1"
+  },
+  "Trust": {
+    "Trust": "Luota"
+  },
+  "Try a different search": {
+    "Try a different search": "Kokeile toista hakua"
+  },
+  "Try a different search or switch filters.": {
+    "Try a different search or switch filters.": "Kokeile toista hakua tai vaihda suodattimia."
+  },
+  "Turn off": {
+    "Turn off": "Sammuta"
+  },
+  "Turn off Do Not Disturb": {
+    "Turn off Do Not Disturb": "Poista Älä häiritse -tila käytöstä"
+  },
+  "Turn off all displays immediately when the lock screen activates": {
+    "Turn off all displays immediately when the lock screen activates": "Sammuta kaikki näytöt heti, kun lukitusnäyttö aktivoituu"
+  },
+  "Turn off monitors after": {
+    "Turn off monitors after": "Sammuta näytöt tämän jälkeen"
+  },
+  "Turn off monitors after lock": {
+    "Turn off monitors after lock": "Sammuta näytöt lukituksen jälkeen"
+  },
+  "Turn off now": {
+    "Turn off now": "Sammuta nyt"
+  },
+  "Type": {
+    "Type": "Kirjoita"
+  },
+  "Type at least 2 characters": {
+    "Type at least 2 characters": "Kirjoita vähintään 2 merkkiä"
+  },
+  "Type at least 2 characters to search files.": {
+    "Type at least 2 characters to search files.": "Kirjoita vähintään 2 merkkiä etsiäksesi tiedostoja."
+  },
+  "Type this prefix to search keybinds": {
+    "Type this prefix to search keybinds": "Kirjoita tämä etuliite etsiäksesi näppäinsidoksia"
+  },
+  "Type to search files": {
+    "Type to search files": "Hae tiedostoja kirjoittamalla"
+  },
+  "Typography": {
+    "Typography": "Typografia"
+  },
+  "Typography & Motion": {
+    "Typography & Motion": "Typografia ja liike"
+  },
+  "URI": {
+    "URI": "URI"
+  },
+  "Unavailable": {
+    "Unavailable": "Ei saatavilla"
+  },
+  "Uncategorized": {
+    "Uncategorized": "Luokittelematon"
+  },
+  "Unfocused Color": {
+    "Unfocused Color": "Keskittymätön väri"
+  },
+  "Unfocused Display(s)": {
+    "Unfocused Display(s)": "Tarkentamattomat näytöt"
+  },
+  "Ungrouped": {
+    "Ungrouped": "Ryhmittelemätön"
+  },
+  "Uninstall": {
+    "Uninstall": "Poista asennus"
+  },
+  "Uninstall Greeter": {
+    "Uninstall Greeter": "Poista Greeterin asennus"
+  },
+  "Uninstall Plugin": {
+    "Uninstall Plugin": "Poista laajennus"
+  },
+  "Uninstall complete. Greeter has been removed.": {
+    "Uninstall complete. Greeter has been removed.": "Asennuksen poisto valmis. Greeter on poistettu."
+  },
+  "Uninstall failed: %1": {
+    "Uninstall failed: %1": "Asennuksen poisto epäonnistui: %1"
+  },
+  "Uninstall the DMS greeter? This will remove configuration and restore your previous display manager. A terminal will open for sudo authentication.": {
+    "Uninstall the DMS greeter? This will remove configuration and restore your previous display manager. A terminal will open for sudo authentication.": "Poistetaanko DMS tervehdys? Tämä poistaa määritykset ja palauttaa edellisen näytönhallinnan. Pääte avautuu sudo-todennusta varten."
+  },
+  "Uninstalled: %1": {
+    "Uninstalled: %1": "Poistettu: %1"
+  },
+  "Uninstalling: %1": {
+    "Uninstalling: %1": "Asennuksen poistaminen: %1"
+  },
+  "Unknown": {
+    "Unknown": "Tuntematon"
+  },
+  "Unknown App": {
+    "Unknown App": "Tuntematon sovellus"
+  },
+  "Unknown Artist": {
+    "Unknown Artist": "Tuntematon Artisti"
+  },
+  "Unknown Config": {
+    "Unknown Config": "Tuntematon kokoonpano"
+  },
+  "Unknown Device": {
+    "Unknown Device": "Tuntematon laite"
+  },
+  "Unknown GPU": {
+    "Unknown GPU": "Tuntematon GPU"
+  },
+  "Unknown Model": {
+    "Unknown Model": "Tuntematon malli"
+  },
+  "Unknown Monitor": {
+    "Unknown Monitor": "Tuntematon monitori"
+  },
+  "Unknown Network": {
+    "Unknown Network": "Tuntematon verkko"
+  },
+  "Unknown Title": {
+    "Unknown Title": "Tuntematon otsikko"
+  },
+  "Unknown Track": {
+    "Unknown Track": "Tuntematon kappale"
+  },
+  "Unload on Close": {
+    "Unload on Close": "Pura suljettaessa"
+  },
+  "Unmute": {
+    "Unmute": "Poista mykistys"
+  },
+  "Unmute popups for %1": {
+    "Unmute popups for %1": "Poista %1:n ponnahdusikkunoiden mykistys"
+  },
+  "Unnamed Rule": {
+    "Unnamed Rule": "Nimetön sääntö"
+  },
+  "Unpair": {
+    "Unpair": "Poista pariliitos"
+  },
+  "Unpair failed": {
+    "Unpair failed": "Parin purkaminen epäonnistui"
+  },
+  "Unpin": {
+    "Unpin": "Irrota kiinnitys"
+  },
+  "Unpin from Dock": {
+    "Unpin from Dock": "Irrota kiinnitys Dockista"
+  },
+  "Unsaved changes": {
+    "Unsaved changes": "Tallentamattomat muutokset"
+  },
+  "Unset": {
+    "Unset": "Unset"
+  },
+  "Until %1": {
+    "Until %1": "%1 asti"
+  },
+  "Until 8 AM": {
+    "Until 8 AM": "Klo 8 asti"
+  },
+  "Until I turn it off": {
+    "Until I turn it off": "Kunnes sammutan sen"
+  },
+  "Until tomorrow, 8:00 AM": {
+    "Until tomorrow, 8:00 AM": "Huomiseen, klo 8.00 asti"
+  },
+  "Untitled": {
+    "Untitled": "Nimetön"
+  },
+  "Untrust": {
+    "Untrust": "Epäluottamus"
+  },
+  "Up to date": {
+    "Up to date": "Ajantasainen"
+  },
+  "Update": {
+    "Update": "Päivitä"
+  },
+  "Update All": {
+    "Update All": "Päivitä kaikki"
+  },
+  "Update Plugin": {
+    "Update Plugin": "Päivitä laajennus"
+  },
+  "Update failed: %1": {
+    "Update failed: %1": "Päivitys epäonnistui: %1"
+  },
+  "Updating %1...": {
+    "Updating %1...": "Päivitetään %1..."
+  },
+  "Updating plugins...": {
+    "Updating plugins...": "Päivitetään laajennuksia..."
+  },
+  "Upgrading...": {
+    "Upgrading...": "Päivitetään..."
+  },
+  "Uptime": {
+    "Uptime": "Päällä"
+  },
+  "Urgent": {
+    "Urgent": "Kiireellinen"
+  },
+  "Urgent Color": {
+    "Urgent Color": "Kiireellinen väri"
+  },
+  "Usage Tips": {
+    "Usage Tips": "Käyttövinkkejä"
+  },
+  "Use 24-hour time format instead of 12-hour AM/PM": {
+    "Use 24-hour time format instead of 12-hour AM/PM": "Käytä 24 tunnin aikamuotoa 12 tunnin AM/PM sijaan"
+  },
+  "Use Custom Command": {
+    "Use Custom Command": "Käytä mukautettua komentoa"
+  },
+  "Use Grid Layout": {
+    "Use Grid Layout": "Käytä ruudukkoasettelua"
+  },
+  "Use HH:MM time format": {
+    "Use HH:MM time format": "Käytä HH:MM-aikamuotoa"
+  },
+  "Use IP Location": {
+    "Use IP Location": "Käytä IP-sijaintia"
+  },
+  "Use Imperial Units": {
+    "Use Imperial Units": "Käytä keisarillisia yksiköitä"
+  },
+  "Use Imperial units (°F, mph, inHg) instead of Metric (°C, km/h, hPa)": {
+    "Use Imperial units (°F, mph, inHg) instead of Metric (°C, km/h, hPa)": "Käytä Imperiumin yksiköitä (°F, mph, inHg) metrinen (°C, km/h, hPa) sijaan"
+  },
+  "Use Inline Expansion": {
+    "Use Inline Expansion": "Käytä sisäistä laajennusta"
+  },
+  "Use Monospace Font": {
+    "Use Monospace Font": "Käytä Monospace-fonttia"
+  },
+  "Use Overlay Layer": {
+    "Use Overlay Layer": "Käytä peittokerrosta"
+  },
+  "Use System Theme": {
+    "Use System Theme": "Käytä järjestelmäteemaa"
+  },
+  "Use a custom image for the lock screen, or leave empty to use your desktop wallpaper.": {
+    "Use a custom image for the lock screen, or leave empty to use your desktop wallpaper.": "Käytä mukautettua kuvaa lukitusnäytössä tai jätä tyhjäksi käyttääksesi työpöydän taustakuvaa."
+  },
+  "Use a custom image for the login screen, or leave empty to use your desktop wallpaper.": {
+    "Use a custom image for the login screen, or leave empty to use your desktop wallpaper.": "Käytä mukautettua kuvaa kirjautumisnäytössä tai jätä tyhjäksi käyttääksesi työpöydän taustakuvaa."
+  },
+  "Use a custom radius for goth corner cutouts": {
+    "Use a custom radius for goth corner cutouts": "Käytä mukautettua sädettä goottikulman leikkauksille"
+  },
+  "Use a fixed shadow direction for this bar": {
+    "Use a fixed shadow direction for this bar": "Käytä kiinteää varjon suuntaa tälle palkille"
+  },
+  "Use a security key for lock screen authentication.": {
+    "Use a security key for lock screen authentication.": "Käytä suojausavainta lukitusnäytön todentamiseen."
+  },
+  "Use album art accent": {
+    "Use album art accent": "Käytä albumin aksenttia"
+  },
+  "Use an external wallpaper manager like swww, hyprpaper, or swaybg.": {
+    "Use an external wallpaper manager like swww, hyprpaper, or swaybg.": "Käytä ulkoista taustakuvanhallintaa, kuten swww, hyprpaper tai swaybg."
+  },
+  "Use animated wave progress bars for media playback": {
+    "Use animated wave progress bars for media playback": "Käytä animoituja aallon etenemispalkkeja median toistoon"
+  },
+  "Use colors extracted from album art instead of system theme colors": {
+    "Use colors extracted from album art instead of system theme colors": "Käytä albumin kuvista poimittuja värejä järjestelmäteeman värien sijaan"
+  },
+  "Use custom border/focus-ring width": {
+    "Use custom border/focus-ring width": "Käytä mukautettua reunaa/tarkennusrenkaan leveyttä"
+  },
+  "Use custom window radius instead of theme radius": {
+    "Use custom window radius instead of theme radius": "Käytä mukautettua ikkunan sädettä teeman säteen sijaan"
+  },
+  "Use desktop wallpaper": {
+    "Use desktop wallpaper": "Käytä työpöydän taustakuvaa"
+  },
+  "Use different icon themes for light and dark mode": {
+    "Use different icon themes for light and dark mode": "Käytä erilaisia kuvaketeemoja vaaleassa ja tummassa tilassa"
+  },
+  "Use different workspace colors on displays that are not focused": {
+    "Use different workspace colors on displays that are not focused": "Käytä eri työtilan värejä näytöissä, joita ei ole tarkennettu"
+  },
+  "Use fingerprint authentication for the lock screen.": {
+    "Use fingerprint authentication for the lock screen.": "Käytä sormenjälkitunnistusta lukitusnäytössä."
+  },
+  "Use keys 1-3 or arrows, Enter/Space to select": {
+    "Use keys 1-3 or arrows, Enter/Space to select": "Käytä näppäimiä 1-3 tai nuolia, Enter/Space valitaksesi"
+  },
+  "Use light theme instead of dark theme": {
+    "Use light theme instead of dark theme": "Käytä vaaleaa teemaa tumman teeman sijaan"
+  },
+  "Use meters per second instead of km/h for wind speed": {
+    "Use meters per second instead of km/h for wind speed": "Käytä tuulen nopeudessa metriä sekunnissa km/h sijasta"
+  },
+  "Use one inset value for every bar": {
+    "Use one inset value for every bar": "Käytä yhtä lisäarvoa jokaiselle palkkille"
+  },
+  "Use smaller notification cards": {
+    "Use smaller notification cards": "Käytä pienempiä ilmoituskortteja"
+  },
+  "Use sound theme from system settings": {
+    "Use sound theme from system settings": "Käytä ääniteemaa järjestelmäasetuksista"
+  },
+  "Use system PAM authentication": {
+    "Use system PAM authentication": "Käytä järjestelmän PAM-todennusta"
+  },
+  "Use the extended surface for launcher content": {
+    "Use the extended surface for launcher content": "Käytä laajennettua pintaa kantorakettisisällölle"
+  },
+  "Use the same position and size on all displays": {
+    "Use the same position and size on all displays": "Käytä samaa sijaintia ja kokoa kaikissa näytöissä"
+  },
+  "Use trigger prefix to activate": {
+    "Use trigger prefix to activate": "Aktivoi liipaisimen etuliite"
+  },
+  "Used for xdg-terminal-exec": {
+    "Used for xdg-terminal-exec": "Käytetään tiedostolle xdg-terminal-exec"
+  },
+  "Used when accent color is set to Custom": {
+    "Used when accent color is set to Custom": "Käytetään, kun korostusväriksi on asetettu Mukautettu"
+  },
+  "User": {
+    "User": "Käyttäjä"
+  },
+  "User Window Rules (%1)": {
+    "User Window Rules (%1)": "Käyttäjäikkunan säännöt (%1)"
+  },
+  "User already exists": {
+    "User already exists": "Käyttäjä on jo olemassa"
+  },
+  "User created": {
+    "User created": "Käyttäjä luotu"
+  },
+  "User created with administrator and greeter login access": {
+    "User created with administrator and greeter login access": "Luotu käyttäjä, jolla on järjestelmänvalvojan ja tervehtimien kirjautumisoikeudet"
+  },
+  "User created with administrator privileges": {
+    "User created with administrator privileges": "Käyttäjä luotu järjestelmänvalvojan oikeuksilla"
+  },
+  "User created with greeter login access": {
+    "User created with greeter login access": "Käyttäjä luotiin tervehdyskirjautumisoikeuksilla"
+  },
+  "User deleted": {
+    "User deleted": "Käyttäjä poistettu"
+  },
+  "User not found": {
+    "User not found": "Käyttäjää ei löydy"
+  },
+  "Username": {
+    "Username": "Käyttäjätunnus"
+  },
+  "Username must start with a lowercase letter or underscore and contain only lowercase letters, digits, hyphens, or underscores.": {
+    "Username must start with a lowercase letter or underscore and contain only lowercase letters, digits, hyphens, or underscores.": "Käyttäjätunnuksen tulee alkaa pienellä kirjaimella tai alaviivalla, ja se sisältää vain pieniä kirjaimia, numeroita, yhdysmerkkejä tai alaviivoja."
+  },
+  "Username...": {
+    "Username...": "Käyttäjätunnus..."
+  },
+  "Users": {
+    "Users": "Käyttäjät"
+  },
+  "Uses sunrise/sunset times based on your location.": {
+    "Uses sunrise/sunset times based on your location.": "Käyttää auringon nousu-/laskuaikoja sijaintisi perusteella."
+  },
+  "Uses sunrise/sunset times to automatically adjust night mode based on your location.": {
+    "Uses sunrise/sunset times to automatically adjust night mode based on your location.": "Käyttää auringonnousun/auringonlaskun aikoja säätääkseen yötilan automaattisesti sijaintisi perusteella."
+  },
+  "Uses the spotlight-bar IPC action and always opens the minimal bar.": {
+    "Uses the spotlight-bar IPC action and always opens the minimal bar.": "Käyttää kohdevalopalkin IPC-toimintoa ja avaa aina minimipalkin."
+  },
+  "Using DankCalendar%1": {
+    "Using DankCalendar%1": "DankCalendar%1:n käyttö"
+  },
+  "Using global monospace font from Settings → Personalization": {
+    "Using global monospace font from Settings → Personalization": "Yleisen monospace-fontin käyttäminen kohdasta Asetukset → Mukauttaminen"
+  },
+  "Using khal": {
+    "Using khal": "Käyttämällä khal"
+  },
+  "Using shared settings from Gamma Control": {
+    "Using shared settings from Gamma Control": "Gamma Controlin jaettujen asetusten käyttäminen"
+  },
+  "Utilities": {
+    "Utilities": "Apuohjelmat"
+  },
+  "VPN": {
+    "VPN": "VPN"
+  },
+  "VPN Connections": {
+    "VPN Connections": "VPN-yhteydet"
+  },
+  "VPN configuration updated": {
+    "VPN configuration updated": "VPN-kokoonpano päivitetty"
+  },
+  "VPN credentials saved": {
+    "VPN credentials saved": "VPN-tunnistetiedot tallennettu"
+  },
+  "VPN deleted": {
+    "VPN deleted": "VPN poistettu"
+  },
+  "VPN imported: %1": {
+    "VPN imported: %1": "VPN tuotu: %1"
+  },
+  "VPN not available": {
+    "VPN not available": "VPN ei ole saatavilla"
+  },
+  "VPN status and quick connect": {
+    "VPN status and quick connect": "VPN-tila ja pikayhteys"
+  },
+  "VRR": {
+    "VRR": "VRR"
+  },
+  "VRR Fullscreen Only": {
+    "VRR Fullscreen Only": "Vain koko näytön VRR"
+  },
+  "VRR On-Demand": {
+    "VRR On-Demand": "VRR On-Demand"
+  },
+  "Variable Refresh Rate": {
+    "Variable Refresh Rate": "Muuttuva virkistystaajuus"
+  },
+  "Verification": {
+    "Verification": "Vahvistus"
+  },
+  "Version": {
+    "Version": "Versio"
+  },
+  "Vertical Deck": {
+    "Vertical Deck": "Pystytaso"
+  },
+  "Vertical Grid": {
+    "Vertical Grid": "Pystysuora ruudukko"
+  },
+  "Vertical Scrolling": {
+    "Vertical Scrolling": "Pystysuuntainen vieritys"
+  },
+  "Vertical Tiling": {
+    "Vertical Tiling": "Pysty laatoitus"
+  },
+  "Very High": {
+    "Very High": "Erittäin korkea"
+  },
+  "Vibrant": {
+    "Vibrant": "Vilkas"
+  },
+  "Vibrant palette with playful saturation.": {
+    "Vibrant palette with playful saturation.": "Eloisa paletti leikkisällä kylläisyydellä."
+  },
+  "Video Path": {
+    "Video Path": "Videopolku"
+  },
+  "Video Player": {
+    "Video Player": "Videosoitin"
+  },
+  "Video Screensaver": {
+    "Video Screensaver": "Video näytönsäästäjä"
+  },
+  "Videos": {
+    "Videos": "Videot"
+  },
+  "View Mode": {
+    "View Mode": "Näytä tila"
+  },
+  "Visibility": {
+    "Visibility": "Näkyvyys"
+  },
+  "Visible Entry Actions": {
+    "Visible Entry Actions": "Näkyvät syöttötoiminnot"
+  },
+  "Visual Effects": {
+    "Visual Effects": "Visuaaliset tehosteet"
+  },
+  "Visual divider between widgets": {
+    "Visual divider between widgets": "Visuaalinen jakaja widgetien välillä"
+  },
+  "Visual effect used when wallpaper changes": {
+    "Visual effect used when wallpaper changes": "Visuaalinen tehoste, jota käytetään taustakuvan vaihtuessa"
+  },
+  "Volume": {
+    "Volume": "Äänenvoimakkuus"
+  },
+  "Volume Changed": {
+    "Volume Changed": "Äänenvoimakkuus muutettu"
+  },
+  "Volume Slider": {
+    "Volume Slider": "Äänenvoimakkuuden liukusäädin"
+  },
+  "Volume, brightness, and other system OSDs": {
+    "Volume, brightness, and other system OSDs": "Äänenvoimakkuus, kirkkaus ja muut järjestelmän OSD:t"
+  },
+  "Votes": {
+    "Votes": "Äänet"
+  },
+  "W": {
+    "W": "W"
+  },
+  "WPA/WPA2": {
+    "WPA/WPA2": "WPA/WPA2"
+  },
+  "Wallpaper": {
+    "Wallpaper": "Taustakuva"
+  },
+  "Wallpaper Error": {
+    "Wallpaper Error": "Taustakuvan virhe"
+  },
+  "Wallpaper Monitor": {
+    "Wallpaper Monitor": "Taustakuvan näyttö"
+  },
+  "Wallpaper fill mode": {
+    "Wallpaper fill mode": "Taustakuvan täyttötila"
+  },
+  "Wallpaper processing failed": {
+    "Wallpaper processing failed": "Taustakuvan käsittely epäonnistui"
+  },
+  "Wallpaper processing failed - check wallpaper path": {
+    "Wallpaper processing failed - check wallpaper path": "Taustakuvan käsittely epäonnistui - tarkista taustakuvan polku"
+  },
+  "Wallpapers": {
+    "Wallpapers": "Taustakuvat"
+  },
+  "Warm color temperature to apply": {
+    "Warm color temperature to apply": "Lämmin värilämpötila levitettäväksi"
+  },
+  "Warning": {
+    "Warning": "Varoitus"
+  },
+  "Warnings": {
+    "Warnings": "Varoitukset"
+  },
+  "Wave Progress Bars": {
+    "Wave Progress Bars": "Wave Progress Bars"
+  },
+  "Weather": {
+    "Weather": "Sää"
+  },
+  "Weather Widget": {
+    "Weather Widget": "Sää-widget"
+  },
+  "Web Browser": {
+    "Web Browser": "Web-selain"
+  },
+  "Welcome": {
+    "Welcome": "Tervetuloa"
+  },
+  "Welcome to DankMaterialShell": {
+    "Welcome to DankMaterialShell": "Tervetuloa DankMaterialShell:ään"
+  },
+  "When clicking a dock window in a Hyprland special workspace, bring that special workspace back before focusing the window": {
+    "When clicking a dock window in a Hyprland special workspace, bring that special workspace back before focusing the window": "Kun napsautat telakointiikkunaa Hyprland-erikoistyötilassa, tuo erityinen työtila takaisin ennen ikkunan tarkentamista"
+  },
+  "When enabled, apps are sorted alphabetically. When disabled, apps are sorted by usage frequency.": {
+    "When enabled, apps are sorted alphabetically. When disabled, apps are sorted by usage frequency.": "Kun tämä on käytössä, sovellukset lajitellaan aakkosjärjestyksessä. Kun se ei ole käytössä, sovellukset lajitellaan käyttötiheyden mukaan."
+  },
+  "When enabled, checks updates on startup. When disabled, only the interval above or a manual refresh runs a check.": {
+    "When enabled, checks updates on startup. When disabled, only the interval above or a manual refresh runs a check.": "Kun tämä on käytössä, tarkistaa päivitykset käynnistyksen yhteydessä. Kun se on poistettu käytöstä, vain yllä oleva aikaväli tai manuaalinen päivitys suorittaa tarkistuksen."
+  },
+  "When locked": {
+    "When locked": "Kun lukittu"
+  },
+  "Which PAM service the lock screen uses to authenticate": {
+    "Which PAM service the lock screen uses to authenticate": "Lukitusnäytön todennuksessa käytettävä PAM-palvelu"
+  },
+  "White": {
+    "White": "Valkoinen"
+  },
+  "Wi-Fi and Ethernet connection": {
+    "Wi-Fi and Ethernet connection": "Wi-Fi- ja Ethernet-yhteys"
+  },
+  "Wi-Fi not available": {
+    "Wi-Fi not available": "Wi-Fi ei ole käytettävissä"
+  },
+  "WiFi": {
+    "WiFi": "WiFi"
+  },
+  "WiFi Device": {
+    "WiFi Device": "WiFi-laite"
+  },
+  "WiFi QR code for ": {
+    "WiFi QR code for ": "WiFi QR-koodi"
+  },
+  "WiFi disabled": {
+    "WiFi disabled": "WiFi pois käytöstä"
+  },
+  "WiFi enabled": {
+    "WiFi enabled": "WiFi käytössä"
+  },
+  "WiFi is off": {
+    "WiFi is off": "WiFi on pois päältä"
+  },
+  "WiFi off": {
+    "WiFi off": "WiFi pois päältä"
+  },
+  "Wide (BT2020)": {
+    "Wide (BT2020)": "Leveä (BT2020)"
+  },
+  "Widget Background Color": {
+    "Widget Background Color": "Widgetin taustaväri"
+  },
+  "Widget Management": {
+    "Widget Management": "Widgetien hallinta"
+  },
+  "Widget Opacity": {
+    "Widget Opacity": "Widgetin läpinäkyvyys"
+  },
+  "Widget Outline": {
+    "Widget Outline": "Widgetin ääriviivat"
+  },
+  "Widget Styling": {
+    "Widget Styling": "Widget-tyyli"
+  },
+  "Widget Text Style": {
+    "Widget Text Style": "Widgetin tekstityyli"
+  },
+  "Widget added": {
+    "Widget added": "Widget lisätty"
+  },
+  "Widget removed": {
+    "Widget removed": "Widget poistettu"
+  },
+  "Widgets": {
+    "Widgets": "Widgetit"
+  },
+  "Widgets & Notifications": {
+    "Widgets & Notifications": "Widgetit ja ilmoitukset"
+  },
+  "Widgets, layout, style": {
+    "Widgets, layout, style": "Widgetit, asettelu, tyyli"
+  },
+  "Width": {
+    "Width": "Leveys"
+  },
+  "Width of the border in pixels": {
+    "Width of the border in pixels": "Reunuksen leveys pikseleinä"
+  },
+  "Width of the widget outline in pixels": {
+    "Width of the widget outline in pixels": "Widgetin ääriviivan leveys pikseleinä"
+  },
+  "Width of window border": {
+    "Width of window border": "Ikkunan reunan leveys"
+  },
+  "Width of window border and focus ring": {
+    "Width of window border and focus ring": "Ikkunan reunan ja tarkennusrenkaan leveys"
+  },
+  "Wind": {
+    "Wind": "Tuuli"
+  },
+  "Wind Speed": {
+    "Wind Speed": "Tuulen nopeus"
+  },
+  "Wind Speed in m/s": {
+    "Wind Speed in m/s": "Tuulen nopeus m/s"
+  },
+  "Window Corner Radius": {
+    "Window Corner Radius": "Ikkunan kulman säde"
+  },
+  "Window Gaps": {
+    "Window Gaps": "Ikkunavälit"
+  },
+  "Window Gaps (px)": {
+    "Window Gaps (px)": "Ikkunavälit (px)"
+  },
+  "Window Height": {
+    "Window Height": "Ikkunan korkeus"
+  },
+  "Window Opening": {
+    "Window Opening": "Ikkunan avaaminen"
+  },
+  "Window Rules": {
+    "Window Rules": "Ikkunan säännöt"
+  },
+  "Wipe": {
+    "Wipe": "Pyyhi"
+  },
+  "Working...": {
+    "Working...": "Työskentelee..."
+  },
+  "Workspace": {
+    "Workspace": "Työtila"
+  },
+  "Workspace Index Numbers": {
+    "Workspace Index Numbers": "Työtilan indeksinumerot"
+  },
+  "Workspace Names": {
+    "Workspace Names": "Työtilojen nimet"
+  },
+  "Workspace Padding": {
+    "Workspace Padding": "Työtilan täyte"
+  },
+  "Workspace Switcher": {
+    "Workspace Switcher": "Työtilan vaihtaja"
+  },
+  "Workspace name": {
+    "Workspace name": "Työtilan nimi"
+  },
+  "Workspaces": {
+    "Workspaces": "Työtilat"
+  },
+  "Wrap the app command. %command% is replaced with the actual executable": {
+    "Wrap the app command. %command% is replaced with the actual executable": "Kääri sovelluskomento. %command% korvataan varsinaisella suoritettavalla tiedostolla"
+  },
+  "Write:": {
+    "Write:": "Kirjoita:"
+  },
+  "X": {
+    "X": "X"
+  },
+  "X Axis": {
+    "X Axis": "X-akseli"
+  },
+  "X-Ray": {
+    "X-Ray": "Röntgen"
+  },
+  "XWayland": {
+    "XWayland": "XWayland"
+  },
+  "Xray Blur Effect": {
+    "Xray Blur Effect": "Röntgensumutusefekti"
+  },
+  "Xray blurs only the wallpaper (efficient) and is the default when Blur is on. Set Xray to Off for regular full blur of everything beneath the window (more expensive).": {
+    "Xray blurs only the wallpaper (efficient) and is the default when Blur is on. Set Xray to Off for regular full blur of everything beneath the window (more expensive).": "Röntgensäde sumentaa vain taustakuvaa (tehokas) ja on oletusarvo, kun Blur on käytössä. Aseta Xray pois päältä saadaksesi kaiken ikkunan alla olevan sumennuksen normaalisti (kalliimpi)."
+  },
+  "Xray options are in Compositor → Layout": {
+    "Xray options are in Compositor → Layout": "Röntgenasetukset ovat kohdassa Compositor → Layout"
+  },
+  "Y": {
+    "Y": "Y"
+  },
+  "Y Axis": {
+    "Y Axis": "Y-akseli"
+  },
+  "Yes": {
+    "Yes": "Kyllä"
+  },
+  "Yesterday": {
+    "Yesterday": "eilen"
+  },
+  "You have unsaved changes. Save before continuing?": {
+    "You have unsaved changes. Save before continuing?": "Sinulla on tallentamattomia muutoksia. Tallennetaanko ennen jatkamista?"
+  },
+  "You need to set either:\nQT_QPA_PLATFORMTHEME=gtk3 OR\nQT_QPA_PLATFORMTHEME=qt6ct\nas environment variables, and then restart the shell.\n\nqt6ct requires qt6ct-kde to be installed.": {
+    "You need to set either:\nQT_QPA_PLATFORMTHEME=gtk3 OR\nQT_QPA_PLATFORMTHEME=qt6ct\nas environment variables, and then restart the shell.\n\nqt6ct requires qt6ct-kde to be installed.": "Sinun on asetettava jompikumpi:\nQT_QPA_PLATFORMTHEME=gtk3 TAI\nQT_QPA_PLATFORMTHEME=qt6ct\nympäristömuuttujina ja käynnistä sitten komentotulkki uudelleen.\n\nqt6ct vaatii qt6ct-kde:n asennuksen."
+  },
+  "You'll enter your password at the greeter after the next reboot.": {
+    "You'll enter your password at the greeter after the next reboot.": "Syötät salasanasi tervehdykseen seuraavan uudelleenkäynnistyksen jälkeen."
+  },
+  "You'll skip the greeter password after the next reboot. The lock screen and signing out still require your password.": {
+    "You'll skip the greeter password after the next reboot. The lock screen and signing out still require your password.": "Ohitat tervehdyssalasanan seuraavan uudelleenkäynnistyksen jälkeen. Lukitusnäyttö ja uloskirjautuminen vaativat silti salasanasi."
+  },
+  "You're All Set!": {
+    "You're All Set!": "Kaikki on valmista!"
+  },
+  "Your compositor does not support background blur (ext-background-effect-v1)": {
+    "Your compositor does not support background blur (ext-background-effect-v1)": "Säveltäjäsi ei tue taustan sumennusta (ext-background-effect-v1)"
+  },
+  "Your system is up to date!": {
+    "Your system is up to date!": "Järjestelmäsi on ajan tasalla!"
+  },
+  "admin": {
+    "admin": "järjestelmänvalvoja"
+  },
+  "attached": {
+    "attached": "liitteenä"
+  },
+  "brandon": {
+    "brandon": "brandon"
+  },
+  "broken": {
+    "broken": "rikki"
+  },
+  "by %1": {
+    "by %1": "tekijä: %1"
+  },
+  "checked %1d ago": {
+    "checked %1d ago": "tarkistettu %1d sitten"
+  },
+  "checked %1h ago": {
+    "checked %1h ago": "tarkastettu %1h sitten"
+  },
+  "checked %1m ago": {
+    "checked %1m ago": "tarkistettu %1m sitten"
+  },
+  "checked just now": {
+    "checked just now": "tarkastettu juuri nyt"
+  },
+  "days": {
+    "days": "päivää"
+  },
+  "deprecated": {
+    "deprecated": "poistettu käytöstä"
+  },
+  "detached": {
+    "detached": "irrotettu"
+  },
+  "device": {
+    "device": "laite"
+  },
+  "dgop not available": {
+    "dgop not available": "dgop ei ole saatavilla"
+  },
+  "direct": {
+    "direct": "suoraan"
+  },
+  "discuss": {
+    "discuss": "keskustella"
+  },
+  "display rotation option": {
+    "Normal": "Normaali"
+  },
+  "dms is a highly customizable, modern desktop shell with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": {
+    "dms is a highly customizable, modern desktop shell with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": "dms on erittäin mukautettava moderni työpöytäkuori, jonka ulkoasu on <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">Material 3:n inspiroima</a>.<br /><br/>Se on toteutettu <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshellillä</a>, joka on työpöytäkuorten rakentamiseen tarkoitettu QT6-kehys, sekä staattisesti tyypitetyllä ja käännettävällä <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>-ohjelmointikielellä."
+  },
+  "e.g. /usr/bin/my-script --flag": {
+    "e.g. /usr/bin/my-script --flag": "esim. /usr/bin/my-script --lippu"
+  },
+  "e.g. My Script": {
+    "e.g. My Script": "esim. Minun Script"
+  },
+  "e.g. alice": {
+    "e.g. alice": "esim. alice"
+  },
+  "e.g., firefox, kitty --title foo": {
+    "e.g., firefox, kitty --title foo": "esim. firefox, kitty --title foo"
+  },
+  "e.g., focus-workspace 3, resize-column -10": {
+    "e.g., focus-workspace 3, resize-column -10": "esim. tarkennus-työtila 3, kokoa-sarake -10"
+  },
+  "e.g., hl.dsp.focus({ workspace = \"3\" })": {
+    "e.g., hl.dsp.focus({ workspace = \"3\" })": "esim. hl.dsp.focus({ työtila = \"3\" })"
+  },
+  "e.g., notify-send 'Hello' && sleep 1": {
+    "e.g., notify-send 'Hello' && sleep 1": "esim. ilmoitus-lähetä 'Hei' && nukkua 1"
+  },
+  "e.g., scratch, /^tmp_.*/, build": {
+    "e.g., scratch, /^tmp_.*/, build": "esim. scratch, /^tmp_.*/, rakentaa"
+  },
+  "ext": {
+    "ext": "ext"
+  },
+  "featured": {
+    "featured": "esillä"
+  },
+  "khal": {
+    "khal": "khal"
+  },
+  "last seen %1": {
+    "last seen %1": "viimeksi nähty %1"
+  },
+  "leave empty for default": {
+    "leave empty for default": "jätä tyhjäksi oletuksena"
+  },
+  "loginctl activate failed (exit %1)": {
+    "loginctl activate failed (exit %1)": "loginctl-aktivointi epäonnistui (poistu %1)"
+  },
+  "loginctl not available - lock integration requires DMS socket connection": {
+    "loginctl not available - lock integration requires DMS socket connection": "loginctl ei ole käytettävissä - lukon integrointi vaatii DMS-pistokeyhteyden"
+  },
+  "mango: config reloaded": {
+    "mango: config reloaded": "mango: konfiguraatio ladattu uudelleen"
+  },
+  "mango: failed to reload config": {
+    "mango: failed to reload config": "mango: asetusten uudelleenlataus epäonnistui"
+  },
+  "mangowc Discord Server": {
+    "mangowc Discord Server": "mangowc Discord-palvelin"
+  },
+  "mangowc GitHub": {
+    "mangowc GitHub": "mangowc GitHub"
+  },
+  "matugen not available or disabled - cannot apply %1 colors": {
+    "matugen not available or disabled - cannot apply %1 colors": "matugen ei ole saatavilla tai se on poistettu käytöstä – %1-värejä ei voi ottaa käyttöön"
+  },
+  "matugen not found - install matugen package for dynamic theming": {
+    "matugen not found - install matugen package for dynamic theming": "matugen ei löydy - asenna matugen-paketti dynaamista teemaa varten"
+  },
+  "minutes": {
+    "minutes": "minuuttia"
+  },
+  "ms": {
+    "ms": "ms"
+  },
+  "nav": {
+    "nav": "nav"
+  },
+  "network security type": {
+    "Open": "Avaa"
+  },
+  "niri GitHub": {
+    "niri GitHub": "niri GitHub"
+  },
+  "niri Matrix Chat": {
+    "niri Matrix Chat": "niri Matrix Chat"
+  },
+  "niri shortcuts config": {
+    "niri shortcuts config": "niri pikakuvakkeet config"
+  },
+  "niri/dms Discord": {
+    "niri/dms Discord": "niri/dms Discord"
+  },
+  "niri: config reloaded": {
+    "niri: config reloaded": "niri: konfiguraatio ladattu uudelleen"
+  },
+  "niri: failed to load config": {
+    "niri: failed to load config": "niri: asetusten lataaminen epäonnistui"
+  },
+  "now": {
+    "now": "nyt"
+  },
+  "official": {
+    "official": "virkamies"
+  },
+  "on Hyprland": {
+    "on Hyprland": "Hyprland:ssä"
+  },
+  "on MangoWC": {
+    "on MangoWC": "MangoWC:ssä"
+  },
+  "on Miracle WM": {
+    "on Miracle WM": "Miracle WM:ssä"
+  },
+  "on Niri": {
+    "on Niri": "Niri:ssä"
+  },
+  "on Scroll": {
+    "on Scroll": "Scrollissa"
+  },
+  "on Sway": {
+    "on Sway": "Sway:ssä"
+  },
+  "or run ": {
+    "or run ": "tai juosta"
+  },
+  "power-profiles-daemon not available": {
+    "power-profiles-daemon not available": "power-profiles-daemon ei ole saatavilla"
+  },
+  "primary network connection label": {
+    "Primary": "Ensisijainen"
+  },
+  "procs": {
+    "procs": "pros"
+  },
+  "r/niri Subreddit": {
+    "r/niri Subreddit": "r/niri Subreddit"
+  },
+  "relay: %1": {
+    "relay: %1": "rele: %1"
+  },
+  "remote": {
+    "remote": "kaukosäädin"
+  },
+  "reviewed": {
+    "reviewed": "tarkistettu"
+  },
+  "seconds": {
+    "seconds": "sekuntia"
+  },
+  "session %1": {
+    "session %1": "istunto %1"
+  },
+  "source": {
+    "source": "lähde"
+  },
+  "the Qt 6 Multimedia QML module": {
+    "the Qt 6 Multimedia QML module": "Qt 6 Multimedia QML -moduuli"
+  },
+  "this app": {
+    "this app": "tämä sovellus"
+  },
+  "unmaintained": {
+    "unmaintained": "huoltamaton"
+  },
+  "until %1": {
+    "until %1": "%1 asti"
+  },
+  "up": {
+    "up": "ylös"
+  },
+  "update dms for NM integration.": {
+    "update dms for NM integration.": "päivitä dms NM-integraatiota varten."
+  },
+  "useradd failed (exit %1)": {
+    "useradd failed (exit %1)": "käyttäjän lisäys epäonnistui (poistu %1)"
+  },
+  "userdel failed (exit %1)": {
+    "userdel failed (exit %1)": "userdel epäonnistui (poistu %1)"
+  },
+  "usermod failed (exit %1)": {
+    "usermod failed (exit %1)": "usermod epäonnistui (poistu %1)"
+  },
+  "v%1 by %2": {
+    "v%1 by %2": "v%1, tekijä %2"
+  },
+  "• Install only from trusted sources": {
+    "• Install only from trusted sources": "• Asenna vain luotettavista lähteistä"
+  },
+  "• M - Month (1-12)": {
+    "• M - Month (1-12)": "• K - kuukausi (1-12)"
+  },
+  "• MM - Month (01-12)": {
+    "• MM - Month (01-12)": "• MM - kuukausi (01-12)"
+  },
+  "• MMM - Month (Jan)": {
+    "• MMM - Month (Jan)": "• MMM – kuukausi (tammikuu)"
+  },
+  "• MMMM - Month (January)": {
+    "• MMMM - Month (January)": "• MMMM – kuukausi (tammikuu)"
+  },
+  "• Plugins may contain bugs or security issues": {
+    "• Plugins may contain bugs or security issues": "• Laajennukset voivat sisältää virheitä tai tietoturvaongelmia"
+  },
+  "• Review code before installation when possible": {
+    "• Review code before installation when possible": "• Tarkista koodi ennen asennusta, jos mahdollista"
+  },
+  "• d - Day (1-31)": {
+    "• d - Day (1-31)": "• d - päivä (1-31)"
+  },
+  "• dd - Day (01-31)": {
+    "• dd - Day (01-31)": "• dd - päivä (01-31)"
+  },
+  "• ddd - Day name (Mon)": {
+    "• ddd - Day name (Mon)": "• ddd - päivän nimi (ma)"
+  },
+  "• dddd - Day name (Monday)": {
+    "• dddd - Day name (Monday)": "• dddd - päivän nimi (maanantai)"
+  },
+  "• yy - Year (24)": {
+    "• yy - Year (24)": "• vv - vuosi (24)"
+  },
+  "• yyyy - Year (2024)": {
+    "• yyyy - Year (2024)": "• yyyy - vuosi (2024)"
+  },
+  "↑/↓: Nav • Space: Expand • Enter: Action/Expand • E: Text": {
+    "↑/↓: Nav • Space: Expand • Enter: Action/Expand • E: Text": "↑/↓: Nav • Välilyönti: Laajenna • Enter: Toiminto/Laajenna • E: Teksti"
+  },
+  "↑/↓: Navigate • Enter/Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": {
+    "↑/↓: Navigate • Enter/Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": "↑/↓: Navigoi • Enter/Ctrl+C: Kopioi • Del: Poista • Ctrl+E: Muokkaa • Ctrl+S: Kiinnitä/irrota • F10: Ohje"
+  },
+  "↑/↓: Navigate • Enter: Paste • Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": {
+    "↑/↓: Navigate • Enter: Paste • Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": "↑/↓: Navigoi • Enter: Liitä • Ctrl+C: Kopioi • Del: Poista • Ctrl+E: Muokkaa • Ctrl+S: Kiinnitä/Poista kiinnitys • F10: Ohje"
+  }
+}


### PR DESCRIPTION
## What changed

- add a Finnish (`fi`) translation covering all 3,004 current translation contexts
- register Finnish in the POEditor synchronization language map

## Why

DankMaterialShell does not currently ship a Finnish interface translation. Adding `fi.json` also makes Finnish available in both the interface locale and time/date locale selectors.

## Translation status

This is a machine-assisted initial translation. The most visible shell, settings, locale, time, and date terminology was manually reviewed, but the PR is intentionally a draft so native-speaker and maintainer review can refine wording before merge.

## Validation

- verified an exact match with all 3,004 context/term pairs in `template.json`
- verified no missing, extra, or empty translations
- verified all `%1`-style placeholders are preserved
- parsed `fi.json` with Python's JSON parser
- ran `check_term_variants.py`
- ran `git diff --check`
- tested the translation locally on DMS 1.5.1 with `fi_FI.UTF-8`
