### PR TITLE
Add option to ignore app-requested notification timeout

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -916,6 +916,7 @@ Singleton {
     property int notificationTimeoutLow: 5000
     property int notificationTimeoutNormal: 5000
     property int notificationTimeoutCritical: 0
+    property bool notificationIgnoreAppTimeout: false
     property bool notificationCompactMode: false
     property bool notificationShowTimeoutBar: false
     property bool notificationDedupeEnabled: true

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -477,6 +477,7 @@ var SPEC = {
     notificationTimeoutLow: { def: 5000 },
     notificationTimeoutNormal: { def: 5000 },
     notificationTimeoutCritical: { def: 0 },
+    notificationIgnoreAppTimeout: { def: false },
     notificationCompactMode: { def: false },
     notificationShowTimeoutBar: { def: false },
     notificationDedupeEnabled: { def: true },

--- a/quickshell/Modules/Settings/NotificationsTab.qml
+++ b/quickshell/Modules/Settings/NotificationsTab.qml
@@ -844,6 +844,15 @@ Item {
                         }
                     }
                 }
+
+                SettingsToggleRow {
+                    settingKey: "notificationIgnoreAppTimeout"
+                    tags: ["notification", "timeout", "expire", "app", "override", "duration"]
+                    text: I18n.tr("Ignore App-Requested Timeout")
+                    description: I18n.tr("Always use the durations above, even if an app requests a shorter or longer one")
+                    checked: SettingsData.notificationIgnoreAppTimeout
+                    onToggled: checked => SettingsData.set("notificationIgnoreAppTimeout", checked)
+                }
             }
 
             SettingsCard {

--- a/quickshell/Services/NotificationService.qml
+++ b/quickshell/Services/NotificationService.qml
@@ -777,7 +777,7 @@ Singleton {
                     return 5000;
                 // expireTimeout is in milliseconds; -1 defers to our settings.
                 const appTimeout = wrapper.notification.expireTimeout;
-                if (appTimeout >= 0)
+                if (appTimeout >= 0 && !SettingsData.notificationIgnoreAppTimeout)
                     return Math.round(appTimeout);
                 switch (wrapper.urgency) {
                 case NotificationUrgency.Low:

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -6123,6 +6123,34 @@
     "description": "Save dismissed notifications to history"
   },
   {
+    "section": "notificationIgnoreAppTimeout",
+    "label": "Ignore App-Requested Timeout",
+    "tabIndex": 17,
+    "category": "Notifications",
+    "keywords": [
+      "above",
+      "alerts",
+      "always",
+      "app",
+      "duration",
+      "durations",
+      "even",
+      "expire",
+      "ignore",
+      "longer",
+      "messages",
+      "notification",
+      "notifications",
+      "override",
+      "requested",
+      "requests",
+      "shorter",
+      "timeout",
+      "toast"
+    ],
+    "description": "Always use the durations above, even if an app requests a shorter or longer one"
+  },
+  {
     "section": "lockScreenNotifications",
     "label": "Lock Screen",
     "tabIndex": 17,
@@ -6515,18 +6543,26 @@
     "tabIndex": 17,
     "category": "Notifications",
     "keywords": [
+      "above",
       "alerts",
+      "always",
       "duration",
+      "durations",
+      "even",
+      "longer",
       "low",
       "messages",
       "notification",
       "notifications",
       "priority",
+      "requests",
+      "shorter",
       "timeout",
       "timeouts",
       "toast"
     ],
-    "icon": "timer"
+    "icon": "timer",
+    "description": "Always use the durations above, even if an app requests a shorter or longer one"
   },
   {
     "section": "osdAlwaysShowValue",


### PR DESCRIPTION
Closes #2908

## Summary
- Adds `notificationIgnoreAppTimeout` setting (default `false`, preserving current spec-compliant behavior) that, when enabled, always uses the configured Low/Normal/Critical durations instead of a notifying app's `expireTimeout` hint.
- Exposes it as a toggle in Settings → Notifications → Timeouts, right below the Critical Priority duration.
- Registers the new key in `SettingsSpec.js` and regenerates `settings_search_index.json`.

## Why
`NotificationService.qml`'s timer-interval logic gives any app-supplied `expireTimeout >= 0` absolute priority over the user's configured timeout. That's spec-compliant, but from a user's perspective popups can seem to vanish faster (or slower) than configured, with zero interaction involved, depending on which app sent the notification. This setting lets users opt into forcing their own durations.

## Test plan
- [x] Ran a local `dms run --config` build with the change; toggle appears under Settings → Notifications → Timeouts and persists via `SettingsData.set`.
- [x] Verified enabling the toggle causes `NotificationService`'s timer interval to fall through to `SettingsData.notificationTimeoutLow/Normal/Critical` instead of the app's `expireTimeout`.
- [x] `python3 quickshell/translations/check_term_freeze.py` — inactive, no issues.
- [x] `python3 quickshell/translations/check_term_variants.py` — no term variants.
- [x] `python3 quickshell/translations/extract_settings_index.py` — regenerated and committed `settings_search_index.json`.