### PR TITLE
fix(notifications): do not show battery notification when already charging

### DIFF
--- a/quickshell/Services/BatteryService.qml
+++ b/quickshell/Services/BatteryService.qml
@@ -131,6 +131,16 @@ Singleton {
     property bool _hasNotifiedCriticalBattery: false
     property bool _hasNotifiedChargeLimit: false
 
+    // AC plug detection (onBattery) can precede the battery device reporting
+    // Charging by a few seconds. Timestamp plug-ins so alerts can be
+    // suppressed only for a short grace period instead of whenever on AC.
+    property var _lastPluggedInTime: 0
+    readonly property int _pluggedInGracePeriod: 5000
+
+    function _recentlyPluggedIn() {
+        return isPluggedIn && _lastPluggedInTime > 0 && Date.now() - _lastPluggedInTime < _pluggedInGracePeriod;
+    }
+
     function _syncLastIsCharging() {
         if (_hasKnownChargingState)
             _lastIsCharging = _currentIsCharging;
@@ -139,7 +149,11 @@ Singleton {
     on_HasKnownChargingStateChanged: _syncLastIsCharging()
     on_CurrentIsChargingChanged: _syncLastIsCharging()
 
-    Component.onCompleted: _syncLastIsCharging()
+    Component.onCompleted: {
+        _syncLastIsCharging();
+        if (isPluggedIn)
+            _lastPluggedInTime = Date.now();
+    }
 
     function sendAlert(title, message, isWarning, category, notificationType) {
         if (notificationType === 1) {
@@ -163,7 +177,10 @@ Singleton {
             _hasNotifiedChargeLimit = false;
         }
 
-        if (isCharging) {
+        // Suppress low/critical alerts while charging or right after plugging
+        // in. A level drop long after plug-in means the battery isn't
+        // actually charging (e.g. faulty charger), so alert as usual then.
+        if (isCharging || _recentlyPluggedIn()) {
             _hasNotifiedLowBattery = false;
             _hasNotifiedCriticalBattery = false;
             return;
@@ -215,6 +232,9 @@ Singleton {
     }
 
     onIsPluggedInChanged: {
+        if (isPluggedIn)
+            _lastPluggedInTime = Date.now();
+
         if (suppressSound || !batteryAvailable) {
             previousPluggedState = isPluggedIn;
             return;
@@ -231,6 +251,9 @@ Singleton {
         applyPowerProfile();
 
         if (isPluggedIn) {
+            _hasNotifiedLowBattery = false;
+            _hasNotifiedCriticalBattery = false;
+
             const dismissLow = SettingsData.batteryLowNotificationType === 1 && SettingsData.notificationTimeoutNormal === 0;
             const dismissCritical = SettingsData.batteryCriticalNotificationType === 1 && SettingsData.notificationTimeoutCritical === 0;
 


### PR DESCRIPTION
## Description

I had a case where:

1. Laptop wasn't charging, it was working on battery
2. Battery fell to 20%
3. I got the notification about battery being low, asking me to charge (good)
4. I connected a charger
5. After short time I got the same notification again (bad)

This should fix it.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [ ] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
