### PR TITLE
fix(dock): cycle niri overview groups

### DIFF
--- a/quickshell/Modules/Dock/DockAppButton.qml
+++ b/quickshell/Modules/Dock/DockAppButton.qml
@@ -199,6 +199,15 @@ Item {
             }
         }
 
+        if (currentIndex < 0 && CompositorService.isNiri && NiriService.inOverview && NiriService.lastFocusedWindowId !== null) {
+            for (let i = 0; i < toplevels.length; i++) {
+                if (toplevels[i].niriWindowId === NiriService.lastFocusedWindowId) {
+                    currentIndex = i;
+                    break;
+                }
+            }
+        }
+
         const nextToplevel = toplevels[(currentIndex + 1) % toplevels.length];
         if (restoreSpecialWorkspaceWindow(nextToplevel))
             return;

--- a/quickshell/Services/NiriService.qml
+++ b/quickshell/Services/NiriService.qml
@@ -24,6 +24,7 @@ Singleton {
     property var outputs: ({})
     property var windows: []
     property var displayScales: ({})
+    property var lastFocusedWindowId: null
 
     property var _realOutputs: ({})
 
@@ -483,6 +484,8 @@ Singleton {
 
     function handleWindowFocusChanged(data) {
         const focusedWindowId = data.id;
+        if (focusedWindowId !== null && focusedWindowId !== undefined)
+            lastFocusedWindowId = focusedWindowId;
 
         // Only clone windows whose focus flag changes; skip reassignment if nothing changed.
         let focusedWindow = null;
@@ -536,6 +539,8 @@ Singleton {
                 updatedWs[prop] = ws[prop];
             }
             updatedWs.active_window_id = data.active_window_id;
+            if (data.active_window_id !== null && data.active_window_id !== undefined)
+                lastFocusedWindowId = data.active_window_id;
 
             const updatedWorkspaces = {};
             for (const id in root.workspaces) {


### PR DESCRIPTION
## Description

Fix grouped dock app cycling in Niri overview when the previously focused window is the first window in the group.

Niri overview can clear the active window state, so the dock now falls back to the last focused Niri window when deciding which grouped window to cycle from.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)