### PR TITLE
feat(settings): add location search to theme & gamma coordinates

### DIFF
--- a/quickshell/Modules/Settings/GammaControlTab.qml
+++ b/quickshell/Modules/Settings/GammaControlTab.qml
@@ -320,100 +320,10 @@ Item {
                             }
                         }
 
-                        Column {
-                            property bool isLocationMode: SessionData.nightModeAutoMode === "location"
-                            visible: isLocationMode
-                            spacing: Theme.spacingM
+                        SettingsLocationSection {
                             width: parent.width
-
-                            DankToggle {
-                                id: ipLocationToggle
-                                width: parent.width
-                                text: I18n.tr("Use IP Location")
-                                description: I18n.tr("Automatically detect location based on IP address")
-                                checked: SessionData.nightModeUseIPLocation || false
-                                onToggled: checked => {
-                                    SessionData.setNightModeUseIPLocation(checked);
-                                }
-
-                                Connections {
-                                    target: SessionData
-                                    function onNightModeUseIPLocationChanged() {
-                                        ipLocationToggle.checked = SessionData.nightModeUseIPLocation;
-                                    }
-                                }
-                            }
-
-                            Column {
-                                width: parent.width
-                                spacing: Theme.spacingM
-                                leftPadding: Theme.spacingM
-                                visible: !SessionData.nightModeUseIPLocation
-
-                                StyledText {
-                                    text: I18n.tr("Manual Coordinates")
-                                    font.pixelSize: Theme.fontSizeMedium
-                                    color: Theme.surfaceText
-                                }
-
-                                Row {
-                                    spacing: Theme.spacingL
-
-                                    Column {
-                                        spacing: Theme.spacingXS
-
-                                        StyledText {
-                                            text: I18n.tr("Latitude")
-                                            font.pixelSize: Theme.fontSizeSmall
-                                            color: Theme.surfaceVariantText
-                                        }
-
-                                        DankTextField {
-                                            width: 120
-                                            height: 40
-                                            text: SessionData.latitude.toString()
-                                            placeholderText: "0.0"
-                                            onEditingFinished: {
-                                                const lat = parseFloat(text);
-                                                if (!isNaN(lat) && lat >= -90 && lat <= 90 && lat !== SessionData.latitude) {
-                                                    SessionData.setLatitude(lat);
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    Column {
-                                        spacing: Theme.spacingXS
-
-                                        StyledText {
-                                            text: I18n.tr("Longitude")
-                                            font.pixelSize: Theme.fontSizeSmall
-                                            color: Theme.surfaceVariantText
-                                        }
-
-                                        DankTextField {
-                                            width: 120
-                                            height: 40
-                                            text: SessionData.longitude.toString()
-                                            placeholderText: "0.0"
-                                            onEditingFinished: {
-                                                const lon = parseFloat(text);
-                                                if (!isNaN(lon) && lon >= -180 && lon <= 180 && lon !== SessionData.longitude) {
-                                                    SessionData.setLongitude(lon);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-
-                                StyledText {
-                                    text: I18n.tr("Uses sunrise/sunset times to automatically adjust night mode based on your location.")
-                                    font.pixelSize: Theme.fontSizeSmall
-                                    color: Theme.surfaceVariantText
-                                    width: parent.width - parent.leftPadding
-                                    wrapMode: Text.WordWrap
-                                }
-                            }
+                            visible: SessionData.nightModeAutoMode === "location"
+                            description: I18n.tr("Uses sunrise/sunset times to automatically adjust night mode based on your location.")
                         }
 
                         Rectangle {

--- a/quickshell/Modules/Settings/ThemeColorsTab.qml
+++ b/quickshell/Modules/Settings/ThemeColorsTab.qml
@@ -1486,101 +1486,11 @@ Item {
                             }
                         }
 
-                        Column {
+                        SettingsLocationSection {
                             width: parent.width
-                            spacing: Theme.spacingM
                             visible: SessionData.themeModeAutoMode === "location" && !SessionData.themeModeShareGammaSettings
-
-                            DankToggle {
-                                id: themeModeIpLocationToggle
-                                width: parent.width
-                                text: I18n.tr("Use IP Location")
-                                checked: SessionData.nightModeUseIPLocation || false
-                                onToggled: checked => {
-                                    SessionData.setNightModeUseIPLocation(checked);
-                                }
-
-                                Connections {
-                                    target: SessionData
-                                    function onNightModeUseIPLocationChanged() {
-                                        themeModeIpLocationToggle.checked = SessionData.nightModeUseIPLocation;
-                                    }
-                                }
-                            }
-
-                            Column {
-                                width: parent.width
-                                spacing: Theme.spacingM
-                                visible: !SessionData.nightModeUseIPLocation
-
-                                StyledText {
-                                    text: I18n.tr("Manual Coordinates")
-                                    font.pixelSize: Theme.fontSizeMedium
-                                    color: Theme.surfaceText
-                                    horizontalAlignment: Text.AlignHCenter
-                                    width: parent.width
-                                }
-
-                                Row {
-                                    spacing: Theme.spacingL
-                                    anchors.horizontalCenter: parent.horizontalCenter
-
-                                    Column {
-                                        spacing: Theme.spacingXS
-
-                                        StyledText {
-                                            text: I18n.tr("Latitude")
-                                            font.pixelSize: Theme.fontSizeSmall
-                                            color: Theme.surfaceVariantText
-                                        }
-
-                                        DankTextField {
-                                            width: 120
-                                            height: 40
-                                            text: SessionData.latitude.toString()
-                                            placeholderText: "0.0"
-                                            onEditingFinished: {
-                                                const lat = parseFloat(text);
-                                                if (!isNaN(lat) && lat >= -90 && lat <= 90 && lat !== SessionData.latitude) {
-                                                    SessionData.setLatitude(lat);
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    Column {
-                                        spacing: Theme.spacingXS
-
-                                        StyledText {
-                                            text: I18n.tr("Longitude")
-                                            font.pixelSize: Theme.fontSizeSmall
-                                            color: Theme.surfaceVariantText
-                                        }
-
-                                        DankTextField {
-                                            width: 120
-                                            height: 40
-                                            text: SessionData.longitude.toString()
-                                            placeholderText: "0.0"
-                                            onEditingFinished: {
-                                                const lon = parseFloat(text);
-                                                if (!isNaN(lon) && lon >= -180 && lon <= 180 && lon !== SessionData.longitude) {
-                                                    SessionData.setLongitude(lon);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-
-                                StyledText {
-                                    text: I18n.tr("Uses sunrise/sunset times based on your location.")
-                                    font.pixelSize: Theme.fontSizeSmall
-                                    color: Theme.surfaceVariantText
-                                    width: parent.width
-                                    wrapMode: Text.WordWrap
-                                    horizontalAlignment: Text.AlignHCenter
-                                }
-                            }
+                            centered: true
+                            description: I18n.tr("Uses sunrise/sunset times based on your location.")
                         }
 
                         StyledText {

--- a/quickshell/Modules/Settings/Widgets/SettingsLocationSection.qml
+++ b/quickshell/Modules/Settings/Widgets/SettingsLocationSection.qml
@@ -58,10 +58,23 @@ Column {
                 }
 
                 DankTextField {
+                    id: latitudeField
                     width: 120
                     height: 40
-                    text: SessionData.latitude.toString()
+                    text: ""
                     placeholderText: "0.0"
+
+                    Component.onCompleted: {
+                        text = SessionData.latitude.toString();
+                    }
+
+                    Connections {
+                        target: SessionData
+                        function onLatitudeChanged() {
+                            latitudeField.text = SessionData.latitude.toString();
+                        }
+                    }
+
                     onEditingFinished: {
                         const lat = parseFloat(text);
                         if (!isNaN(lat) && lat >= -90 && lat <= 90 && lat !== SessionData.latitude) {
@@ -81,10 +94,23 @@ Column {
                 }
 
                 DankTextField {
+                    id: longitudeField
                     width: 120
                     height: 40
-                    text: SessionData.longitude.toString()
+                    text: ""
                     placeholderText: "0.0"
+
+                    Component.onCompleted: {
+                        text = SessionData.longitude.toString();
+                    }
+
+                    Connections {
+                        target: SessionData
+                        function onLongitudeChanged() {
+                            longitudeField.text = SessionData.longitude.toString();
+                        }
+                    }
+
                     onEditingFinished: {
                         const lon = parseFloat(text);
                         if (!isNaN(lon) && lon >= -180 && lon <= 180 && lon !== SessionData.longitude) {
@@ -111,9 +137,11 @@ Column {
                     const lon = parseFloat(coords[1]);
                     if (!isNaN(lat) && lat >= -90 && lat <= 90) {
                         SessionData.setLatitude(lat);
+                        latitudeField.text = coords[0].trim();
                     }
                     if (!isNaN(lon) && lon >= -180 && lon <= 180) {
                         SessionData.setLongitude(lon);
+                        longitudeField.text = coords[1].trim();
                     }
                 }
             }

--- a/quickshell/Modules/Settings/Widgets/SettingsLocationSection.qml
+++ b/quickshell/Modules/Settings/Widgets/SettingsLocationSection.qml
@@ -1,0 +1,131 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import qs.Common
+import qs.Widgets
+
+Column {
+    id: root
+
+    property string description: I18n.tr("Uses sunrise/sunset times based on your location.")
+    property bool centered: false
+
+    width: parent.width
+    spacing: Theme.spacingM
+
+    DankToggle {
+        id: ipLocationToggle
+        width: parent.width
+        text: I18n.tr("Use IP Location")
+        description: I18n.tr("Automatically detect location based on IP address")
+        checked: SessionData.nightModeUseIPLocation || false
+        onToggled: checked => {
+            SessionData.setNightModeUseIPLocation(checked);
+        }
+
+        Connections {
+            target: SessionData
+            function onNightModeUseIPLocationChanged() {
+                ipLocationToggle.checked = SessionData.nightModeUseIPLocation;
+            }
+        }
+    }
+
+    Column {
+        width: parent.width
+        spacing: Theme.spacingM
+        visible: !SessionData.nightModeUseIPLocation
+
+        StyledText {
+            text: I18n.tr("Manual Coordinates")
+            font.pixelSize: Theme.fontSizeMedium
+            color: Theme.surfaceText
+            width: parent.width
+            horizontalAlignment: root.centered ? Text.AlignHCenter : Text.AlignLeft
+        }
+
+        Row {
+            spacing: Theme.spacingL
+            anchors.horizontalCenter: root.centered ? parent.horizontalCenter : undefined
+
+            Column {
+                spacing: Theme.spacingXS
+
+                StyledText {
+                    text: I18n.tr("Latitude")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceVariantText
+                }
+
+                DankTextField {
+                    width: 120
+                    height: 40
+                    text: SessionData.latitude.toString()
+                    placeholderText: "0.0"
+                    onEditingFinished: {
+                        const lat = parseFloat(text);
+                        if (!isNaN(lat) && lat >= -90 && lat <= 90 && lat !== SessionData.latitude) {
+                            SessionData.setLatitude(lat);
+                        }
+                    }
+                }
+            }
+
+            Column {
+                spacing: Theme.spacingXS
+
+                StyledText {
+                    text: I18n.tr("Longitude")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceVariantText
+                }
+
+                DankTextField {
+                    width: 120
+                    height: 40
+                    text: SessionData.longitude.toString()
+                    placeholderText: "0.0"
+                    onEditingFinished: {
+                        const lon = parseFloat(text);
+                        if (!isNaN(lon) && lon >= -180 && lon <= 180 && lon !== SessionData.longitude) {
+                            SessionData.setLongitude(lon);
+                        }
+                    }
+                }
+            }
+        }
+
+        StyledText {
+            text: I18n.tr("Location Search")
+            font.pixelSize: Theme.fontSizeSmall
+            color: Theme.surfaceVariantText
+            font.weight: Font.Medium
+        }
+
+        DankLocationSearch {
+            width: parent.width
+            onLocationSelected: (displayName, coordinates) => {
+                const coords = coordinates.split(',');
+                if (coords.length >= 2) {
+                    const lat = parseFloat(coords[0]);
+                    const lon = parseFloat(coords[1]);
+                    if (!isNaN(lat) && lat >= -90 && lat <= 90) {
+                        SessionData.setLatitude(lat);
+                    }
+                    if (!isNaN(lon) && lon >= -180 && lon <= 180) {
+                        SessionData.setLongitude(lon);
+                    }
+                }
+            }
+        }
+
+        StyledText {
+            text: root.description
+            font.pixelSize: Theme.fontSizeSmall
+            color: Theme.surfaceVariantText
+            width: parent.width
+            wrapMode: Text.WordWrap
+            horizontalAlignment: root.centered ? Text.AlignHCenter : Text.AlignLeft
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds a searchable location picker to the automatic location sections of Theme & Colors (Color Mode) and Gamma Control, so users can search for a city and auto-fill the latitude/longitude coordinates (like the weather setting do) instead of typing them by hand.

Extracts the previously duplicated "Use IP Location + manual coordinates" UI into a new shared `SettingsLocationSection` component used by both tabs. The existing weather location search is left unchanged.

Tested on [hardware](https://github.com/Curious-r/nix-config/commit/f9f1cf8bb520c203b1efc060044b82c799fe6c69): search → auto-fill coordinates, cross-tab sync (both tabs share the same coordinates), and the "Share Gamma Control Settings" toggle all work as before. No backend changes. 

Follow-ups: While working on this, I spotted two minor things to address later: remembering and displaying the user's last selection in the search field, and fixing a visual glitch where the error icon flashes post-selection. Since both touch the shared DankLocationSearch component, I'll handle them in a separate PR over at dank-qml-common(maybe later).




## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->
<img width="1224" height="980" alt="1786094443586415099" src="https://github.com/user-attachments/assets/7368f6cc-06c6-4ef4-a2c3-cc5eb85099ca" />
<img width="1224" height="980" alt="1786094455518236885" src="https://github.com/user-attachments/assets/df905d39-f649-4f15-ae64-c82f051904e9" />
<img width="1224" height="980" alt="1786094462625514714" src="https://github.com/user-attachments/assets/5cf1434a-4f31-4bd2-be04-00c0ba1bd055" />


## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
