### PR TITLE
fix(slideout): yield keyboard focus when modal is open on same screen

### DIFF
--- a/quickshell/Common/ModalManager.qml
+++ b/quickshell/Common/ModalManager.qml
@@ -15,7 +15,11 @@ Singleton {
     function openModal(modal) {
         PopoutManager.screenshotActive = false;
         const screenName = modal.effectiveScreen?.name ?? "unknown";
-        currentModalsByScreen[screenName] = modal;
+        var next = {};
+        for (var k in currentModalsByScreen)
+            next[k] = currentModalsByScreen[k];
+        next[screenName] = modal;
+        currentModalsByScreen = next;
         modalChanged();
         Qt.callLater(() => {
             if (!modal.allowStacking)
@@ -34,7 +38,12 @@ Singleton {
     function closeModal(modal) {
         const screenName = modal.effectiveScreen?.name ?? "unknown";
         if (currentModalsByScreen[screenName] === modal) {
-            delete currentModalsByScreen[screenName];
+            var next = {};
+            for (var k in currentModalsByScreen) {
+                if (k !== screenName)
+                    next[k] = currentModalsByScreen[k];
+            }
+            currentModalsByScreen = next;
             modalChanged();
         }
     }

--- a/quickshell/Widgets/DankSlideout.qml
+++ b/quickshell/Widgets/DankSlideout.qml
@@ -105,9 +105,11 @@ PanelWindow {
 
     readonly property bool slideoutBlurActive: root.visible && BlurService.enabled && Theme.connectedSurfaceBlurEnabled
 
+    readonly property string _slideoutScreenName: modelData?.name ?? ""
+
     WlrLayershell.layer: (!suppressOverlayLayer && (triggerUsesOverlayLayer || CompositorService.framePeerSurfacesUseOverlayForScreen(modelData))) ? WlrLayershell.Overlay : WlrLayershell.Top
     WlrLayershell.exclusiveZone: 0
-    WlrLayershell.keyboardFocus: isVisible ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
+    WlrLayershell.keyboardFocus: isVisible && !ModalManager.currentModalsByScreen[_slideoutScreenName] ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
 
     readonly property real dpr: CompositorService.getScreenScale(root.screen)
     readonly property real alignedWidth: Theme.px(expandable && expandedWidth ? expandedWidthValue : slideoutWidth, dpr)


### PR DESCRIPTION
## Description
Fix keyboard focus being stolen by Notepad (slideout) when Launcher is opened after it.

**Root cause:** `DankSlideout` always held `WlrKeyboardFocus.OnDemand` regardless of modals. When Launcher opened (also requesting keyboard focus), the Wayland compositor had no clear priority between the two surfaces, leaving focus on the slideout.

**Fix:**
- `ModalManager.qml` — Made `currentModalsByScreen` reactive (clone object on mutation) so QML bindings re-evaluate when modals open/close
- `DankSlideout.qml` — Yields keyboard focus (`None`) when a modal is active on the same screen, allowing the Launcher (or any modal) to claim focus exclusively

**Known limitation:** When the launcher closes, keyboard focus does not automatically return to the Notepad slideout.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues
_(none)_

## Screenshots / video
_(N/A — keyboard focus behavior, no visual change)_

## Checklist
- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs