### PR TITLE
feat(dock): cycle grouped app windows

### DIFF
--- a/quickshell/Modules/Dock/DockAppButton.qml
+++ b/quickshell/Modules/Dock/DockAppButton.qml
@@ -168,6 +168,25 @@ Item {
         Qt.callLater(() => waylandToplevel.activate());
         return true;
     }
+
+    function cycleGroupedToplevels() {
+        const toplevels = getGroupedToplevels();
+        if (toplevels.length === 0)
+            return;
+
+        let currentIndex = -1;
+        for (let i = 0; i < toplevels.length; i++) {
+            if (toplevels[i].activated) {
+                currentIndex = i;
+                break;
+            }
+        }
+
+        const nextToplevel = toplevels[(currentIndex + 1) % toplevels.length];
+        if (restoreSpecialWorkspaceWindow(nextToplevel))
+            return;
+        nextToplevel.activate();
+    }
     onIsHoveredChanged: {
         if (mouseArea.pressed || dragging)
             return;
@@ -343,9 +362,8 @@ Item {
                             return;
                         groupedToplevel.activate();
                     }
-                } else if (contextMenu) {
-                    const shouldHidePin = appData.appId === "org.quickshell" || appData.appId === "com.danklinux.dms";
-                    contextMenu.showForButton(root, appData, root.height + 25, shouldHidePin, cachedDesktopEntry, parentDockScreen, dockApps);
+                } else {
+                    cycleGroupedToplevels();
                 }
                 break;
             }


### PR DESCRIPTION
## Description

Grouped dock icons currently open the context menu on left click when multiple windows are present, while right click already opens the same menu. This makes left and right click overlap in behavior.

Change left click for grouped apps to cycle through the app's windows instead, matching the Running Apps widget behavior and common dock interaction patterns.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Closes #2035
