### PR TITLE
fix(mpris): remove required non-null artist/title from idle condition

### DIFF
--- a/quickshell/Services/MprisController.qml
+++ b/quickshell/Services/MprisController.qml
@@ -168,7 +168,7 @@ Singleton {
     }
 
     function isIdle(player: MprisPlayer): bool {
-        return player && player.playbackState === MprisPlaybackState.Stopped && !player.trackTitle && !player.trackArtist;
+        return player && player.playbackState === MprisPlaybackState.Stopped;
     }
 
     // Known "<title> | <App>" suffixes stripped for matching only; display keeps the full title


### PR DESCRIPTION
## Description

The current isIdle detection only works if the player has a title _and_ artist metadata,
which is not appropriate for all cases, e.g. MPV playing a video does not set artist.

In the current implementation, after a video stops playing in MPV, and the window closes
(but MPV and the MPRIS plugin server is still running as a background process), the playback controls remain
shown on the bar, and have non-functional controls.

It is sufficient to only check for the "Stopped" playing state. The MPRIS specification
states that Playback_Status==Stopped should be used to indicate that *NO* track is currently
playing. A compliant player should set that, and should also set the CanPlay/CanPause boolean
to false is not track is being played.

See: https://specifications.freedesktop.org/mpris/latest/Player_Interface.html#Enum:Playback_Status

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

This `isIdle` function was introduced in PR #2509. Not sure why the condition on a non-null trackTitle and trackArtist was
required for determining an Idle state.
<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->


## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] ~~New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible~~
- [ ] ~~Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean~~
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] ~~I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs~~

