### PR TITLE
fix(Lockscreen) - cover pixel of the loading Spinner

### DIFF
--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -1329,6 +1329,7 @@ Item {
                                     width: parent.width
                                     height: parent.height / 2
                                     anchors.top: parent.top
+                                    anchors.topMargin: -1
                                     anchors.horizontalCenter: parent.horizontalCenter
                                     color: Theme.withAlpha(Theme.surfaceContainer, 0.9)
                                 }


### PR DESCRIPTION
## Description
When submitting the password in the lock screen the spinner has not all pixels covered on the other half. By changing the margin it should cover the missing pixel.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [x] Other

## Related issues

## Screenshots / video

I have tested the changes locally and it works but I don't know how to take a screenshot of the lock screen. I recreated the loading spinner in quickshell. The change should look like this:
Before:
<img width="360" height="360" alt="loadingSpinnger-before" src="https://github.com/user-attachments/assets/309f58c6-d172-49eb-be53-5032a5bc731f" />
After:
<img width="360" height="379" alt="loadingSpinner-after" src="https://github.com/user-attachments/assets/58f2521b-6927-4a9a-b186-85bcb2af2dc7" />


## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
