### PR TITLE
fix(BatteryService): fix unresolved icons for notifications and dismiss alerts when plugged in

### DIFF
--- a/quickshell/Services/BatteryService.qml
+++ b/quickshell/Services/BatteryService.qml
@@ -136,7 +136,7 @@ Singleton {
 
     function sendAlert(title, message, isWarning, category, notificationType) {
         if (notificationType === 1) {
-            Quickshell.execDetached(["notify-send", "-u", isWarning ? "critical" : "normal", "-a", "DMS", "-i", isWarning ? "battery-caution" : "battery-charging", title, message]);
+            Quickshell.execDetached(["notify-send", "-u", isWarning ? "critical" : "normal", "-a", "DMS", "-i", isWarning ? "material:battery_alert" : "material:battery_charging_full", title, message]);
         } else {
             if (isWarning) {
                 ToastService.showWarning(title, message, "", category);
@@ -150,7 +150,7 @@ Singleton {
         if (isCharging && batteryLevel >= SettingsData.batteryChargeLimit) {
             if (!_hasNotifiedChargeLimit && SettingsData.batteryNotifyChargeLimit) {
                 _hasNotifiedChargeLimit = true;
-                sendAlert(I18n.tr("Charge Limit Reached"), I18n.tr("Battery has charged to your set limit of %1%").arg(SettingsData.batteryChargeLimit), false, "battery-charge-limit", SettingsData.batteryChargeLimitNotificationType);
+                sendAlert(I18n.tr("Charge Limit Reached"), I18n.tr("Battery has charged to your set limit of %1%").arg(SettingsData.batteryChargeLimit), false, "material:battery_profile", SettingsData.batteryChargeLimitNotificationType);
             }
         } else if (!isCharging || batteryLevel < SettingsData.batteryChargeLimit - 2) {
             _hasNotifiedChargeLimit = false;
@@ -166,7 +166,7 @@ Singleton {
         if (isCriticalBattery) {
             if (!_hasNotifiedCriticalBattery && SettingsData.batteryNotifyCritical) {
                 _hasNotifiedCriticalBattery = true;
-                sendAlert(I18n.tr("Critical Battery"), I18n.tr("Battery is at %1% - Connect charger immediately!").arg(batteryLevel), true, "battery-critical", SettingsData.batteryCriticalNotificationType);
+                sendAlert(I18n.tr("Critical Battery"), I18n.tr("Battery is at %1% - Connect charger immediately!").arg(batteryLevel), true, "material:battery_alert", SettingsData.batteryCriticalNotificationType);
             }
             return;
         }
@@ -179,7 +179,7 @@ Singleton {
         if (isLowBattery) {
             if (!_hasNotifiedLowBattery && SettingsData.batteryNotifyLow) {
                 _hasNotifiedLowBattery = true;
-                sendAlert(I18n.tr("Low Battery"), I18n.tr("Battery is at %1% - Consider charging soon").arg(batteryLevel), true, "battery-low", SettingsData.batteryLowNotificationType);
+                sendAlert(I18n.tr("Low Battery"), I18n.tr("Battery is at %1% - Consider charging soon").arg(batteryLevel), true, "material:battery_0_bar", SettingsData.batteryLowNotificationType);
             }
 
             if (SettingsData.batteryAutoPowerSaver && PowerProfileWatcher.available) {

--- a/quickshell/Services/BatteryService.qml
+++ b/quickshell/Services/BatteryService.qml
@@ -223,6 +223,27 @@ Singleton {
 
         applyPowerProfile();
 
+        if (isPluggedIn) {
+            const dismissLow = SettingsData.batteryLowNotificationType === 1 && SettingsData.notificationTimeoutNormal === 0;
+            const dismissCritical = SettingsData.batteryCriticalNotificationType === 1 && SettingsData.notificationTimeoutCritical === 0;
+
+            if (dismissLow || dismissCritical) {
+                const lowSummary = I18n.tr("Low Battery");
+                const criticalSummary = I18n.tr("Critical Battery");
+
+                for (const w of NotificationService.visibleNotifications) {
+                    if (!w || !w.notification)
+                        continue;
+
+                    const summary = w.notification.summary;
+
+                    if ((dismissLow && summary === lowSummary) || (dismissCritical && summary === lowSummary)) {
+                        NotificationService.dismissNotification(w);
+                    }
+                }
+            }
+        }
+
         previousPluggedState = isPluggedIn;
     }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do and why? -->

1. Thanks to 480ffa4a we don't have to rely on [DmsBatteryAlerts](https://github.com/AvengeMedia/dms-plugins/tree/master/DankBatteryAlerts) anymore, but the notifications icons are not resolved without the `material:` prefix.
2. Since battery alerts can be notifications and notifications can be set to never timeout, we dismiss battery alerts notifications (based on their `summary` text) in `onPluggedInChanged` if `isPluggedIn` is `true`.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
