### PR TITLE
feat(settings): add option to suppress config reload toast (#2730)

### DIFF
--- a/quickshell/Common/SessionData.qml
+++ b/quickshell/Common/SessionData.qml
@@ -224,6 +224,7 @@ Singleton {
     property string niriOverviewLastMode: "apps"
     property string settingsSidebarExpandedIds: ","
     property string settingsSidebarCollapsedIds: ","
+    property bool showConfigReloadToast: true
 
     Component.onCompleted: {
         loadSettings();

--- a/quickshell/Common/settings/SessionSpec.js
+++ b/quickshell/Common/settings/SessionSpec.js
@@ -98,7 +98,8 @@ var SPEC = {
     niriOverviewLastMode: { def: "apps" },
 
     settingsSidebarExpandedIds: { def: "," },
-    settingsSidebarCollapsedIds: { def: "," }
+    settingsSidebarCollapsedIds: { def: "," },
+    showConfigReloadToast: { def: true }
 };
 
 function getValidKeys() {

--- a/quickshell/Modules/Settings/CompositorLayoutTab.qml
+++ b/quickshell/Modules/Settings/CompositorLayoutTab.qml
@@ -270,8 +270,8 @@ awk '$1 == "xray" { print FILENAME ":" FNR; exit }' $files 2>/dev/null`;
             SettingsCard {
                 width: parent.width
                 tags: ["compositor", "toast"]
-                title: I18n.tr("Compositor Toasts")
-                settingKey: "compositorToasts"
+                title: I18n.tr("Notifications")
+                settingKey: "compositorNotifications"
                 iconName: "notifications"
                 visible: CompositorService.isNiri || CompositorService.isMango
 

--- a/quickshell/Modules/Settings/CompositorLayoutTab.qml
+++ b/quickshell/Modules/Settings/CompositorLayoutTab.qml
@@ -269,6 +269,24 @@ awk '$1 == "xray" { print FILENAME ":" FNR; exit }' $files 2>/dev/null`;
 
             SettingsCard {
                 width: parent.width
+                tags: ["compositor", "notifications", "toast"]
+                title: I18n.tr("Compositor Notifications")
+                settingKey: "compositorNotifications"
+                iconName: "notifications"
+                visible: CompositorService.isNiri || CompositorService.isMango
+
+                SettingsToggleRow {
+                    tags: ["compositor", "toast", "reload"]
+                    settingKey: "showConfigReloadToast"
+                    text: I18n.tr("Show \"config reloaded\" Toast")
+                    description: I18n.tr("Show a toast when the compositor config is reloaded")
+                    checked: SessionData.showConfigReloadToast
+                    onToggled: checked => SessionData.showConfigReloadToast = checked
+                }
+            }
+
+            SettingsCard {
+                width: parent.width
                 tags: ["niri", "layout", "gaps", "radius", "window", "border"]
                 title: I18n.tr("%1 Layout Overrides").arg("niri")
                 settingKey: "niriLayout"

--- a/quickshell/Modules/Settings/CompositorLayoutTab.qml
+++ b/quickshell/Modules/Settings/CompositorLayoutTab.qml
@@ -269,9 +269,9 @@ awk '$1 == "xray" { print FILENAME ":" FNR; exit }' $files 2>/dev/null`;
 
             SettingsCard {
                 width: parent.width
-                tags: ["compositor", "notifications", "toast"]
-                title: I18n.tr("Compositor Notifications")
-                settingKey: "compositorNotifications"
+                tags: ["compositor", "toast"]
+                title: I18n.tr("Compositor Toasts")
+                settingKey: "compositorToasts"
                 iconName: "notifications"
                 visible: CompositorService.isNiri || CompositorService.isMango
 

--- a/quickshell/Services/MangoService.qml
+++ b/quickshell/Services/MangoService.qml
@@ -473,7 +473,7 @@ Singleton {
     function reloadConfig(showToast, suppressWatch) {
         if (!CompositorService.isMango || !root.available)
             return;
-        const shouldShowToast = showToast !== false;
+        const shouldShowToast = showToast !== false && SessionData.showConfigReloadToast;
         const shouldSuppressWatch = suppressWatch !== false;
         if (shouldSuppressWatch)
             suppressWatchedConfigReloads(1500);

--- a/quickshell/Services/NiriService.qml
+++ b/quickshell/Services/NiriService.qml
@@ -633,7 +633,7 @@ Singleton {
             configGenerationAction.schedule();
         configReloaded();
 
-        if (hasInitialConnection && !suppressConfigToast && !suppressNextConfigToast && !matugenSuppression) {
+        if (hasInitialConnection && !suppressConfigToast && !suppressNextConfigToast && !matugenSuppression && SessionData.showConfigReloadToast) {
             ToastService.showInfo(I18n.tr("niri: config reloaded"), "", "", "niri-config");
         } else if (suppressNextConfigToast) {
             suppressNextConfigToast = false;

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -8872,28 +8872,6 @@
     "description": "Width of window border and focus ring"
   },
   {
-    "section": "compositorToasts",
-    "label": "Compositor Toasts",
-    "tabIndex": 37,
-    "category": "Personalization",
-    "keywords": [
-      "appearance",
-      "compositor",
-      "config",
-      "custom",
-      "customize",
-      "personal",
-      "personalization",
-      "reloaded",
-      "show",
-      "toast",
-      "toasts"
-    ],
-    "icon": "notifications",
-    "description": "Show a toast when the compositor config is reloaded",
-    "conditionKey": "isNiri"
-  },
-  {
     "section": "hyprlandLayoutBarXrayEnabled",
     "label": "Frame Xray",
     "tabIndex": 37,
@@ -9090,6 +9068,32 @@
       "windows"
     ],
     "description": "Space between windows"
+  },
+  {
+    "section": "compositorNotifications",
+    "label": "Notifications",
+    "tabIndex": 37,
+    "category": "Personalization",
+    "keywords": [
+      "alert",
+      "alerts",
+      "appearance",
+      "compositor",
+      "config",
+      "custom",
+      "customize",
+      "notif",
+      "notifications",
+      "notifs",
+      "personal",
+      "personalization",
+      "reloaded",
+      "show",
+      "toast"
+    ],
+    "icon": "notifications",
+    "description": "Show a toast when the compositor config is reloaded",
+    "conditionKey": "isNiri"
   },
   {
     "section": "hyprlandLayoutGapsOutOverride",

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -8872,26 +8872,22 @@
     "description": "Width of window border and focus ring"
   },
   {
-    "section": "compositorNotifications",
-    "label": "Compositor Notifications",
+    "section": "compositorToasts",
+    "label": "Compositor Toasts",
     "tabIndex": 37,
     "category": "Personalization",
     "keywords": [
-      "alert",
-      "alerts",
       "appearance",
       "compositor",
       "config",
       "custom",
       "customize",
-      "notif",
-      "notifications",
-      "notifs",
       "personal",
       "personalization",
       "reloaded",
       "show",
-      "toast"
+      "toast",
+      "toasts"
     ],
     "icon": "notifications",
     "description": "Show a toast when the compositor config is reloaded",

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -8872,6 +8872,32 @@
     "description": "Width of window border and focus ring"
   },
   {
+    "section": "compositorNotifications",
+    "label": "Compositor Notifications",
+    "tabIndex": 37,
+    "category": "Personalization",
+    "keywords": [
+      "alert",
+      "alerts",
+      "appearance",
+      "compositor",
+      "config",
+      "custom",
+      "customize",
+      "notif",
+      "notifications",
+      "notifs",
+      "personal",
+      "personalization",
+      "reloaded",
+      "show",
+      "toast"
+    ],
+    "icon": "notifications",
+    "description": "Show a toast when the compositor config is reloaded",
+    "conditionKey": "isNiri"
+  },
+  {
     "section": "hyprlandLayoutBarXrayEnabled",
     "label": "Frame Xray",
     "tabIndex": 37,
@@ -9279,6 +9305,26 @@
       "windows"
     ],
     "description": "Resize windows by dragging their edges with the mouse"
+  },
+  {
+    "section": "showConfigReloadToast",
+    "label": "Show \\",
+    "tabIndex": 37,
+    "category": "Personalization",
+    "keywords": [
+      "appearance",
+      "compositor",
+      "config",
+      "custom",
+      "customize",
+      "personal",
+      "personalization",
+      "reload",
+      "reloaded",
+      "show",
+      "toast"
+    ],
+    "description": "Show a toast when the compositor config is reloaded"
   },
   {
     "section": "hyprlandLayoutRadiusOverride",


### PR DESCRIPTION
## Description

Add a toggle in Settings → Personalization → Niri/Mango to disable the "config reloaded" info toast for Niri and MangoWC. When disabled, the toast is suppressed on both manual config edits and programmatic reloads.

<img width="550" height="540" alt="image" src="https://github.com/user-attachments/assets/ae7caa54-7c9e-4825-8333-b044d1d3f5b7" />

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

Closes #2730

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs