### PR TITLE
feat(wallpaper): support random cycling order

### DIFF
--- a/quickshell/Common/SessionData.qml
+++ b/quickshell/Common/SessionData.qml
@@ -144,6 +144,7 @@ Singleton {
     property var includedTransitions: availableWallpaperTransitions.filter(t => t !== "none")
 
     property bool wallpaperCyclingEnabled: false
+    property bool wallpaperCyclingRandom: false
     property string wallpaperCyclingMode: "interval"
     property int wallpaperCyclingInterval: 300
     property string wallpaperCyclingTime: "06:00"
@@ -649,6 +650,11 @@ Singleton {
         saveSettings();
     }
 
+    function setWallpaperCyclingRandom(random) {
+        wallpaperCyclingRandom = random;
+        saveSettings();
+    }
+
     function setWallpaperCyclingMode(mode) {
         wallpaperCyclingMode = mode;
         saveSettings();
@@ -691,6 +697,37 @@ Singleton {
 
         newSettings[identifier] = getMonitorCyclingSettings(screenName);
         newSettings[identifier].enabled = enabled;
+        monitorCyclingSettings = newSettings;
+        saveSettings();
+    }
+
+    function setMonitorCyclingRandom(screenName, random) {
+        var screen = null;
+        var screens = Quickshell.screens;
+        for (var i = 0; i < screens.length; i++) {
+            if (screens[i].name === screenName) {
+                screen = screens[i];
+                break;
+            }
+        }
+
+        if (!screen) {
+            log.warn("Screen not found");
+            return;
+        }
+
+        var identifier = typeof SettingsData !== "undefined" ? SettingsData.getScreenDisplayName(screen) : screen.name;
+
+        var newSettings = {};
+        for (var key in monitorCyclingSettings) {
+            var isThisScreen = key === screen.name || (screen.model && key === screen.model);
+            if (!isThisScreen) {
+                newSettings[key] = monitorCyclingSettings[key];
+            }
+        }
+
+        newSettings[identifier] = getMonitorCyclingSettings(screenName);
+        newSettings[identifier].random = random;
         monitorCyclingSettings = newSettings;
         saveSettings();
     }
@@ -1376,6 +1413,7 @@ Singleton {
     function getMonitorCyclingSettings(screenName) {
         var defaults = {
             "enabled": false,
+            "random": false,
             "mode": "interval",
             "interval": 300,
             "time": "06:00"

--- a/quickshell/Common/settings/SessionSpec.js
+++ b/quickshell/Common/settings/SessionSpec.js
@@ -19,6 +19,7 @@ var SPEC = {
     includedTransitions: { def: ["fade", "wipe", "disc", "stripes", "iris bloom", "pixelate", "portal"] },
 
     wallpaperCyclingEnabled: { def: false },
+    wallpaperCyclingRandom: { def: false },
     wallpaperCyclingMode: { def: "interval" },
     wallpaperCyclingInterval: { def: 300 },
     wallpaperCyclingTime: { def: "06:00" },

--- a/quickshell/Modules/Settings/WallpaperTab.qml
+++ b/quickshell/Modules/Settings/WallpaperTab.qml
@@ -977,6 +977,33 @@ Item {
                         }
                     }
 
+                    SettingsToggleRow {
+                        id: randomToggle
+                        tab: "wallpaper"
+                        tags: ["cycling", "automatic", "random", "shuffle"]
+                        settingKey: "wallpaperCyclingRandom"
+                        width: parent.width - Theme.spacingM * 2
+                        text: I18n.tr("Random Order")
+                        description: I18n.tr("Select a random wallpaper instead of cycling in alphabetical order")
+                        checked: SessionData.perMonitorWallpaper ? SessionData.getMonitorCyclingSettings(selectedMonitorName).random : SessionData.wallpaperCyclingRandom
+                        onToggled: toggled => {
+                            if (SessionData.perMonitorWallpaper) {
+                                SessionData.setMonitorCyclingRandom(selectedMonitorName, toggled);
+                            } else {
+                                SessionData.setWallpaperCyclingRandom(toggled);
+                            }
+                        }
+
+                        Connections {
+                            target: root
+                            function onSelectedMonitorNameChanged() {
+                                randomToggle.checked = Qt.binding(() => {
+                                    return SessionData.perMonitorWallpaper ? SessionData.getMonitorCyclingSettings(selectedMonitorName).random : SessionData.wallpaperCyclingRandom;
+                                });
+                            }
+                        }
+                    }
+
                     SettingsDropdownRow {
                         id: intervalDropdown
                         property var intervalOptions: [I18n.tr("5 seconds", "wallpaper interval"), I18n.tr("10 seconds", "wallpaper interval"), I18n.tr("15 seconds", "wallpaper interval"), I18n.tr("20 seconds", "wallpaper interval"), I18n.tr("25 seconds", "wallpaper interval"), I18n.tr("30 seconds", "wallpaper interval"), I18n.tr("35 seconds", "wallpaper interval"), I18n.tr("40 seconds", "wallpaper interval"), I18n.tr("45 seconds", "wallpaper interval"), I18n.tr("50 seconds", "wallpaper interval"), I18n.tr("55 seconds", "wallpaper interval"), I18n.tr("1 minute", "wallpaper interval"), I18n.tr("5 minutes", "wallpaper interval"), I18n.tr("15 minutes", "wallpaper interval"), I18n.tr("30 minutes", "wallpaper interval"), I18n.tr("1 hour", "wallpaper interval"), I18n.tr("1 hour 30 minutes", "wallpaper interval"), I18n.tr("2 hours", "wallpaper interval"), I18n.tr("3 hours", "wallpaper interval"), I18n.tr("4 hours", "wallpaper interval"), I18n.tr("6 hours", "wallpaper interval"), I18n.tr("8 hours", "wallpaper interval"), I18n.tr("12 hours", "wallpaper interval")]

--- a/quickshell/Services/WallpaperCyclingService.qml
+++ b/quickshell/Services/WallpaperCyclingService.qml
@@ -230,11 +230,28 @@ Singleton {
         if (currentIndex === -1)
             currentIndex = 0;
 
-        let targetIndex;
-        if (goToPrevious) {
-            targetIndex = currentIndex === 0 ? wallpaperList.length - 1 : currentIndex - 1;
+        let isRandom = false;
+        if (targetScreenName) {
+            isRandom = !!SessionData.getMonitorCyclingSettings(targetScreenName).random;
         } else {
-            targetIndex = (currentIndex + 1) % wallpaperList.length;
+            isRandom = !!SessionData.wallpaperCyclingRandom;
+        }
+
+        let targetIndex;
+        if (isRandom) {
+            if (wallpaperList.length > 1) {
+                do {
+                    targetIndex = Math.floor(Math.random() * wallpaperList.length);
+                } while (targetIndex === currentIndex);
+            } else {
+                targetIndex = 0;
+            }
+        } else {
+            if (goToPrevious) {
+                targetIndex = currentIndex === 0 ? wallpaperList.length - 1 : currentIndex - 1;
+            } else {
+                targetIndex = (currentIndex + 1) % wallpaperList.length;
+            }
         }
         const targetWallpaper = wallpaperList[targetIndex];
         if (!targetWallpaper || targetWallpaper === currentPath)

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -339,6 +339,33 @@
     "icon": "palette"
   },
   {
+    "section": "wallpaperCyclingRandom",
+    "label": "Random Order",
+    "tabIndex": 0,
+    "category": "Personalization",
+    "keywords": [
+      "alphabetical",
+      "appearance",
+      "automatic",
+      "background",
+      "bg",
+      "custom",
+      "customize",
+      "cycling",
+      "desktop",
+      "image",
+      "order",
+      "personal",
+      "personalization",
+      "picture",
+      "random",
+      "select",
+      "shuffle",
+      "wallpaper"
+    ],
+    "description": "Select a random wallpaper instead of cycling in alphabetical order"
+  },
+  {
     "section": "wallpaperTransition",
     "label": "Transition Effect",
     "tabIndex": 0,


### PR DESCRIPTION
## Description

This PR introduces a **Random Order** option for automatic wallpaper cycling. Currently, wallpapers in the active folder are strictly cycled in alphabetical order. With this change, users can enable random cycling so that the next wallpaper is selected at random, providing a surprise element.

### How tested
- Verified that the "Random Order" switch displays in the settings under "Automatic Cycling".
- Verified that with random cycling enabled, wallpapers change in non-alphabetical random order and avoid duplicating the active image.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Closes #1085

## Screenshots / video

<img width="1678" height="1092" alt="dms_capture_1785065763152" src="https://github.com/user-attachments/assets/103c02ab-c946-4077-b9d2-4b02b58f04f6" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
