### PR TITLE
feat(ipc): add 'dismiss' function to notifications ipc

### DIFF
--- a/quickshell/Modals/NotificationModal.qml
+++ b/quickshell/Modals/NotificationModal.qml
@@ -64,6 +64,10 @@ DankModal {
         NotificationService.dismissAllPopups();
     }
 
+    function dismissLastNotification() {
+        NotificationService.dismissLastNotification();
+    }
+
     modalWidth: Math.min(500, screenWidth - 48)
     modalHeight: Math.min(700, screenHeight * 0.85)
     backgroundColor: Theme.withAlpha(Theme.surfaceContainer, Theme.popupTransparency)
@@ -188,6 +192,11 @@ DankModal {
         function dismissAllPopups(): string {
             notificationModal.dismissAllPopups();
             return "NOTIFICATION_MODAL_DISMISS_ALL_POPUPS_SUCCESS";
+        }
+
+        function dismiss(): string {
+            notificationModal.dismissLastNotification();
+            return "NOTIFICATION_DISMISS_SUCCESS";
         }
 
         target: "notifications"

--- a/quickshell/Services/NotificationService.qml
+++ b/quickshell/Services/NotificationService.qml
@@ -889,6 +889,12 @@ Singleton {
         NotifWrapper {}
     }
 
+    function dismissLastNotification() {
+        const w = visibleNotifications[visibleNotifications.length - 1];
+        if (w)
+            dismissNotification(w);
+    }
+
     function dismissAllPopups() {
         for (const w of visibleNotifications) {
             if (w) {


### PR DESCRIPTION
## Description

Allow to dismiss the last visible notification only instead of resorting directly to `dismissAllPopups`.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
