### PR TITLE
feat(lock): run face auth concurrently with the password field

### DIFF
--- a/core/cmd/gaze-observe/main.go
+++ b/core/cmd/gaze-observe/main.go
@@ -1,0 +1,139 @@
+// gaze-observe subscribes to the Gaze daemon's scrubbed auth-phase broadcast
+// (com.gundulabs.Gaze.AuthPhase) and prints one key=value record per change
+// to stdout. It is the read-only status channel for the shell's auth HUD:
+// the daemon fan-out is uid-checked on registration, and the payload contains
+// phase and camera status codes plus the surface class — never face names or
+// match scores.
+//
+// Protocol (stdout, one record per line, fields space-separated):
+//
+//	ready=1                                   after successful registration
+//	phase=waiting rgb=no-face ir=unused surface=elevation
+//	phase=matched rgb=ready ir=unused surface=elevation
+//	phase=not-recognized rgb=no-face ir=unused surface=elevation
+//
+// phase values: waiting | matched | not-recognized | unavailable | idle
+// rgb/ir values: unused | no-face | too-dark | clipped | not-centered |
+//
+//	too-far | too-close | ready | usable
+//
+// surface values: screen_lock | elevation | login | direct
+//
+// The helper exits non-zero when the daemon or its observer API is
+// unavailable; consumers fall back to their in-process PAM feedback.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	gazeService = "com.gundulabs.Gaze"
+	gazePath    = "/com/gundulabs/Gaze"
+	gazeIface   = "com.gundulabs.Gaze"
+)
+
+func phaseName(code byte) string {
+	switch code {
+	case 0:
+		return "waiting"
+	case 1:
+		return "matched"
+	case 2:
+		return "not-recognized"
+	case 3:
+		return "unavailable"
+	default:
+		return "idle"
+	}
+}
+
+func statusName(code byte) string {
+	switch code {
+	case 0:
+		return "unused"
+	case 1:
+		return "no-face"
+	case 2:
+		return "too-dark"
+	case 3:
+		return "clipped"
+	case 4:
+		return "not-centered"
+	case 5:
+		return "too-far"
+	case 6:
+		return "too-close"
+	case 7:
+		return "ready"
+	case 8:
+		return "usable"
+	default:
+		return "unknown"
+	}
+}
+
+func main() {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		os.Exit(1)
+	}
+
+	obj := conn.Object(gazeService, gazePath)
+
+	// Registration is uid-derived from the caller's bus credentials inside the
+	// daemon; the uid is never passed as an argument.
+	if err := obj.Call(gazeIface+".RegisterObserver", 0).Err; err != nil {
+		os.Exit(2)
+	}
+	defer obj.Call(gazeIface+".UnregisterObserver", 0)
+
+	rule := fmt.Sprintf("type='signal',sender='%s',path='%s',interface='%s',member='AuthPhase'",
+		gazeService, gazePath, gazeIface)
+	if err := conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, rule).Err; err != nil {
+		os.Exit(3)
+	}
+	defer conn.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, rule)
+
+	// The parent closes stdin to shut us down; on EOF, release and exit.
+	go func() {
+		bufio.NewReader(os.Stdin).ReadByte()
+		os.Exit(0)
+	}()
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-sig
+		os.Exit(0)
+	}()
+
+	// Consumers use this line to distinguish "connected, waiting" from "no
+	// daemon" (which exits non-zero before any output).
+	fmt.Println("ready=1")
+
+	signals := make(chan *dbus.Signal, 16)
+	conn.Signal(signals)
+	defer conn.RemoveSignal(signals)
+
+	for s := range signals {
+		if s.Name != gazeIface+".AuthPhase" || len(s.Body) < 4 {
+			continue
+		}
+		phase, ok := s.Body[0].(byte)
+		if !ok {
+			continue
+		}
+		rgb, _ := s.Body[1].(byte)
+		ir, _ := s.Body[2].(byte)
+		surface, _ := s.Body[3].(string)
+		fmt.Printf("phase=%s rgb=%s ir=%s surface=%s\n",
+			phaseName(phase), statusName(rgb), statusName(ir), surface)
+	}
+}

--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,7 @@
               src = ./core;
               vendorHash = "sha256-1G56AkZmYwFWW1sBzo6Bg/qpvPlt376IQS1XHMXnzQ8=";
 
-              subPackages = [ "cmd/dms" ];
+              subPackages = [ "cmd/dms" "cmd/gaze-observe" ];
 
               ldflags = [
                 "-s"

--- a/quickshell/DMSShell.qml
+++ b/quickshell/DMSShell.qml
@@ -1169,6 +1169,12 @@ Item {
 
                     delegate: AudioOutputOSD {}
                 }
+
+                Variants {
+                    model: SettingsData.getFilteredScreens("osd")
+
+                    delegate: AuthHudPill {}
+                }
             }
         }
     }

--- a/quickshell/Modals/PolkitAuthContent.qml
+++ b/quickshell/Modals/PolkitAuthContent.qml
@@ -111,7 +111,8 @@ FocusScope {
             }
             root.awaitingFprintForPassword = false;
             root.isLoading = false;
-            root.passwordInput = "";
+            // Keep whatever the user typed while the face scan was running;
+            // it is submitted by the next Enter, never automatically.
             passwordField.forceActiveFocus();
         }
 

--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -95,6 +95,27 @@ Item {
         return pam && (pam.u2fState === "waiting" || pam.u2fState === "insert") && !pam.u2fPending;
     }
 
+    // Lock-screen auth HUD state, derived from the PAM feedback strings Gaze
+    // emits in-process (PAM_TEXT_INFO) plus DMS's own PAM state. The strings
+    // are Gaze's own English constants (see pam-gaze-core), not PAM
+    // translations, so matching is stable across locales.
+    readonly property string authFeedbackState: {
+        if (!pam)
+            return "waiting";
+        const text = pam.lockMessage ?? "";
+        if (text.includes("Face Verified"))
+            return "matched";
+        if (text.includes("not recognized") || text.includes("timed out") || text.includes("unavailable"))
+            return "failed";
+        if (pamState === "error" || pamState === "fail" || pamState === "max")
+            return "failed";
+        if (text.includes("look at the camera") || text.includes("light") || text.includes("closer")
+                || text.includes("back up") || text.includes("center") || text.includes("Hold still")
+                || text.includes("clipped"))
+            return "waiting";
+        return "waiting";
+    }
+
     function canStartSecurityKeyUnlock() {
         return !demoMode && pam && pam.u2f && pam.u2f.available && SettingsData.enableU2f && SettingsData.u2fMode === "or" && !pam.passwd.active && !pam.u2f.active && !pam.u2fPending && !root.unlocking;
     }
@@ -941,9 +962,18 @@ Item {
                         activeFocusOnTab: !demoMode
                         onTextChanged: cursorPosition = text.length
                         onAccepted: {
-                            if (!demoMode && !root.unlocking && !pam.passwd.active && !pam.u2fPending) {
-                                pam.passwd.start();
+                            if (demoMode || root.unlocking)
+                                return;
+                            if (pam.passwd.active) {
+                                // Concurrent auth: Enter with a password answers
+                                // the pending prompt; empty Enter is a no-op that
+                                // keeps the face flow alive.
+                                pam.submitPassword();
+                                return;
                             }
+                            if (pam.u2fPending)
+                                return;
+                            pam.passwd.start();
                         }
                         Keys.onPressed: event => handleKey(event)
 
@@ -963,16 +993,23 @@ Item {
                                     event.accepted = true;
                                     return;
                                 }
+                                if (pam.passwd.active) {
+                                    // Abort the running attempt; the typed buffer
+                                    // survives for the next one.
+                                    pam.cancelActiveAuth();
+                                    event.accepted = true;
+                                    return;
+                                }
                                 clear();
                                 event.accepted = true;
                                 return;
                             }
 
-                            if (pam.passwd.active) {
-                                log.debug("PAM is active, ignoring input");
-                                event.accepted = true;
-                                return;
-                            }
+                            // Deliberately NOT swallowed while pam.passwd.active:
+                            // with a concurrent face module the password field
+                            // stays live for the whole scan, and the buffer is
+                            // submitted by Enter (submitPassword) or discarded
+                            // when the face match wins.
 
                             if ((event.modifiers & Qt.ControlModifier) && !(event.modifiers & (Qt.AltModifier | Qt.MetaModifier))) {
                                 if (securityKeyShortcutMatches(event) && canStartSecurityKeyUnlock()) {
@@ -1087,7 +1124,9 @@ Item {
                                     return;
                                 const committed = text;
                                 text = "";
-                                if (demoMode || root.unlocking || pam.passwd.active)
+                                // Input stays live while PAM is active so the
+                                // password can be typed during the face scan.
+                                if (demoMode || root.unlocking)
                                     return;
                                 passwordField.insertText(committed);
                             }
@@ -1373,9 +1412,17 @@ Item {
                         visible: (demoMode || (!pam.passwd.active && !root.unlocking && !pam.u2fPending))
                         enabled: !demoMode
                         onClicked: {
-                            if (!demoMode && !root.unlocking && !pam.u2fPending) {
-                                pam.passwd.start();
+                            if (demoMode || root.unlocking)
+                                return;
+                            if (pam.passwd.active) {
+                                // Same semantics as Enter: submit the typed
+                                // password against the pending prompt, or no-op.
+                                pam.submitPassword();
+                                return;
                             }
+                            if (pam.u2fPending)
+                                return;
+                            pam.passwd.start();
                         }
 
                         Behavior on opacity {
@@ -1401,7 +1448,18 @@ Item {
                 Layout.fillWidth: true
                 Layout.preferredHeight: text.length > 0 ? Math.min(implicitHeight, Math.ceil(Theme.fontSizeSmall * 4.5)) : 0
                 text: root.currentAuthFeedbackText()
-                color: root.authFeedbackIsHint() ? Theme.outline : Theme.error
+                color: {
+                    if (root.authFeedbackIsHint())
+                        return Theme.outline;
+                    switch (root.authFeedbackState) {
+                    case "matched":
+                        return Theme.success;
+                    case "failed":
+                        return Theme.error;
+                    default:
+                        return Theme.primary;
+                    }
+                }
                 font.pixelSize: Theme.fontSizeSmall
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap

--- a/quickshell/Modules/Lock/Pam.qml
+++ b/quickshell/Modules/Lock/Pam.qml
@@ -70,6 +70,38 @@ Scope {
         }
     }
 
+    // The password module wants a response. The response is deliberately NOT
+    // sent automatically: with a concurrent face module (`pam_gaze_grosshack`)
+    // the prompt fires while the scan is still running, and auto-responding
+    // with an empty or partial buffer loses the race and fails the attempt.
+    // The user submits with Enter (see submitPassword), so the typed password
+    // stays intact and a successful face match can still win.
+    readonly property bool responsePending: passwd.responseRequired
+
+    function submitPassword(): void {
+        if (!passwd.responseRequired)
+            return;
+        if (root.buffer.length === 0)
+            return; // empty Enter is a no-op while an attempt is in flight
+        passwd.respond(root.buffer);
+    }
+
+    // Esc on the lock screen: abort the running attempt without burning the
+    // typed buffer. The stack is held open indefinitely while awaiting the
+    // user's Enter, so this is the only way out besides answering.
+    function cancelActiveAuth(): void {
+        if (!passwd.active)
+            return;
+        resetAuthFlows();
+        root.state = "";
+        root.lockMessage = "";
+        root.attemptInfoMessages = [];
+        root.lockoutAnnouncedThisAttempt = false;
+        flashMsg();
+        fprint.checkAvail();
+        u2f.checkAvail();
+    }
+
     function proceedAfterPrimaryAuth(): void {
         if (!root.u2fSuppressedByPrimaryPam && SettingsData.enableU2f && SettingsData.u2fMode === "and" && u2f.available) {
             u2f.startForSecondFactor();
@@ -199,7 +231,9 @@ Scope {
             }
             root.attemptInfoMessages = [];
 
-            respond(root.buffer);
+            // The response phase is untimed by design: the stack waits for the
+            // user's Enter (submitPassword). Stop the scan-phase stall guard.
+            passwdActiveTimeout.running = false;
         }
 
         onCompleted: res => {
@@ -253,6 +287,14 @@ Scope {
             } else {
                 passwdActiveTimeout.running = false;
             }
+        }
+
+        function onResponseRequiredChanged() {
+            // After the user answers, processing resumes; re-arm the guard so a
+            // hung module cannot hold the stack forever. Only the wait-for-Enter
+            // phase itself is untimed.
+            if (!passwd.responseRequired && passwd.active)
+                passwdActiveTimeout.restart();
         }
     }
 
@@ -448,7 +490,10 @@ Scope {
 
         interval: 15000
         onTriggered: {
-            if (passwd.active)
+            // Scan-phase backstop only. Once the password module asks
+            // (responseRequired), the attempt legitimately waits on the user's
+            // Enter for as long as they need; recovery is Esc.
+            if (passwd.active && !passwd.responseRequired)
                 root.recoverFromAuthStall("error");
         }
     }

--- a/quickshell/Modules/OSD/AuthHudPill.qml
+++ b/quickshell/Modules/OSD/AuthHudPill.qml
@@ -1,0 +1,221 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Io
+import Quickshell.Wayland
+import qs.Common
+import qs.Services
+import qs.Widgets
+
+// AuthHudPill: top-center status pill for face authentication that DMS cannot
+// see in-process (terminal sudo, doas, pkexec). It subscribes to the Gaze
+// daemon's scrubbed auth-phase broadcast through the `gaze-observe` helper and
+// shows the active claim's phase while it runs.
+//
+// The pill only renders elevation surfaces: the lock screen and polkit modal
+// render their own in-process feedback, and the greeter owns its surface.
+PanelWindow {
+    id: root
+    readonly property var log: Log.scoped("AuthHudPill")
+
+    WlrLayershell.namespace: "dms:authhud"
+    WlrLayershell.layer: LayerShell.fromEnv("DMS_OSD_LAYER", WlrLayer.Overlay, {
+        "allow": ["top", "overlay"],
+        "invalidLayer": WlrLayer.Overlay,
+        "label": "OSDs"
+    })
+    WlrLayershell.exclusiveZone: -1
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+
+    screen: modelData
+    visible: root.shouldShow
+    color: "transparent"
+
+    readonly property real dpr: CompositorService.getScreenScale(screen)
+
+    property bool observerReady: false
+    property string phase: "waiting"
+    property string rgbStatus: "unused"
+    property string irStatus: "unused"
+    property string surface: ""
+
+    readonly property bool shouldShow: observerReady && root.surface === "elevation" && root.phase !== "idle"
+
+    readonly property string phaseText: {
+        switch (root.phase) {
+        case "matched":
+            return I18n.tr("Face matched");
+        case "not-recognized":
+            return I18n.tr("Face not recognized");
+        case "unavailable":
+            return I18n.tr("Face auth unavailable");
+        default:
+            return I18n.tr("Waiting for face");
+        }
+    }
+
+    readonly property string phaseDetail: {
+        if (root.phase !== "waiting")
+            return "";
+        const status = root.rgbStatus === "unused" ? root.irStatus : root.rgbStatus;
+        switch (status) {
+        case "no-face":
+            return I18n.tr("Look at the camera");
+        case "too-dark":
+            return I18n.tr("Need more light");
+        case "too-far":
+            return I18n.tr("Come closer");
+        case "too-close":
+            return I18n.tr("Back up");
+        case "not-centered":
+        case "clipped":
+            return I18n.tr("Center your face");
+        default:
+            return "";
+        }
+    }
+
+    readonly property color phaseColor: {
+        switch (root.phase) {
+        case "matched":
+            return Theme.success;
+        case "not-recognized":
+        case "unavailable":
+            return Theme.error;
+        default:
+            return Theme.primary;
+        }
+    }
+
+    // --- observer process -------------------------------------------------
+
+    property string outputBuffer: ""
+    property int outputConsumed: 0
+
+    function handleObserverLine(line: string): void {
+        const fields = line.trim().split(" ");
+        const values = {};
+        for (const field of fields) {
+            const eq = field.indexOf("=");
+            if (eq <= 0)
+                continue;
+            values[field.substring(0, eq)] = field.substring(eq + 1);
+        }
+        if (values["phase"] !== undefined)
+            root.phase = values["phase"];
+        if (values["rgb"] !== undefined)
+            root.rgbStatus = values["rgb"];
+        if (values["ir"] !== undefined)
+            root.irStatus = values["ir"];
+        if (values["surface"] !== undefined)
+            root.surface = values["surface"];
+        if (values["ready"] !== undefined)
+            root.observerReady = true;
+    }
+
+    function drainObserverOutput(): void {
+        const text = observerOutput.text;
+        if (text.length > root.outputConsumed) {
+            root.outputBuffer += text.substring(root.outputConsumed);
+            root.outputConsumed = text.length;
+        }
+        let idx = -1;
+        while ((idx = root.outputBuffer.indexOf("\n")) >= 0) {
+            const line = root.outputBuffer.substring(0, idx);
+            root.outputBuffer = root.outputBuffer.substring(idx + 1);
+            root.handleObserverLine(line);
+        }
+    }
+
+    Process {
+        id: observerProcess
+
+        command: ["gaze-observe"]
+        running: false
+
+        stdout: StdioCollector {
+            id: observerOutput
+
+            waitForEnd: false
+            onDataChanged: root.drainObserverOutput()
+        }
+
+        onRunningChanged: {
+            if (!observerProcess.running) {
+                root.observerReady = false;
+                root.phase = "waiting";
+                root.rgbStatus = "unused";
+                root.irStatus = "unused";
+                root.surface = "";
+                retryTimer.restart();
+            }
+        }
+    }
+
+    Timer {
+        id: retryTimer
+
+        interval: 10000
+        repeat: false
+        onTriggered: observerProcess.running = true
+    }
+
+    Component.onCompleted: observerProcess.running = true
+
+    // --- presentation ------------------------------------------------------
+
+    Rectangle {
+        id: pill
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: Theme.px(Theme.spacingL, root.dpr)
+        width: pillRow.implicitWidth + Theme.spacingL * 2
+        height: pillRow.implicitHeight + Theme.spacingM * 2
+        radius: Theme.cornerRadius
+        color: Theme.surfaceContainer
+        border.color: root.phaseColor
+        border.width: 2
+        opacity: root.shouldShow ? 1 : 0
+        visible: opacity > 0
+
+        Behavior on opacity {
+            NumberAnimation {
+                duration: Theme.shortDuration
+                easing.type: Theme.standardEasing
+            }
+        }
+
+        RowLayout {
+            id: pillRow
+
+            anchors.centerIn: parent
+            spacing: Theme.spacingS
+
+            DankIcon {
+                name: "face"
+                size: Theme.iconSizeSmall
+                color: root.phaseColor
+            }
+
+            Column {
+                spacing: 2
+                Layout.fillWidth: true
+
+                StyledText {
+                    text: root.phaseText
+                    color: Theme.surfaceText
+                    font.pixelSize: Theme.fontSizeSmall
+                    font.weight: Font.DemiBold
+                }
+
+                StyledText {
+                    text: root.phaseDetail
+                    color: Theme.surfaceVariantText
+                    font.pixelSize: Theme.fontSizeSmall
+                    visible: text !== ""
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

With a concurrent face module (`pam_gaze_grosshack.so`) the PAM password prompt fires while the face scan is still running — but the lock screen swallowed all input during `passwd.active` and auto-responded with the buffer the instant the prompt arrived, so typing a password during the scan was impossible and partial text was submitted as a password.

This PR changes the lock screen so the scan never interferes with the password input:

- **Input stays live during `passwd.active`** (`handleKey` + `imeCommitSink`): the buffer keeps accepting keystrokes for the whole scan.
- **Respond on explicit Enter only** (`Pam.qml` `submitPassword`): the auto-respond in `onResponseRequiredChanged` is gone. A typed password is submitted intact when the scan settles; if the face matched first, it's discarded with the unlock.
- **Empty Enter during an attempt is a no-op** — a reflex Enter can't kill a face match in progress.
- **Esc aborts the attempt** (`cancelActiveAuth`) without clearing the buffer.
- **Response phase is untimed**: the 15 s stall guard covers the scan phase only; once the password module asks, the stack waits on the user's Enter indefinitely (Esc is the escape). The guard re-arms after a response so a hung module can't hold the stack forever.
- **Polkit modal**: keeps input typed while the scan runs (it already deferred submits until `responseRequired`).
- **Lock feedback line**: Gaze's in-process phase strings now render in state colors (waiting = primary, matched = success, failed = error) instead of blanket error red.

Second commit: `gaze-observe` helper + `AuthHudPill` — a top-center pill for terminal sudo/polkit prompts that DMS can't see in-process, fed by the daemon's scrubbed `auth_phase` broadcast ([Gaze PR](https://github.com/GunduLabs/gaze/pull/491)). Elevation surfaces only; hides on `idle`; self-healing observer. The helper is a new Go binary in the existing module (godbus already a dependency) — no vendorHash change.

## Behaviour

- Enter with the right password during the scan → unlocks, face flow dropped.
- Face match during typing → unlocks, pending password discarded.
- Empty Enter → nothing; Esc → abort, buffer kept.

## Testing

- `go test ./internal/qmlchecks/` passes.
- Go helper: `go build` + `go vet` clean.
- QML reviewed manually; no qmllint available in this environment.
- Needs a real session for the interaction matrix (type-during-scan, Esc, wrong-password-during-race, faillock) and the pill's layer placement.

Depends on the Gaze gate from [GunduLabs/gaze#491](https://github.com/GunduLabs/gaze/pull/491) for the actual race; the input semantics ship standalone with the plain module.