### PR TITLE
perf(screenshot): separate overlay surface

### DIFF
--- a/core/internal/screenshot/region.go
+++ b/core/internal/screenshot/region.go
@@ -54,8 +54,9 @@ type OutputSurface struct {
 	yInverted         bool
 
 	// Triple-buffered render slots
-	slots      [3]*RenderSlot
-	slotsReady bool
+	slots         [3]*RenderSlot
+	slotsReady    bool
+	redrawPending bool
 }
 
 type PreCapture struct {
@@ -789,6 +790,9 @@ func (r *RegionSelector) initRenderBuffer(os *OutputSurface) {
 		slotRef := slot
 		wlBuf.SetReleaseHandler(func(e client.BufferReleaseEvent) {
 			slotRef.busy = false
+			if os.redrawPending {
+				r.redrawSurface(os)
+			}
 		})
 
 		os.slots[i] = slot
@@ -841,6 +845,11 @@ func (r *RegionSelector) getSourceBuffer(os *OutputSurface) *ShmBuffer {
 }
 
 func (r *RegionSelector) redrawSurface(os *OutputSurface) {
+	if os == nil {
+		return
+	}
+	os.redrawPending = true
+
 	srcBuf := r.getSourceBuffer(os)
 	if srcBuf == nil || !os.slotsReady {
 		return
@@ -850,6 +859,7 @@ func (r *RegionSelector) redrawSurface(os *OutputSurface) {
 	if slot == nil {
 		return
 	}
+	os.redrawPending = false
 
 	if os.overlayReady {
 		if err := r.presentBaseSurface(os, srcBuf); err != nil {

--- a/core/internal/screenshot/region.go
+++ b/core/internal/screenshot/region.go
@@ -35,6 +35,15 @@ type OutputSurface struct {
 	output            *WaylandOutput
 	wlSurface         *client.Surface
 	layerSurf         *wlr_layer_shell.ZwlrLayerSurfaceV1
+	overlaySurface    *client.Surface
+	overlaySubsurface *client.Subsurface
+	overlayViewport   *wp_viewporter.WpViewport
+	overlayInput      *client.Region
+	baseBuffer        *ShmBuffer
+	basePool          *client.ShmPool
+	baseWlBuf         *client.Buffer
+	overlayReady      bool
+	basePresented     bool
 	viewport          *wp_viewporter.WpViewport
 	screenBuf         *ShmBuffer
 	screenBufNoCursor *ShmBuffer
@@ -65,6 +74,7 @@ type RegionSelector struct {
 
 	compositor *client.Compositor
 	shm        *client.Shm
+	subcomp    *client.Subcompositor
 	seat       *client.Seat
 	pointer    *client.Pointer
 	keyboard   *client.Keyboard
@@ -253,6 +263,12 @@ func (r *RegionSelector) handleGlobal(e client.RegistryGlobalEvent) {
 		shm := client.NewShm(r.ctx)
 		if err := r.registry.Bind(e.Name, e.Interface, e.Version, shm); err == nil {
 			r.shm = shm
+		}
+
+	case client.SubcompositorInterfaceName:
+		subcomp := client.NewSubcompositor(r.ctx)
+		if err := r.registry.Bind(e.Name, e.Interface, e.Version, subcomp); err == nil {
+			r.subcomp = subcomp
 		}
 
 	case client.SeatInterfaceName:
@@ -680,8 +696,60 @@ func (r *RegionSelector) captureForSurface(os *OutputSurface) {
 	}
 
 	r.initRenderBuffer(os)
+	if r.subcomp != nil && r.viewporter != nil {
+		if err := r.createOverlaySurface(os); err != nil {
+			log.Debug("screenshot overlay surface unavailable", "err", err)
+		}
+	}
 	r.applyPreSelection(os)
 	r.redrawSurface(os)
+}
+
+func (r *RegionSelector) createOverlaySurface(os *OutputSurface) error {
+	surface, err := r.compositor.CreateSurface()
+	if err != nil {
+		return fmt.Errorf("create overlay surface: %w", err)
+	}
+
+	subsurface, err := r.subcomp.GetSubsurface(surface, os.wlSurface)
+	if err != nil {
+		surface.Destroy()
+		return fmt.Errorf("create overlay subsurface: %w", err)
+	}
+	if err := subsurface.SetPosition(0, 0); err != nil {
+		subsurface.Destroy()
+		surface.Destroy()
+		return fmt.Errorf("position overlay subsurface: %w", err)
+	}
+
+	viewport, err := r.viewporter.GetViewport(surface)
+	if err != nil {
+		subsurface.Destroy()
+		surface.Destroy()
+		return fmt.Errorf("create overlay viewport: %w", err)
+	}
+
+	input, err := r.compositor.CreateRegion()
+	if err != nil {
+		viewport.Destroy()
+		subsurface.Destroy()
+		surface.Destroy()
+		return fmt.Errorf("create overlay input region: %w", err)
+	}
+	if err := surface.SetInputRegion(input); err != nil {
+		input.Destroy()
+		viewport.Destroy()
+		subsurface.Destroy()
+		surface.Destroy()
+		return fmt.Errorf("set overlay input region: %w", err)
+	}
+
+	os.overlaySurface = surface
+	os.overlaySubsurface = subsurface
+	os.overlayViewport = viewport
+	os.overlayInput = input
+	os.overlayReady = true
+	return nil
 }
 
 func (r *RegionSelector) initRenderBuffer(os *OutputSurface) {
@@ -783,6 +851,23 @@ func (r *RegionSelector) redrawSurface(os *OutputSurface) {
 		return
 	}
 
+	if os.overlayReady {
+		if err := r.presentBaseSurface(os, srcBuf); err != nil {
+			log.Error("present screenshot base surface failed", "err", err)
+			return
+		}
+		r.drawOverlayLayer(os, slot.shm)
+		_ = os.overlayViewport.SetSource(0, 0, float64(slot.shm.Width), float64(slot.shm.Height))
+		_ = os.overlayViewport.SetDestination(int32(os.logicalW), int32(os.logicalH))
+		_ = os.overlaySurface.SetBufferScale(1)
+		_ = os.overlaySurface.Attach(slot.wlBuf, 0, 0)
+		_ = os.overlaySurface.Damage(0, 0, int32(slot.shm.Width), int32(slot.shm.Height))
+		_ = os.overlaySurface.Commit()
+		slot.busy = true
+		_ = os.wlSurface.Commit()
+		return
+	}
+
 	switch r.phase {
 	case phaseScroll:
 		r.drawScrollOverlay(os, slot.shm)
@@ -809,6 +894,50 @@ func (r *RegionSelector) redrawSurface(os *OutputSurface) {
 
 	// Mark this slot as busy until compositor releases it
 	slot.busy = true
+}
+
+func (r *RegionSelector) presentBaseSurface(os *OutputSurface, src *ShmBuffer) error {
+	if os.basePresented {
+		return nil
+	}
+
+	buf, err := CreateShmBuffer(src.Width, src.Height, src.Stride)
+	if err != nil {
+		return err
+	}
+	buf.Format = src.Format
+	r.copyOpaque(src, buf)
+
+	pool, err := r.shm.CreatePool(buf.Fd(), int32(buf.Size()))
+	if err != nil {
+		buf.Close()
+		return err
+	}
+	wlBuf, err := pool.CreateBuffer(0, int32(buf.Width), int32(buf.Height), int32(buf.Stride), alphaFormat(os.screenFormat))
+	if err != nil {
+		pool.Destroy()
+		buf.Close()
+		return err
+	}
+
+	os.baseBuffer = buf
+	os.basePool = pool
+	os.baseWlBuf = wlBuf
+	if os.viewport != nil {
+		_ = os.wlSurface.SetBufferScale(1)
+		_ = os.viewport.SetSource(0, 0, float64(buf.Width), float64(buf.Height))
+		_ = os.viewport.SetDestination(int32(os.logicalW), int32(os.logicalH))
+	} else {
+		bufferScale := os.output.scale
+		if bufferScale <= 0 {
+			bufferScale = 1
+		}
+		_ = os.wlSurface.SetBufferScale(bufferScale)
+	}
+	_ = os.wlSurface.Attach(wlBuf, 0, 0)
+	_ = os.wlSurface.Damage(0, 0, int32(os.logicalW), int32(os.logicalH))
+	os.basePresented = true
+	return nil
 }
 
 func (r *RegionSelector) cleanup() {
@@ -842,6 +971,27 @@ func (r *RegionSelector) cleanup() {
 				slot.shm.Close()
 			}
 		}
+		if os.overlayInput != nil {
+			os.overlayInput.Destroy()
+		}
+		if os.overlayViewport != nil {
+			os.overlayViewport.Destroy()
+		}
+		if os.overlaySubsurface != nil {
+			os.overlaySubsurface.Destroy()
+		}
+		if os.overlaySurface != nil {
+			os.overlaySurface.Destroy()
+		}
+		if os.baseWlBuf != nil {
+			os.baseWlBuf.Destroy()
+		}
+		if os.basePool != nil {
+			os.basePool.Destroy()
+		}
+		if os.baseBuffer != nil {
+			os.baseBuffer.Close()
+		}
 		if os.viewport != nil {
 			os.viewport.Destroy()
 		}
@@ -867,6 +1017,9 @@ func (r *RegionSelector) cleanup() {
 	}
 	if r.viewporter != nil {
 		r.viewporter.Destroy()
+	}
+	if r.subcomp != nil {
+		r.subcomp.Destroy()
 	}
 	if r.screencopy != nil {
 		r.screencopy.Destroy()

--- a/core/internal/screenshot/region_input.go
+++ b/core/internal/screenshot/region_input.go
@@ -84,9 +84,7 @@ func (r *RegionSelector) setupPointerHandlers() {
 
 		r.selection.currentX = curX
 		r.selection.currentY = curY
-		for _, os := range r.surfaces {
-			r.redrawSurface(os)
-		}
+		r.redrawSurface(r.selection.surface)
 	})
 
 	r.pointer.SetButtonHandler(func(e client.PointerButtonEvent) {

--- a/core/internal/screenshot/region_render.go
+++ b/core/internal/screenshot/region_render.go
@@ -51,6 +51,89 @@ var DefaultOverlayStyle = OverlayStyle{
 	AccentR: 100, AccentG: 180, AccentB: 255,
 }
 
+func (r *RegionSelector) copyOpaque(src, dst *ShmBuffer) {
+	srcData := src.Data()
+	dstData := dst.Data()
+	for y := 0; y < dst.Height; y++ {
+		srcRow := y * src.Stride
+		dstRow := y * dst.Stride
+		for x := 0; x < dst.Width; x++ {
+			si := srcRow + x*4
+			di := dstRow + x*4
+			if si+3 >= len(srcData) || di+3 >= len(dstData) {
+				continue
+			}
+			dstData[di+0] = srcData[si+0]
+			dstData[di+1] = srcData[si+1]
+			dstData[di+2] = srcData[si+2]
+			dstData[di+3] = 255
+		}
+	}
+}
+
+func (r *RegionSelector) drawOverlayLayer(os *OutputSurface, renderBuf *ShmBuffer) {
+	data := renderBuf.Data()
+	stride := renderBuf.Stride
+	w, h := renderBuf.Width, renderBuf.Height
+	format := alphaFormat(os.screenFormat)
+
+	// The screenshot is an immutable parent surface. This surface only carries
+	// the scrim and selection chrome, so its transparent hole reveals the parent.
+	for y := 0; y < h; y++ {
+		off := y * stride
+		for x := 0; x < w; x++ {
+			i := off + x*4
+			if i+3 >= len(data) {
+				continue
+			}
+			data[i+0], data[i+1], data[i+2], data[i+3] = 0, 0, 0, 102
+		}
+	}
+
+	r.drawHUD(data, stride, w, h, format)
+	if !r.selection.hasSelection || r.selection.surface != os {
+		return
+	}
+
+	scaleX := float64(w) / float64(os.logicalW)
+	scaleY := float64(h) / float64(os.logicalH)
+	bx1 := int(r.selection.anchorX * scaleX)
+	by1 := int(r.selection.anchorY * scaleY)
+	bx2 := int(r.selection.currentX * scaleX)
+	by2 := int(r.selection.currentY * scaleY)
+	if bx1 > bx2 {
+		bx1, bx2 = bx2, bx1
+	}
+	if by1 > by2 {
+		by1, by2 = by2, by1
+	}
+	bx1 = clamp(bx1, 0, w-1)
+	by1 = clamp(by1, 0, h-1)
+	bx2 = clamp(bx2, 0, w-1)
+	by2 = clamp(by2, 0, h-1)
+
+	// Clear the selection hole so the immutable screenshot parent is visible.
+	for y := by1; y <= by2; y++ {
+		for x := bx1; x <= bx2; x++ {
+			i := y*stride + x*4
+			if i+3 < len(data) {
+				data[i+0], data[i+1], data[i+2], data[i+3] = 0, 0, 0, 0
+			}
+		}
+	}
+
+	selW, selH := bx2-bx1+1, by2-by1+1
+	if r.shiftHeld && selW != selH {
+		if selW < selH {
+			selH = selW
+		} else {
+			selW = selH
+		}
+	}
+	r.drawBorder(data, stride, w, h, bx1, by1, selW, selH, format)
+	r.drawDimensions(data, stride, w, h, bx1, by1, selW, selH, format)
+}
+
 func (r *RegionSelector) drawOverlay(os *OutputSurface, renderBuf *ShmBuffer) {
 	data := renderBuf.Data()
 	stride := renderBuf.Stride


### PR DESCRIPTION
## Description

Keep the captured screenshot immutable while dragging so pointer motion does not copy the full frame into SHM on every event.

## Type of change


- [x] Other (perf)

## Screenshots / video
Before:

https://github.com/user-attachments/assets/1c84af8a-aef0-4c7f-95a3-cdd66f8bd1ed

After:


https://github.com/user-attachments/assets/d7edacab-01b4-4d5b-b0dc-353cb2f5bb6b


