### PR TITLE
launcher: add Steam and Waydroid badges

### DIFF
--- a/quickshell/Modals/DankLauncherV2/ControllerUtils.js
+++ b/quickshell/Modals/DankLauncherV2/ControllerUtils.js
@@ -131,6 +131,12 @@ function classifyAppSource(app) {
         || exec.indexOf("/etc/profiles/per-user/") !== -1)
         return "nix";
 
+    if (exec.indexOf("steam steam://rungameid/") !== -1)
+        return "steam";
+
+    if (exec.indexOf("waydroid app ") !== -1)
+        return "waydroid";
+
     return "system";
 }
 

--- a/quickshell/Modals/DankLauncherV2/SourceBadge.qml
+++ b/quickshell/Modals/DankLauncherV2/SourceBadge.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import Quickshell
 import Quickshell.Widgets
 import qs.Common
 
@@ -12,7 +13,9 @@ Item {
             "flatpak": "../../assets/package-sources/flatpak.svg",
             "snap": "../../assets/package-sources/snap.svg",
             "appimage": "../../assets/package-sources/appimage.svg",
-            "nix": "../../assets/package-sources/nix.svg"
+            "nix": "../../assets/package-sources/nix.svg",
+            "steam": "steam",
+            "waydroid": "waydroid"
         })
 
     readonly property string assetPath: sourceAsset[source] || ""
@@ -23,7 +26,16 @@ Item {
 
     IconImage {
         anchors.fill: parent
-        source: root.assetPath ? Qt.resolvedUrl(root.assetPath) : ""
+        source: {
+            if (!root.assetPath) {
+                return "";
+            }
+            if (root.assetPath.indexOf("/") !== -1) {
+                return Qt.resolvedUrl(root.assetPath);
+            } else {
+                return Quickshell.iconPath(root.assetPath);
+            }
+        }
         implicitSize: root.glyphSize * 2
         backer.sourceSize: Qt.size(root.glyphSize * 2, root.glyphSize * 2)
         smooth: true


### PR DESCRIPTION
## Description
This PR adds Steam and Waydroid badges to the launcher.
It uses system icons instead of images from the asset folder.
<!-- What does this PR do and why? -->

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
