### PR TITLE
fix(nix): declare notification bus readiness

### DIFF
--- a/distro/nix/home.nix
+++ b/distro/nix/home.nix
@@ -94,6 +94,8 @@ in
       };
 
       Service = {
+        Type = "dbus";
+        BusName = "org.freedesktop.Notifications";
         ExecStart = lib.getExe cfg.package + " run --session";
         Restart = "on-failure";
       };

--- a/distro/nix/nixos.nix
+++ b/distro/nix/nixos.nix
@@ -34,6 +34,8 @@ in
       restartIfChanged = cfg.systemd.restartIfChanged;
 
       serviceConfig = {
+        Type = "dbus";
+        BusName = "org.freedesktop.Notifications";
         ExecStart = lib.getExe cfg.package + " run --session";
         Restart = "on-failure";
       };

--- a/distro/nix/tests/home-manager-module.nix
+++ b/distro/nix/tests/home-manager-module.nix
@@ -84,6 +84,8 @@ pkgs.testers.runNixOSTest {
 
     machine.wait_for_unit("multi-user.target")
 
+    machine.succeed("test $(systemctl --machine=danklinux@ --user show dms.service --property=Type --value) = dbus")
+    machine.succeed("test $(systemctl --machine=danklinux@ --user show dms.service --property=BusName --value) = org.freedesktop.Notifications")
     machine.succeed("su -- danklinux -c 'command -v dms'")
     machine.succeed("su -- danklinux -c 'test -f ~/.config/DankMaterialShell/settings.json'")
     machine.succeed("su -- danklinux -c 'test -f ~/.config/DankMaterialShell/clsettings.json'")

--- a/distro/nix/tests/nixos-service-start-module.nix
+++ b/distro/nix/tests/nixos-service-start-module.nix
@@ -6,7 +6,9 @@
 let
   fakeDms = pkgs.writeShellScriptBin "dms" ''
     printf '%s\n' "$@" > /tmp/dms-service-args
-    exec ${pkgs.coreutils}/bin/sleep 300
+    exec ${pkgs.dbus}/bin/dbus-test-tool echo \
+      --session \
+      --name=org.freedesktop.Notifications
   '';
 in
 pkgs.testers.runNixOSTest {
@@ -41,6 +43,8 @@ pkgs.testers.runNixOSTest {
 
     machine.succeed("systemctl --machine=danklinux@ --user start dms.service")
     machine.wait_until_succeeds("systemctl --machine=danklinux@ --user is-active dms.service")
+    machine.succeed("test $(systemctl --machine=danklinux@ --user show dms.service --property=Type --value) = dbus")
+    machine.succeed("test $(systemctl --machine=danklinux@ --user show dms.service --property=BusName --value) = org.freedesktop.Notifications")
     machine.wait_until_succeeds("test -f /tmp/dms-service-args")
     machine.succeed("grep -Fx run /tmp/dms-service-args")
     machine.succeed("grep -Fx -- --session /tmp/dms-service-args")


### PR DESCRIPTION
## Description

The NixOS and Home Manager modules declared DMS as started before its QuickShell process acquired `org.freedesktop.Notifications`. Consumers ordered after `dms.service` could therefore initialize too early and permanently fall back to non-system notifications.

Configure both module variants as `Type=dbus` with `BusName=org.freedesktop.Notifications`. Update the service-start test double to acquire that name and assert the readiness contract in both module tests.

This lets dependent user services reliably use `After=dms.service`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

None.

## Screenshots / video

Not applicable; this changes service startup ordering.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs

Validation:

- `nix flake check --no-build --show-trace`
- `nix build .#nixosTests.x86_64-linux.nixos-service-start-module`
- repository pre-commit hooks
