### PR TITLE
fix(tray): don't dismiss click-opened tray menus from the hover controller

### DIFF
--- a/quickshell/Common/TrayMenuManager.qml
+++ b/quickshell/Common/TrayMenuManager.qml
@@ -22,6 +22,18 @@ Singleton {
         activeTrayMenus = newMenus
     }
 
+    function closeHoverMenus() {
+        for (const screenName in activeTrayMenus) {
+            const menu = activeTrayMenus[screenName]
+            if (!menu || menu.openedByHover !== true) continue
+            if (typeof menu.close === "function") {
+                menu.close()
+            } else if (menu.showMenu !== undefined) {
+                menu.showMenu = false
+            }
+        }
+    }
+
     function closeAllMenus() {
         for (const screenName in activeTrayMenus) {
             const menu = activeTrayMenus[screenName]

--- a/quickshell/Modules/DankBar/DankBarHoverController.qml
+++ b/quickshell/Modules/DankBar/DankBarHoverController.qml
@@ -609,7 +609,7 @@ Item {
         _closeHoverNotepad();
         activeHoverTrigger = "";
         PopoutManager.dismissHoverPopoutForScreen(barWindow?.screen);
-        TrayMenuManager.closeAllMenus();
+        TrayMenuManager.closeHoverMenus();
     }
 
     function _beginSupersededCloseForActive() {

--- a/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
+++ b/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
@@ -1484,6 +1484,7 @@ BasePill {
             property bool isVertical: false
             property var axis: null
             property bool showMenu: false
+            property bool openedByHover: false
             property var menuHandle: null
 
             ListModel {
@@ -1493,7 +1494,8 @@ BasePill {
                 return entryStack.count ? entryStack.get(entryStack.count - 1).handle : null;
             }
 
-            function showForTrayItem(item, anchor, screen, atBottom, vertical, axisObj) {
+            function showForTrayItem(item, anchor, screen, atBottom, vertical, axisObj, byHover) {
+                openedByHover = byHover === true;
                 trayItem = item;
                 anchorItem = anchor;
                 parentScreen = screen;
@@ -2084,7 +2086,7 @@ BasePill {
         }
     }
 
-    function showForTrayItem(item, anchor, screen, atBottom, vertical, axisObj) {
+    function showForTrayItem(item, anchor, screen, atBottom, vertical, axisObj, byHover) {
         if (!screen)
             return;
         if (currentTrayMenu) {
@@ -2099,7 +2101,7 @@ BasePill {
         currentTrayMenu = trayMenuComponent.createObject(null);
         if (!currentTrayMenu)
             return;
-        currentTrayMenu.showForTrayItem(item, anchor, screen, atBottom, vertical ?? false, axisObj);
+        currentTrayMenu.showForTrayItem(item, anchor, screen, atBottom, vertical ?? false, axisObj, byHover === true);
     }
 
     function _trayLayoutRoot() {
@@ -2147,7 +2149,7 @@ BasePill {
         if (!hit?.trayItem?.hasMenu)
             return false;
         const anchor = hit.children?.length > 0 ? hit.children[0] : hit;
-        showForTrayItem(hit.trayItem, anchor, parentScreen, isAtBottom, isVerticalOrientation, axis);
+        showForTrayItem(hit.trayItem, anchor, parentScreen, isAtBottom, isVerticalOrientation, axis, true);
         return true;
     }
 }


### PR DESCRIPTION
Fixes #2978

## Problem

`DankBarHoverController.closeHoverSurfaces()` calls `TrayMenuManager.closeAllMenus()`, which tears down every registered tray menu — including ones opened by right-click. With `hoverPopouts` enabled, moving the pointer after a right-click reaches that call through one of the two sites that skip the `cursorOverHoverChain()` guard, and the menu is gone before it can be used.

## Approach

`TrayMenuManager` could not tell a hover-opened menu from a click-opened one — both go through the same `showForTrayItem()`. This tags the menu with how it was opened and adds a narrower `closeHoverMenus()` for the hover controller. `closeAllMenus()` is untouched.

Click-driven callers pass no argument, so `byHover` stays `undefined` and `byHover === true` is `false` — no changes needed there. +19/-5 across three files.

Adding the guard to the two unguarded call sites instead would also stop the symptom, but that check returns true whenever *any* tray menu is registered, so hover-opened ones would stop being dismissed too.

## Testing

Against the running shell via `DMS_SHELL_DIR`, on Niri with `hoverPopouts: true`, `hoverPopoutDelay: 350`:

- Right-click menu stays open while the pointer travels to it, entries selectable — previously it closed on the first movement.
- Hover popouts on bar widgets unchanged.
- Commenting out the `closeAllMenus()` call produced the same result, isolating it as the cause.

Not verified: the `openedByHover === true` path. Tray icons never open on hover here — see #2978 for why — so it rests on reading the code, not a measurement.

## Environment

DMS `ef191ba`, quickshell-git `0.3.0.r19.g43d4fa9-1`, Niri, single output, Arch Linux.