### PR TITLE
feat(theme): add extract dynamic theme to JSON file

### DIFF
--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -283,7 +283,7 @@ Singleton {
             "surfaceContainer": getMatugenColorForMode(colorMode, "surface_container", "#1e2023"),
             "surfaceContainerHigh": getMatugenColorForMode(colorMode, "surface_container_high", "#292b2f"),
             "surfaceContainerHighest": getMatugenColorForMode(colorMode, "surface_container_highest", "#343740"),
-            "error": "#F2B8B5",
+            "error": getMatugenColorForMode(colorMode, "error", "#F2B8B5"),
             "warning": "#FF9800",
             "info": "#2196F3",
             "success": "#4CAF50"

--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -201,6 +201,10 @@ Singleton {
 
     function getMatugenColor(path, fallback) {
         const colorMode = (typeof SessionData !== "undefined" && SessionData.isLightMode) ? "light" : "dark";
+        return getMatugenColorForMode(colorMode, path, fallback);
+    }
+
+    function getMatugenColorForMode(colorMode, path, fallback) {
         let cur = matugenColors && matugenColors.colors && matugenColors.colors[colorMode];
         for (const part of path.split(".")) {
             if (!cur || typeof cur !== "object" || !(part in cur))
@@ -208,6 +212,82 @@ Singleton {
             cur = cur[part];
         }
         return cur || fallback;
+    }
+
+    function extractCurrentTheme(themeName) {
+        var name = themeName || "Extracted Theme";
+        var dark = {};
+        var light = {};
+
+        if (currentTheme === dynamic) {
+            dark = buildExtractedDynamicMode("dark", name + " Dark");
+            light = buildExtractedDynamicMode("light", name + " Light");
+        } else if (currentTheme === custom && customThemeRawData) {
+            var rawDark = customThemeRawData.dark || null;
+            var rawLight = customThemeRawData.light || null;
+            if (rawDark) {
+                dark = JSON.parse(JSON.stringify(rawDark));
+                if (!dark.name)
+                    dark.name = name + " Dark";
+            } else if (rawLight) {
+                dark = buildExtractedDynamicMode("dark", name + " Dark");
+            } else {
+                dark = currentThemeData ? JSON.parse(JSON.stringify(currentThemeData)) : {};
+                dark.name = name + " Dark";
+            }
+            if (rawLight) {
+                light = JSON.parse(JSON.stringify(rawLight));
+                if (!light.name)
+                    light.name = name + " Light";
+            } else if (rawDark) {
+                light = buildExtractedDynamicMode("light", name + " Light");
+            } else {
+                light = currentThemeData ? JSON.parse(JSON.stringify(currentThemeData)) : {};
+                light.name = name + " Light";
+            }
+        } else {
+            var darkTheme = StockThemes.getThemeByName(currentTheme, false);
+            var lightTheme = StockThemes.getThemeByName(currentTheme, true);
+            dark = darkTheme ? JSON.parse(JSON.stringify(darkTheme)) : {};
+            light = lightTheme ? JSON.parse(JSON.stringify(lightTheme)) : {};
+            dark.name = name + " Dark";
+            light.name = name + " Light";
+        }
+
+        return JSON.stringify({
+            dark: dark,
+            light: light
+        }, null, 2);
+    }
+
+    function buildExtractedDynamicMode(colorMode, name) {
+        return {
+            "name": name,
+            "primary": getMatugenColorForMode(colorMode, "primary", "#42a5f5"),
+            "primaryText": getMatugenColorForMode(colorMode, "on_primary", "#ffffff"),
+            "primaryContainer": getMatugenColorForMode(colorMode, "primary_container", "#1976d2"),
+            "secondary": getMatugenColorForMode(colorMode, "secondary", "#8ab4f8"),
+            "secondaryContainer": getMatugenColorForMode(colorMode, "secondary_container", getMatugenColorForMode(colorMode, "surface_container_high", "#292b2f")),
+            "tertiary": getMatugenColorForMode(colorMode, "tertiary", "#efb8c8"),
+            "tertiaryContainer": getMatugenColorForMode(colorMode, "tertiary_container", getMatugenColorForMode(colorMode, "surface_container_high", "#292b2f")),
+            "surface": getMatugenColorForMode(colorMode, "surface", "#1a1c1e"),
+            "surfaceText": getMatugenColorForMode(colorMode, "on_background", "#e3e8ef"),
+            "surfaceVariant": getMatugenColorForMode(colorMode, "surface_variant", "#44464f"),
+            "surfaceVariantText": getMatugenColorForMode(colorMode, "on_surface_variant", "#c4c7c5"),
+            "surfaceTint": getMatugenColorForMode(colorMode, "surface_tint", "#8ab4f8"),
+            "background": getMatugenColorForMode(colorMode, "background", "#1a1c1e"),
+            "backgroundText": getMatugenColorForMode(colorMode, "on_background", "#e3e8ef"),
+            "outline": getMatugenColorForMode(colorMode, "outline", "#8e918f"),
+            "surfaceContainerLowest": getMatugenColorForMode(colorMode, "surface_container_lowest", "#0e1013"),
+            "surfaceContainerLow": getMatugenColorForMode(colorMode, "surface_container_low", "#181a1d"),
+            "surfaceContainer": getMatugenColorForMode(colorMode, "surface_container", "#1e2023"),
+            "surfaceContainerHigh": getMatugenColorForMode(colorMode, "surface_container_high", "#292b2f"),
+            "surfaceContainerHighest": getMatugenColorForMode(colorMode, "surface_container_highest", "#343740"),
+            "error": "#F2B8B5",
+            "warning": "#FF9800",
+            "info": "#2196F3",
+            "success": "#4CAF50"
+        };
     }
 
     readonly property var currentThemeData: {

--- a/quickshell/Modules/Settings/ThemeColorsTab.qml
+++ b/quickshell/Modules/Settings/ThemeColorsTab.qml
@@ -779,18 +779,18 @@ Item {
                             opacity: enabled ? 1 : 0.4
                             onSliderDragFinished: finalValue => SettingsData.setMatugenContrast(finalValue / 100)
                         }
-                    }
 
-                    DankButton {
-                        text: I18n.tr("Extract Theme", "extract theme button")
-                        iconName: "download"
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        onClicked: {
-                            var themeDataName = Theme.getThemeColors(Theme.currentThemeName).name || Theme.currentThemeName;
-                            pendingExtractJson = Theme.extractCurrentTheme(themeDataName);
-                            saveBrowserLoader.active = true;
-                            if (saveBrowserLoader.item)
-                                saveBrowserLoader.item.open();
+                        DankButton {
+                            text: I18n.tr("Extract Theme", "extract theme button")
+                            iconName: "download"
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            onClicked: {
+                                var themeDataName = Theme.getThemeColors(Theme.currentThemeName).name || Theme.currentThemeName;
+                                pendingExtractJson = Theme.extractCurrentTheme(themeDataName);
+                                saveBrowserLoader.active = true;
+                                if (saveBrowserLoader.item)
+                                    saveBrowserLoader.item.open();
+                            }
                         }
                     }
 

--- a/quickshell/Modules/Settings/ThemeColorsTab.qml
+++ b/quickshell/Modules/Settings/ThemeColorsTab.qml
@@ -785,8 +785,7 @@ Item {
                             iconName: "download"
                             anchors.horizontalCenter: parent.horizontalCenter
                             onClicked: {
-                                var themeDataName = Theme.getThemeColors(Theme.currentThemeName).name || Theme.currentThemeName;
-                                pendingExtractJson = Theme.extractCurrentTheme(themeDataName);
+                                pendingExtractJson = Theme.extractCurrentTheme();
                                 saveBrowserLoader.active = true;
                                 if (saveBrowserLoader.item)
                                     saveBrowserLoader.item.open();
@@ -3185,8 +3184,7 @@ Item {
             defaultFileName: "dms-extracted-theme.json"
 
             onFileSelected: path => {
-                const cleanPath = decodeURI(path.toString().replace(/^file:\/\//, ''));
-                saveExtractedTheme(pendingExtractJson, cleanPath);
+                saveExtractedTheme(pendingExtractJson, Paths.strip(path));
                 close();
             }
         }
@@ -3208,30 +3206,25 @@ Item {
             themeBrowserLoader.item.show();
     }
 
-    Process {
-        id: extractSaveProcess
-        property string outputPath: ""
-        running: false
-        stdout: SplitParser {
-            onRead: data => {}
-        }
-        stderr: SplitParser {
-            onRead: data => {}
+    FileView {
+        id: extractSaveFileView
+        blockWrites: true
+        preload: false
+        atomicWrites: true
+        printErrors: true
+
+        onSaved: {
+            ToastService.showInfo(I18n.tr("Theme extracted to: %1", "extract theme success").arg(Paths.strip(extractSaveFileView.path)));
         }
 
-        onExited: exitCode => {
-            if (exitCode === 0) {
-                ToastService.showInfo(I18n.tr("Theme extracted to: %1", "extract theme success").arg(extractSaveProcess.outputPath));
-            } else {
-                ToastService.showError(I18n.tr("Failed to extract theme (exit code: %1)", "extract theme error").arg(exitCode));
-            }
+        onSaveFailed: error => {
+            ToastService.showError(I18n.tr("Failed to extract theme", "extract theme error"));
+            log.warn("Failed to write extracted theme to " + extractSaveFileView.path + ": " + error);
         }
     }
 
     function saveExtractedTheme(json, outputPath) {
-        var tempFile = Paths.strip(StandardPaths.writableLocation(StandardPaths.TempLocation)) + "/dms-extract-" + Date.now() + ".json";
-        extractSaveProcess.outputPath = outputPath;
-        extractSaveProcess.command = ["sh", "-c", "cat > " + tempFile + " << 'DMS_THEME_EXTRACT_EOF'\n" + json + "\nDMS_THEME_EXTRACT_EOF\ncp " + tempFile + " " + outputPath + " && rm -f " + tempFile];
-        extractSaveProcess.running = true;
+        extractSaveFileView.path = outputPath;
+        extractSaveFileView.setText(json);
     }
 }

--- a/quickshell/Modules/Settings/ThemeColorsTab.qml
+++ b/quickshell/Modules/Settings/ThemeColorsTab.qml
@@ -781,41 +781,16 @@ Item {
                         }
                     }
 
-                    Item {
-                        width: parent.width
-                        height: extractRow.implicitHeight
-
-                        Row {
-                            id: extractRow
-                            anchors.horizontalCenter: parent.horizontalCenter
-                            spacing: Theme.spacingS
-
-                            DankIcon {
-                                name: "download"
-                                size: Theme.iconSizeSmall
-                                color: Theme.primary
-                                anchors.verticalCenter: parent.verticalCenter
-                            }
-
-                            StyledText {
-                                text: I18n.tr("Extract current theme to file", "extract theme description")
-                                font.pixelSize: Theme.fontSizeSmall
-                                color: Theme.surfaceVariantText
-                                anchors.verticalCenter: parent.verticalCenter
-                            }
-
-                            DankButton {
-                                text: I18n.tr("Extract", "extract theme button")
-                                iconName: "download"
-                                anchors.verticalCenter: parent.verticalCenter
-                                onClicked: {
-                                    var themeDataName = Theme.getThemeColors(Theme.currentThemeName).name || Theme.currentThemeName;
-                                    pendingExtractJson = Theme.extractCurrentTheme(themeDataName);
-                                    saveBrowserLoader.active = true;
-                                    if (saveBrowserLoader.item)
-                                        saveBrowserLoader.item.open();
-                                }
-                            }
+                    DankButton {
+                        text: I18n.tr("Extract Theme", "extract theme button")
+                        iconName: "download"
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        onClicked: {
+                            var themeDataName = Theme.getThemeColors(Theme.currentThemeName).name || Theme.currentThemeName;
+                            pendingExtractJson = Theme.extractCurrentTheme(themeDataName);
+                            saveBrowserLoader.active = true;
+                            if (saveBrowserLoader.item)
+                                saveBrowserLoader.item.open();
                         }
                     }
 

--- a/quickshell/Modules/Settings/ThemeColorsTab.qml
+++ b/quickshell/Modules/Settings/ThemeColorsTab.qml
@@ -1,6 +1,7 @@
 import QtCore
 import QtQuick
 import Quickshell
+import Quickshell.Io
 import Quickshell.Widgets
 import qs.Common
 import qs.Modals.FileBrowser
@@ -14,6 +15,7 @@ Item {
     id: themeColorsTab
 
     property var parentModal: null
+    property string pendingExtractJson: ""
     readonly property bool connectedFrameModeActive: SettingsData.connectedFrameModeActive
     readonly property bool frameModeActive: SettingsData.frameEnabled
     property var cachedIconThemes: SettingsData.availableIconThemes
@@ -776,6 +778,44 @@ Item {
                             enabled: Theme.matugenAvailable
                             opacity: enabled ? 1 : 0.4
                             onSliderDragFinished: finalValue => SettingsData.setMatugenContrast(finalValue / 100)
+                        }
+                    }
+
+                    Item {
+                        width: parent.width
+                        height: extractRow.implicitHeight
+
+                        Row {
+                            id: extractRow
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            spacing: Theme.spacingS
+
+                            DankIcon {
+                                name: "download"
+                                size: Theme.iconSizeSmall
+                                color: Theme.primary
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            StyledText {
+                                text: I18n.tr("Extract current theme to file", "extract theme description")
+                                font.pixelSize: Theme.fontSizeSmall
+                                color: Theme.surfaceVariantText
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            DankButton {
+                                text: I18n.tr("Extract", "extract theme button")
+                                iconName: "download"
+                                anchors.verticalCenter: parent.verticalCenter
+                                onClicked: {
+                                    var themeDataName = Theme.getThemeColors(Theme.currentThemeName).name || Theme.currentThemeName;
+                                    pendingExtractJson = Theme.extractCurrentTheme(themeDataName);
+                                    saveBrowserLoader.active = true;
+                                    if (saveBrowserLoader.item)
+                                        saveBrowserLoader.item.open();
+                                }
+                            }
                         }
                     }
 
@@ -3155,6 +3195,29 @@ Item {
     }
 
     LazyLoader {
+        id: saveBrowserLoader
+        active: false
+
+        FileBrowserSurfaceModal {
+            id: saveBrowser
+
+            browserTitle: I18n.tr("Save Extracted Theme", "extract theme save dialog title")
+            browserIcon: "download"
+            browserType: "default"
+            fileExtensions: ["*.json"]
+            allowStacking: true
+            saveMode: true
+            defaultFileName: "dms-extracted-theme.json"
+
+            onFileSelected: path => {
+                const cleanPath = decodeURI(path.toString().replace(/^file:\/\//, ''));
+                saveExtractedTheme(pendingExtractJson, cleanPath);
+                close();
+            }
+        }
+    }
+
+    LazyLoader {
         id: themeBrowserLoader
         active: false
 
@@ -3168,5 +3231,32 @@ Item {
         themeBrowserLoader.active = true;
         if (themeBrowserLoader.item)
             themeBrowserLoader.item.show();
+    }
+
+    Process {
+        id: extractSaveProcess
+        property string outputPath: ""
+        running: false
+        stdout: SplitParser {
+            onRead: data => {}
+        }
+        stderr: SplitParser {
+            onRead: data => {}
+        }
+
+        onExited: exitCode => {
+            if (exitCode === 0) {
+                ToastService.showInfo(I18n.tr("Theme extracted to: %1", "extract theme success").arg(extractSaveProcess.outputPath));
+            } else {
+                ToastService.showError(I18n.tr("Failed to extract theme (exit code: %1)", "extract theme error").arg(exitCode));
+            }
+        }
+    }
+
+    function saveExtractedTheme(json, outputPath) {
+        var tempFile = Paths.strip(StandardPaths.writableLocation(StandardPaths.TempLocation)) + "/dms-extract-" + Date.now() + ".json";
+        extractSaveProcess.outputPath = outputPath;
+        extractSaveProcess.command = ["sh", "-c", "cat > " + tempFile + " << 'DMS_THEME_EXTRACT_EOF'\n" + json + "\nDMS_THEME_EXTRACT_EOF\ncp " + tempFile + " " + outputPath + " && rm -f " + tempFile];
+        extractSaveProcess.running = true;
     }
 }

--- a/quickshell/Modules/Settings/ThemeColorsTab.qml
+++ b/quickshell/Modules/Settings/ThemeColorsTab.qml
@@ -689,7 +689,7 @@ Item {
                             }
 
                             Column {
-                                width: parent.width - 120 - Theme.spacingM
+                                width: parent.width - 120 - Theme.spacingM - 36 - Theme.spacingM
                                 spacing: Theme.spacingS
                                 anchors.verticalCenter: parent.verticalCenter
 
@@ -711,6 +711,7 @@ Item {
                                 }
 
                                 StyledText {
+                                    id: wallpaperPathText
                                     text: {
                                         if (ToastService.wallpaperErrorStatus === "error")
                                             return I18n.tr("Wallpaper processing failed", "wallpaper processing error");
@@ -726,6 +727,22 @@ Item {
                                     maximumLineCount: 2
                                     width: parent.width
                                     wrapMode: Text.WordWrap
+                                }
+                            }
+
+                            DankActionButton {
+                                buttonSize: 36
+                                iconName: "download"
+                                iconSize: Theme.iconSize
+                                backgroundColor: Theme.primaryHover
+                                iconColor: Theme.primary
+                                tooltipText: I18n.tr("Extract theme to JSON", "extract theme tooltip")
+                                anchors.bottom: wallpaperPathText.bottom
+                                onClicked: {
+                                    pendingExtractJson = Theme.extractCurrentTheme();
+                                    saveBrowserLoader.active = true;
+                                    if (saveBrowserLoader.item)
+                                        saveBrowserLoader.item.open();
                                 }
                             }
                         }
@@ -778,18 +795,6 @@ Item {
                             enabled: Theme.matugenAvailable
                             opacity: enabled ? 1 : 0.4
                             onSliderDragFinished: finalValue => SettingsData.setMatugenContrast(finalValue / 100)
-                        }
-
-                        DankButton {
-                            text: I18n.tr("Extract Theme", "extract theme button")
-                            iconName: "download"
-                            anchors.horizontalCenter: parent.horizontalCenter
-                            onClicked: {
-                                pendingExtractJson = Theme.extractCurrentTheme();
-                                saveBrowserLoader.active = true;
-                                if (saveBrowserLoader.item)
-                                    saveBrowserLoader.item.open();
-                            }
                         }
                     }
 


### PR DESCRIPTION
## Description

Adds an 'Extract Theme' button in Settings > Theme Color that exports the **dynamic** theme (Auto) to a dual-mode dark+light JSON file via the DMS file save dialog.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Screenshots / video

<img width="2169" height="1220" alt="dms_capture_1786074132866" src="https://github.com/user-attachments/assets/33a6b1c0-4278-4359-a282-4cd8df2a8cae" />
