### PR TITLE
feat(clipboard): add overlay layer option

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -108,6 +108,7 @@ Singleton {
     property bool clipboardClickToPaste: false
     property bool clipboardEnterToPaste: false
     property bool clipboardRememberTypeFilter: false
+    property bool clipboardUseOverlayLayer: false
     property string clipboardTypeFilter: "all"
     property var clipboardVisibleEntryActions: ["pin", "edit", "delete"]
 

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -678,6 +678,7 @@ var SPEC = {
     clipboardClickToPaste: { def: false },
     clipboardEnterToPaste: { def: false },
     clipboardRememberTypeFilter: { def: false },
+    clipboardUseOverlayLayer: { def: false },
     clipboardTypeFilter: { def: "all" },
     clipboardVisibleEntryActions: { def: ["pin", "edit", "delete"] },
 

--- a/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
@@ -73,6 +73,7 @@ DankModal {
 
     visible: false
     keepContentLoaded: true
+    useOverlayLayer: SettingsData.clipboardUseOverlayLayer
     modalWidth: ClipboardConstants.modalWidth
     modalHeight: ClipboardConstants.modalHeight
     backgroundColor: Theme.withAlpha(Theme.surfaceContainer, Theme.popupTransparency)

--- a/quickshell/Modules/Settings/ClipboardTab.qml
+++ b/quickshell/Modules/Settings/ClipboardTab.qml
@@ -483,6 +483,16 @@ Item {
                     onToggled: checked => SettingsData.set("clipboardRememberTypeFilter", checked)
                 }
 
+                SettingsToggleRow {
+                    tab: "clipboard"
+                    tags: ["clipboard", "fullscreen", "overlay", "layer", "behavior"]
+                    settingKey: "clipboardUseOverlayLayer"
+                    text: I18n.tr("Use Overlay Layer", "clipboard layer toggle: use Wayland overlay layer")
+                    description: I18n.tr("Place clipboard history on the Wayland overlay layer")
+                    checked: SettingsData.clipboardUseOverlayLayer
+                    onToggled: checked => SettingsData.set("clipboardUseOverlayLayer", checked)
+                }
+
                 SettingsButtonGroupRow {
                     tab: "clipboard"
                     tags: ["clipboard", "actions", "buttons", "hide", "density", "copy", "paste", "pin", "edit", "delete"]

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -8511,6 +8511,29 @@
     "description": "Keep the clipboard type filter when reopening history"
   },
   {
+    "section": "clipboardUseOverlayLayer",
+    "label": "Use Overlay Layer",
+    "tabIndex": 23,
+    "category": "System",
+    "keywords": [
+      "behavior",
+      "clipboard",
+      "cliphist",
+      "copy",
+      "fullscreen",
+      "history",
+      "layer",
+      "linux",
+      "os",
+      "overlay",
+      "paste",
+      "place",
+      "system",
+      "wayland"
+    ],
+    "description": "Place clipboard history on the Wayland overlay layer"
+  },
+  {
     "section": "clipboardVisibleEntryActions",
     "label": "Visible Entry Actions",
     "tabIndex": 23,


### PR DESCRIPTION
## Description

Add an opt-in setting to place Clipboard History on the Wayland overlay layer, matching the existing launcher overlay behavior for fullscreen workflows.

Default remains unchanged.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

Closes #2796

![dms_capture_1786386741731](https://github.com/user-attachments/assets/c87cfd05-ca89-43b3-9aa4-148061f6d5b9)
