### PR TITLE
fix(dock): preserve overview-only visibility

### DIFF
--- a/quickshell/Modules/Dock/Dock.qml
+++ b/quickshell/Modules/Dock/Dock.qml
@@ -9,7 +9,7 @@ import qs.Widgets
 Variants {
     id: dockVariants
     // Connected frame mode renders the dock inside the frame surface; skip the standalone window there.
-    model: SettingsData.showDock ? SettingsData.getFilteredScreens("dock").filter(screen => !CompositorService.frameHostsDockForScreen(screen)) : []
+    model: (SettingsData.showDock || (CompositorService.isNiri && SettingsData.dockOpenOnOverview)) ? SettingsData.getFilteredScreens("dock").filter(screen => !CompositorService.frameHostsDockForScreen(screen)) : []
 
     property var contextMenu
     property var trashContextMenu

--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -381,7 +381,7 @@ Item {
     }
 
     readonly property real dockReserveZone: dockGeometry.reserveZone
-    readonly property bool shouldReserveDockSpace: dockGeometry.shouldReserveSpace
+    readonly property bool shouldReserveDockSpace: SettingsData.showDock && dockGeometry.shouldReserveSpace
 
     readonly property real surfaceExclusiveZone: {
         if (!dock.shouldReserveDockSpace)


### PR DESCRIPTION
## Description
Fix a regression from #3014 where the dock layer was not created when `showDock` was disabled, which also prevented `dockOpenOnOverview` from showing the dock in Niri Overview.

This PR keeps the dock hidden normally while still allowing it to appear in Overview when `dockOpenOnOverview` is enabled.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues
https://github.com/AvengeMedia/DankMaterialShell/pull/3023#issuecomment-5232975445
