### PR TITLE
popout: re-apply surface geometry after shouldBeVisible

### DIFF
--- a/quickshell/Widgets/DankPopoutStandalone.qml
+++ b/quickshell/Widgets/DankPopoutStandalone.qml
@@ -379,6 +379,9 @@ Item {
 
         animationsEnabled = true;
         shouldBeVisible = true;
+        // Content-sized popouts lay out when contentWindow maps, while the geometry
+        // handlers are still gated off. Re-snapshot so the surface isn't left short.
+        _setSettledSurfaceGeometry();
         if (screen) {
             PopoutManager.showPopout(popoutHandle);
             opened();


### PR DESCRIPTION
## Description

Popouts sized from their content sometimes open too short and clip what they render, then come back correct on the next open.

open() snapshots the surface geometry before setting shouldBeVisible, and the onAligned{X,Y,Width,Height}Changed handlers are all gated on that flag. Mapping contentWindow happens in between, and that's what finally runs the layout Qt deferred while the window was hidden. Content-sized popouts pick up their real height in that gap, so the correction is dropped and the surface stays short. Re-snapshot once the flag is set.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<img width="488" height="271" alt="08 01_22 39 09" src="https://github.com/user-attachments/assets/f46d8dcc-61d5-4165-8670-ccaa8c00d2da" />

(not a great screencap): the orange squiggle is showing where the plugin window clipped. in this case, the plugin is a list of pipewire nodes/streams. 

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
