### PR TITLE
fix(launcher): honor source badge setting in grid mode

### DIFF
--- a/quickshell/Modals/DankLauncherV2/SourceBadge.qml
+++ b/quickshell/Modals/DankLauncherV2/SourceBadge.qml
@@ -7,6 +7,7 @@ Item {
 
     property string source: ""
     property int glyphSize: 14
+    property bool badgeVisible: true
 
     readonly property var sourceAsset: ({
             "flatpak": "../../assets/package-sources/flatpak.svg",
@@ -17,7 +18,7 @@ Item {
 
     readonly property string assetPath: sourceAsset[source] || ""
 
-    visible: SettingsData.dankLauncherV2ShowSourceBadges && assetPath.length > 0
+    visible: badgeVisible && SettingsData.dankLauncherV2ShowSourceBadges && assetPath.length > 0
     implicitWidth: glyphSize
     implicitHeight: glyphSize
 

--- a/quickshell/Modals/DankLauncherV2/TileItem.qml
+++ b/quickshell/Modals/DankLauncherV2/TileItem.qml
@@ -178,7 +178,7 @@ Rectangle {
                 anchors.margins: Theme.spacingXS
                 source: root.item?.type === "app" ? (root.item.source || "") : ""
                 glyphSize: 16
-                visible: !root.isSelected && !!source
+                badgeVisible: !root.isSelected
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes package source badges still appearing in the launcher tile view when "Show Package Source Badges" is disabled.

`TileItem` was overriding `SourceBadge.visible` directly, which bypassed the shared `SettingsData.dankLauncherV2ShowSourceBadges` check inside `SourceBadge`. This adds a separate `badgeVisible` property so tile view can keep its selected-item visibility behavior without replacing the global setting binding.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Closes #2948

## Screenshots / video

<img width="2364" height="1330" alt="Screenshot-2026-08-06_11-04-09" src="https://github.com/user-attachments/assets/f0ba6b23-facd-4ade-b8c3-20071c638ee7" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
