### PR TITLE
feat(niri): close overview on window focus

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -15,7 +15,7 @@ Singleton {
     id: root
     readonly property var log: Log.scoped("SettingsData")
 
-    readonly property int settingsConfigVersion: 15
+    readonly property int settingsConfigVersion: 16
 
     enum Position {
         Top,
@@ -548,7 +548,7 @@ Singleton {
     property string appPickerViewMode: "grid"
     property bool sortAppsAlphabetically: false
     property int appLauncherGridColumns: 4
-    property bool spotlightCloseNiriOverview: true
+    property bool closeNiriOverviewOnWindowFocus: true
     property bool rememberLastQuery: false
     property bool rememberLastMode: true
     property var spotlightSectionViewModes: ({})

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -280,7 +280,7 @@ var SPEC = {
     appPickerViewMode: { def: "grid" },
     sortAppsAlphabetically: { def: false },
     appLauncherGridColumns: { def: 4 },
-    spotlightCloseNiriOverview: { def: true },
+    closeNiriOverviewOnWindowFocus: { def: true },
     rememberLastQuery: { def: false },
     rememberLastMode: { def: true },
     spotlightSectionViewModes: { def: {} },

--- a/quickshell/Common/settings/SettingsStore.js
+++ b/quickshell/Common/settings/SettingsStore.js
@@ -389,5 +389,17 @@ function migrateToVersion(obj, targetVersion) {
         settings.configVersion = 15;
     }
 
+    if (currentVersion < 16) {
+        console.info("Migrating settings from version", currentVersion, "to version 16");
+        console.info("Moving Niri overview close behavior to the window focus setting");
+
+        if (settings.closeNiriOverviewOnWindowFocus === undefined && settings.spotlightCloseNiriOverview !== undefined) {
+            settings.closeNiriOverviewOnWindowFocus = settings.spotlightCloseNiriOverview;
+        }
+        delete settings.spotlightCloseNiriOverview;
+
+        settings.configVersion = 16;
+    }
+
     return settings;
 }

--- a/quickshell/Modals/DankLauncherV2/LauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/LauncherContent.qml
@@ -73,9 +73,6 @@ FocusScope {
             if (root.parentModal) {
                 root.parentModal.hide();
             }
-            if (SettingsData.spotlightCloseNiriOverview && NiriService.inOverview) {
-                NiriService.toggleOverview();
-            }
         }
     }
 

--- a/quickshell/Modals/DankLauncherV2/SpotlightLauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/SpotlightLauncherContent.qml
@@ -224,8 +224,6 @@ FocusScope {
 
         onItemExecuted: {
             root.parentModal?.hide();
-            if (SettingsData.spotlightCloseNiriOverview && NiriService.inOverview)
-                NiriService.toggleOverview();
         }
     }
 

--- a/quickshell/Modals/Settings/SettingsModal.qml
+++ b/quickshell/Modals/Settings/SettingsModal.qml
@@ -44,6 +44,7 @@ DankFloatingWindow {
         if (visible && !backingWindowVisible) {
             visible = false;
         }
+        CompositorService.closeNiriOverviewOnWindowFocus();
         visible = true;
     }
 

--- a/quickshell/Modules/Dock/DockAppButton.qml
+++ b/quickshell/Modules/Dock/DockAppButton.qml
@@ -182,7 +182,7 @@ Item {
             return false;
 
         HyprlandService.toggleSpecial(specialName);
-        Qt.callLater(() => waylandToplevel.activate());
+        Qt.callLater(() => CompositorService.activateToplevel(waylandToplevel));
         return true;
     }
 

--- a/quickshell/Modules/Settings/CompositorLayoutTab.qml
+++ b/quickshell/Modules/Settings/CompositorLayoutTab.qml
@@ -287,6 +287,24 @@ awk '$1 == "xray" { print FILENAME ":" FNR; exit }' $files 2>/dev/null`;
 
             SettingsCard {
                 width: parent.width
+                tags: ["niri", "overview", "window", "focus", "launch", "launcher", "dock", "settings"]
+                title: I18n.tr("Overview")
+                settingKey: "niriOverview"
+                iconName: "overview"
+                visible: CompositorService.isNiri
+
+                SettingsToggleRow {
+                    tags: ["niri", "overview", "window", "focus", "launch", "launcher", "dock", "settings"]
+                    settingKey: "closeNiriOverviewOnWindowFocus"
+                    text: I18n.tr("Close Niri Overview on Window Focus", "Niri setting to leave Niri overview when DMS launches or focuses a window")
+                    description: I18n.tr("Auto-close Niri overview when DMS launches or focuses a window.", "Description of the close Niri overview on window focus setting")
+                    checked: SettingsData.closeNiriOverviewOnWindowFocus
+                    onToggled: checked => SettingsData.set("closeNiriOverviewOnWindowFocus", checked)
+                }
+            }
+
+            SettingsCard {
+                width: parent.width
                 tags: ["niri", "layout", "gaps", "radius", "window", "border"]
                 title: I18n.tr("%1 Layout Overrides").arg("niri")
                 settingKey: "niriLayout"

--- a/quickshell/Modules/Settings/LauncherTab.qml
+++ b/quickshell/Modules/Settings/LauncherTab.qml
@@ -778,15 +778,6 @@ Item {
                 visible: CompositorService.isNiri
 
                 SettingsToggleRow {
-                    settingKey: "spotlightCloseNiriOverview"
-                    tags: ["launcher", "niri", "overview", "close", "launch"]
-                    text: I18n.tr("Close Overview on Launch")
-                    description: I18n.tr("Auto-close Niri overview when launching apps.")
-                    checked: SettingsData.spotlightCloseNiriOverview
-                    onToggled: checked => SettingsData.set("spotlightCloseNiriOverview", checked)
-                }
-
-                SettingsToggleRow {
                     settingKey: "niriOverviewOverlayEnabled"
                     tags: ["launcher", "niri", "overview", "overlay", "enable"]
                     text: I18n.tr("Enable Overview Overlay")

--- a/quickshell/Modules/WorkspaceOverlays/NiriOverviewOverlay.qml
+++ b/quickshell/Modules/WorkspaceOverlays/NiriOverviewOverlay.qml
@@ -115,7 +115,7 @@ Scope {
                             niriOverviewScope.hideSpotlight();
                             return;
                         }
-                        NiriService.toggleOverview();
+                        NiriService.closeOverview();
                     }
                 }
 
@@ -200,7 +200,7 @@ Scope {
                         if (overlayWindow.shouldShowSpotlight || niriOverviewScope.isClosing)
                             return;
                         if ([Qt.Key_Escape, Qt.Key_Return].includes(event.key)) {
-                            NiriService.toggleOverview();
+                            NiriService.closeOverview();
                             event.accepted = true;
                             return;
                         }

--- a/quickshell/Services/CompositorService.qml
+++ b/quickshell/Services/CompositorService.qml
@@ -51,9 +51,15 @@ Singleton {
         return supportsMinimize && toplevel && toplevel.minimized !== undefined;
     }
 
+    function closeNiriOverviewOnWindowFocus() {
+        if (SettingsData.closeNiriOverviewOnWindowFocus && isNiri && NiriService.inOverview)
+            NiriService.toggleOverview();
+    }
+
     function activateToplevel(toplevel) {
         if (!toplevel)
             return;
+        closeNiriOverviewOnWindowFocus();
         if (canMinimize(toplevel) && toplevel.minimized)
             toplevel.minimized = false;
         toplevel.activate();
@@ -63,19 +69,18 @@ Singleton {
         if (!toplevel)
             return;
         if (!canMinimize(toplevel)) {
-            toplevel.activate();
+            activateToplevel(toplevel);
             return;
         }
         if (toplevel.minimized) {
-            toplevel.minimized = false;
-            toplevel.activate();
+            activateToplevel(toplevel);
             return;
         }
         if (toplevel.activated) {
             toplevel.minimized = true;
             return;
         }
-        toplevel.activate();
+        activateToplevel(toplevel);
     }
 
     function fetchRandrData() {

--- a/quickshell/Services/CompositorService.qml
+++ b/quickshell/Services/CompositorService.qml
@@ -53,7 +53,7 @@ Singleton {
 
     function closeNiriOverviewOnWindowFocus() {
         if (SettingsData.closeNiriOverviewOnWindowFocus && isNiri && NiriService.inOverview)
-            NiriService.toggleOverview();
+            NiriService.closeOverview();
     }
 
     function activateToplevel(toplevel) {

--- a/quickshell/Services/NiriService.qml
+++ b/quickshell/Services/NiriService.qml
@@ -795,6 +795,14 @@ Singleton {
         });
     }
 
+    function closeOverview() {
+        return send({
+            "Action": {
+                "CloseOverview": {}
+            }
+        });
+    }
+
     function focusMonitor(outputName) {
         return send({
             "Action": {

--- a/quickshell/Services/PopoutService.qml
+++ b/quickshell/Services/PopoutService.qml
@@ -460,7 +460,7 @@ Singleton {
                     settingsModal.hide();
                     return;
                 }
-                toplevel.activate();
+                CompositorService.activateToplevel(toplevel);
                 return;
             }
         }
@@ -479,7 +479,7 @@ Singleton {
                 }
                 var idx = settingsModal.resolveTabIndex(tabName);
                 settingsModal.setTabIndex(idx);
-                toplevel.activate();
+                CompositorService.activateToplevel(toplevel);
                 return;
             }
         }

--- a/quickshell/Services/SessionService.qml
+++ b/quickshell/Services/SessionService.qml
@@ -281,6 +281,7 @@ Singleton {
     function launchDesktopEntry(desktopEntry, useNvidia) {
         if (!desktopEntry || !desktopEntry.command)
             return;
+        CompositorService.closeNiriOverviewOnWindowFocus();
         let cmd = desktopEntry.command;
 
         const appId = desktopEntry.id || desktopEntry.execString || desktopEntry.exec || "";
@@ -338,6 +339,7 @@ Singleton {
     function launchDesktopAction(desktopEntry, action, useNvidia) {
         if (!desktopEntry || !action || !action.command)
             return;
+        CompositorService.closeNiriOverviewOnWindowFocus();
         let cmd = action.command;
 
         const appId = desktopEntry.id || desktopEntry.execString || desktopEntry.exec || "";

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -2890,31 +2890,6 @@
     ]
   },
   {
-    "section": "niriOverviewOverlayEnabled",
-    "label": "Enable Overview Overlay",
-    "tabIndex": 9,
-    "category": "Launcher",
-    "keywords": [
-      "another",
-      "app drawer",
-      "app menu",
-      "applications",
-      "disable",
-      "drawer",
-      "enable",
-      "launcher",
-      "menu",
-      "niri",
-      "overlay",
-      "overview",
-      "show",
-      "start",
-      "start menu",
-      "typing"
-    ],
-    "description": "Show launcher overlay when typing in Niri overview. Disable to use another launcher."
-  },
-  {
     "section": "appLauncherGridColumns",
     "label": "Grid Columns",
     "tabIndex": 9,
@@ -3090,29 +3065,31 @@
     "description": "Show darkened overlay behind modal dialogs"
   },
   {
-    "section": "closeNiriOverviewOnWindowFocus",
-    "label": "Overview",
-    "tabIndex": 37,
-    "category": "Personalization",
+    "section": "niriOverviewOverlayEnabled",
+    "label": "Niri Integration",
+    "tabIndex": 9,
+    "category": "Launcher",
     "keywords": [
-      "apps",
-      "auto",
-      "close",
-      "dock",
+      "another",
+      "app drawer",
+      "app menu",
+      "applications",
+      "disable",
       "drawer",
-      "focus",
+      "enable",
       "integration",
-      "launch",
       "launcher",
-      "launching",
       "menu",
       "niri",
+      "overlay",
       "overview",
-      "settings",
-      "start"
+      "show",
+      "start",
+      "start menu",
+      "typing"
     ],
-    "icon": "overview",
-    "description": "Auto-close Niri overview when DMS launches or focuses a window.",
+    "icon": "open_in_new",
+    "description": "Show launcher overlay when typing in Niri overview. Disable to use another launcher.",
     "conditionKey": "isNiri"
   },
   {
@@ -10099,6 +10076,32 @@
     "description": "Width of window border and focus ring"
   },
   {
+    "section": "closeNiriOverviewOnWindowFocus",
+    "label": "Close Niri Overview on Window Focus",
+    "tabIndex": 37,
+    "category": "Personalization",
+    "keywords": [
+      "appearance",
+      "auto",
+      "close",
+      "custom",
+      "customize",
+      "dock",
+      "focus",
+      "focuses",
+      "launch",
+      "launcher",
+      "launches",
+      "niri",
+      "overview",
+      "personal",
+      "personalization",
+      "settings",
+      "window"
+    ],
+    "description": "Auto-close Niri overview when DMS launches or focuses a window."
+  },
+  {
     "section": "hyprlandLayoutBarXrayEnabled",
     "label": "Frame Xray",
     "tabIndex": 37,
@@ -10509,6 +10512,34 @@
       "window"
     ],
     "description": "Use custom window radius instead of theme radius"
+  },
+  {
+    "section": "niriOverview",
+    "label": "Overview",
+    "tabIndex": 37,
+    "category": "Personalization",
+    "keywords": [
+      "appearance",
+      "auto",
+      "close",
+      "custom",
+      "customize",
+      "dock",
+      "focus",
+      "focuses",
+      "launch",
+      "launcher",
+      "launches",
+      "niri",
+      "overview",
+      "personal",
+      "personalization",
+      "settings",
+      "window"
+    ],
+    "icon": "overview",
+    "description": "Auto-close Niri overview when DMS launches or focuses a window.",
+    "conditionKey": "isNiri"
   },
   {
     "section": "hyprlandResizeOnBorder",

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -3090,15 +3090,17 @@
     "description": "Show darkened overlay behind modal dialogs"
   },
   {
-    "section": "spotlightCloseNiriOverview",
-    "label": "Niri Integration",
-    "tabIndex": 9,
-    "category": "Launcher",
+    "section": "closeNiriOverviewOnWindowFocus",
+    "label": "Overview",
+    "tabIndex": 37,
+    "category": "Personalization",
     "keywords": [
       "apps",
       "auto",
       "close",
+      "dock",
       "drawer",
+      "focus",
       "integration",
       "launch",
       "launcher",
@@ -3106,10 +3108,11 @@
       "menu",
       "niri",
       "overview",
+      "settings",
       "start"
     ],
-    "icon": "open_in_new",
-    "description": "Auto-close Niri overview when launching apps.",
+    "icon": "overview",
+    "description": "Auto-close Niri overview when DMS launches or focuses a window.",
     "conditionKey": "isNiri"
   },
   {


### PR DESCRIPTION
## Description

Adds a single Niri-only **Close Overview on Window Focus** option under **Personalization → Niri → Overview**.

When enabled, DMS closes Niri's overview when an action launches or focuses a window from:

- the Full and Spotlight launchers
- the standalone Dock and the Apps Dock bar widget
- Dock context-menu actions
- Settings links in Control Center

This replaces the launcher-specific **Close Overview on Launch** option. Existing `spotlightCloseNiriOverview` values are migrated to the new shared setting, preserving the user's current preference.

The option is enabled by default. Disabling it keeps the overview open. Non-Niri sessions are unaffected and never attempt to toggle Niri's overview.

## Possible follow-up

The remaining **Enable Overview Overlay** option still lives under **Launcher → Niri Integration**. It may make sense to move it to **Personalization → Niri → Overview** in a separate change, keeping all Niri overview behavior in one place.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Closes #2379

## Screenshots / video

<!-- Drag the demonstration video here. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: not applicable
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document the new behavior
