### PR TITLE
powermenu: support user-defined custom power buttons

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -973,6 +973,7 @@ Singleton {
     property string customPowerActionHibernate: ""
     property string customPowerActionReboot: ""
     property string customPowerActionPowerOff: ""
+    property var customPowerButtons: []
 
     property bool updaterHideWidget: false
     property bool updaterCheckOnStart: false

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -533,6 +533,7 @@ var SPEC = {
     customPowerActionHibernate: { def: "" },
     customPowerActionReboot: { def: "" },
     customPowerActionPowerOff: { def: "" },
+    customPowerButtons: { def: [] },
 
     updaterHideWidget: { def: false },
     updaterCheckOnStart: { def: false },

--- a/quickshell/Modals/PowerMenuModal.qml
+++ b/quickshell/Modals/PowerMenuModal.qml
@@ -129,6 +129,13 @@ DankModal {
             switchUserRequested();
             return;
         }
+        if (action.startsWith("custom:")) {
+            const button = (SettingsData.customPowerButtons || [])[parseInt(action.slice(7), 10)];
+            close();
+            if (button?.command)
+                Quickshell.execDetached(["sh", "-c", button.command]);
+            return;
+        }
         close();
         root.powerActionRequested(action, "", "");
     }
@@ -172,11 +179,12 @@ DankModal {
 
     function updateVisibleActions() {
         const allActions = SettingsData.powerMenuActions || ["reboot", "logout", "poweroff", "lock", "suspend", "restart"];
+        const customButtons = SettingsData.customPowerButtons || [];
         visibleActions = allActions.filter(action => {
             if (action === "hibernate" && !SessionService.hibernateSupported)
                 return false;
             return true;
-        });
+        }).concat(customButtons.map((button, i) => "custom:" + i));
 
         if (!SettingsData.powerMenuGridLayout)
             return;
@@ -216,6 +224,14 @@ DankModal {
     }
 
     function getActionData(action) {
+        if (action.startsWith("custom:")) {
+            const button = (SettingsData.customPowerButtons || [])[parseInt(action.slice(7), 10)];
+            return {
+                "icon": button?.icon || "terminal",
+                "label": button?.label || button?.command || "",
+                "key": ""
+            };
+        }
         switch (action) {
         case "reboot":
             return {
@@ -668,6 +684,7 @@ DankModal {
                                 height: 16
                                 radius: 4
                                 color: Theme.onSurface_12
+                                visible: gridButtonRect.actionData.key !== ""
                                 anchors.horizontalCenter: parent.horizontalCenter
 
                                 StyledText {
@@ -800,6 +817,7 @@ DankModal {
                             height: 20
                             radius: 4
                             color: Theme.onSurface_12
+                            visible: listButtonRect.actionData.key !== ""
                             anchors {
                                 right: parent.right
                                 rightMargin: Theme.spacingM


### PR DESCRIPTION
The power menu only offers the built-in actions (Lock/Logout/Suspend/Hibernate/Reboot/Power Off/Restart DMS/Switch User). The `customPowerActionReboot`-style settings can change what a built-in does, but there is no way to add a new entry. My case: I dual boot, and I want a "reboot into Windows" button (`systemctl reboot --boot-loader-entry=auto-windows`) without hijacking the normal reboot button or keeping a script outside the shell.

This adds a `customPowerButtons` array setting:

```json
"customPowerButtons": [
  { "label": "Windows", "icon": "desktop_windows", "command": "systemctl reboot --boot-loader-entry=auto-windows" }
]
```

Each entry renders after the built-ins in both list and grid layout with the same styling, participates in grid sizing and keyboard navigation, and gets the same hold-to-confirm flow as reboot. Commands run detached via `sh -c`, same as the existing `customPowerAction*` overrides in SessionService. Icons are Material Symbols names, labels are user content and shown untranslated. The setting itself is declared in `SettingsSpec.js`/`SettingsData.qml` like any other spec-backed setting and defaults to `[]`, so existing configs are unaffected. `PowerMenuModal` maps entries to `custom:N` action ids resolved in `getActionData`/`executeAction`.

I left the lock screen's own power menu alone on purpose: running arbitrary configured commands from a locked session doesn't seem like something we want. The ControlCenter and DankBar power buttons open this modal anyway, so they pick the custom buttons up automatically. Config file only for now, no settings UI page.

Verified with qmllint (identical diagnostics to master, just the pre-existing unresolved-import noise you get when linting outside the shell's VFS), qmlformat, and the repo pre-commit hooks. The full `make lint-qml` harness needs the `.qmlls.ini` a running shell generates, which this checkout doesn't have.