### PR TITLE
Fix(spotlight): improve file search query restoration and mode switching

### DIFF
--- a/quickshell/Modals/DankLauncherV2/Controller.qml
+++ b/quickshell/Modals/DankLauncherV2/Controller.qml
@@ -461,6 +461,10 @@ Item {
             if (explicitType !== null && SessionData.launcherLastFileSearchType !== explicitType) {
                 SessionData.setLauncherLastFileSearchType(explicitType);
             }
+        } else {
+            if (searchMode === "files") {
+                restorePreviousMode();
+            }
         }
 
         var filesInAll = searchMode === "all" && (SettingsData.dankLauncherV2IncludeFilesInAll || SettingsData.dankLauncherV2IncludeFoldersInAll);

--- a/quickshell/Modals/DankLauncherV2/Controller.qml
+++ b/quickshell/Modals/DankLauncherV2/Controller.qml
@@ -449,6 +449,11 @@ Item {
         searchQuery = query;
         requestSearch();
 
+        if (autoSwitchedToFiles && !query.startsWith("/")) {
+            restorePreviousMode();
+            return;
+        }
+
         if (query.startsWith("/")) {
             var prefix = Utils.parseFileSearchPrefix(query);
             var explicitType = prefix && prefix.type !== null ? prefix.type : null;
@@ -460,10 +465,6 @@ Item {
             }
             if (explicitType !== null && SessionData.launcherLastFileSearchType !== explicitType) {
                 SessionData.setLauncherLastFileSearchType(explicitType);
-            }
-        } else {
-            if (searchMode === "files") {
-                restorePreviousMode();
             }
         }
 

--- a/quickshell/Modals/DankLauncherV2/Controller.qml
+++ b/quickshell/Modals/DankLauncherV2/Controller.qml
@@ -449,7 +449,7 @@ Item {
         searchQuery = query;
         requestSearch();
 
-        if (searchMode !== "plugins" && query.startsWith("/")) {
+        if (query.startsWith("/")) {
             var prefix = Utils.parseFileSearchPrefix(query);
             var explicitType = prefix && prefix.type !== null ? prefix.type : null;
             var targetType = explicitType !== null ? explicitType : (SessionData.launcherLastFileSearchType || "all");

--- a/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalStandalone.qml
+++ b/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalStandalone.qml
@@ -174,9 +174,12 @@ Item {
             spotlightContent.controller.selectedFlatIndex = 0;
             spotlightContent.controller.selectedItem = null;
             spotlightContent.controller.historyIndex = -1;
-            spotlightContent.controller.searchQuery = targetQuery;
-
-            spotlightContent.controller.performSearch();
+            if (targetQuery) {
+                spotlightContent.controller.setSearchQuery(targetQuery);
+            } else {
+                spotlightContent.controller.searchQuery = "";
+                spotlightContent.controller.performSearch();
+            }
         }
         if (spotlightContent.resetScroll) {
             spotlightContent.resetScroll();

--- a/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalStandalone.qml
+++ b/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalStandalone.qml
@@ -274,7 +274,7 @@ Item {
         target: spotlightContent?.controller ?? null
 
         function onModeChanged(mode, userInitiated) {
-            if (!userInitiated || !SettingsData.rememberLastMode || (mode !== "all" && mode !== "apps"))
+            if (!userInitiated || !SettingsData.rememberLastMode)
                 return;
             SessionData.setLauncherLastMode(mode);
         }


### PR DESCRIPTION
## Description

- **Fix empty results on query restore:** fix(spotlight): fix empty results on restoring last file search query.
- **Proper mode restoration:** Ensures the last selected mode (tab) is correctly restored upon launch when the setting is enabled.
- **File trigger in plugins mode:** Allows the `/` file search trigger in the plugins tab.
- **Clear `/` prefix behavior:** Prevents the launcher from getting stuck in "files" mode when the `/` prefix is deleted, now correctly reverting to the "All" tab or remembered mode(tab).

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor / internal cleanup

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] QML changes: ran `make lint-qml` with no new warnings
