### PR TITLE
osd: click to hide some osds

### DIFF
--- a/quickshell/Modules/OSD/BrightnessOSD.qml
+++ b/quickshell/Modules/OSD/BrightnessOSD.qml
@@ -42,6 +42,11 @@ DankOSD {
             width: parent.width - Theme.spacingS * 2
             height: 40
 
+            MouseArea {
+                anchors.fill: parent
+                onClicked: root.hide()
+            }
+
             Rectangle {
                 width: Theme.iconSize
                 height: Theme.iconSize
@@ -124,6 +129,11 @@ DankOSD {
         Item {
             anchors.fill: parent
             property int gap: Theme.spacingS
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: root.hide()
+            }
 
             Rectangle {
                 width: Theme.iconSize

--- a/quickshell/Modules/OSD/MediaVolumeOSD.qml
+++ b/quickshell/Modules/OSD/MediaVolumeOSD.qml
@@ -81,6 +81,11 @@ DankOSD {
             width: parent.width - Theme.spacingS * 2
             height: 40
 
+            MouseArea {
+                anchors.fill: parent
+                onClicked: root.hide()
+            }
+
             Rectangle {
                 width: Theme.iconSize
                 height: Theme.iconSize
@@ -146,6 +151,11 @@ DankOSD {
         Item {
             anchors.fill: parent
             property int gap: Theme.spacingS
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: root.hide()
+            }
 
             Rectangle {
                 width: Theme.iconSize

--- a/quickshell/Modules/OSD/MicVolumeOSD.qml
+++ b/quickshell/Modules/OSD/MicVolumeOSD.qml
@@ -65,6 +65,11 @@ DankOSD {
             width: parent.width - Theme.spacingS * 2
             height: 40
 
+            MouseArea {
+                anchors.fill: parent
+                onClicked: root.hide()
+            }
+
             Rectangle {
                 width: Theme.iconSize
                 height: Theme.iconSize
@@ -136,6 +141,11 @@ DankOSD {
         Item {
             anchors.fill: parent
             property int gap: Theme.spacingS
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: root.hide()
+            }
 
             Rectangle {
                 width: Theme.iconSize

--- a/quickshell/Modules/OSD/VolumeOSD.qml
+++ b/quickshell/Modules/OSD/VolumeOSD.qml
@@ -60,6 +60,11 @@ DankOSD {
             width: parent.width - Theme.spacingS * 2
             height: 40
 
+            MouseArea {
+                anchors.fill: parent
+                onClicked: root.hide()
+            }
+
             Rectangle {
                 width: Theme.iconSize
                 height: Theme.iconSize
@@ -131,6 +136,11 @@ DankOSD {
         Item {
             anchors.fill: parent
             property int gap: Theme.spacingS
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: root.hide()
+            }
 
             Rectangle {
                 width: Theme.iconSize


### PR DESCRIPTION
## Description

Adds click-to-hide to the edges of:
- VolumeOSD
- MediaVolumeOSD
- MicVolumeOSD
- BrightnessOSD

These used to stay on the screen for a set time no matter what, and this PR lets users click on the outside of the interactable areas to dismiss them. Media playback OSD already had this functionality and it fits well in these OSDs too.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [X] My code follows the conventions in CONTRIBUTING.md
- [X] I have tested my changes locally
- [n/a] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [n/a] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [X] QML changes: ran `make lint-qml` with no new warnings
- [n/a] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
