### PR TITLE
Add live network speed to Control Center and DankBar

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -15,7 +15,7 @@ Singleton {
     id: root
     readonly property var log: Log.scoped("SettingsData")
 
-    readonly property int settingsConfigVersion: 12
+    readonly property int settingsConfigVersion: 13
 
     enum Position {
         Top,
@@ -990,7 +990,7 @@ Singleton {
             "showOnLastDisplay": true,
             "leftWidgets": ["launcherButton", "workspaceSwitcher", "focusedWindow"],
             "centerWidgets": ["music", "clock", "weather"],
-            "rightWidgets": ["systemTray", "clipboard", "cpuUsage", "memUsage", "notificationButton", "battery", "controlCenterButton"],
+            "rightWidgets": ["systemTray", "clipboard", "cpuUsage", "memUsage", "network_speed_monitor", "notificationButton", "battery", "controlCenterButton"],
             "spacing": 4,
             "innerPadding": 4,
             "barInsetPadding": -1,

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -550,7 +550,7 @@ var SPEC = {
             showOnLastDisplay: true,
             leftWidgets: ["launcherButton", "workspaceSwitcher", "focusedWindow"],
             centerWidgets: ["music", "clock", "weather"],
-            rightWidgets: ["systemTray", "clipboard", "cpuUsage", "memUsage", "notificationButton", "battery", "controlCenterButton"],
+            rightWidgets: ["systemTray", "clipboard", "cpuUsage", "memUsage", "network_speed_monitor", "notificationButton", "battery", "controlCenterButton"],
             spacing: 4,
             innerPadding: 4,
             bottomGap: 0,

--- a/quickshell/Common/settings/SettingsStore.js
+++ b/quickshell/Common/settings/SettingsStore.js
@@ -263,6 +263,20 @@ function migrateToVersion(obj, targetVersion) {
         settings.configVersion = 12;
     }
 
+    if (currentVersion < 13) {
+        console.info("Migrating settings from version", currentVersion, "to version 13");
+        if (Array.isArray(settings.barConfigs)) {
+            for (var b = 0; b < settings.barConfigs.length; b++) {
+                var rc = settings.barConfigs[b].rightWidgets;
+                if (Array.isArray(rc) && rc.indexOf("network_speed_monitor") < 0) {
+                    var memIdx = rc.indexOf("memUsage");
+                    rc.splice(memIdx >= 0 ? memIdx + 1 : rc.length, 0, "network_speed_monitor");
+                }
+            }
+        }
+        settings.configVersion = 13;
+    }
+
     return settings;
 }
 

--- a/quickshell/Modules/ControlCenter/Details/NetworkDetail.qml
+++ b/quickshell/Modules/ControlCenter/Details/NetworkDetail.qml
@@ -28,12 +28,33 @@ Rectangle {
     border.color: Theme.outlineMedium
     border.width: Theme.layerOutlineWidth
 
+    function formatSpeed(bytesPerSec) {
+        if (bytesPerSec < 1024) {
+            return bytesPerSec.toFixed(0) + " B/s";
+        } else if (bytesPerSec < 1024 * 1024) {
+            return (bytesPerSec / 1024).toFixed(1) + " KB/s";
+        } else if (bytesPerSec < 1024 * 1024 * 1024) {
+            return (bytesPerSec / (1024 * 1024)).toFixed(1) + " MB/s";
+        } else {
+            return (bytesPerSec / (1024 * 1024 * 1024)).toFixed(1) + " GB/s";
+        }
+    }
+
+    function formatSpeedPair() {
+        return "\u2193" + formatSpeed(DgopService.networkRxRate) + " \u2191" + formatSpeed(DgopService.networkTxRate);
+    }
+
+    readonly property bool wifiCarriesTraffic: NetworkService.networkStatus === "wifi" || (NetworkService.networkStatus === "vpn" && NetworkService.wifiConnected && !NetworkService.ethernetConnected)
+    readonly property bool ethernetCarriesTraffic: NetworkService.networkStatus === "ethernet" || (NetworkService.networkStatus === "vpn" && NetworkService.ethernetConnected)
+
     Component.onCompleted: {
         NetworkService.addRef();
+        DgopService.addRef(["network"]);
     }
 
     Component.onDestruction: {
         NetworkService.removeRef();
+        DgopService.removeRef(["network"]);
     }
 
     property bool hasEthernetAvailable: (NetworkService.ethernetDevices?.length ?? 0) > 0
@@ -537,6 +558,13 @@ Rectangle {
                                 elide: Text.ElideRight
                                 width: parent.width
                             }
+
+                            StyledText {
+                                text: formatSpeedPair()
+                                font.pixelSize: Theme.fontSizeSmall
+                                color: Theme.primary
+                                visible: wiredDelegate.isActive && root.ethernetCarriesTraffic
+                            }
                         }
                     }
 
@@ -837,6 +865,13 @@ Rectangle {
                             text: (modelData.saved ? "\u2022 " : "") + wifiDelegate.signalStrength + "%"
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceVariantText
+                        }
+
+                        StyledText {
+                            text: "\u2022 " + formatSpeedPair()
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.primary
+                            visible: wifiDelegate.isConnected && root.wifiCarriesTraffic
                         }
                     }
                 }


### PR DESCRIPTION
## Description

Includes live network speed (↓/↑) in the wired/WiFi delegates in the network details pane of the Control Center, fetching directly from the `DgopService` speeds. Also provides the existing `NetworkMonitor` bar widget out-of-the-box for new/upgrading users (v13 migration).

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

None

## Screenshots / video

<img width="381" height="39" alt="image" src="https://github.com/user-attachments/assets/61bb3e98-f4f1-4711-bc4c-66b34bc1dee0" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
