### PR TITLE
fix(osd): clamp vertical brightness slider

### DIFF
--- a/quickshell/Modules/OSD/BrightnessOSD.qml
+++ b/quickshell/Modules/OSD/BrightnessOSD.qml
@@ -257,7 +257,7 @@ DankOSD {
                         if (!DisplayService.brightnessAvailable)
                             return;
                         const ratio = 1.0 - (mouse.y / height);
-                        const newValue = Math.round(vertSlider.minimum + ratio * (vertSlider.maximum - vertSlider.minimum));
+                        const newValue = Math.max(vertSlider.minimum, Math.min(vertSlider.maximum, Math.round(vertSlider.minimum + ratio * (vertSlider.maximum - vertSlider.minimum))));
                         vertSlider.value = newValue;
                         DisplayService.setBrightness(newValue, DisplayService.lastIpcDevice, true);
                         resetHideTimer();

--- a/quickshell/Modules/OSD/BrightnessOSD.qml
+++ b/quickshell/Modules/OSD/BrightnessOSD.qml
@@ -109,6 +109,7 @@ DankOSD {
                 onSliderValueChanged: newValue => {
                     if (!DisplayService.brightnessAvailable)
                         return;
+                    root._displayBrightness = newValue;
                     DisplayService.setBrightness(newValue, DisplayService.lastIpcDevice, true);
                     resetHideTimer();
                 }
@@ -259,6 +260,7 @@ DankOSD {
                         const ratio = 1.0 - (mouse.y / height);
                         const newValue = Math.max(vertSlider.minimum, Math.min(vertSlider.maximum, Math.round(vertSlider.minimum + ratio * (vertSlider.maximum - vertSlider.minimum))));
                         vertSlider.value = newValue;
+                        root._displayBrightness = newValue;
                         DisplayService.setBrightness(newValue, DisplayService.lastIpcDevice, true);
                         resetHideTimer();
                     }


### PR DESCRIPTION
Fixes #3066 

Edit: Fixed an issue with clamping both vertical and horizontal brightness sliders.

https://github.com/user-attachments/assets/1f25b4ae-e005-4e15-82fd-aec67e176147

