### PR TITLE
fix(brightness): initialize display state

### DIFF
--- a/quickshell/DMSShell.qml
+++ b/quickshell/DMSShell.qml
@@ -31,6 +31,7 @@ Item {
     id: root
     readonly property var log: Log.scoped("DMSShell")
     readonly property var _sessionsServiceRef: SessionsService
+    readonly property var _displayServiceRef: DisplayService
 
     property var core: null
 

--- a/quickshell/Services/DisplayService.qml
+++ b/quickshell/Services/DisplayService.qml
@@ -1346,6 +1346,22 @@ Singleton {
         });
     }
 
+    function requestBrightnessState() {
+        if (!DMSService.isConnected) {
+            return;
+        }
+
+        DMSService.sendRequest("brightness.getState", null, response => {
+            if (response.error) {
+                log.error("Failed to request brightness state:", response.error);
+                return;
+            }
+            if (response.result) {
+                updateFromBrightnessState(response.result);
+            }
+        });
+    }
+
     function updateDeviceBrightnessDisplay(deviceName) {
         brightnessVersion++;
         brightnessChanged();
@@ -1371,6 +1387,7 @@ Singleton {
         deviceBrightnessUserSet = Object.assign({}, SessionData.brightnessUserSetValues);
         if (DMSService.isConnected) {
             checkGammaControlAvailability();
+            requestBrightnessState();
         }
     }
 
@@ -1410,6 +1427,7 @@ Singleton {
         function onConnectionStateChanged() {
             if (DMSService.isConnected) {
                 checkGammaControlAvailability();
+                requestBrightnessState();
             } else {
                 brightnessAvailable = false;
                 gammaControlAvailable = false;


### PR DESCRIPTION
## Description

Fix brightness controls starting unavailable when the initial brightness state is missed during shell startup.

This keeps `DisplayService` initialized with the shell and requests the current brightness state on startup/reconnect, so Control Center and brightness IPC do not depend on opening Settings first.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes #2954
