### PR TITLE
fix(launcher): hide spotlight placeholder during IME input

### DIFF
--- a/quickshell/Modals/DankLauncherV2/SpotlightLauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/SpotlightLauncherContent.qml
@@ -393,7 +393,7 @@ FocusScope {
                 font.pixelSize: 18
                 font.weight: Font.Medium
                 color: Theme.outlineButton
-                visible: searchInput.text.length === 0
+                visible: searchInput.text.length === 0 && !searchInput.inputMethodComposing
                 clip: true
             }
 


### PR DESCRIPTION
Closes #3069

<img width="1496" height="312" alt="image" src="https://github.com/user-attachments/assets/ae170bd7-0cfb-41bc-9b06-eda83f93f409" />
