### PR TITLE
feat: add QR Generator launcher

### DIFF
--- a/core/internal/server/network/handlers.go
+++ b/core/internal/server/network/handlers.go
@@ -43,6 +43,8 @@ func HandleRequest(conn *models.Conn, req models.Request, manager *Manager) {
 		handleGetNetworkQRCode(conn, req, manager)
 	case "network.qrcode-content":
 		handleGetNetworkQRCodeContent(conn, req, manager)
+	case "network.qrcode.generate":
+		handleGenerateQRCode(conn, req)
 	case "network.delete-qrcode":
 		handleDeleteQRCode(conn, req, manager)
 	case "network.ethernet.info":
@@ -363,6 +365,22 @@ func handleGetNetworkQRCodeContent(conn *models.Conn, req models.Request, manage
 	}
 
 	models.Respond(conn, req.ID, content)
+}
+
+func handleGenerateQRCode(conn *models.Conn, req models.Request) {
+	text, err := params.String(req.Params, "text")
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+
+	paths, err := GenerateTextQRCode(text)
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+
+	models.Respond(conn, req.ID, paths)
 }
 
 func handleDeleteQRCode(conn *models.Conn, req models.Request, _ *Manager) {

--- a/core/internal/server/network/handlers.go
+++ b/core/internal/server/network/handlers.go
@@ -43,7 +43,7 @@ func HandleRequest(conn *models.Conn, req models.Request, manager *Manager) {
 		handleGetNetworkQRCode(conn, req, manager)
 	case "network.qrcode-content":
 		handleGetNetworkQRCodeContent(conn, req, manager)
-	case "network.qrcode.generate":
+	case "network.generate-qrcode":
 		handleGenerateQRCode(conn, req)
 	case "network.delete-qrcode":
 		handleDeleteQRCode(conn, req, manager)
@@ -374,7 +374,7 @@ func handleGenerateQRCode(conn *models.Conn, req models.Request) {
 		return
 	}
 
-	paths, err := GenerateTextQRCode(text)
+	paths, err := generateTextQRCode(text)
 	if err != nil {
 		models.RespondError(conn, req.ID, err.Error())
 		return

--- a/core/internal/server/network/qr_generator.go
+++ b/core/internal/server/network/qr_generator.go
@@ -1,0 +1,50 @@
+package network
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/yeqown/go-qrcode/v2"
+	"github.com/yeqown/go-qrcode/writer/standard"
+)
+
+const textQRCodeTmpPrefix = "/tmp/dank-text-qrcode-"
+
+func GenerateTextQRCode(text string) ([2]string, error) {
+	qrc, err := qrcode.New(text)
+	if err != nil {
+		return [2]string{}, fmt.Errorf("failed to create QR code for text: %w", err)
+	}
+
+	pathThemed, pathNormal := textQRCodePaths(text)
+
+	wThemed, err := standard.New(
+		pathThemed,
+		standard.WithBuiltinImageEncoder(standard.PNG_FORMAT),
+		standard.WithBgTransparent(),
+		standard.WithFgColorRGBHex("#ffffff"),
+	)
+	if err != nil {
+		return [2]string{}, fmt.Errorf("failed to create themed QR code writer: %w", err)
+	}
+	if err := qrc.Save(wThemed); err != nil {
+		return [2]string{}, fmt.Errorf("failed to save themed QR code: %w", err)
+	}
+
+	wNormal, err := standard.New(pathNormal, standard.WithBuiltinImageEncoder(standard.PNG_FORMAT))
+	if err != nil {
+		return [2]string{}, fmt.Errorf("failed to create normal QR code writer: %w", err)
+	}
+	if err := qrc.Save(wNormal); err != nil {
+		return [2]string{}, fmt.Errorf("failed to save normal QR code: %w", err)
+	}
+
+	return [2]string{pathThemed, pathNormal}, nil
+}
+
+func textQRCodePaths(text string) (themed, normal string) {
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(text)))[:16]
+	themed = fmt.Sprintf("%s%s-themed.png", textQRCodeTmpPrefix, hash)
+	normal = fmt.Sprintf("%s%s-normal.png", textQRCodeTmpPrefix, hash)
+	return
+}

--- a/core/internal/server/network/qr_generator.go
+++ b/core/internal/server/network/qr_generator.go
@@ -3,6 +3,8 @@ package network
 import (
 	"crypto/sha256"
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/yeqown/go-qrcode/v2"
 	"github.com/yeqown/go-qrcode/writer/standard"
@@ -10,7 +12,7 @@ import (
 
 const textQRCodeTmpPrefix = "/tmp/dank-text-qrcode-"
 
-func GenerateTextQRCode(text string) ([2]string, error) {
+func generateTextQRCode(text string) ([2]string, error) {
 	qrc, err := qrcode.New(text)
 	if err != nil {
 		return [2]string{}, fmt.Errorf("failed to create QR code for text: %w", err)
@@ -18,33 +20,45 @@ func GenerateTextQRCode(text string) ([2]string, error) {
 
 	pathThemed, pathNormal := textQRCodePaths(text)
 
-	wThemed, err := standard.New(
-		pathThemed,
-		standard.WithBuiltinImageEncoder(standard.PNG_FORMAT),
-		standard.WithBgTransparent(),
-		standard.WithFgColorRGBHex("#ffffff"),
-	)
-	if err != nil {
-		return [2]string{}, fmt.Errorf("failed to create themed QR code writer: %w", err)
+	if err := saveQRCodePNG(qrc, pathThemed, standard.WithBgTransparent(), standard.WithFgColorRGBHex("#ffffff")); err != nil {
+		return [2]string{}, err
 	}
-	if err := qrc.Save(wThemed); err != nil {
-		return [2]string{}, fmt.Errorf("failed to save themed QR code: %w", err)
-	}
-
-	wNormal, err := standard.New(pathNormal, standard.WithBuiltinImageEncoder(standard.PNG_FORMAT))
-	if err != nil {
-		return [2]string{}, fmt.Errorf("failed to create normal QR code writer: %w", err)
-	}
-	if err := qrc.Save(wNormal); err != nil {
-		return [2]string{}, fmt.Errorf("failed to save normal QR code: %w", err)
+	if err := saveQRCodePNG(qrc, pathNormal); err != nil {
+		return [2]string{}, err
 	}
 
 	return [2]string{pathThemed, pathNormal}, nil
 }
 
+// Write to a temp file and rename into place so the shell's Image never
+// observes a partially written PNG.
+func saveQRCodePNG(qrc *qrcode.QRCode, path string, opts ...standard.ImageOption) error {
+	tmpPath := path + ".tmp"
+	opts = append(opts, standard.WithBuiltinImageEncoder(standard.PNG_FORMAT))
+
+	w, err := standard.New(tmpPath, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create QR code writer: %w", err)
+	}
+	if err := qrc.Save(w); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to save QR code: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to move QR code into place: %w", err)
+	}
+	return nil
+}
+
+// Paths are unique per generation, not per text: the library's mask selection
+// is non-deterministic, so regenerating the same text produces different
+// bytes, and reusing a path lets the shell's URL-keyed pixmap cache serve a
+// stale pattern over the new file.
 func textQRCodePaths(text string) (themed, normal string) {
-	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(text)))[:16]
-	themed = fmt.Sprintf("%s%s-themed.png", textQRCodeTmpPrefix, hash)
-	normal = fmt.Sprintf("%s%s-normal.png", textQRCodeTmpPrefix, hash)
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(text)))[:8]
+	nonce := time.Now().UnixNano()
+	themed = fmt.Sprintf("%s%s-%d-themed.png", textQRCodeTmpPrefix, hash, nonce)
+	normal = fmt.Sprintf("%s%s-%d-normal.png", textQRCodeTmpPrefix, hash, nonce)
 	return
 }

--- a/core/internal/server/network/wifi_qrcode.go
+++ b/core/internal/server/network/wifi_qrcode.go
@@ -24,7 +24,7 @@ func qrCodePaths(ssid string) (themed, normal string) {
 
 func isValidQRCodePath(path string) bool {
 	clean := filepath.Clean(path)
-	return strings.HasPrefix(clean, qrCodeTmpPrefix) && strings.HasSuffix(clean, ".png")
+	return (strings.HasPrefix(clean, qrCodeTmpPrefix) || strings.HasPrefix(clean, textQRCodeTmpPrefix)) && strings.HasSuffix(clean, ".png")
 }
 
 var safePathChar = regexp.MustCompile(`[^a-zA-Z0-9_-]`)

--- a/quickshell/DMSShell.qml
+++ b/quickshell/DMSShell.qml
@@ -446,6 +446,23 @@ Item {
     }
 
     LazyLoader {
+        id: qrGeneratorModalLoader
+        active: false
+
+        Component.onCompleted: {
+            PopoutService.qrGeneratorModalLoader = qrGeneratorModalLoader;
+        }
+
+        QRGeneratorModal {
+            id: qrGeneratorModalItem
+
+            Component.onCompleted: {
+                PopoutService.qrGeneratorModal = qrGeneratorModalItem;
+            }
+        }
+    }
+
+    LazyLoader {
         id: polkitAuthModalLoader
         active: false
         readonly property PolkitAuthModal loadedModal: item as PolkitAuthModal

--- a/quickshell/Modals/QRGeneratorModal.qml
+++ b/quickshell/Modals/QRGeneratorModal.qml
@@ -1,0 +1,256 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Effects
+import Quickshell
+import Quickshell.Io
+import qs.Modals.Common
+import qs.Modals.FileBrowser
+import qs.Common
+import qs.Services
+import qs.Widgets
+
+DankModal {
+    id: root
+    visible: false
+    layerNamespace: "dms:qr-generator"
+
+    property bool disablePopupTransparency: true
+    property bool generating: false
+    property string themedQrCodePath: ""
+    property string normalQrCodePath: ""
+    modalWidth: 420
+    modalHeight: 440
+    onBackgroundClicked: hide()
+    onOpened: {
+        Qt.callLater(() => {
+            modalFocusScope.forceActiveFocus();
+            if (contentLoader.item?.textInput) {
+                contentLoader.item.textInput.forceActiveFocus();
+            }
+            contentLoader.item.saveBrowserLoader = saveBrowserLoader;
+        });
+    }
+
+    function show() {
+        generating = false;
+        open();
+    }
+
+    function hide() {
+        if (themedQrCodePath.length > 0)
+            DMSService.sendRequest("network.delete-qrcode", {path: themedQrCodePath});
+        if (normalQrCodePath.length > 0)
+            DMSService.sendRequest("network.delete-qrcode", {path: normalQrCodePath});
+        close();
+    }
+
+    Timer {
+        id: genTimer
+        interval: 200
+        repeat: false
+        onTriggered: root.generateQR(root._pendingPayload)
+    }
+
+    property string _pendingPayload: ""
+    property string _generatingPayload: ""
+    property string _pendingThemed: ""
+    property string _pendingNormal: ""
+
+    function generateQR(text) {
+        if (!text || text.trim().length === 0 || generating)
+            return;
+
+        var trimmed = text.trim();
+        if (!contentLoader.item)
+            return;
+
+        _generatingPayload = trimmed;
+        generating = true;
+
+        DMSService.sendRequest("network.qrcode.generate", {text: trimmed}, response => {
+            if (response.error) {
+                ToastService.showError(I18n.tr("Failed to generate QR code: %1").arg(JSON.stringify(response.error)));
+                root.generating = false;
+            } else if (response.result && contentLoader.item) {
+                if (root._generatingPayload !== root._pendingPayload) {
+                    root.generating = false;
+                    return;
+                }
+                _pendingThemed = response.result[0];
+                _pendingNormal = response.result[1];
+                if (contentLoader.item?.qrContainer)
+                    contentLoader.item.qrContainer.opacity = 0;
+            }
+        });
+    }
+
+    function onTextChanged(text) {
+        _pendingPayload = text;
+        if (!text || text.trim().length === 0) {
+            genTimer.stop();
+            return;
+        }
+        genTimer.restart();
+    }
+
+    LazyLoader {
+        id: saveBrowserLoader
+        active: false
+
+        FileBrowserSurfaceModal {
+            id: saveBrowser
+
+            browserTitle: I18n.tr("Save QR Code")
+            browserIcon: "qr_code"
+            browserType: "default"
+            fileExtensions: ["*.png"]
+            allowStacking: true
+            saveMode: true
+            defaultFileName: "qrcode.png"
+            onFileSelected: path => {
+                const cleanPath = decodeURI(path.toString().replace(/^file:\/\//, ''));
+                copyQrCodeProcess.exec(["cp", root.normalQrCodePath, cleanPath, "-f"]);
+            }
+
+            Process {
+                id: copyQrCodeProcess
+
+                stdout: StdioCollector {
+                    onStreamFinished: {
+                        saveBrowser.close();
+                    }
+                }
+            }
+        }
+    }
+
+    content: Component {
+            Item {
+                id: theItem
+                property alias themedQrCodePath: qrCodeImg.source
+                property alias textInput: textInput
+                property alias qrContainer: qrContainer
+                property var saveBrowserLoader: null
+                anchors.fill: parent
+
+
+            Column {
+                anchors.fill: parent
+                anchors.margins: Theme.spacingL
+                spacing: Theme.spacingL
+
+                RowLayout {
+                    id: modalTitle
+                    width: parent.width
+
+                    StyledText {
+                        text: I18n.tr("QR Generator")
+                        font.pixelSize: Theme.fontSizeLarge
+                        color: Theme.surfaceText
+                        font.weight: Font.Bold
+                        Layout.alignment: Qt.AlignLeft
+                        Layout.fillWidth: true
+                    }
+
+                    DankActionButton {
+                        iconName: "close"
+                        iconSize: Theme.iconSize - 4
+                        iconColor: Theme.surfaceText
+                        onClicked: root.hide()
+                        Layout.alignment: Qt.AlignRight
+                    }
+                }
+
+                DankTextField {
+                    id: textInput
+                    width: parent.width
+                    placeholderText: I18n.tr("Enter text to encode")
+                    showClearButton: true
+                    focus: true
+                    onTextEdited: root.onTextChanged(text)
+                    Keys.onEscapePressed: event => {
+                        event.accepted = true;
+                        root.hide();
+                    }
+                }
+
+                Item {
+                    id: qrContainer
+                    height: Math.min(parent.height - parent.spacing - modalTitle.height - textInput.height - parent.spacing * 4, 260)
+                    width: height
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    opacity: 1
+
+                    Behavior on opacity { NumberAnimation { duration: 80; easing.type: Easing.OutCubic } }
+
+                    onOpacityChanged: {
+                        if (opacity <= 0 && root._pendingThemed.length > 0) {
+                            var oldThemed = root.themedQrCodePath;
+                            var oldNormal = root.normalQrCodePath;
+                            root.themedQrCodePath = root._pendingThemed;
+                            root.normalQrCodePath = root._pendingNormal;
+                            themedQrCodePath = root._pendingThemed;
+                            root._pendingThemed = "";
+                            root._pendingNormal = "";
+                            root.generating = false;
+                            if (oldThemed.length > 0)
+                                DMSService.sendRequest("network.delete-qrcode", {path: oldThemed});
+                            if (oldNormal.length > 0)
+                                DMSService.sendRequest("network.delete-qrcode", {path: oldNormal});
+                        }
+                    }
+
+                    Image {
+                        id: qrCodeImg
+                        anchors.fill: parent
+                        fillMode: Image.PreserveAspectFit
+                        asynchronous: true
+
+                        onStatusChanged: {
+                            if (status === Image.Ready)
+                                qrContainer.opacity = 1;
+                        }
+
+                        MultiEffect {
+                            source: qrCodeImg
+                            anchors.fill: source
+                            colorization: 1.0
+                            colorizationColor: Theme.primary
+                        }
+                    }
+                }
+
+                RowLayout {
+                    width: parent.width
+                    visible: root.themedQrCodePath.length > 0
+                    Layout.alignment: Qt.AlignHCenter
+
+                    Item {
+                        Layout.fillWidth: true
+                    }
+
+                    DankButton {
+                        text: I18n.tr("Save")
+                        iconName: "save"
+                        onClicked: {
+                            saveBrowserLoader.active = true;
+                            if (saveBrowserLoader.item) {
+                                saveBrowserLoader.item.open();
+                            }
+                        }
+                    }
+
+                    DankButton {
+                        text: I18n.tr("Close")
+                        iconName: "close"
+                        onClicked: root.hide()
+                    }
+
+                    Item {
+                        Layout.fillWidth: true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/quickshell/Modals/QRGeneratorModal.qml
+++ b/quickshell/Modals/QRGeneratorModal.qml
@@ -232,6 +232,8 @@ DankModal {
                     DankButton {
                         text: I18n.tr("Save")
                         iconName: "save"
+                        backgroundColor: Theme.surfaceContainer
+                        textColor: Theme.surfaceText
                         onClicked: {
                             saveBrowserLoader.active = true;
                             if (saveBrowserLoader.item) {
@@ -241,9 +243,14 @@ DankModal {
                     }
 
                     DankButton {
-                        text: I18n.tr("Close")
-                        iconName: "close"
-                        onClicked: root.hide()
+                        text: I18n.tr("Copy")
+                        iconName: "content_copy"
+                        backgroundColor: Theme.primary
+                        textColor: Theme.onPrimary
+                        onClicked: {
+                            if (root.normalQrCodePath.length > 0)
+                                DMSService.sendRequest("clipboard.copyFile", {filePath: root.normalQrCodePath});
+                        }
                     }
 
                     Item {

--- a/quickshell/Modals/QRGeneratorModal.qml
+++ b/quickshell/Modals/QRGeneratorModal.qml
@@ -18,30 +18,58 @@ DankModal {
     property bool generating: false
     property string themedQrCodePath: ""
     property string normalQrCodePath: ""
+    property string initialText: ""
+    property string _pendingPayload: ""
+    property string _generatingPayload: ""
+    property string _displayedPayload: ""
     modalWidth: 420
     modalHeight: 440
     onBackgroundClicked: hide()
     onOpened: {
         Qt.callLater(() => {
             modalFocusScope.forceActiveFocus();
-            if (contentLoader.item?.textInput) {
-                contentLoader.item.textInput.forceActiveFocus();
+            const item = contentLoader.item;
+            if (!item)
+                return;
+            item.saveBrowserLoader = saveBrowserLoader;
+            if (item.textInput) {
+                item.textInput.text = initialText;
+                item.textInput.forceActiveFocus();
             }
-            contentLoader.item.saveBrowserLoader = saveBrowserLoader;
+            if (initialText.length > 0) {
+                _pendingPayload = initialText;
+                generateQR(initialText);
+            }
         });
     }
 
-    function show() {
+    function show(text) {
         generating = false;
+        initialText = text || "";
+        _pendingPayload = "";
+        _generatingPayload = "";
+        _displayedPayload = "";
+        themedQrCodePath = "";
+        normalQrCodePath = "";
         open();
     }
 
     function hide() {
-        if (themedQrCodePath.length > 0)
-            DMSService.sendRequest("network.delete-qrcode", {path: themedQrCodePath});
-        if (normalQrCodePath.length > 0)
-            DMSService.sendRequest("network.delete-qrcode", {path: normalQrCodePath});
+        deleteQrCodeFiles(themedQrCodePath, normalQrCodePath);
+        themedQrCodePath = "";
+        normalQrCodePath = "";
         close();
+    }
+
+    function deleteQrCodeFiles(themed, normal) {
+        if (themed.length > 0)
+            DMSService.sendRequest("network.delete-qrcode", {
+                path: themed
+            });
+        if (normal.length > 0)
+            DMSService.sendRequest("network.delete-qrcode", {
+                path: normal
+            });
     }
 
     Timer {
@@ -51,42 +79,43 @@ DankModal {
         onTriggered: root.generateQR(root._pendingPayload)
     }
 
-    property string _pendingPayload: ""
-    property string _generatingPayload: ""
-    property string _pendingThemed: ""
-    property string _pendingNormal: ""
-
     function generateQR(text) {
-        if (!text || text.trim().length === 0 || generating)
-            return;
-
-        var trimmed = text.trim();
-        if (!contentLoader.item)
+        const trimmed = (text || "").trim();
+        if (trimmed.length === 0 || trimmed === _displayedPayload || generating)
             return;
 
         _generatingPayload = trimmed;
         generating = true;
 
-        DMSService.sendRequest("network.qrcode.generate", {text: trimmed}, response => {
+        DMSService.sendRequest("network.generate-qrcode", {
+            text: trimmed
+        }, response => {
+            root.generating = false;
             if (response.error) {
                 ToastService.showError(I18n.tr("Failed to generate QR code: %1").arg(JSON.stringify(response.error)));
-                root.generating = false;
-            } else if (response.result && contentLoader.item) {
-                if (root._generatingPayload !== root._pendingPayload) {
-                    root.generating = false;
-                    return;
-                }
-                _pendingThemed = response.result[0];
-                _pendingNormal = response.result[1];
-                if (contentLoader.item?.qrContainer)
-                    contentLoader.item.qrContainer.opacity = 0;
+                return;
             }
+            if (!response.result)
+                return;
+            if (root._generatingPayload !== root._pendingPayload.trim()) {
+                root.deleteQrCodeFiles(response.result[0], response.result[1]);
+                genTimer.restart();
+                return;
+            }
+
+            const oldThemed = root.themedQrCodePath;
+            const oldNormal = root.normalQrCodePath;
+            root._displayedPayload = root._generatingPayload;
+            root.themedQrCodePath = response.result[0];
+            root.normalQrCodePath = response.result[1];
+            root.deleteQrCodeFiles(oldThemed, oldNormal);
         });
     }
 
     function onTextChanged(text) {
         _pendingPayload = text;
-        if (!text || text.trim().length === 0) {
+        const trimmed = text.trim();
+        if (trimmed.length === 0 || trimmed === _displayedPayload) {
             genTimer.stop();
             return;
         }
@@ -109,7 +138,7 @@ DankModal {
             defaultFileName: "qrcode.png"
             onFileSelected: path => {
                 const cleanPath = decodeURI(path.toString().replace(/^file:\/\//, ''));
-                copyQrCodeProcess.exec(["cp", root.normalQrCodePath, cleanPath, "-f"]);
+                copyQrCodeProcess.exec(["cp", "-f", root.normalQrCodePath, cleanPath]);
             }
 
             Process {
@@ -125,14 +154,13 @@ DankModal {
     }
 
     content: Component {
-            Item {
-                id: theItem
-                property alias themedQrCodePath: qrCodeImg.source
-                property alias textInput: textInput
-                property alias qrContainer: qrContainer
-                property var saveBrowserLoader: null
-                anchors.fill: parent
+        Item {
+            id: contentItem
 
+            property alias textInput: textInput
+            property var saveBrowserLoader: null
+
+            anchors.fill: parent
 
             Column {
                 anchors.fill: parent
@@ -181,42 +209,34 @@ DankModal {
                     anchors.horizontalCenter: parent.horizontalCenter
                     opacity: 1
 
-                    Behavior on opacity { NumberAnimation { duration: 80; easing.type: Easing.OutCubic } }
-
-                    onOpacityChanged: {
-                        if (opacity <= 0 && root._pendingThemed.length > 0) {
-                            var oldThemed = root.themedQrCodePath;
-                            var oldNormal = root.normalQrCodePath;
-                            root.themedQrCodePath = root._pendingThemed;
-                            root.normalQrCodePath = root._pendingNormal;
-                            themedQrCodePath = root._pendingThemed;
-                            root._pendingThemed = "";
-                            root._pendingNormal = "";
-                            root.generating = false;
-                            if (oldThemed.length > 0)
-                                DMSService.sendRequest("network.delete-qrcode", {path: oldThemed});
-                            if (oldNormal.length > 0)
-                                DMSService.sendRequest("network.delete-qrcode", {path: oldNormal});
+                    Behavior on opacity {
+                        NumberAnimation {
+                            duration: 80
+                            easing.type: Easing.OutCubic
                         }
                     }
 
                     Image {
                         id: qrCodeImg
                         anchors.fill: parent
+                        source: root.themedQrCodePath
                         fillMode: Image.PreserveAspectFit
                         asynchronous: true
+                        cache: false
+                        visible: false
 
+                        onSourceChanged: qrContainer.opacity = 0
                         onStatusChanged: {
                             if (status === Image.Ready)
                                 qrContainer.opacity = 1;
                         }
+                    }
 
-                        MultiEffect {
-                            source: qrCodeImg
-                            anchors.fill: source
-                            colorization: 1.0
-                            colorizationColor: Theme.primary
-                        }
+                    MultiEffect {
+                        source: qrCodeImg
+                        anchors.fill: qrCodeImg
+                        colorization: 1.0
+                        colorizationColor: Theme.primary
                     }
                 }
 
@@ -235,9 +255,9 @@ DankModal {
                         backgroundColor: Theme.surfaceContainer
                         textColor: Theme.surfaceText
                         onClicked: {
-                            saveBrowserLoader.active = true;
-                            if (saveBrowserLoader.item) {
-                                saveBrowserLoader.item.open();
+                            contentItem.saveBrowserLoader.active = true;
+                            if (contentItem.saveBrowserLoader.item) {
+                                contentItem.saveBrowserLoader.item.open();
                             }
                         }
                     }
@@ -249,7 +269,9 @@ DankModal {
                         textColor: Theme.onPrimary
                         onClicked: {
                             if (root.normalQrCodePath.length > 0)
-                                DMSService.sendRequest("clipboard.copyFile", {filePath: root.normalQrCodePath});
+                                DMSService.sendRequest("clipboard.copyFile", {
+                                    filePath: root.normalQrCodePath
+                                });
                         }
                     }
 

--- a/quickshell/Modules/Settings/LauncherTab.qml
+++ b/quickshell/Modules/Settings/LauncherTab.qml
@@ -822,7 +822,7 @@ Item {
                     spacing: Theme.spacingS
 
                     Repeater {
-                        model: ["dms_settings", "dms_notepad", "dms_sysmon", "dms_settings_search", "dms_clipboard_search", "dms_colorpicker"]
+                        model: ["dms_settings", "dms_notepad", "dms_sysmon", "dms_settings_search", "dms_clipboard_search", "dms_colorpicker", "dms_qr_generator"]
 
                         delegate: Rectangle {
                             id: pluginDelegate

--- a/quickshell/Services/AppSearchService.qml
+++ b/quickshell/Services/AppSearchService.qml
@@ -210,6 +210,17 @@ Singleton {
                 defaultTrigger: "",
                 isLauncher: false
             },
+            "dms_qr_generator": {
+                id: "dms_qr_generator",
+                name: I18n.tr("QR Generator"),
+                icon: "svg+corner:" + dmsLogoPath + "|qr_code",
+                cornerIcon: "qr_code",
+                comment: "DMS",
+                action: "ipc:qr-generator",
+                categories: ["Utility"],
+                defaultTrigger: "",
+                isLauncher: false
+            },
             "dms_settings_search": {
                 id: "dms_settings_search",
                 name: I18n.tr("Settings Search"),
@@ -377,6 +388,9 @@ Singleton {
             return true;
         case "color-picker":
             PopoutService.showColorPicker();
+            return true;
+        case "qr-generator":
+            PopoutService.showQRGeneratorModal();
             return true;
         }
         return false;

--- a/quickshell/Services/AppSearchService.qml
+++ b/quickshell/Services/AppSearchService.qml
@@ -218,8 +218,10 @@ Singleton {
                 comment: "DMS",
                 action: "ipc:qr-generator",
                 categories: ["Utility"],
-                defaultTrigger: "",
-                isLauncher: false
+                defaultTrigger: "qrg",
+                isLauncher: true,
+                viewMode: "list",
+                viewModeEnforced: true
             },
             "dms_settings_search": {
                 id: "dms_settings_search",
@@ -255,7 +257,7 @@ Singleton {
             if (!SettingsData.getBuiltInPluginSetting(pluginId, "enabled", true))
                 continue;
             const plugin = builtInPlugins[pluginId];
-            if (plugin.isLauncher)
+            if (plugin.isLauncher && !plugin.action)
                 continue;
             apps.push({
                 name: plugin.name,
@@ -320,6 +322,20 @@ Singleton {
                     }));
         }
 
+        if (pluginId === "dms_qr_generator") {
+            const text = (query || "").toString().trim();
+            return [
+                {
+                    name: text.length > 0 ? text : I18n.tr("Enter text to encode"),
+                    icon: "material:qr_code",
+                    comment: I18n.tr("QR Generator"),
+                    action: "qr_generate:" + text,
+                    isBuiltInLauncher: true,
+                    builtInPluginId: pluginId
+                }
+            ];
+        }
+
         if (pluginId !== "dms_settings_search")
             return [];
 
@@ -351,14 +367,20 @@ Singleton {
             return false;
 
         const parts = item.action.split(":");
-        if (parts[0] !== "settings_nav")
-            return false;
-
-        const tabIndex = parseInt(parts[1]);
-        const section = parts.slice(2).join(":");
-        SettingsSearchService.navigateToSection(section);
-        PopoutService.openSettingsWithTabIndex(tabIndex);
-        return true;
+        switch (parts[0]) {
+        case "settings_nav":
+            {
+                const tabIndex = parseInt(parts[1]);
+                const section = parts.slice(2).join(":");
+                SettingsSearchService.navigateToSection(section);
+                PopoutService.openSettingsWithTabIndex(tabIndex);
+                return true;
+            }
+        case "qr_generate":
+            PopoutService.showQRGeneratorModal(parts.slice(1).join(":"));
+            return true;
+        }
+        return false;
     }
 
     function getCoreApps(query) {

--- a/quickshell/Services/PopoutService.qml
+++ b/quickshell/Services/PopoutService.qml
@@ -893,11 +893,11 @@ Singleton {
             wifiQRCodeModal.show(ssid);
     }
 
-    function showQRGeneratorModal() {
+    function showQRGeneratorModal(initialText) {
         if (qrGeneratorModalLoader)
             qrGeneratorModalLoader.active = true;
         if (qrGeneratorModal)
-            qrGeneratorModal.show();
+            qrGeneratorModal.show(initialText || "");
     }
 
     function showHiddenNetworkModal() {

--- a/quickshell/Services/PopoutService.qml
+++ b/quickshell/Services/PopoutService.qml
@@ -47,6 +47,8 @@ Singleton {
     property var wifiPasswordModalLoader: null
     property var wifiQRCodeModal: null
     property var wifiQRCodeModalLoader: null
+    property var qrGeneratorModal: null
+    property var qrGeneratorModalLoader: null
     property var polkitAuthModal: null
     property var polkitAuthModalLoader: null
     property var bluetoothPairingModal: null
@@ -889,6 +891,13 @@ Singleton {
             wifiQRCodeModalLoader.active = true;
         if (wifiQRCodeModal)
             wifiQRCodeModal.show(ssid);
+    }
+
+    function showQRGeneratorModal() {
+        if (qrGeneratorModalLoader)
+            qrGeneratorModalLoader.active = true;
+        if (qrGeneratorModal)
+            qrGeneratorModal.show();
     }
 
     function showHiddenNetworkModal() {


### PR DESCRIPTION
## Summary

Since BB recently exposed the QR generator API, I think it makes sense to make this an official feature instead of relying on a third-party plugin.

Some parts of the design were borrowed from my own plugin, but they still follow DMS's design language, so they should fit in well.

## Screenshot
<img width="610" height="175" alt="image" src="https://github.com/user-attachments/assets/16876f51-5719-4427-bc00-943bf597e298" />
<img width="418" height="433" alt="image" src="https://github.com/user-attachments/assets/b3a19023-fa94-421e-8892-ca94e996e445" />
<img width="550" height="520" alt="dms_capture_1785135570574" src="https://github.com/user-attachments/assets/b861e157-cb18-4b57-9f22-2a368d971251" />

