### PR TITLE
systemlogo: Add Zirconium

### DIFF
--- a/quickshell/Widgets/SystemLogo.qml
+++ b/quickshell/Widgets/SystemLogo.qml
@@ -70,6 +70,10 @@ Item {
                     iconImage.source = "file:///run/current-system/profile/share/icons/hicolor/scalable/apps/guix-icon.svg"
                     return
                 }
+                if (logo === "zirconium") {
+                    iconImage.source = "file:///usr/share/zirconium/pixmaps/logo-z.svg"
+                    return
+                }
                 iconImage.source = Quickshell.iconPath(logo, true)
             }, 0)
         }, 0)


### PR DESCRIPTION
## Description

<!-- What does this PR do and why? -->

This adds support for [Zirconium](https://zirconium.gay)'s system logo. DMS currently uses Fedora's logo, or in the case of [Zirconium Hawaii](https://github.com/zirconium-dev/zirconium-hawaii), shows no logo at all.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

<img width="257" height="83" alt="image" src="https://github.com/user-attachments/assets/4da0bfcd-3b26-4c53-9f43-fe51db7a921a" />
<img width="213" height="90" alt="image" src="https://github.com/user-attachments/assets/b26449af-5aa5-4cb0-bb1f-124f24f596c1" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
