### PR TITLE
fix(lock): hold sleep inhibitor until compositor confirms lock

### DIFF
--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -36,6 +36,7 @@ Item {
     property int hyprlandLayoutCount: 0
     property bool lockerReadySent: false
     property bool lockerReadyArmed: false
+    property var sessionLock: null
     readonly property bool hasCustomWallpaper: SettingsData.lockScreenWallpaperPath !== ""
     readonly property string lockFontFamily: SettingsData.lockScreenFontFamily
 
@@ -134,10 +135,25 @@ Item {
             return;
         if (!root.visible || root.opacity <= 0)
             return;
+        // Don't report ready until the compositor has confirmed the session is
+        // locked (ext-session-lock `locked` event). Qt's afterRendering fires
+        // before the lock surface is committed/presented, so releasing the sleep
+        // inhibitor on it lets the machine freeze with the desktop still on screen,
+        // which then flashes on resume. secure=true guarantees the desktop is hidden.
+        if (root.sessionLock && !root.sessionLock.secure)
+            return;
         Qt.callLater(() => {
             if (root.visible && root.opacity > 0 && !root.unlocking)
                 sendLockerReadyOnce();
         });
+    }
+
+    Connections {
+        target: root.sessionLock
+        enabled: target !== null
+        function onSecureChanged() {
+            root.maybeSend();
+        }
     }
 
     Connections {

--- a/quickshell/Modules/Lock/LockSurface.qml
+++ b/quickshell/Modules/Lock/LockSurface.qml
@@ -33,6 +33,7 @@ FocusScope {
 
         anchors.fill: parent
         demoMode: false
+        sessionLock: root.lock
         pam: root.pam
         passwordBuffer: root.sharedPasswordBuffer
         screenName: root.screenName


### PR DESCRIPTION
Fixes #2906.

### Problem

`lock before suspend` releases the logind sleep **delay** inhibitor as soon as Qt reports the lock rendered (`onAfterAnimating` / `onAfterRendering` in `LockScreenContent.qml`). Those signals fire when Qt finishes its render pass — before the compositor has committed/presented the `ext-session-lock` surface. The machine then freezes ~1 frame later with the desktop still the last presented frame, and on resume the desktop is briefly visible before the lock appears (suspend and hibernate alike).

Measured on niri / s2idle (3 outputs): `lockerReady` was sent **18 ms** before `PM: suspend entry`. The handshake and fallback logic in `core/internal/server/loginctl/monitor.go` are correct — only the readiness signal was too early.

### Change

Gate `lockerReady` on `WlSessionLock.secure` — the `ext-session-lock` `locked` event, i.e. the compositor's own confirmation that the session is locked and the desktop is hidden:

- `LockSurface.qml` passes the `WlSessionLock` down to the content as `sessionLock`.
- `LockScreenContent.qml` `maybeSend()` returns early while `sessionLock && !sessionLock.secure`, and a `Connections { onSecureChanged }` re-fires the check when the compositor confirms the lock.

The Go-side 2–4 s fallback timer is unchanged as the backstop. When no lock object is present (e.g. demo mode) behavior is unchanged.

### Testing

Built as an external shell dir (`dms run -c`) on the reporter's machine (niri, s2idle, 3 outputs), same build otherwise:

- **Before:** desktop flashes on resume every cycle; `lockerReady` sent 18 ms before `PM: suspend entry`.
- **After:** no flash on resume, suspend and hibernate.

### Note

With multiple outputs, the Go side releases the inhibitor on the _first_ of the N per-output `lockerReady` calls (`handlers.go` `handleLockerReady`). Not the cause here (all outputs reported within the same ms), but flagging it as a possible secondary race for a follow-up.
