### PR TITLE
feat(settings): echo location name in location search

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "dank-qml-common": {
       "flake": false,
       "locked": {
-        "lastModified": 1786309712,
-        "narHash": "sha256-VMUI9bvzHOXdyp99EoJ917KgsV9AaEg9dMVL6Xh+w4M=",
+        "lastModified": 1786649745,
+        "narHash": "sha256-61G4G6nQqSV4DWNyZAYlZOLAY6+Ug+JQA1SaifacaSI=",
         "owner": "AvengeMedia",
         "repo": "dank-qml-common",
-        "rev": "83518beaf2c28b87ca0b3862eceeb0917a6c47a0",
+        "rev": "3373281fdba24e030ef47325f9db01494780a4a3",
         "type": "github"
       },
       "original": {

--- a/quickshell/Common/SessionData.qml
+++ b/quickshell/Common/SessionData.qml
@@ -167,6 +167,7 @@ Singleton {
     property real longitude: 0.0
     property bool nightModeUseIPLocation: false
     property string nightModeLocationProvider: ""
+    property string nightModeLocationName: ""
 
     property bool themeModeAutoEnabled: false
     property string themeModeAutoMode: "time"
@@ -879,6 +880,11 @@ Singleton {
 
     function setLongitude(lng) {
         longitude = lng;
+        saveSettings();
+    }
+
+    function setNightModeLocationName(name) {
+        nightModeLocationName = name;
         saveSettings();
     }
 

--- a/quickshell/Common/settings/SessionSpec.js
+++ b/quickshell/Common/settings/SessionSpec.js
@@ -38,6 +38,7 @@ var SPEC = {
     longitude: { def: 0.0 },
     nightModeUseIPLocation: { def: false },
     nightModeLocationProvider: { def: "" },
+    nightModeLocationName: { def: "" },
 
     themeModeAutoEnabled: { def: false },
     themeModeAutoMode: { def: "time" },

--- a/quickshell/Modules/Settings/ThemeColorsTab.qml
+++ b/quickshell/Modules/Settings/ThemeColorsTab.qml
@@ -1508,7 +1508,6 @@ Item {
                         SettingsLocationSection {
                             width: parent.width
                             visible: SessionData.themeModeAutoMode === "location" && !SessionData.themeModeShareGammaSettings
-                            centered: true
                             description: I18n.tr("Uses sunrise/sunset times based on your location.")
                         }
 

--- a/quickshell/Modules/Settings/TimeWeatherTab.qml
+++ b/quickshell/Modules/Settings/TimeWeatherTab.qml
@@ -9,6 +9,8 @@ import qs.Modules.Settings.Widgets
 Item {
     id: root
 
+    property bool _internalChange: false
+
     readonly property string _systemDefaultLabel: I18n.tr("System Default")
 
     function weekStartQt() {
@@ -564,11 +566,13 @@ Item {
                                             keyNavigationTab: longitudeInput
 
                                             Component.onCompleted: {
+                                                root._internalChange = true;
                                                 if (SettingsData.weatherCoordinates) {
                                                     const coords = SettingsData.weatherCoordinates.split(',');
                                                     if (coords.length > 0)
                                                         text = coords[0].trim();
                                                 }
+                                                root._internalChange = false;
                                             }
 
                                             Connections {
@@ -583,6 +587,8 @@ Item {
                                             }
 
                                             onTextEdited: {
+                                                if (root._internalChange)
+                                                    return;
                                                 if (text && longitudeInput.text) {
                                                     const coords = text + "," + longitudeInput.text;
                                                     SessionData.weatherCoordinates = coords;
@@ -615,11 +621,13 @@ Item {
                                             keyNavigationBacktab: latitudeInput
 
                                             Component.onCompleted: {
+                                                root._internalChange = true;
                                                 if (SettingsData.weatherCoordinates) {
                                                     const coords = SettingsData.weatherCoordinates.split(',');
                                                     if (coords.length > 1)
                                                         text = coords[1].trim();
                                                 }
+                                                root._internalChange = false;
                                             }
 
                                             Connections {
@@ -634,6 +642,8 @@ Item {
                                             }
 
                                             onTextEdited: {
+                                                if (root._internalChange)
+                                                    return;
                                                 if (text && latitudeInput.text) {
                                                     const coords = latitudeInput.text + "," + text;
                                                     SessionData.weatherCoordinates = coords;
@@ -663,12 +673,14 @@ Item {
                                         placeholderText: I18n.tr("New York, NY")
                                         keyNavigationBacktab: longitudeInput
                                         onLocationSelected: (displayName, coordinates) => {
+                                            root._internalChange = true;
                                             SettingsData.setWeatherLocation(displayName, coordinates);
                                             const coords = coordinates.split(',');
                                             if (coords.length >= 2) {
                                                 latitudeInput.text = coords[0].trim();
                                                 longitudeInput.text = coords[1].trim();
                                             }
+                                            root._internalChange = false;
                                         }
                                     }
                                 }

--- a/quickshell/Modules/Settings/TimeWeatherTab.qml
+++ b/quickshell/Modules/Settings/TimeWeatherTab.qml
@@ -659,7 +659,7 @@ Item {
                                     DankLocationSearch {
                                         id: locationSearchInput
                                         width: parent.width
-                                        currentLocation: ""
+                                        currentLocation: SettingsData.weatherLocation
                                         placeholderText: I18n.tr("New York, NY")
                                         keyNavigationBacktab: longitudeInput
                                         onLocationSelected: (displayName, coordinates) => {

--- a/quickshell/Modules/Settings/Widgets/SettingsLocationSection.qml
+++ b/quickshell/Modules/Settings/Widgets/SettingsLocationSection.qml
@@ -8,7 +8,6 @@ Column {
     id: root
 
     property string description: I18n.tr("Uses sunrise/sunset times based on your location.")
-    property bool centered: false
 
     width: parent.width
     spacing: Theme.spacingM
@@ -32,7 +31,8 @@ Column {
     }
 
     Column {
-        width: parent.width
+        width: parent.width - Theme.spacingM * 2
+        x: Theme.spacingM
         spacing: Theme.spacingM
         visible: !SessionData.nightModeUseIPLocation
 
@@ -40,15 +40,15 @@ Column {
             text: I18n.tr("Manual Coordinates")
             font.pixelSize: Theme.fontSizeMedium
             color: Theme.surfaceText
-            width: parent.width
-            horizontalAlignment: root.centered ? Text.AlignHCenter : Text.AlignLeft
+            font.weight: Font.Medium
         }
 
         Row {
-            spacing: Theme.spacingL
-            anchors.horizontalCenter: root.centered ? parent.horizontalCenter : undefined
+            width: parent.width
+            spacing: Theme.spacingM
 
             Column {
+                width: (parent.width - Theme.spacingM) / 2
                 spacing: Theme.spacingXS
 
                 StyledText {
@@ -59,10 +59,14 @@ Column {
 
                 DankTextField {
                     id: latitudeField
-                    width: 120
-                    height: 40
+                    width: parent.width
+                    height: 48
                     text: ""
-                    placeholderText: "0.0"
+                    placeholderText: "40.7128"
+                    backgroundColor: Theme.surfaceVariant
+                    normalBorderColor: Theme.primarySelected
+                    focusedBorderColor: Theme.primary
+                    keyNavigationTab: longitudeField
 
                     Component.onCompleted: {
                         text = SessionData.latitude.toString();
@@ -86,6 +90,7 @@ Column {
             }
 
             Column {
+                width: (parent.width - Theme.spacingM) / 2
                 spacing: Theme.spacingXS
 
                 StyledText {
@@ -96,10 +101,14 @@ Column {
 
                 DankTextField {
                     id: longitudeField
-                    width: 120
-                    height: 40
+                    width: parent.width
+                    height: 48
                     text: ""
-                    placeholderText: "0.0"
+                    placeholderText: "-74.0060"
+                    backgroundColor: Theme.surfaceVariant
+                    normalBorderColor: Theme.primarySelected
+                    focusedBorderColor: Theme.primary
+                    keyNavigationBacktab: latitudeField
 
                     Component.onCompleted: {
                         text = SessionData.longitude.toString();
@@ -157,7 +166,6 @@ Column {
             color: Theme.surfaceVariantText
             width: parent.width
             wrapMode: Text.WordWrap
-            horizontalAlignment: root.centered ? Text.AlignHCenter : Text.AlignLeft
         }
     }
 }

--- a/quickshell/Modules/Settings/Widgets/SettingsLocationSection.qml
+++ b/quickshell/Modules/Settings/Widgets/SettingsLocationSection.qml
@@ -79,6 +79,7 @@ Column {
                         const lat = parseFloat(text);
                         if (!isNaN(lat) && lat >= -90 && lat <= 90 && lat !== SessionData.latitude) {
                             SessionData.setLatitude(lat);
+                            SessionData.setNightModeLocationName("");
                         }
                     }
                 }
@@ -115,6 +116,7 @@ Column {
                         const lon = parseFloat(text);
                         if (!isNaN(lon) && lon >= -180 && lon <= 180 && lon !== SessionData.longitude) {
                             SessionData.setLongitude(lon);
+                            SessionData.setNightModeLocationName("");
                         }
                     }
                 }
@@ -130,7 +132,9 @@ Column {
 
         DankLocationSearch {
             width: parent.width
+            currentLocation: SessionData.nightModeLocationName
             onLocationSelected: (displayName, coordinates) => {
+                SessionData.setNightModeLocationName(displayName);
                 const coords = coordinates.split(',');
                 if (coords.length >= 2) {
                     const lat = parseFloat(coords[0]);


### PR DESCRIPTION
## Description

Adds city-name echo to the location search field in all three places and fixes a couple of related issues found while testing:

- Theme & Gamma auto-location now persist the selected city name in a new `nightModeLocationName` session property and prefill the search field with it; manually editing coordinates clears the name again.
- Weather search gets the same echo via the existing `weatherLocation`, and no longer silently loses it when the settings tab initializes or fills coordinates from a search result.
- Manual coordinate fields in Theme & Gamma now use the same full-width layout as the weather page (aligned insets, matching title weight).
- `DankLocationSearch` (via the submodule bump) now shows a selected-state check icon after picking a result instead of a misleading error icon, and supports the `currentLocation` echo.

Have tested on hardware with https://github.com/Curious-r/nix-config/tree/test/dms-location-search-echo

- Search → select a city: lat/lon auto-fill and the day/night switch reacts in both Theme & Colors and Gamma Control.
- Echo: after selection, reopening settings or switching tabs prefills the search field with the city name; manually editing lat/lon clears it back to the placeholder.
- Cross-tab: coordinates and the echoed name stay in sync in both directions (Gamma ⇄ Theme), including after manual edits.
- Icon: focusing the search field after a selection shows the check icon rather than the red error icon.
- Layout: the unified manual-coordinates form renders correctly in both tabs.


## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->
<img width="1216" height="979" alt="1786419135292595840" src="https://github.com/user-attachments/assets/0b7a6d80-4294-47ae-aace-2a1c4342d89f" />
<img width="1216" height="979" alt="1786419141485273120" src="https://github.com/user-attachments/assets/26e518a1-42c4-4982-a7b8-d4ce175751d8" />


## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
