### PR TITLE
fix(settings): reset AppBrowserPopup model on close to avoid crash

### DIFF
--- a/quickshell/Modules/Settings/Widgets/AppBrowserPopup.qml
+++ b/quickshell/Modules/Settings/Widgets/AppBrowserPopup.qml
@@ -167,7 +167,13 @@ FloatingWindow {
                         width: parent.width
                         height: parent.height - searchField.height - Theme.spacingM
                         spacing: Theme.spacingS
-                        model: root.filteredApps
+                        // Start with no model. It is (re)bound in show() so that each open
+                        // gets a fresh QQmlDelegateModel, avoiding a crash where a stale
+                        // incubation queue from a previous open races with a background
+                        // refreshApplications() replacing the underlying DesktopEntries
+                        // QObjectModel (SIGSEGV in QQmlIncubatorPrivate::incubate via
+                        // libQt6QmlModels). See hide()/onVisibleChanged() for the teardown.
+                        model: null
                         clip: true
 
                         delegate: Rectangle {
@@ -316,11 +322,21 @@ FloatingWindow {
 
     function show() {
         updateFilteredApps();
+        // Rebind the model reactively (search relies on filteredApps changes flowing
+        // through), and do it after populating so the ListView starts incubating from
+        // a fully-formed array rather than [].
+        appList.model = Qt.binding(() => root.filteredApps);
         visible = true;
         Qt.callLater(() => searchField.forceActiveFocus());
     }
 
     function hide() {
+        // Drop the model before clearing visible, so the ListView releases its
+        // QQmlDelegateModel (and any in-flight incubators) synchronously on this
+        // frame. This is the crux of the fix: a later show() will allocate a fresh
+        // DelegateModel instead of reusing one whose incubation queue may hold
+        // references invalidated by a concurrent refreshApplications().
+        appList.model = null;
         visible = false;
         searchQuery = "";
         filteredApps = [];
@@ -330,6 +346,9 @@ FloatingWindow {
 
     onVisibleChanged: {
         if (!visible) {
+            // Guard against visibility being cleared without going through hide()
+            // (e.g. window manager close, FloatingWindow.onClosed -> hide()).
+            appList.model = null;
             searchQuery = "";
             filteredApps = [];
             selectedIndex = -1;


### PR DESCRIPTION
### What went wrong

Reopening the autostart "Browse" app picker (Settings -> Applications -> Autostart) crashed DMS with a segfault. Open the picker, close it, open it again -> crash (intermittent, but reproducible enough to hit three times in one session).

### Fix

The picker's list view reused its internal model across open/close. When reopening while the app list was being refreshed in the background, the view was reading data that had just been replaced - leading to the crash.

Now the list model is dropped on close and rebuilt fresh on each open, so there's no stale state to collide with a background refresh.

### Verified

Tested by running a local dev build against the edited file and repeating the original open/close/reopen flow (with app rescans and Bluetooth activity happening in the background). No crash.