### PR TITLE
fix(BatteryService): fix typo in notification check

### DIFF
--- a/quickshell/Services/BatteryService.qml
+++ b/quickshell/Services/BatteryService.qml
@@ -237,7 +237,7 @@ Singleton {
 
                     const summary = w.notification.summary;
 
-                    if ((dismissLow && summary === lowSummary) || (dismissCritical && summary === lowSummary)) {
+                    if ((dismissLow && summary === lowSummary) || (dismissCritical && summary === criticalSummary)) {
                         NotificationService.dismissNotification(w);
                     }
                 }


### PR DESCRIPTION
## Description

<!-- What does this PR do and why? -->

My previous PR #2943 checked twice for the low battery notification summary, and not at all for the critical one.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
