### PR TITLE
fix(settings): hide removed widget tooltip

### DIFF
--- a/quickshell/Modules/Settings/WidgetsTabSection.qml
+++ b/quickshell/Modules/Settings/WidgetsTabSection.qml
@@ -18,6 +18,8 @@ Column {
         id: sharedTooltip
     }
 
+    Component.onDestruction: sharedTooltip.hide()
+
     signal itemEnabledChanged(string sectionId, string itemId, bool enabled)
     signal itemOrderChanged(string sectionId, var orderedIds)
     signal addWidget(string sectionId)
@@ -1215,6 +1217,7 @@ Column {
                             iconSize: 18
                             iconColor: Theme.error
                             onClicked: {
+                                sharedTooltip.hide();
                                 root.removeWidget(root.sectionId, index);
                             }
                             onEntered: {


### PR DESCRIPTION
## Description

Hide removed widget tooltip

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Related issues

Closes #2739 

## Screenshots / video


https://github.com/user-attachments/assets/6038619d-5e53-4dc5-a754-b0e11fb4db25


