### PR TITLE
Complete pt-BR translation in quickshell translations

### DIFF
--- a/quickshell/translations/poexports/pt.json
+++ b/quickshell/translations/poexports/pt.json
@@ -1,18 +1,18 @@
 {
   "%1 (+%2 more)": {
-    "%1 (+%2 more)": ""
+    "%1 (+%2 more)": "%1 (+%2 mais)"
   },
   "%1 Animation Speed": {
     "%1 Animation Speed": "%1 Velocidade de Animação"
   },
   "%1 Layout Overrides": {
-    "%1 Layout Overrides": ""
+    "%1 Layout Overrides": "%1 Substituições de Layout"
   },
   "%1 Sessions": {
     "%1 Sessions": "%1 Sessões"
   },
   "%1 Startup Failed": {
-    "%1 Startup Failed": ""
+    "%1 Startup Failed": "%1 Falha na Inicialização"
   },
   "%1 active session": {
     "%1 active session": "%1 sessão ativa"
@@ -21,10 +21,10 @@
     "%1 active sessions": "%1 sessões ativas"
   },
   "%1 adapter, none connected": {
-    "%1 adapter, none connected": ""
+    "%1 adapter, none connected": "%1 adaptador, nenhum conectado"
   },
   "%1 adapters, none connected": {
-    "%1 adapters, none connected": ""
+    "%1 adapters, none connected": "%1 adaptadores, nenhum conectado"
   },
   "%1 character": {
     "%1 character": "%1 caractere"
@@ -36,7 +36,7 @@
     "%1 connected": "%1 conectado(s)"
   },
   "%1 copied": {
-    "%1 copied": ""
+    "%1 copied": "%1 copiado"
   },
   "%1 disconnected": {
     "%1 disconnected": "%1 desconectado"
@@ -45,19 +45,19 @@
     "%1 disconnected (hidden)": "%1 desconectado (oculto)"
   },
   "%1 display": {
-    "%1 display": ""
+    "%1 display": "%1 monitor"
   },
   "%1 displays": {
-    "%1 displays": ""
+    "%1 displays": "%1 monitores"
   },
   "%1 filtered": {
     "%1 filtered": "%1 filtrado"
   },
   "%1 h %2 m left": {
-    "%1 h %2 m left": ""
+    "%1 h %2 m left": "restam %1 h %2 m"
   },
   "%1 h left": {
-    "%1 h left": ""
+    "%1 h left": "resta %1 h"
   },
   "%1 is now included in config": {
     "%1 is now included in config": "%1 agora está incluído na configuração"
@@ -69,52 +69,52 @@
     "%1 issues found": "%1 problemas encontrados"
   },
   "%1 min left": {
-    "%1 min left": ""
+    "%1 min left": "resta %1 min"
   },
   "%1 notifications": {
     "%1 notifications": "%1 notificações"
   },
   "%1 online": {
-    "%1 online": ""
+    "%1 online": "%1 online"
   },
   "%1 tasks": {
-    "%1 tasks": ""
+    "%1 tasks": "%1 tarefas"
   },
   "%1 update": {
-    "%1 update": ""
+    "%1 update": "%1 atualização"
   },
   "%1 updates": {
-    "%1 updates": ""
+    "%1 updates": "%1 atualizações"
   },
   "%1 variants": {
     "%1 variants": "%1 variantes"
   },
   "%1 wallpaper  •  %2 / %3": {
-    "%1 wallpaper  •  %2 / %3": ""
+    "%1 wallpaper  •  %2 / %3": "%1 papel de parede  •  %2 / %3"
   },
   "%1 wallpapers  •  %2 / %3": {
-    "%1 wallpapers  •  %2 / %3": ""
+    "%1 wallpapers  •  %2 / %3": "%1 papéis de parede  •  %2 / %3"
   },
   "%1 widgets": {
     "%1 widgets": "%1 widgets"
   },
   "%1 window": {
-    "%1 window": ""
+    "%1 window": "%1 janela"
   },
   "%1 windows": {
-    "%1 windows": ""
+    "%1 windows": "%1 janelas"
   },
   "%1: %2": {
-    "%1: %2": ""
+    "%1: %2": "%1: %2"
   },
   "%1m ago": {
     "%1m ago": "%1m atrás"
   },
   "%command%": {
-    "%command%": ""
+    "%command%": "%command%"
   },
   "'Alternative' lets the key unlock on its own. 'Second factor' requires password or fingerprint first, then the key.": {
-    "'Alternative' lets the key unlock on its own. 'Second factor' requires password or fingerprint first, then the key.": ""
+    "'Alternative' lets the key unlock on its own. 'Second factor' requires password or fingerprint first, then the key.": "'Alternativo' permite que a chave desbloqueie sozinha. 'Segundo fator' exige senha ou impressão digital primeiro, depois a chave."
   },
   "(Unnamed)": {
     "(Unnamed)": "(Sem nome)"
@@ -132,7 +132,7 @@
     "1 day": "1 dia"
   },
   "1 day before": {
-    "1 day before": ""
+    "1 day before": "1 dia antes"
   },
   "1 hour": {
     "1 hour": "1 hora"
@@ -141,7 +141,7 @@
     "1 hour 30 minutes": "1 hora e 30 minutos"
   },
   "1 hour before": {
-    "1 hour before": ""
+    "1 hour before": "1 hora antes"
   },
   "1 minute": {
     "1 minute": "1 minuto"
@@ -153,10 +153,10 @@
     "1 second": "1 segundo"
   },
   "1 task": {
-    "1 task": ""
+    "1 task": "1 tarefa"
   },
   "10 min before": {
-    "10 min before": ""
+    "10 min before": "10 min antes"
   },
   "10 minutes": {
     "10 minutes": "10 minutos"
@@ -174,10 +174,10 @@
     "14 days": "14 dias"
   },
   "15 min": {
-    "15 min": ""
+    "15 min": "15 min"
   },
   "15 min before": {
-    "15 min before": ""
+    "15 min before": "15 min antes"
   },
   "15 minutes": {
     "15 minutes": "15 minutos"
@@ -198,7 +198,7 @@
     "2 seconds": "2 segundos"
   },
   "2.4 GHz": {
-    "2.4 GHz": ""
+    "2.4 GHz": "2,4 GHz"
   },
   "20 minutes": {
     "20 minutes": "20 minutos"
@@ -234,10 +234,10 @@
     "30 days": "30 dias"
   },
   "30 min": {
-    "30 min": ""
+    "30 min": "30 min"
   },
   "30 min before": {
-    "30 min before": ""
+    "30 min before": "30 min antes"
   },
   "30 minutes": {
     "30 minutes": "30 minutos"
@@ -264,10 +264,10 @@
     "45 seconds": "45 segundos"
   },
   "5 GHz": {
-    "5 GHz": ""
+    "5 GHz": "5 GHz"
   },
   "5 min before": {
-    "5 min before": ""
+    "5 min before": "5 min antes"
   },
   "5 minutes": {
     "5 minutes": "5 minutos"
@@ -309,13 +309,13 @@
     "A modern desktop shell for Wayland compositors": "Um shell de desktop moderno para compositores Wayland"
   },
   "A separate minimal launcher action that works in Standalone, Separate Frame Mode, and Connected Frame Mode.": {
-    "A separate minimal launcher action that works in Standalone, Separate Frame Mode, and Connected Frame Mode.": ""
+    "A separate minimal launcher action that works in Standalone, Separate Frame Mode, and Connected Frame Mode.": "Uma ação de inicializador mínima separada que funciona nos modos Standalone, Frame Separado e Frame Conectado."
   },
   "A user with that name already exists.": {
-    "A user with that name already exists.": ""
+    "A user with that name already exists.": "Já existe um usuário com esse nome."
   },
   "AC Adapter (Plugged In)": {
-    "AC Adapter (Plugged In)": ""
+    "AC Adapter (Plugged In)": "Adaptador AC (Conectado)"
   },
   "AC Power": {
     "AC Power": "Energia AC"
@@ -324,7 +324,7 @@
     "API": "API"
   },
   "AUR helpers are interactive — see the terminal window for prompts. This popout will return to idle when the upgrade exits.": {
-    "AUR helpers are interactive — see the terminal window for prompts. This popout will return to idle when the upgrade exits.": ""
+    "AUR helpers are interactive — see the terminal window for prompts. This popout will return to idle when the upgrade exits.": "Os auxiliares AUR são interativos — veja a janela do terminal para instruções. Este popout voltará ao estado ocioso quando a atualização terminar."
   },
   "Aborted": {
     "Aborted": "Abortado"
@@ -333,7 +333,7 @@
     "About": "Sobre"
   },
   "Acceleration Profile": {
-    "Acceleration Profile": ""
+    "Acceleration Profile": "Perfil de Aceleração"
   },
   "Accent Color": {
     "Accent Color": "Cor de Destaque"
@@ -363,22 +363,25 @@
     "Action failed or terminal was closed.": "A ação falhou ou o termianl foi fechado."
   },
   "Action performed when scrolling horizontally on the bar": {
-    "Action performed when scrolling horizontally on the bar": ""
+    "Action performed when scrolling horizontally on the bar": "Ação executada ao rolar horizontalmente na barra"
   },
   "Action performed when scrolling vertically on the bar": {
-    "Action performed when scrolling vertically on the bar": ""
+    "Action performed when scrolling vertically on the bar": "Ação executada ao rolar verticalmente na barra"
+  },
+  "Actions": {
+    "Actions": "Ações"
   },
   "Activate": {
     "Activate": "Ativar"
   },
   "Activate Greeter": {
-    "Activate Greeter": ""
+    "Activate Greeter": "Ativar Greeter"
   },
   "Activate the DMS greeter? A terminal will open for sudo authentication. Run Sync after activation to apply your settings.": {
-    "Activate the DMS greeter? A terminal will open for sudo authentication. Run Sync after activation to apply your settings.": ""
+    "Activate the DMS greeter? A terminal will open for sudo authentication. Run Sync after activation to apply your settings.": "Ativar o greeter do DMS? Um terminal abrirá para autenticação sudo. Execute Sync após a ativação para aplicar suas configurações."
   },
   "Activates immediately": {
-    "Activates immediately": ""
+    "Activates immediately": "Ativa imediatamente"
   },
   "Activation": {
     "Activation": "Ativação"
@@ -390,10 +393,10 @@
     "Active Color": "Cor Ativa"
   },
   "Active VPN": {
-    "Active VPN": ""
+    "Active VPN": "VPN Ativa"
   },
   "Active in Column": {
-    "Active in Column": ""
+    "Active in Column": "Ativo na Coluna"
   },
   "Active tile background and icon color": {
     "Active tile background and icon color": "Cor de fundo e ícone do bloco ativo"
@@ -411,22 +414,19 @@
     "Adapters": "Adaptadores"
   },
   "Adaptive": {
-    "Adaptive": ""
+    "Adaptive": "Adaptativo"
   },
   "Adaptive Media Width": {
-    "Adaptive Media Width": ""
+    "Adaptive Media Width": "Largura Adaptativa da Mídia"
   },
   "Add": {
     "Add": "Adicionar"
   },
   "Add \"%1\" to the %2 group?": {
-    "Add \"%1\" to the %2 group?": ""
-  },
-  "Add \"%1\" to the %2 group? They must log out and back in, then run dms greeter sync --profile to publish their login-screen theme.": {
-    "Add \"%1\" to the %2 group? They must log out and back in, then run dms greeter sync --profile to publish their login-screen theme.": ""
+    "Add \"%1\" to the %2 group?": "Adicionar \"%1\" ao grupo %2?"
   },
   "Add \"%1\" to the %2 group? They must log out and back in, then run dms-greeter sync --profile to publish their login-screen theme.": {
-    "Add \"%1\" to the %2 group? They must log out and back in, then run dms-greeter sync --profile to publish their login-screen theme.": ""
+    "Add \"%1\" to the %2 group? They must log out and back in, then run dms-greeter sync --profile to publish their login-screen theme.": "Adicionar \"%1\" ao grupo %2? Eles devem sair e entrar novamente e então executar dms-greeter sync --profile para publicar o tema da tela de login."
   },
   "Add Bar": {
     "Add Bar": "Adicionar Barra"
@@ -435,7 +435,7 @@
     "Add Desktop Widget": "Adicionar Widget de Área de Trabalho"
   },
   "Add Entry": {
-    "Add Entry": ""
+    "Add Entry": "Adicionar Entrada"
   },
   "Add Printer": {
     "Add Printer": "Adicionar Impressora"
@@ -447,10 +447,10 @@
     "Add Widget": "Adicionar Widget"
   },
   "Add Widget to %1": {
-    "Add Widget to %1": ""
+    "Add Widget to %1": "Adicionar Widget a %1"
   },
   "Add Window Rule": {
-    "Add Window Rule": ""
+    "Add Window Rule": "Adicionar Regra de Janela"
   },
   "Add a border around the dock": {
     "Add a border around the dock": "Adicionar uma borda ao redor da dock"
@@ -459,7 +459,7 @@
     "Add a custom prefix to all application launches. This can be used for things like 'uwsm-app', 'systemd-run', or other command wrappers.": "Adicionar um prefixo personalizado para todos os inicializações de aplicativos. Isso pode ser usado para coisas como 'uwsm-app', 'systemd-run' ou outros invólucros de comandos."
   },
   "Add a task...": {
-    "Add a task...": ""
+    "Add a task...": "Adicionar uma tarefa..."
   },
   "Add and configure widgets that appear on your desktop": {
     "Add and configure widgets that appear on your desktop": "Adicionar e configurar widgets que aparecem na sua área de trabalho"
@@ -468,64 +468,61 @@
     "Add by Address": "Adicionar por Endereço"
   },
   "Add location": {
-    "Add location": ""
+    "Add location": "Adicionar local"
   },
   "Add match": {
-    "Add match": ""
+    "Add match": "Adicionar correspondência"
   },
   "Add notes": {
-    "Add notes": ""
-  },
-  "Add the new user to the %1 group so they can run dms greeter sync --profile.": {
-    "Add the new user to the %1 group so they can run dms greeter sync --profile.": ""
+    "Add notes": "Adicionar notas"
   },
   "Add the new user to the %1 group so they can run dms-greeter sync --profile.": {
-    "Add the new user to the %1 group so they can run dms-greeter sync --profile.": ""
+    "Add the new user to the %1 group so they can run dms-greeter sync --profile.": "Adicione o novo usuário ao grupo %1 para que possa executar dms-greeter sync --profile."
   },
   "Add the new user to the %1 group so they can use sudo.": {
-    "Add the new user to the %1 group so they can use sudo.": ""
+    "Add the new user to the %1 group so they can use sudo.": "Adicione o novo usuário ao grupo %1 para que possa usar sudo."
   },
   "Add to Autostart": {
-    "Add to Autostart": ""
+    "Add to Autostart": "Adicionar à Inicialização Automática"
   },
   "Adjust pointer sensitivity speed": {
-    "Adjust pointer sensitivity speed": ""
+    "Adjust pointer sensitivity speed": "Ajustar a velocidade de sensibilidade do ponteiro"
   },
   "Adjust scrolling sensitivity multiplier": {
-    "Adjust scrolling sensitivity multiplier": ""
+    "Adjust scrolling sensitivity multiplier": "Ajustar o multiplicador de sensibilidade de rolagem"
   },
   "Adjust the bar height via inner padding": {
-    "Adjust the bar height via inner padding": ""
+    "Adjust the bar height via inner padding": "Ajustar a altura da barra por meio do preenchimento interno"
   },
   "Adjust the number of columns in grid view mode.": {
     "Adjust the number of columns in grid view mode.": "Ajusta o número de colunas no modo de visualização em grade"
   },
   "Adjust touchpad pointer speed": {
-    "Adjust touchpad pointer speed": ""
+    "Adjust touchpad pointer speed": "Ajustar a velocidade do ponteiro do touchpad"
   },
   "Adjust volume per scroll indent": {
     "Adjust volume per scroll indent": "Ajustar volume por rolagem"
   },
   "Adjusts contrast of generated colors (-100 = minimum, 0 = standard, 100 = maximum)": {
-    "Adjusts contrast of generated colors (-100 = minimum, 0 = standard, 100 = maximum)": ""
+    "Adjusts contrast of generated colors (-100 = minimum, 0 = standard, 100 = maximum)": "Ajusta o contraste das cores geradas (-100 = mínimo, 0 = padrão, 100 = máximo)"
   },
   "Administrator access is required. Use the Sync button in Settings → Greeter to apply.": {
-    "Administrator access is required. Use the Sync button in Settings → Greeter to apply.": ""
+    "Administrator access is required. Use the Sync button in Settings → Greeter to apply.": "É necessário acesso de administrador. Use o botão Sync em Configurações → Greeter para aplicar."
   },
   "Administrator group:": {
-    "Administrator group:": ""
+    "Administrator group:": "Grupo de administradores:"
   },
   "Advanced": {
     "Advanced": "Avançado"
   },
   "Advanced comma-separated libxkbcommon options.": {
-    "Advanced comma-separated libxkbcommon options.": ""
+    "Advanced comma-separated libxkbcommon options.": "Opções avançadas do libxkbcommon separadas por vírgula."
   },
   "Afternoon": {
     "Afternoon": "Tarde"
   },
   "Alerts": {
-    "Alerts": ""
+    "Alerts": "Alertas"
   },
   "All": {
     "All": "Todos"
@@ -543,10 +540,10 @@
     "Allow": "Permitir"
   },
   "Allow LAN access": {
-    "Allow LAN access": ""
+    "Allow LAN access": "Permitir acesso à LAN"
   },
   "Allow adjusting device volume by scrolling on the right half of items in the device list": {
-    "Allow adjusting device volume by scrolling on the right half of items in the device list": ""
+    "Allow adjusting device volume by scrolling on the right half of items in the device list": "Permitir ajustar o volume do dispositivo rolando na metade direita dos itens da lista de dispositivos"
   },
   "Allow clicks to pass through the widget": {
     "Allow clicks to pass through the widget": "Permitir cliques passarem pelo widget"
@@ -558,16 +555,16 @@
     "Allow greeter login access": "Permitir acesso de login ao greeter"
   },
   "Already on that session": {
-    "Already on that session": ""
+    "Already on that session": "Já está nessa sessão"
   },
   "Also group repeated application icons on the active workspace": {
-    "Also group repeated application icons on the active workspace": ""
+    "Also group repeated application icons on the active workspace": "Também agrupar ícones de aplicativos repetidos no espaço de trabalho ativo"
   },
   "Alt + Shift": {
-    "Alt + Shift": ""
+    "Alt + Shift": "Alt + Shift"
   },
   "Alternative (OR)": {
-    "Alternative (OR)": ""
+    "Alternative (OR)": "Alternativo (OU)"
   },
   "Always Active": {
     "Always Active": "Sempre Ativo"
@@ -576,7 +573,7 @@
     "Always Show Percentage": "Sempre Mostrar Porcentagem"
   },
   "Always blur against the wallpaper, even with Xray off": {
-    "Always blur against the wallpaper, even with Xray off": ""
+    "Always blur against the wallpaper, even with Xray off": "Sempre desfocar contra o papel de parede, mesmo com Xray desativado"
   },
   "Always hide the dock and reveal it when hovering near the dock area": {
     "Always hide the dock and reveal it when hovering near the dock area": "Sempre ocultar o dock e revelá-lo ao passar próximo à área do dock"
@@ -594,16 +591,16 @@
     "Always show when there's only one connected display": "Sempre mostrar quando houver apenas um monitor conectado"
   },
   "Always use the durations above, even if an app requests a shorter or longer one": {
-    "Always use the durations above, even if an app requests a shorter or longer one": ""
+    "Always use the durations above, even if an app requests a shorter or longer one": "Sempre usar as durações acima, mesmo que um aplicativo solicite uma mais curta ou mais longa"
   },
   "Always use this app for %1": {
-    "Always use this app for %1": ""
+    "Always use this app for %1": "Sempre usar este aplicativo para %1"
   },
   "Amount": {
     "Amount": "Quantidade"
   },
   "An xray rule at %1 may conflict with the Xray settings below": {
-    "An xray rule at %1 may conflict with the Xray settings below": ""
+    "An xray rule at %1 may conflict with the Xray settings below": "Uma regra de xray em %1 pode conflitar com as configurações de Xray abaixo"
   },
   "Analog": {
     "Analog": "Analógico"
@@ -615,7 +612,7 @@
     "Analyzing configuration...": "Analisando configuração..."
   },
   "Anchor": {
-    "Anchor": ""
+    "Anchor": "Âncora"
   },
   "Animation Duration": {
     "Animation Duration": "Duração da Animação"
@@ -624,7 +621,7 @@
     "Animation Speed": "Velocidade de Animação"
   },
   "Animation Style": {
-    "Animation Style": ""
+    "Animation Style": "Estilo de Animação"
   },
   "Anonymous Identity": {
     "Anonymous Identity": "Identidade Anônima"
@@ -633,22 +630,22 @@
     "Anonymous Identity (optional)": "Identidade Anônima (opcional)"
   },
   "Any window": {
-    "Any window": ""
+    "Any window": "Qualquer janela"
   },
   "App Customizations": {
     "App Customizations": "Personalizações do Aplicativo"
   },
   "App ID": {
-    "App ID": ""
+    "App ID": "ID do Aplicativo"
   },
   "App ID (e.g. firefox)": {
-    "App ID (e.g. firefox)": ""
+    "App ID (e.g. firefox)": "ID do aplicativo (ex.: firefox)"
   },
   "App ID Substitutions": {
     "App ID Substitutions": "Substituições de ID de Aplicativo"
   },
   "App ID regex": {
-    "App ID regex": ""
+    "App ID regex": "Regex do ID do aplicativo"
   },
   "App ID regex (e.g. ^firefox$)": {
     "App ID regex (e.g. ^firefox$)": "Regex de ID de Aplicativo (ex: ^firefox$)"
@@ -663,16 +660,16 @@
     "App Theming": "Tema de Aplicativos"
   },
   "App name or identity (e.g., firefox)": {
-    "App name or identity (e.g., firefox)": ""
+    "App name or identity (e.g., firefox)": "Nome ou identidade do aplicativo (ex.: firefox)"
   },
   "Appearance": {
     "Appearance": "Aparência"
   },
   "Apple Music animated covers": {
-    "Apple Music animated covers": ""
+    "Apple Music animated covers": "Capas animadas do Apple Music"
   },
   "Application": {
-    "Application": ""
+    "Application": "Aplicativo"
   },
   "Application Dock": {
     "Application Dock": "Dock de Aplicativos"
@@ -681,16 +678,16 @@
     "Applications": "Aplicativos"
   },
   "Applications and commands to start automatically when you log in": {
-    "Applications and commands to start automatically when you log in": ""
+    "Applications and commands to start automatically when you log in": "Aplicativos e comandos para iniciar automaticamente ao entrar"
   },
   "Applies on the next greeter sync": {
-    "Applies on the next greeter sync": ""
+    "Applies on the next greeter sync": "Aplica-se na próxima sincronização do greeter"
   },
   "Apply Changes": {
     "Apply Changes": "Aplicar Alterações"
   },
   "Apply Flatpak updates alongside system updates when running 'Update All'.": {
-    "Apply Flatpak updates alongside system updates when running 'Update All'.": ""
+    "Apply Flatpak updates alongside system updates when running 'Update All'.": "Aplicar atualizações Flatpak juntamente com as atualizações do sistema ao executar 'Atualizar Tudo'."
   },
   "Apply GTK Colors": {
     "Apply GTK Colors": "Aplicar cores no GTK"
@@ -699,22 +696,22 @@
     "Apply Qt Colors": "Aplicar cores no QT"
   },
   "Apply compositor blur behind the frame border": {
-    "Apply compositor blur behind the frame border": ""
+    "Apply compositor blur behind the frame border": "Aplicar desfoque do compositor atrás da borda do frame"
   },
   "Apply inverse concave corner cutouts to the bar": {
-    "Apply inverse concave corner cutouts to the bar": ""
+    "Apply inverse concave corner cutouts to the bar": "Aplicar recortes de canto côncavos inversos à barra"
   },
   "Apply to Hardware": {
-    "Apply to Hardware": ""
+    "Apply to Hardware": "Aplicar ao Hardware"
   },
   "Apply warm color temperature to reduce eye strain. Use automation settings below to control when it activates.": {
     "Apply warm color temperature to reduce eye strain. Use automation settings below to control when it activates.": "Aplicar temperatura de cor quente para reduzir a fadiga ocular. Use as configurações de automação abaixo para controlar quando ela será ativada."
   },
   "Applying authentication changes...": {
-    "Applying authentication changes...": ""
+    "Applying authentication changes...": "Aplicando alterações de autenticação..."
   },
   "Applying auto-login on startup...": {
-    "Applying auto-login on startup...": ""
+    "Applying auto-login on startup...": "Aplicando login automático na inicialização..."
   },
   "Apps": {
     "Apps": "Aplicativos"
@@ -738,28 +735,28 @@
     "Apps with notification popups muted. Unmute or delete to remove.": "Aplicativos com popups de notificação silenciados. Dessilenciar ou excluir para remover."
   },
   "Arc Extender": {
-    "Arc Extender": ""
+    "Arc Extender": "Extensor de Arco"
   },
   "Architecture": {
     "Architecture": "Arquitetura"
   },
   "Are you sure you want to kill session \"%1\"?": {
-    "Are you sure you want to kill session \"%1\"?": ""
+    "Are you sure you want to kill session \"%1\"?": "Tem certeza de que deseja encerrar a sessão \"%1\"?"
   },
   "Arrange displays and configure resolution, refresh rate, and VRR": {
     "Arrange displays and configure resolution, refresh rate, and VRR": "Organizar monitores e configurar resolução, taxa de atualização e VRR"
   },
   "At Startup": {
-    "At Startup": ""
+    "At Startup": "Na Inicialização"
   },
   "At least one output must remain enabled": {
-    "At least one output must remain enabled": ""
+    "At least one output must remain enabled": "Pelo menos uma saída deve permanecer ativada"
   },
   "At start": {
-    "At start": ""
+    "At start": "No início"
   },
   "Attach": {
-    "Attach": ""
+    "Attach": "Anexar"
   },
   "Audio": {
     "Audio": "Áudio"
@@ -803,9 +800,6 @@
   "Authenticate": {
     "Authenticate": "Autenticar"
   },
-  "Authenticated!": {
-    "Authenticated!": ""
-  },
   "Authentication": {
     "Authentication": "Autenticação"
   },
@@ -813,16 +807,22 @@
     "Authentication Required": "Autenticação Necessária"
   },
   "Authentication Source": {
-    "Authentication Source": ""
+    "Authentication Source": "Fonte de Autenticação"
   },
   "Authentication changes applied": {
-    "Authentication changes applied": ""
+    "Authentication changes applied": "Alterações de autenticação aplicadas"
   },
   "Authentication changes apply automatically": {
-    "Authentication changes apply automatically": ""
+    "Authentication changes apply automatically": "As alterações de autenticação são aplicadas automaticamente"
   },
   "Authentication changes need sudo. Opening terminal so you can use password or fingerprint.": {
-    "Authentication changes need sudo. Opening terminal so you can use password or fingerprint.": ""
+    "Authentication changes need sudo. Opening terminal so you can use password or fingerprint.": "As alterações de autenticação precisam de sudo. Abrindo o terminal para que você possa usar senha ou impressão digital."
+  },
+  "Authentication error - try again": {
+    "Authentication error - try again": "Erro de autenticação - tente novamente"
+  },
+  "Authentication failed - try again": {
+    "Authentication failed - try again": "Falha na autenticação - tente novamente"
   },
   "Authorize": {
     "Authorize": "Autorizar"
@@ -837,37 +837,37 @@
     "Auto": "Automático"
   },
   "Auto (Bar-aware)": {
-    "Auto (Bar-aware)": ""
+    "Auto (Bar-aware)": "Auto (ciente da barra)"
   },
   "Auto (Wide)": {
     "Auto (Wide)": "Automático (Largo)"
   },
   "Auto Compositor Gaps": {
-    "Auto Compositor Gaps": ""
+    "Auto Compositor Gaps": "Lacunas Automáticas do Compositor"
   },
   "Auto Location": {
     "Auto Location": "Localização Automática"
   },
   "Auto Overflow": {
-    "Auto Overflow": ""
+    "Auto Overflow": "Estouro Automático"
   },
   "Auto Popup Gaps": {
     "Auto Popup Gaps": "Espaçamento Automático de Popup"
   },
   "Auto Power Saver": {
-    "Auto Power Saver": ""
+    "Auto Power Saver": "Economia de Energia Automática"
   },
   "Auto matches bar spacing; Off leaves gaps to your %1 config": {
-    "Auto matches bar spacing; Off leaves gaps to your %1 config": ""
+    "Auto matches bar spacing; Off leaves gaps to your %1 config": "Auto corresponde ao espaçamento da barra; Desligado deixa as lacunas para sua configuração do %1"
   },
   "Auto mode is on. Manual profile selection is disabled.": {
-    "Auto mode is on. Manual profile selection is disabled.": ""
+    "Auto mode is on. Manual profile selection is disabled.": "O modo automático está ativado. A seleção manual de perfil está desativada."
   },
   "Auto saved": {
-    "Auto saved": ""
+    "Auto saved": "Salvo automaticamente"
   },
   "Auto uses an installed or bundled key-only service.": {
-    "Auto uses an installed or bundled key-only service.": ""
+    "Auto uses an installed or bundled key-only service.": "Auto usa um serviço somente-chave instalado ou incluído."
   },
   "Auto-Clear After": {
     "Auto-Clear After": "Auto-Limpeza Depois"
@@ -888,19 +888,19 @@
     "Auto-hide Dock": "Esconder Automaticamente o Dock"
   },
   "Auto-login change needs a sync": {
-    "Auto-login change needs a sync": ""
+    "Auto-login change needs a sync": "A alteração do login automático precisa de uma sincronização"
   },
   "Auto-login disabled": {
-    "Auto-login disabled": ""
+    "Auto-login disabled": "Login automático desativado"
   },
   "Auto-login enabled": {
-    "Auto-login enabled": ""
+    "Auto-login enabled": "Login automático ativado"
   },
   "Auto-login on startup": {
-    "Auto-login on startup": ""
+    "Auto-login on startup": "Login automático na inicialização"
   },
   "Auto-save to disk": {
-    "Auto-save to disk": ""
+    "Auto-save to disk": "Salvar automaticamente no disco"
   },
   "Autoconnect": {
     "Autoconnect": "Conectar automáticamente"
@@ -912,10 +912,7 @@
     "Autoconnect enabled": "Conexão automática ativada"
   },
   "Autofill last remembered query when opened": {
-    "Autofill last remembered query when opened": ""
-  },
-  "Automatic Color Mode": {
-    "Automatic Color Mode": "Modo de Cor Automático"
+    "Autofill last remembered query when opened": "Preencher automaticamente a última consulta lembrada ao abrir"
   },
   "Automatic Control": {
     "Automatic Control": "Controle Automático"
@@ -924,7 +921,7 @@
     "Automatic Cycling": "Rotação Automática"
   },
   "Automatically calculate popup gap based on bar spacing": {
-    "Automatically calculate popup gap based on bar spacing": ""
+    "Automatically calculate popup gap based on bar spacing": "Calcular automaticamente a lacuna do popup com base no espaçamento da barra"
   },
   "Automatically cycle through wallpapers in the same folder": {
     "Automatically cycle through wallpapers in the same folder": "Circular automaticamente dentre os papéis de parede na mesma pasta"
@@ -939,7 +936,7 @@
     "Automatically determine your location using your IP address": "Detectar automaticamente a sua localização usando o seu endereço de IP"
   },
   "Automatically hide the bar when the pointer moves away": {
-    "Automatically hide the bar when the pointer moves away": ""
+    "Automatically hide the bar when the pointer moves away": "Ocultar a barra automaticamente quando o ponteiro se afastar"
   },
   "Automatically lock after": {
     "Automatically lock after": "Bloquear automaticamente após"
@@ -951,22 +948,22 @@
     "Automatically lock the screen when the system prepares to suspend": "Bloquear tela automaticamente quando o sistema é preparado para suspensão"
   },
   "Automatically save changes to opened files as you type": {
-    "Automatically save changes to opened files as you type": ""
+    "Automatically save changes to opened files as you type": "Salvar automaticamente as alterações em arquivos abertos enquanto você digita"
   },
   "Automatically turn on Num Lock at startup": {
-    "Automatically turn on Num Lock at startup": ""
+    "Automatically turn on Num Lock at startup": "Ativar automaticamente o Num Lock na inicialização"
   },
   "Automatically turn on Power Saver profile when battery is low.": {
-    "Automatically turn on Power Saver profile when battery is low.": ""
+    "Automatically turn on Power Saver profile when battery is low.": "Ativar automaticamente o perfil de Economia de Energia quando a bateria estiver baixa."
   },
   "Automation": {
     "Automation": "Automação"
   },
   "Autostart Apps": {
-    "Autostart Apps": ""
+    "Autostart Apps": "Aplicativos de Inicialização"
   },
   "Autostart Entries": {
-    "Autostart Entries": ""
+    "Autostart Entries": "Entradas de Inicialização"
   },
   "Available": {
     "Available": "Disponível"
@@ -984,7 +981,7 @@
     "Available Screens (%1)": "Telas Disponíveis (%1)"
   },
   "Available Updates (%1)": {
-    "Available Updates (%1)": ""
+    "Available Updates (%1)": "Atualizações Disponíveis (%1)"
   },
   "Available in Detailed and Forecast view modes": {
     "Available in Detailed and Forecast view modes": "Disponível em modos de visualização Detalhada e Previsão"
@@ -999,22 +996,22 @@
     "Backend": "Backend"
   },
   "Background": {
-    "Background": ""
+    "Background": "Fundo"
   },
   "Background Blur": {
-    "Background Blur": ""
+    "Background Blur": "Desfoque de Fundo"
   },
   "Background Color": {
-    "Background Color": ""
+    "Background Color": "Cor de Fundo"
   },
   "Background Effect": {
-    "Background Effect": ""
+    "Background Effect": "Efeito de Fundo"
   },
   "Background Opacity": {
     "Background Opacity": "Opacidade do Fundo"
   },
   "Background authentication sync failed. Trying terminal mode.": {
-    "Background authentication sync failed. Trying terminal mode.": ""
+    "Background authentication sync failed. Trying terminal mode.": "A sincronização de autenticação em segundo plano falhou. Tentando o modo de terminal."
   },
   "Background image": {
     "Background image": "Imagem de fundo"
@@ -1032,31 +1029,31 @@
     "Balanced palette with focused accents (default).": "Paleta equilibrada com destaques de cor focados (padrão)."
   },
   "Band": {
-    "Band": ""
+    "Band": "Banda"
   },
   "Bar": {
-    "Bar": ""
+    "Bar": "Barra"
   },
   "Bar %1": {
-    "Bar %1": ""
+    "Bar %1": "Barra %1"
   },
   "Bar Inset Padding": {
-    "Bar Inset Padding": ""
+    "Bar Inset Padding": "Preenchimento Interno da Barra"
   },
   "Bar Opacity": {
-    "Bar Opacity": ""
+    "Bar Opacity": "Opacidade da Barra"
   },
   "Bar Shadows": {
     "Bar Shadows": "Sombras da Barra"
   },
   "Bar Spacing": {
-    "Bar Spacing": ""
+    "Bar Spacing": "Espaçamento da Barra"
   },
   "Bar corners and background": {
-    "Bar corners and background": ""
+    "Bar corners and background": "Cantos e fundo da barra"
   },
   "Bar shadow, border, and corners": {
-    "Bar shadow, border, and corners": ""
+    "Bar shadow, border, and corners": "Sombra, borda e cantos da barra"
   },
   "Base color for shadows (opacity is applied automatically)": {
     "Base color for shadows (opacity is applied automatically)": "Cor base para sombras (a opacidade é aplicada automaticamente)"
@@ -1068,31 +1065,31 @@
     "Battery": "Bateria"
   },
   "Battery %1": {
-    "Battery %1": ""
+    "Battery %1": "Bateria %1"
   },
   "Battery Charge Limit": {
     "Battery Charge Limit": "Limite de Carga da Bateria"
   },
   "Battery Health": {
-    "Battery Health": ""
+    "Battery Health": "Saúde da Bateria"
   },
   "Battery Power": {
-    "Battery Power": ""
+    "Battery Power": "Energia da Bateria"
   },
   "Battery and power management": {
     "Battery and power management": "Gerenciamento de bateria e energia"
   },
   "Battery has charged to your set limit of %1%": {
-    "Battery has charged to your set limit of %1%": ""
+    "Battery has charged to your set limit of %1%": "A bateria carregou até o limite definido de %1%"
   },
   "Battery is at %1% - Connect charger immediately!": {
-    "Battery is at %1% - Connect charger immediately!": ""
+    "Battery is at %1% - Connect charger immediately!": "A bateria está em %1% - Conecte o carregador imediatamente!"
   },
   "Battery is at %1% - Consider charging soon": {
-    "Battery is at %1% - Consider charging soon": ""
+    "Battery is at %1% - Consider charging soon": "A bateria está em %1% - Considere carregar em breve"
   },
   "Battery percentage to trigger a critical alert.": {
-    "Battery percentage to trigger a critical alert.": ""
+    "Battery percentage to trigger a critical alert.": "Percentual da bateria para acionar um alerta crítico."
   },
   "Behavior": {
     "Behavior": "Comportamento"
@@ -1101,7 +1098,7 @@
     "Bind lock screen to dbus signals from loginctl. Disable if using an external lock screen": "Vincular o bloqueio de tela aos sinais do DBus do loginctl. Desative se estiver usando um bloqueio de tela externo"
   },
   "Bind the %1 IPC action in your compositor config.": {
-    "Bind the %1 IPC action in your compositor config.": ""
+    "Bind the %1 IPC action in your compositor config.": "Vincule a ação IPC do %1 na configuração do seu compositor."
   },
   "Binds include added": {
     "Binds include added": "Atalhos incluem adicionados"
@@ -1110,10 +1107,10 @@
     "Bit Depth": "Profundidade de Bits"
   },
   "Black": {
-    "Black": ""
+    "Black": "Preto"
   },
   "Blend between Surface High and the selected custom color": {
-    "Blend between Surface High and the selected custom color": ""
+    "Blend between Surface High and the selected custom color": "Misturar entre Surface High e a cor personalizada selecionada"
   },
   "Block Out": {
     "Block Out": "Bloquear"
@@ -1140,7 +1137,7 @@
     "Bluetooth not available": "Bluetooth indisponível"
   },
   "Blur": {
-    "Blur": ""
+    "Blur": "Desfoque"
   },
   "Blur Wallpaper Layer": {
     "Blur Wallpaper Layer": "Camada de Papel de Parede com Desfoque"
@@ -1149,22 +1146,22 @@
     "Blur on Overview": "Desfoque na Visão Geral"
   },
   "Blur the background behind bars, popouts, modals, and notifications. Requires compositor support. Adjust Opacity accordingly.": {
-    "Blur the background behind bars, popouts, modals, and notifications. Requires compositor support. Adjust Opacity accordingly.": ""
+    "Blur the background behind bars, popouts, modals, and notifications. Requires compositor support. Adjust Opacity accordingly.": "Desfocar o fundo atrás de barras, popouts, modais e notificações. Requer suporte do compositor. Ajuste a Opacidade de acordo."
   },
   "Blur wallpaper when niri overview is open": {
     "Blur wallpaper when niri overview is open": "Desfoque de papel de parede quando a visão geral do niri estiver aberta"
   },
   "Blurred surfaces show the wallpaper instead of the content beneath": {
-    "Blurred surfaces show the wallpaper instead of the content beneath": ""
+    "Blurred surfaces show the wallpaper instead of the content beneath": "Superfícies desfocadas mostram o papel de parede em vez do conteúdo abaixo"
   },
   "Body": {
     "Body": "Corpo"
   },
   "Body Font Size": {
-    "Body Font Size": ""
+    "Body Font Size": "Tamanho da Fonte do Corpo"
   },
   "Bold": {
-    "Bold": ""
+    "Bold": "Negrito"
   },
   "Border": {
     "Border": "Borda"
@@ -1173,13 +1170,13 @@
     "Border Color": "Cor da Borda"
   },
   "Border Off": {
-    "Border Off": ""
+    "Border Off": "Borda Desligada"
   },
   "Border Opacity": {
     "Border Opacity": "Opacidade da Borda"
   },
   "Border Radius": {
-    "Border Radius": ""
+    "Border Radius": "Raio da Borda"
   },
   "Border Size": {
     "Border Size": "Tamanho da Borda"
@@ -1188,16 +1185,16 @@
     "Border Thickness": "Espessura da Borda"
   },
   "Border Width": {
-    "Border Width": ""
+    "Border Width": "Largura da Borda"
   },
   "Border color around popouts, modals, and other shell surfaces": {
-    "Border color around popouts, modals, and other shell surfaces": ""
+    "Border color around popouts, modals, and other shell surfaces": "Cor da borda ao redor de popouts, modais e outras superfícies do shell"
   },
   "Border w/ Bg": {
-    "Border w/ Bg": ""
+    "Border w/ Bg": "Borda c/ Fundo"
   },
   "Border with Background": {
-    "Border with Background": ""
+    "Border with Background": "Borda com Fundo"
   },
   "Bottom": {
     "Bottom": "Inferior"
@@ -1242,7 +1239,7 @@
     "Browse Themes": "Navegar Temas"
   },
   "Browse and set wallpapers": {
-    "Browse and set wallpapers": ""
+    "Browse and set wallpapers": "Navegar e definir papéis de parede"
   },
   "Browse or search plugins": {
     "Browse or search plugins": "Procurar ou pesquisar plugins"
@@ -1284,16 +1281,19 @@
     "CUPS not available": "CUPS indisponível"
   },
   "Calendar": {
-    "Calendar": ""
+    "Calendar": "Calendário"
   },
   "Calendar Backend": {
-    "Calendar Backend": ""
+    "Calendar Backend": "Backend do Calendário"
   },
   "Calls / Headset": {
-    "Calls / Headset": ""
+    "Calls / Headset": "Chamadas / Fone"
   },
   "Camera": {
     "Camera": "Câmera"
+  },
+  "Cancel": {
+    "Cancel": "Cancelar"
   },
   "Cancel all jobs for \"%1\"?": {
     "Cancel all jobs for \"%1\"?": "Cancelar todos os trabalhos para \"%1\"?"
@@ -1302,22 +1302,22 @@
     "Canceled": "Cancelado"
   },
   "Cannot delete the only administrator": {
-    "Cannot delete the only administrator": ""
+    "Cannot delete the only administrator": "Não é possível excluir o único administrador"
   },
   "Cannot disable the only output": {
-    "Cannot disable the only output": ""
+    "Cannot disable the only output": "Não é possível desativar a única saída"
   },
   "Cannot open trash: '%1' is not installed": {
-    "Cannot open trash: '%1' is not installed": ""
+    "Cannot open trash: '%1' is not installed": "Não é possível abrir a lixeira: '%1' não está instalado"
   },
   "Cannot open trash: no custom command set": {
-    "Cannot open trash: no custom command set": ""
+    "Cannot open trash: no custom command set": "Não é possível abrir a lixeira: nenhum comando personalizado definido"
   },
   "Cannot pair": {
     "Cannot pair": "Não foi possível parear"
   },
   "Cannot remove the only administrator": {
-    "Cannot remove the only administrator": ""
+    "Cannot remove the only administrator": "Não é possível remover o único administrador"
   },
   "Capabilities": {
     "Capabilities": "Capacidades"
@@ -1335,10 +1335,10 @@
     "Caps Lock is on": "Caps Lock está ligado"
   },
   "Cast Target": {
-    "Cast Target": ""
+    "Cast Target": "Destino de Transmissão"
   },
   "Category": {
-    "Category": ""
+    "Category": "Categoria"
   },
   "Center Section": {
     "Center Section": "Seção Central"
@@ -1368,16 +1368,16 @@
     "Channel": "Canal"
   },
   "Characters per second while holding down key": {
-    "Characters per second while holding down key": ""
+    "Characters per second while holding down key": "Caracteres por segundo ao manter a tecla pressionada"
   },
   "Charge Level": {
-    "Charge Level": ""
+    "Charge Level": "Nível de Carga"
   },
   "Charge Limit Reached": {
-    "Charge Limit Reached": ""
+    "Charge Limit Reached": "Limite de Carga Atingido"
   },
   "Charge limit applied successfully": {
-    "Charge limit applied successfully": ""
+    "Charge limit applied successfully": "Limite de carga aplicado com sucesso"
   },
   "Charging": {
     "Charging": "Carregando"
@@ -1386,19 +1386,19 @@
     "Check for system updates": "Verificar por atualizações de sistema"
   },
   "Check interval": {
-    "Check interval": ""
+    "Check interval": "Intervalo de verificação"
   },
   "Check on startup": {
-    "Check on startup": ""
+    "Check on startup": "Verificar na inicialização"
   },
   "Check your custom command in Settings → Dock → Trash.": {
-    "Check your custom command in Settings → Dock → Trash.": ""
+    "Check your custom command in Settings → Dock → Trash.": "Verifique seu comando personalizado em Configurações → Dock → Lixeira."
   },
   "Checking for updates...": {
     "Checking for updates...": "Verificando por atualizações..."
   },
   "Checking whether sudo authentication is needed...": {
-    "Checking whether sudo authentication is needed...": ""
+    "Checking whether sudo authentication is needed...": "Verificando se a autenticação sudo é necessária..."
   },
   "Checking...": {
     "Checking...": "Verificando..."
@@ -1422,10 +1422,10 @@
     "Choose a color": "Escolha uma cor"
   },
   "Choose a power profile": {
-    "Choose a power profile": ""
+    "Choose a power profile": "Escolha um perfil de energia"
   },
   "Choose a shortcut key to cycle between keyboard layouts": {
-    "Choose a shortcut key to cycle between keyboard layouts": ""
+    "Choose a shortcut key to cycle between keyboard layouts": "Escolha uma tecla de atalho para alternar entre layouts de teclado"
   },
   "Choose colors from palette": {
     "Choose colors from palette": "Escolha cores da paleta"
@@ -1434,31 +1434,31 @@
     "Choose how the weather widget is displayed": "Escolha como o widget de clima é exibido"
   },
   "Choose how this bar resolves shadow direction": {
-    "Choose how this bar resolves shadow direction": ""
+    "Choose how this bar resolves shadow direction": "Escolha como esta barra resolve a direção da sombra"
   },
   "Choose how to be notified about critical battery alerts.": {
-    "Choose how to be notified about critical battery alerts.": ""
+    "Choose how to be notified about critical battery alerts.": "Escolha como ser notificado sobre alertas críticos de bateria."
   },
   "Choose how to be notified about low battery alerts.": {
-    "Choose how to be notified about low battery alerts.": ""
+    "Choose how to be notified about low battery alerts.": "Escolha como ser notificado sobre alertas de bateria baixa."
   },
   "Choose how to be notified when charge limit is reached.": {
-    "Choose how to be notified when charge limit is reached.": ""
+    "Choose how to be notified when charge limit is reached.": "Escolha como ser notificado quando o limite de carga for atingido."
   },
   "Choose monochrome or a theme color tint for system tray icons": {
-    "Choose monochrome or a theme color tint for system tray icons": ""
+    "Choose monochrome or a theme color tint for system tray icons": "Escolha monocromático ou um tom de cor do tema para os ícones da bandeja do sistema"
   },
   "Choose neutral or accent-colored widget text": {
-    "Choose neutral or accent-colored widget text": ""
+    "Choose neutral or accent-colored widget text": "Escolha texto de widget neutro ou na cor de destaque"
   },
   "Choose the logo displayed on the launcher button in DankBar": {
     "Choose the logo displayed on the launcher button in DankBar": "Escolher a logo que será exibida no botão do Lançador no DankBar"
   },
   "Choose wallpaper folder": {
-    "Choose wallpaper folder": ""
+    "Choose wallpaper folder": "Escolher pasta de papel de parede"
   },
   "Choose when to generate scrolling events": {
-    "Choose when to generate scrolling events": ""
+    "Choose when to generate scrolling events": "Escolha quando gerar eventos de rolagem"
   },
   "Choose where notification popups appear on screen": {
     "Choose where notification popups appear on screen": "Escolher onde as notificações irão aparecer na tela"
@@ -1467,16 +1467,16 @@
     "Choose where on-screen displays appear on screen": "Escolher onde OSDs aparecerão na tela"
   },
   "Choose whether to launch a desktop app or a command": {
-    "Choose whether to launch a desktop app or a command": ""
+    "Choose whether to launch a desktop app or a command": "Escolha se deseja iniciar um aplicativo da área de trabalho ou um comando"
   },
   "Choose which action buttons appear on clipboard entries": {
-    "Choose which action buttons appear on clipboard entries": ""
+    "Choose which action buttons appear on clipboard entries": "Escolha quais botões de ação aparecem nas entradas da área de transferência"
   },
   "Choose which displays show this widget": {
     "Choose which displays show this widget": "Escolha quais monitores mostrarão este widget"
   },
   "Choose which monitors show the lock screen interface. Other monitors will display a solid color for OLED burn-in protection.": {
-    "Choose which monitors show the lock screen interface. Other monitors will display a solid color for OLED burn-in protection.": ""
+    "Choose which monitors show the lock screen interface. Other monitors will display a solid color for OLED burn-in protection.": "Escolha quais monitores mostram a interface da tela de bloqueio. Outros monitores exibirão uma cor sólida para proteção contra queima da tela OLED."
   },
   "Chroma Style": {
     "Chroma Style": "Estilo Chroma"
@@ -1488,7 +1488,7 @@
     "Circle": "Círculo"
   },
   "Class regex": {
-    "Class regex": ""
+    "Class regex": "Regex de classe"
   },
   "Class regex (e.g. ^firefox$)": {
     "Class regex (e.g. ^firefox$)": "Regex de Classe (ex: ^firefox$)"
@@ -1521,19 +1521,19 @@
     "Click Import to add a .ovpn or .conf": "Clique em Importar para adicionar um arquivo .ovpn ou .conf"
   },
   "Click Refresh to check status.": {
-    "Click Refresh to check status.": ""
+    "Click Refresh to check status.": "Clique em Atualizar para verificar o status."
   },
   "Click Through": {
     "Click Through": "Atravessar Clique"
   },
   "Click an entry to paste directly instead of copying": {
-    "Click an entry to paste directly instead of copying": ""
+    "Click an entry to paste directly instead of copying": "Clique em uma entrada para colar diretamente em vez de copiar"
   },
   "Click any shortcut to edit. Changes save to %1": {
     "Click any shortcut to edit. Changes save to %1": "Clique em qualquer atalho para editar. Alterações salvas em %1"
   },
   "Click to Paste": {
-    "Click to Paste": ""
+    "Click to Paste": "Clique para Colar"
   },
   "Click to capture": {
     "Click to capture": "Clique para capturar"
@@ -1557,7 +1557,7 @@
     "Clipboard Manager": "Gerenciador da Área de Transferência"
   },
   "Clipboard Saved": {
-    "Clipboard Saved": ""
+    "Clipboard Saved": "Área de Transferência Salva"
   },
   "Clipboard sent": {
     "Clipboard sent": "Área de transferência enviada"
@@ -1572,7 +1572,7 @@
     "Clock Style": "Estilo de Relógio"
   },
   "Clock, calendar, system info and profile": {
-    "Clock, calendar, system info and profile": ""
+    "Clock, calendar, system info and profile": "Relógio, calendário, informações do sistema e perfil"
   },
   "Close": {
     "Close": "Fechar"
@@ -1587,22 +1587,19 @@
     "Close Window": "Fechar Janela"
   },
   "Codec switched successfully": {
-    "Codec switched successfully": ""
+    "Codec switched successfully": "Codec alternado com sucesso"
   },
   "Codec switching is unavailable because WirePlumber was not found": {
-    "Codec switching is unavailable because WirePlumber was not found": ""
-  },
-  "Codec switching is unavailable because pactl was not found": {
-    "Codec switching is unavailable because pactl was not found": ""
+    "Codec switching is unavailable because WirePlumber was not found": "A alternância de codec não está disponível porque o WirePlumber não foi encontrado"
   },
   "Codec switching is unavailable. WirePlumber wpexec was not found.": {
-    "Codec switching is unavailable. WirePlumber wpexec was not found.": ""
+    "Codec switching is unavailable. WirePlumber wpexec was not found.": "A alternância de codec não está disponível. O wpexec do WirePlumber não foi encontrado."
   },
   "Color": {
     "Color": "Cor"
   },
   "Color %1 copied": {
-    "Color %1 copied": ""
+    "Color %1 copied": "Cor %1 copiada"
   },
   "Color Gamut": {
     "Color Gamut": "Gamut de Cor"
@@ -1629,7 +1626,7 @@
     "Color for primary action buttons": "Cor para botões de ação primária"
   },
   "Color shown for areas not covered by wallpaper": {
-    "Color shown for areas not covered by wallpaper": ""
+    "Color shown for areas not covered by wallpaper": "Cor mostrada para áreas não cobertas pelo papel de parede"
   },
   "Color temperature for night mode": {
     "Color temperature for night mode": "Temperatura da cor para o modo noturno"
@@ -1665,16 +1662,16 @@
     "Column Width": "Largura da Coluna"
   },
   "Comma-separated list of layout names. Leave empty to use the system keyboard settings.": {
-    "Comma-separated list of layout names. Leave empty to use the system keyboard settings.": ""
+    "Comma-separated list of layout names. Leave empty to use the system keyboard settings.": "Lista de nomes de layouts separados por vírgula. Deixe vazio para usar as configurações de teclado do sistema."
   },
   "Comma-separated list of session names to hide. Wrap in slashes for regex (e.g., /^_.*/).": {
-    "Comma-separated list of session names to hide. Wrap in slashes for regex (e.g., /^_.*/).": ""
+    "Comma-separated list of session names to hide. Wrap in slashes for regex (e.g., /^_.*/).": "Lista de nomes de sessão separados por vírgula para ocultar. Coloque entre barras para regex (ex.: /^_.*/)."
   },
   "Command": {
     "Command": "Comando"
   },
   "Command Line": {
-    "Command Line": ""
+    "Command Line": "Linha de Comando"
   },
   "Commands": {
     "Commands": "Comandos"
@@ -1698,7 +1695,7 @@
     "Compositor Settings": "Configurações do Compositor"
   },
   "Compositor actions (focus, move, etc.)": {
-    "Compositor actions (focus, move, etc.)": ""
+    "Compositor actions (focus, move, etc.)": "Ações do compositor (foco, mover, etc.)"
   },
   "Config Format": {
     "Config Format": "Formato de Configuração"
@@ -1719,7 +1716,7 @@
     "Configuration will be preserved when this display reconnects": "A configuração será mantida quando esse monitor reconectar"
   },
   "Configurations": {
-    "Configurations": ""
+    "Configurations": "Configurações"
   },
   "Configure": {
     "Configure": "Configurar"
@@ -1737,10 +1734,10 @@
     "Configure match criteria and actions": "Configurar critérios de correspondência e ações"
   },
   "Configure one in Settings → Dock → Trash.": {
-    "Configure one in Settings → Dock → Trash.": ""
+    "Configure one in Settings → Dock → Trash.": "Configure um em Configurações → Dock → Lixeira."
   },
-  "Configure which displays show \"%1": {
-    "Configure which displays show \"%1\"": "Configurar quais telas mostram \"%1\""
+  "Configure which displays show \"%1\"": {
+    "Configure which displays show \"%1\"": "Configurar quais monitores mostram \"%1\""
   },
   "Configure which displays show shell components": {
     "Configure which displays show shell components": "Configurar em quais telas serão mostrados os componentes do shell"
@@ -1785,19 +1782,19 @@
     "Connected Displays": "Telas Conectadas"
   },
   "Connected Frame Mode uses the connected launcher for default launcher shortcuts.": {
-    "Connected Frame Mode uses the connected launcher for default launcher shortcuts.": ""
+    "Connected Frame Mode uses the connected launcher for default launcher shortcuts.": "O Modo Frame Conectado usa o inicializador conectado para os atalhos padrão do inicializador."
   },
   "Connected Options": {
-    "Connected Options": ""
+    "Connected Options": "Opções Conectadas"
   },
   "Connected to %1": {
-    "Connected to %1": ""
+    "Connected to %1": "Conectado a %1"
   },
   "Connecting to Device": {
     "Connecting to Device": "Conectando ao Dispositivo"
   },
   "Connecting to clipboard service...": {
-    "Connecting to clipboard service...": ""
+    "Connecting to clipboard service...": "Conectando ao serviço da área de transferência..."
   },
   "Connecting...": {
     "Connecting...": "Conectando..."
@@ -1818,10 +1815,10 @@
     "Contrast": "Contraste"
   },
   "Contrast by variant": {
-    "Contrast by variant": ""
+    "Contrast by variant": "Contraste por variante"
   },
   "Contributor": {
-    "Contributor": ""
+    "Contributor": "Contribuidor"
   },
   "Control Center": {
     "Control Center": "Painel de Controle"
@@ -1845,31 +1842,31 @@
     "Control workspaces and columns by scrolling on the bar": "Controle espaços de trabalho e colunas rolando na barra"
   },
   "Controls how much original icon color is removed before applying tint": {
-    "Controls how much original icon color is removed before applying tint": ""
+    "Controls how much original icon color is removed before applying tint": "Controla quanto da cor original do ícone é removido antes de aplicar o tom"
   },
   "Controls how strongly the selected tint color is applied": {
-    "Controls how strongly the selected tint color is applied": ""
+    "Controls how strongly the selected tint color is applied": "Controla com que intensidade a cor de tom selecionada é aplicada"
   },
   "Controls opacity of shell surfaces, popouts, and modals": {
-    "Controls opacity of shell surfaces, popouts, and modals": ""
+    "Controls opacity of shell surfaces, popouts, and modals": "Controla a opacidade das superfícies do shell, popouts e modais"
   },
   "Controls outlines around foreground cards, pills, and notification cards": {
-    "Controls outlines around foreground cards, pills, and notification cards": ""
+    "Controls outlines around foreground cards, pills, and notification cards": "Controla os contornos ao redor de cartões de primeiro plano, pílulas e cartões de notificação"
   },
   "Controls shadow cast direction for elevation layers": {
-    "Controls shadow cast direction for elevation layers": ""
+    "Controls shadow cast direction for elevation layers": "Controla a direção da sombra projetada para camadas de elevação"
   },
   "Controls the base blur radius and offset of shadows": {
-    "Controls the base blur radius and offset of shadows": ""
+    "Controls the base blur radius and offset of shadows": "Controla o raio de desfoque base e o deslocamento das sombras"
   },
   "Controls the outline of popouts, modals, and other shell surfaces": {
-    "Controls the outline of popouts, modals, and other shell surfaces": ""
+    "Controls the outline of popouts, modals, and other shell surfaces": "Controla o contorno de popouts, modais e outras superfícies do shell"
   },
   "Convenience options for the login screen": {
-    "Convenience options for the login screen": ""
+    "Convenience options for the login screen": "Opções de conveniência para a tela de login"
   },
   "Convert to DMS": {
-    "Convert to DMS": ""
+    "Convert to DMS": "Converter para DMS"
   },
   "Cooldown": {
     "Cooldown": "Tempo de espera"
@@ -1910,6 +1907,9 @@
   "Copy Text": {
     "Copy Text": "Copiar Texto"
   },
+  "Copy path": {
+    "Copy path": "Copiar caminho"
+  },
   "Corner Radius": {
     "Corner Radius": "Arredondamento"
   },
@@ -1920,7 +1920,7 @@
     "Corners & Background": "Cantos e Fundo"
   },
   "Couldn't load hotspot password": {
-    "Couldn't load hotspot password": ""
+    "Couldn't load hotspot password": "Não foi possível carregar a senha do hotspot"
   },
   "Count Only": {
     "Count Only": "Apenas Contagem"
@@ -1938,13 +1938,13 @@
     "Create Printer": "Criar Impressora"
   },
   "Create User": {
-    "Create User": ""
+    "Create User": "Criar Usuário"
   },
   "Create Window Rule": {
     "Create Window Rule": "Criar Regra de Janela"
   },
   "Create a new %1 session (^N)": {
-    "Create a new %1 session (^N)": ""
+    "Create a new %1 session (^N)": "Criar uma nova sessão %1 (^N)"
   },
   "Create rule for:": {
     "Create rule for:": "Criar regra para:"
@@ -1953,49 +1953,49 @@
     "Create rules to mute, ignore, hide from history, or override notification priority. Default only overrides priority; notifications still show normally.": "Criar regras para silenciar, ignorar, ocultar do histórico ou substituir a prioridade de notificação. O padrão apenas substitui a prioridade; as notificações ainda aparecem normalmente."
   },
   "Created plugin directory: %1": {
-    "Created plugin directory: %1": ""
+    "Created plugin directory: %1": "Diretório de plugins criado: %1"
   },
   "Creating...": {
     "Creating...": "Criando..."
   },
   "Credentials": {
-    "Credentials": ""
+    "Credentials": "Credenciais"
   },
   "Critical Battery": {
-    "Critical Battery": ""
+    "Critical Battery": "Bateria Crítica"
   },
   "Critical Battery Alert": {
-    "Critical Battery Alert": ""
+    "Critical Battery Alert": "Alerta de Bateria Crítica"
   },
   "Critical Battery Notifications": {
-    "Critical Battery Notifications": ""
+    "Critical Battery Notifications": "Notificações de Bateria Crítica"
   },
   "Critical Priority": {
     "Critical Priority": "Prioridade Crítica"
   },
   "Critical Threshold": {
-    "Critical Threshold": ""
+    "Critical Threshold": "Limite Crítico"
   },
   "Ctrl + Shift": {
-    "Ctrl + Shift": ""
+    "Ctrl + Shift": "Ctrl + Shift"
   },
   "Ctrl+%1 is used for password editing": {
-    "Ctrl+%1 is used for password editing": ""
+    "Ctrl+%1 is used for password editing": "Ctrl+%1 é usado para edição de senha"
   },
   "Ctrl+A: Select All • Ctrl+P: Preview • Enter/Shift+Enter: Find Next/Previous • Esc: Close": {
-    "Ctrl+A: Select All • Ctrl+P: Preview • Enter/Shift+Enter: Find Next/Previous • Esc: Close": ""
+    "Ctrl+A: Select All • Ctrl+P: Preview • Enter/Shift+Enter: Find Next/Previous • Esc: Close": "Ctrl+A: Selecionar Tudo • Ctrl+P: Visualizar • Enter/Shift+Enter: Localizar Próxima/Anterior • Esc: Fechar"
   },
   "Ctrl+S: Save • Ctrl+O: Open • Ctrl+N: New • Ctrl+F: Find": {
-    "Ctrl+S: Save • Ctrl+O: Open • Ctrl+N: New • Ctrl+F: Find": ""
+    "Ctrl+S: Save • Ctrl+O: Open • Ctrl+N: New • Ctrl+F: Find": "Ctrl+S: Salvar • Ctrl+O: Abrir • Ctrl+N: Novo • Ctrl+F: Localizar"
   },
   "Ctrl+Tab: Switch Tab • Ctrl+S: Pin/Unpin • Shift+Del: Clear All • Esc: Close": {
-    "Ctrl+Tab: Switch Tab • Ctrl+S: Pin/Unpin • Shift+Del: Clear All • Esc: Close": ""
+    "Ctrl+Tab: Switch Tab • Ctrl+S: Pin/Unpin • Shift+Del: Clear All • Esc: Close": "Ctrl+Tab: Alternar Aba • Ctrl+S: Fixar/Desfixar • Shift+Del: Limpar Tudo • Esc: Fechar"
   },
   "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Copy • Shift+Del: Clear All • F10: Help • Esc: Close": {
-    "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Copy • Shift+Del: Clear All • F10: Help • Esc: Close": ""
+    "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Copy • Shift+Del: Clear All • F10: Help • Esc: Close": "Ctrl+Tab: Alternar Abas • Ctrl+S: Fixar/Desfixar • Shift+Enter: Copiar • Shift+Del: Limpar Tudo • F10: Ajuda • Esc: Fechar"
   },
   "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Paste • Shift+Del: Clear All • F10: Help • Esc: Close": {
-    "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Paste • Shift+Del: Clear All • F10: Help • Esc: Close": ""
+    "Ctrl+Tab: Switch Tabs • Ctrl+S: Pin/Unpin • Shift+Enter: Paste • Shift+Del: Clear All • F10: Help • Esc: Close": "Ctrl+Tab: Alternar Abas • Ctrl+S: Fixar/Desfixar • Shift+Enter: Colar • Shift+Del: Limpar Tudo • F10: Ajuda • Esc: Fechar"
   },
   "Current": {
     "Current": "Atual"
@@ -2004,7 +2004,7 @@
     "Current Items": "Itens Atuais"
   },
   "Current Locale": {
-    "Current Locale": ""
+    "Current Locale": "Localidade Atual"
   },
   "Current Monitor": {
     "Current Monitor": "Monitor Atual"
@@ -2043,19 +2043,19 @@
     "Cursor Theme": "Tema do Cursor"
   },
   "Curve": {
-    "Curve": ""
+    "Curve": "Curva"
   },
   "Curve: curve rasterizer.": {
-    "Curve: curve rasterizer.": ""
+    "Curve: curve rasterizer.": "Curve: rasterizador de curvas."
   },
   "Custom": {
     "Custom": "Customizado"
   },
   "Custom / None": {
-    "Custom / None": ""
+    "Custom / None": "Personalizado / Nenhum"
   },
   "Custom Blend": {
-    "Custom Blend": ""
+    "Custom Blend": "Mistura Personalizada"
   },
   "Custom Color": {
     "Custom Color": "Cor Personalizada"
@@ -2088,22 +2088,22 @@
     "Custom Reboot Command": "Comando Personalizado Para Reiniciar"
   },
   "Custom Shadow Color": {
-    "Custom Shadow Color": ""
+    "Custom Shadow Color": "Cor de Sombra Personalizada"
   },
   "Custom Shadow Override": {
-    "Custom Shadow Override": ""
+    "Custom Shadow Override": "Substituição de Sombra Personalizada"
   },
   "Custom Suspend Command": {
     "Custom Suspend Command": "Comando Personalizado Para Suspender"
   },
   "Custom command and terminal params are split on whitespace; paths with spaces will break.": {
-    "Custom command and terminal params are split on whitespace; paths with spaces will break.": ""
+    "Custom command and terminal params are split on whitespace; paths with spaces will break.": "O comando personalizado e os parâmetros do terminal são divididos por espaços; caminhos com espaços quebrarão."
   },
   "Custom interval in minutes (minimum 5)": {
-    "Custom interval in minutes (minimum 5)": ""
+    "Custom interval in minutes (minimum 5)": "Intervalo personalizado em minutos (mínimo 5)"
   },
   "Custom open-trash command": {
-    "Custom open-trash command": ""
+    "Custom open-trash command": "Comando personalizado de abertura da lixeira"
   },
   "Custom power profile": {
     "Custom power profile": "Perfil de energia personalizado"
@@ -2112,7 +2112,7 @@
     "Custom theme loaded from JSON file": "Tema personalizado carregado do arquivo JSON"
   },
   "Custom update command": {
-    "Custom update command": ""
+    "Custom update command": "Comando de atualização personalizado"
   },
   "Custom...": {
     "Custom...": "Customizado..."
@@ -2121,7 +2121,7 @@
     "Customizable empty space": "Espaço vazio customizável"
   },
   "Customize the font and background of the lock screen, or leave empty to use your theme font and desktop wallpaper. Changes apply instantly.": {
-    "Customize the font and background of the lock screen, or leave empty to use your theme font and desktop wallpaper. Changes apply instantly.": ""
+    "Customize the font and background of the lock screen, or leave empty to use your theme font and desktop wallpaper. Changes apply instantly.": "Personalize a fonte e o fundo da tela de bloqueio ou deixe vazio para usar a fonte do tema e o papel de parede da área de trabalho. As alterações são aplicadas instantaneamente."
   },
   "Customize which actions appear in the power menu": {
     "Customize which actions appear in the power menu": "Customize quais ações aparecerão no menu de energia"
@@ -2133,31 +2133,31 @@
     "DEMO MODE - Click anywhere to exit": "MODO DEMONSTRAÇÃO - Clique em qualquer lugar para sair"
   },
   "DMS Chooser": {
-    "DMS Chooser": ""
+    "DMS Chooser": "Seletor DMS"
   },
   "DMS Plugin Manager Unavailable": {
     "DMS Plugin Manager Unavailable": "Gerenciador de Plugins DMS indispónivel"
   },
   "DMS Settings": {
-    "DMS Settings": ""
+    "DMS Settings": "Configurações do DMS"
   },
   "DMS Settings writes Lua keybinds. Add the DMS include so edits apply.": {
-    "DMS Settings writes Lua keybinds. Add the DMS include so edits apply.": ""
+    "DMS Settings writes Lua keybinds. Add the DMS include so edits apply.": "As Configurações do DMS gravam atalhos Lua. Adicione o include do DMS para que as edições sejam aplicadas."
   },
   "DMS Shortcuts": {
     "DMS Shortcuts": "Atalhos DMS"
   },
   "DMS is a highly customizable modern desktop shell with a %1 inspired design.<br/><br/>It is built with %2, a QT6 framework for building desktop shells, and %3, a statically typed, compiled programming language.": {
-    "DMS is a highly customizable modern desktop shell with a %1 inspired design.<br/><br/>It is built with %2, a QT6 framework for building desktop shells, and %3, a statically typed, compiled programming language.": ""
+    "DMS is a highly customizable modern desktop shell with a %1 inspired design.<br/><br/>It is built with %2, a QT6 framework for building desktop shells, and %3, a statically typed, compiled programming language.": "O DMS é um shell de área de trabalho moderno altamente personalizável com design inspirado em %1.<br/><br/>Ele é construído com %2, um framework QT6 para criar shells de área de trabalho, e %3, uma linguagem de programação compilada e estaticamente tipada."
   },
   "DMS out of date": {
     "DMS out of date": "DMS desatualizado"
   },
   "DMS removes its managed block from /etc/pam.d/greetd and stops write services": {
-    "DMS removes its managed block from /etc/pam.d/greetd and stops write services": ""
+    "DMS removes its managed block from /etc/pam.d/greetd and stops write services": "O DMS remove seu bloco gerenciado de /etc/pam.d/greetd e interrompe os serviços de gravação"
   },
   "DMS server is outdated (API v%1, expected v%2)": {
-    "DMS server is outdated (API v%1, expected v%2)": ""
+    "DMS server is outdated (API v%1, expected v%2)": "O servidor DMS está desatualizado (API v%1, esperada v%2)"
   },
   "DMS service is not connected. Clipboard settings are unavailable.": {
     "DMS service is not connected. Clipboard settings are unavailable.": "Serviço do DMS não está conectado. Configurações de área de transferência não estão disponíveis."
@@ -2181,22 +2181,22 @@
     "Dank Bar": "Dank Bar"
   },
   "Dank Bar Xray": {
-    "Dank Bar Xray": ""
+    "Dank Bar Xray": "Xray da Barra Dank"
   },
   "Dank Dash": {
-    "Dank Dash": ""
+    "Dank Dash": "Dank Dash"
   },
   "DankBar": {
     "DankBar": "DankBar"
   },
   "DankCalendar": {
-    "DankCalendar": ""
+    "DankCalendar": "DankCalendar"
   },
   "DankCalendar isn't installed": {
-    "DankCalendar isn't installed": ""
+    "DankCalendar isn't installed": "O DankCalendar não está instalado"
   },
   "DankCalendar isn't running": {
-    "DankCalendar isn't running": ""
+    "DankCalendar isn't running": "O DankCalendar não está em execução"
   },
   "DankMaterialShell is ready to use": {
     "DankMaterialShell is ready to use": "DankMaterialShell está pronto para uso"
@@ -2208,13 +2208,13 @@
     "Dark Mode": "Modo Escuro"
   },
   "Dark Mode Icon Theme": {
-    "Dark Mode Icon Theme": ""
+    "Dark Mode Icon Theme": "Tema de Ícones do Modo Escuro"
   },
   "Dark mode base": {
-    "Dark mode base": ""
+    "Dark mode base": "Base do modo escuro"
   },
   "Dark mode harmony": {
-    "Dark mode harmony": ""
+    "Dark mode harmony": "Harmonia do modo escuro"
   },
   "Darken Modal Background": {
     "Darken Modal Background": "Escurecer Fundo de Modais"
@@ -2253,34 +2253,34 @@
     "Default": "Padrão"
   },
   "Default (Black)": {
-    "Default (Black)": ""
+    "Default (Black)": "Padrão (Preto)"
   },
   "Default (Global)": {
-    "Default (Global)": ""
+    "Default (Global)": "Padrão (Global)"
   },
   "Default Apps": {
-    "Default Apps": ""
+    "Default Apps": "Aplicativos Padrão"
   },
   "Default Launcher": {
-    "Default Launcher": ""
+    "Default Launcher": "Inicializador Padrão"
   },
   "Default Launcher Shortcut": {
-    "Default Launcher Shortcut": ""
+    "Default Launcher Shortcut": "Atalho Padrão do Inicializador"
   },
   "Default Mode": {
-    "Default Mode": ""
+    "Default Mode": "Modo Padrão"
   },
   "Default Opens": {
-    "Default Opens": ""
+    "Default Opens": "Abertura Padrão"
   },
   "Default Width (%)": {
     "Default Width (%)": "Largura Padrão (%)"
   },
   "Default launcher shortcuts open the full launcher with mode tabs, grid view, and action panel.": {
-    "Default launcher shortcuts open the full launcher with mode tabs, grid view, and action panel.": ""
+    "Default launcher shortcuts open the full launcher with mode tabs, grid view, and action panel.": "Os atalhos padrão do inicializador abrem o inicializador completo com abas de modo, visualização em grade e painel de ações."
   },
   "Default launcher shortcuts open the minimal Spotlight Bar. The dedicated Spotlight Bar shortcut below stays independent.": {
-    "Default launcher shortcuts open the minimal Spotlight Bar. The dedicated Spotlight Bar shortcut below stays independent.": ""
+    "Default launcher shortcuts open the minimal Spotlight Bar. The dedicated Spotlight Bar shortcut below stays independent.": "Os atalhos padrão do inicializador abrem a Barra Spotlight mínima. O atalho dedicado da Barra Spotlight abaixo permanece independente."
   },
   "Default selected action": {
     "Default selected action": "Ação selecionada por padrão"
@@ -2295,13 +2295,13 @@
     "Del: Clear • Shift+Del: Clear All • 1-9: Actions • F10: Help • Esc: Close": "Del: Limpar • Shift+Del: Limpar Tudo • 1-9: Ações • F10: Ajuda • Esc: Fechar"
   },
   "Delay before characters start repeating": {
-    "Delay before characters start repeating": ""
+    "Delay before characters start repeating": "Atraso antes de os caracteres começarem a repetir"
   },
   "Delete": {
     "Delete": "Excluir"
   },
   "Delete \"%1\" and remove the home directory? This cannot be undone.": {
-    "Delete \"%1\" and remove the home directory? This cannot be undone.": ""
+    "Delete \"%1\" and remove the home directory? This cannot be undone.": "Excluir \"%1\" e remover o diretório pessoal? Isso não pode ser desfeito."
   },
   "Delete \"%1\"?": {
     "Delete \"%1\"?": "Excluir \"%1\"?"
@@ -2313,7 +2313,7 @@
     "Delete Printer": "Excluir Impressora"
   },
   "Delete Rule": {
-    "Delete Rule": ""
+    "Delete Rule": "Excluir Regra"
   },
   "Delete Saved Item?": {
     "Delete Saved Item?": "Excluir Item Salvo?"
@@ -2328,19 +2328,19 @@
     "Delete profile \"%1\"?": "Excluir perfil \"%1\"?"
   },
   "Delete user": {
-    "Delete user": ""
+    "Delete user": "Excluir usuário"
   },
   "Demi Bold": {
-    "Demi Bold": ""
+    "Demi Bold": "Demi Bold"
   },
   "Dependencies & documentation": {
-    "Dependencies & documentation": ""
+    "Dependencies & documentation": "Dependências e documentação"
   },
   "Depth": {
-    "Depth": ""
+    "Depth": "Profundidade"
   },
   "Depth: Panels scale up from small as they slide in — a dramatic pop-forward depth effect.": {
-    "Depth: Panels scale up from small as they slide in — a dramatic pop-forward depth effect.": ""
+    "Depth: Panels scale up from small as they slide in — a dramatic pop-forward depth effect.": "Profundidade: os painéis crescem de pequenos enquanto deslizam — um efeito dramático de profundidade que avança."
   },
   "Derives colors that closely match the underlying image.": {
     "Derives colors that closely match the underlying image.": "Deriva cores que combinam de perto com a imagem de fundo."
@@ -2349,7 +2349,7 @@
     "Description": "Descrição"
   },
   "Desktop Application": {
-    "Desktop Application": ""
+    "Desktop Application": "Aplicativo da Área de Trabalho"
   },
   "Desktop Clock": {
     "Desktop Clock": "Relógio da Área de Trabalho"
@@ -2369,11 +2369,14 @@
   "Detailed": {
     "Detailed": "Detalhado"
   },
-  "Details for \"%1": {
-    "Details for \"%1\"": ""
+  "Details for \"%1\"": {
+    "Details for \"%1\"": "Detalhes de \"%1\""
   },
   "Detected backends: %1": {
-    "Detected backends: %1": ""
+    "Detected backends: %1": "Backends detectados: %1"
+  },
+  "Development": {
+    "Development": "Desenvolvimento"
   },
   "Device": {
     "Device": "Dispositivo"
@@ -2382,7 +2385,7 @@
     "Device connections": "Conexões de dispositivo"
   },
   "Device list scroll volume": {
-    "Device list scroll volume": ""
+    "Device list scroll volume": "Volume de rolagem da lista de dispositivos"
   },
   "Device names updated": {
     "Device names updated": "Nomes de dispositivos atualizados"
@@ -2394,22 +2397,22 @@
     "Device unpaired": "Dispositivo desemparelhado"
   },
   "Diff": {
-    "Diff": ""
+    "Diff": "Diff"
   },
   "Digital": {
     "Digital": "Digital"
   },
   "Direct path to a .xkb keymap file. Overrides layouts/variants above.": {
-    "Direct path to a .xkb keymap file. Overrides layouts/variants above.": ""
+    "Direct path to a .xkb keymap file. Overrides layouts/variants above.": "Caminho direto para um arquivo de mapa de teclas .xkb. Substitui os layouts/variantes acima."
   },
   "Direction Source": {
-    "Direction Source": ""
+    "Direction Source": "Fonte da Direção"
   },
   "Directional": {
-    "Directional": ""
+    "Directional": "Direcional"
   },
   "Directional: Panels glide in from a larger distance at full size — no scale change, pure clean motion.": {
-    "Directional: Panels glide in from a larger distance at full size — no scale change, pure clean motion.": ""
+    "Directional: Panels glide in from a larger distance at full size — no scale change, pure clean motion.": "Direcional: os painéis deslizam de uma distância maior em tamanho total — sem mudança de escala, movimento puro e limpo."
   },
   "Disable Autoconnect": {
     "Disable Autoconnect": "Desativar conexão automática"
@@ -2424,25 +2427,25 @@
     "Disable Output": "Desabilitar Saída"
   },
   "Disable While Typing": {
-    "Disable While Typing": ""
+    "Disable While Typing": "Desativar ao Digitar"
   },
   "Disable on External Mouse": {
-    "Disable on External Mouse": ""
+    "Disable on External Mouse": "Desativar com Mouse Externo"
   },
   "Disable touchpad when an external mouse is connected": {
-    "Disable touchpad when an external mouse is connected": ""
+    "Disable touchpad when an external mouse is connected": "Desativar o touchpad quando um mouse externo estiver conectado"
   },
   "Disabled": {
     "Disabled": "Desativado"
   },
   "Disabled by Frame Mode": {
-    "Disabled by Frame Mode": ""
+    "Disabled by Frame Mode": "Desativado pelo Modo Frame"
   },
   "Disabling WiFi...": {
     "Disabling WiFi...": "Desativando WiFi..."
   },
   "Disabling auto-login on startup...": {
-    "Disabling auto-login on startup...": ""
+    "Disabling auto-login on startup...": "Desativando o login automático na inicialização..."
   },
   "Disc": {
     "Disc": "Disco"
@@ -2463,7 +2466,7 @@
     "Disconnected from WiFi": "Disconectado do WiFi"
   },
   "Discover Devices": {
-    "Discover Devices": ""
+    "Discover Devices": "Descobrir Dispositivos"
   },
   "Disk": {
     "Disk": "Disco"
@@ -2475,7 +2478,7 @@
     "Disk Usage": "Uso de Disco"
   },
   "Disk Usage Display": {
-    "Disk Usage Display": ""
+    "Disk Usage Display": "Exibição de Uso do Disco"
   },
   "Disks": {
     "Disks": "Discos"
@@ -2508,7 +2511,7 @@
     "Display all priorities over fullscreen apps": "Exibir todas as prioridades em aplicativos de tela cheia"
   },
   "Display and switch MangoWC layouts": {
-    "Display and switch MangoWC layouts": ""
+    "Display and switch MangoWC layouts": "Exibir e alternar layouts do MangoWC"
   },
   "Display application icons in workspace indicators": {
     "Display application icons in workspace indicators": "Mostrar ícones de aplicativos em indicadores de espaço de trabalho"
@@ -2526,10 +2529,10 @@
     "Display hourly weather predictions": "Exibir previsões meteorológicas por hora"
   },
   "Display line numbers in editor": {
-    "Display line numbers in editor": ""
+    "Display line numbers in editor": "Exibir números de linha no editor"
   },
   "Display name for this entry": {
-    "Display name for this entry": ""
+    "Display name for this entry": "Nome de exibição para esta entrada"
   },
   "Display only workspaces that contain windows": {
     "Display only workspaces that contain windows": "Mostrar apenas áreas de trabalho que possuem janelas"
@@ -2538,7 +2541,7 @@
     "Display power menu actions in a grid instead of a list": "Mostra as ações do menu de energia em uma grade ao invés de uma lista"
   },
   "Display setup failed": {
-    "Display setup failed": ""
+    "Display setup failed": "Falha na configuração do monitor"
   },
   "Display the power system menu": {
     "Display the power system menu": "Mostra o menu de energia do sistema"
@@ -2568,16 +2571,19 @@
     "Dock & Launcher": "Dock & Lançador"
   },
   "Dock Opacity": {
-    "Dock Opacity": ""
+    "Dock Opacity": "Opacidade do Dock"
   },
   "Dock margin, opacity, and border": {
-    "Dock margin, opacity, and border": ""
+    "Dock margin, opacity, and border": "Margem, opacidade e borda do dock"
   },
   "Dock window": {
-    "Dock window": ""
+    "Dock window": "Janela do dock"
   },
   "Docs": {
     "Docs": "Documentos"
+  },
+  "Documents": {
+    "Documents": "Documentos"
   },
   "Domain (optional)": {
     "Domain (optional)": "Domínio (opcional)"
@@ -2592,16 +2598,16 @@
     "Door Open": "Porta Aberta"
   },
   "Drag Lock": {
-    "Drag Lock": ""
+    "Drag Lock": "Trava de Arrastar"
   },
   "Drag a widget by its handle here to reorder it or drop it into another group": {
-    "Drag a widget by its handle here to reorder it or drop it into another group": ""
+    "Drag a widget by its handle here to reorder it or drop it into another group": "Arraste um widget pela sua alça aqui para reordená-lo ou solte-o em outro grupo"
   },
   "Drag to Reorder": {
     "Drag to Reorder": "Arraste para Reordenar"
   },
   "Drag to reorder or click to hide tabs. Use ↑/↓ to highlight a tab and Ctrl+↑/↓ to move it.": {
-    "Drag to reorder or click to hide tabs. Use ↑/↓ to highlight a tab and Ctrl+↑/↓ to move it.": ""
+    "Drag to reorder or click to hide tabs. Use ↑/↓ to highlight a tab and Ctrl+↑/↓ to move it.": "Arraste para reordenar ou clique para ocultar as abas. Use ↑/↓ para destacar uma aba e Ctrl+↑/↓ para movê-la."
   },
   "Drag widgets to reorder within sections. Use the eye icon to hide/show widgets (maintains spacing), or X to remove them completely.": {
     "Drag widgets to reorder within sections. Use the eye icon to hide/show widgets (maintains spacing), or X to remove them completely.": "Arraste Widgets para reordená-los nas seções. Use o ícone de olho para esconder ou mostrá-los (manter o espaçamento), ou clique no X para removê-los por completo."
@@ -2610,7 +2616,7 @@
     "Drag workspace indicators to reorder them": "Arraste os indicadores de área de trabalho para reordená-los"
   },
   "Draw a connected picture-frame border around the entire display": {
-    "Draw a connected picture-frame border around the entire display": ""
+    "Draw a connected picture-frame border around the entire display": "Desenhar uma borda de moldura conectada ao redor de todo o monitor"
   },
   "Driver": {
     "Driver": "Driver"
@@ -2619,10 +2625,10 @@
     "Drizzle": "Garoa"
   },
   "Drop here": {
-    "Drop here": ""
+    "Drop here": "Solte aqui"
   },
   "Drop your override for %1 so the DMS default action re-applies?": {
-    "Drop your override for %1 so the DMS default action re-applies?": ""
+    "Drop your override for %1 so the DMS default action re-applies?": "Descartar sua substituição para %1 para que a ação padrão do DMS seja reaplicada?"
   },
   "Duplicate": {
     "Duplicate": "Duplicar"
@@ -2652,37 +2658,37 @@
     "Dynamic Theming": "Tema Dinâmico"
   },
   "Dynamic Width": {
-    "Dynamic Width": ""
+    "Dynamic Width": "Largura Dinâmica"
   },
   "Dynamic colors from wallpaper": {
     "Dynamic colors from wallpaper": "Cores dinâmicas do papel de parede"
   },
   "Dynamic colors parse error: %1": {
-    "Dynamic colors parse error: %1": ""
+    "Dynamic colors parse error: %1": "Erro ao analisar cores dinâmicas: %1"
   },
   "Dynamic colors, presets": {
     "Dynamic colors, presets": "Cores dinâmicas, predefinições"
   },
   "Dynamic: Spring bezier with overshoot — entry briefly exceeds its target then settles. Expressive and alive.": {
-    "Dynamic: Spring bezier with overshoot — entry briefly exceeds its target then settles. Expressive and alive.": ""
+    "Dynamic: Spring bezier with overshoot — entry briefly exceeds its target then settles. Expressive and alive.": "Dinâmico: bezier de mola com overshoot — a entrada excede brevemente seu alvo e depois se estabiliza. Expressivo e vivo."
   },
   "Edge": {
-    "Edge": ""
+    "Edge": "Borda"
   },
   "Edge Hover Reveal": {
-    "Edge Hover Reveal": ""
+    "Edge Hover Reveal": "Revelar ao Passar o Mouse na Borda"
   },
   "Edge Spacing": {
     "Edge Spacing": "Espaçamento de Bordas"
   },
   "Edge spacing, exclusive zone, and popup gaps are managed by Frame": {
-    "Edge spacing, exclusive zone, and popup gaps are managed by Frame": ""
+    "Edge spacing, exclusive zone, and popup gaps are managed by Frame": "Espaçamento da borda, zona exclusiva e lacunas do popup são gerenciados pelo Frame"
   },
   "Edge the launcher slides from": {
-    "Edge the launcher slides from": ""
+    "Edge the launcher slides from": "Borda de onde o inicializador desliza"
   },
   "Edit": {
-    "Edit": ""
+    "Edit": "Editar"
   },
   "Edit App": {
     "Edit App": "Editar Aplicativo"
@@ -2691,7 +2697,7 @@
     "Edit Clipboard": "Editar Área de Transferência"
   },
   "Edit Rule": {
-    "Edit Rule": ""
+    "Edit Rule": "Editar Regra"
   },
   "Edit Window Rule": {
     "Edit Window Rule": "Editar Regra de Janela"
@@ -2700,10 +2706,10 @@
     "Edit clipboard text": "Editar texto da Área de Transferência"
   },
   "Edit event": {
-    "Edit event": ""
+    "Edit event": "Editar evento"
   },
   "Editing changes on %1": {
-    "Editing changes on %1": ""
+    "Editing changes on %1": "Alterações de edição em %1"
   },
   "Education": {
     "Education": "Educação"
@@ -2718,7 +2724,7 @@
     "Empty Trash (%1)": "Lixeira Vazia (%1)"
   },
   "Emulate middle click by pressing left and right buttons": {
-    "Emulate middle click by pressing left and right buttons": ""
+    "Emulate middle click by pressing left and right buttons": "Simular clique do meio pressionando os botões esquerdo e direito"
   },
   "Enable 10-bit color depth for wider color gamut and HDR support": {
     "Enable 10-bit color depth for wider color gamut and HDR support": "Ativar a profundidade de cores de 10 bits para uma gama de cores mais ampla e suporte HDR"
@@ -2733,13 +2739,13 @@
     "Enable Do Not Disturb": "Habilitar Não Perturbe"
   },
   "Enable Frame": {
-    "Enable Frame": ""
+    "Enable Frame": "Ativar Frame"
   },
   "Enable History": {
     "Enable History": "Ativar Histórico"
   },
   "Enable Num Lock": {
-    "Enable Num Lock": ""
+    "Enable Num Lock": "Ativar Num Lock"
   },
   "Enable Overview Overlay": {
     "Enable Overview Overlay": "Habilitar Sobreposição do Overview"
@@ -2751,7 +2757,7 @@
     "Enable System Sounds": "Ativar Sons do Sistema"
   },
   "Enable Video Screensaver": {
-    "Enable Video Screensaver": ""
+    "Enable Video Screensaver": "Ativar Protetor de Tela de Vídeo"
   },
   "Enable Weather": {
     "Enable Weather": "Habilitar Clima"
@@ -2760,10 +2766,10 @@
     "Enable WiFi": "Ativar WiFi"
   },
   "Enable WiFi before starting the hotspot.": {
-    "Enable WiFi before starting the hotspot.": ""
+    "Enable WiFi before starting the hotspot.": "Ative o WiFi antes de iniciar o hotspot."
   },
   "Enable a custom override below to set per-bar shadow intensity, opacity, and color.": {
-    "Enable a custom override below to set per-bar shadow intensity, opacity, and color.": ""
+    "Enable a custom override below to set per-bar shadow intensity, opacity, and color.": "Ative uma substituição personalizada abaixo para definir intensidade, opacidade e cor da sombra por barra."
   },
   "Enable compositor-targetable blur layer (namespace: dms:blurwallpaper). Requires manual niri configuration.": {
     "Enable compositor-targetable blur layer (namespace: dms:blurwallpaper). Requires manual niri configuration.": "Habilitar camada de desfoque direcionável ao compositor (namespace: dms:blurwallpaper). Requer configuração manual do niri."
@@ -2775,16 +2781,16 @@
     "Enable fingerprint authentication": "Habilitar autenticação por impressão digital"
   },
   "Enable fingerprint or security key for DMS Greeter": {
-    "Enable fingerprint or security key for DMS Greeter": ""
+    "Enable fingerprint or security key for DMS Greeter": "Ativar impressão digital ou chave de segurança para o DMS Greeter"
   },
   "Enable loginctl lock integration": {
     "Enable loginctl lock integration": "Ativar integração de bloqueio do loginctl"
   },
   "Enable security key at login": {
-    "Enable security key at login": ""
+    "Enable security key at login": "Ativar chave de segurança no login"
   },
   "Enable security key authentication": {
-    "Enable security key authentication": ""
+    "Enable security key authentication": "Ativar autenticação por chave de segurança"
   },
   "Enabled": {
     "Enabled": "Ativado"
@@ -2796,7 +2802,7 @@
     "End": "Fim"
   },
   "End must be after start": {
-    "End must be after start": ""
+    "End must be after start": "O fim deve ser depois do início"
   },
   "Enlarge on Hover": {
     "Enlarge on Hover": "Aumentar ao Passar o Mouse"
@@ -2814,9 +2820,9 @@
     "Enter PIN for ": "Entre código PIN para "
   },
   "Enter URI or text to share": {
-    "Enter URI or text to share": ""
+    "Enter URI or text to share": "Insira a URI ou o texto para compartilhar"
   },
-  "Enter a new name for session \"%1": {
+  "Enter a new name for session \"%1\"": {
     "Enter a new name for session \"%1\"": "Insira um novo nome para a sessão \"%1\""
   },
   "Enter a new name for this workspace": {
@@ -2850,7 +2856,7 @@
     "Enter password for ": "Insira senha para "
   },
   "Enter text to encode": {
-    "Enter text to encode": ""
+    "Enter text to encode": "Insira o texto para codificar"
   },
   "Enter this passkey on ": {
     "Enter this passkey on ": "Entre esse código em "
@@ -2862,7 +2868,7 @@
     "Enterprise": "Enterprise"
   },
   "Entry Type": {
-    "Entry Type": ""
+    "Entry Type": "Tipo de Entrada"
   },
   "Entry pinned": {
     "Entry pinned": "Entrada fixada"
@@ -2880,13 +2886,13 @@
     "Errors": "Erros"
   },
   "Estimated Time": {
-    "Estimated Time": ""
+    "Estimated Time": "Tempo Estimado"
   },
   "Ethernet": {
     "Ethernet": "Ethernet"
   },
   "Event title": {
-    "Event title": ""
+    "Event title": "Título do evento"
   },
   "Every 15 minutes": {
     "Every 15 minutes": "A cada 15 minutos"
@@ -2904,16 +2910,16 @@
     "Exact": "Exato"
   },
   "Excluded Players": {
-    "Excluded Players": ""
+    "Excluded Players": "Reprodutores Excluídos"
   },
   "Exclusive Zone Offset": {
     "Exclusive Zone Offset": "Ajuste da Zona Exclusiva"
   },
   "Existing Users": {
-    "Existing Users": ""
+    "Existing Users": "Usuários Existentes"
   },
   "Exit node": {
-    "Exit node": ""
+    "Exit node": "Nó de saída"
   },
   "Experimental Feature": {
     "Experimental Feature": "Recurso Experimental"
@@ -2925,7 +2931,7 @@
     "Exponential": "Exponencial"
   },
   "Expose the Arcs": {
-    "Expose the Arcs": ""
+    "Expose the Arcs": "Expor os Arcos"
   },
   "Expressive": {
     "Expressive": "Expressivo"
@@ -2943,10 +2949,10 @@
     "Extra Arguments": "Argumentos Extras"
   },
   "Extra Bold": {
-    "Extra Bold": ""
+    "Extra Bold": "Extra Bold"
   },
   "Extra Light": {
-    "Extra Light": ""
+    "Extra Light": "Extra Light"
   },
   "Fade": {
     "Fade": "Esmaecimento"
@@ -2966,17 +2972,14 @@
   "Failed to add binds include": {
     "Failed to add binds include": "Falha ao adicionar \"include\" dos atalhos"
   },
-  "Failed to add printer to class": {
-    "Failed to add printer to class": "Falha ao adicionar impressora para a classe"
-  },
   "Failed to apply %1 colors": {
-    "Failed to apply %1 colors": ""
+    "Failed to apply %1 colors": "Falha ao aplicar cores de %1"
   },
   "Failed to apply charge limit to system": {
-    "Failed to apply charge limit to system": ""
+    "Failed to apply charge limit to system": "Falha ao aplicar o limite de carga ao sistema"
   },
   "Failed to apply profile": {
-    "Failed to apply profile": ""
+    "Failed to apply profile": "Falha ao aplicar o perfil"
   },
   "Failed to browse device": {
     "Failed to browse device": "Falha ao navegar no dispositivo"
@@ -2991,7 +2994,7 @@
     "Failed to check pin limit": "Falha ao verificar limite de pin"
   },
   "Failed to configure hotspot": {
-    "Failed to configure hotspot": ""
+    "Failed to configure hotspot": "Falha ao configurar o hotspot"
   },
   "Failed to connect VPN": {
     "Failed to connect VPN": "Erro ao conectar à VPN"
@@ -3021,7 +3024,7 @@
     "Failed to disable night mode": "Falha ao desativar o modo noturno"
   },
   "Failed to disable plugin: %1": {
-    "Failed to disable plugin: %1": ""
+    "Failed to disable plugin: %1": "Falha ao desativar o plugin: %1"
   },
   "Failed to disconnect VPN": {
     "Failed to disconnect VPN": "Erro ao desconectar VPN"
@@ -3033,7 +3036,7 @@
     "Failed to disconnect WiFi": "Erro ao disconectar WiFi"
   },
   "Failed to empty trash": {
-    "Failed to empty trash": ""
+    "Failed to empty trash": "Falha ao esvaziar a lixeira"
   },
   "Failed to enable IP location": {
     "Failed to enable IP location": "Falha ao ativar a localização IP"
@@ -3048,13 +3051,13 @@
     "Failed to enable night mode": "Falha ao ativar o modo noturno"
   },
   "Failed to fetch network QR code: %1": {
-    "Failed to fetch network QR code: %1": ""
+    "Failed to fetch network QR code: %1": "Falha ao buscar o código QR da rede: %1"
   },
   "Failed to generate QR code: %1": {
-    "Failed to generate QR code: %1": ""
+    "Failed to generate QR code: %1": "Falha ao gerar o código QR: %1"
   },
   "Failed to generate systemd override": {
-    "Failed to generate systemd override": ""
+    "Failed to generate systemd override": "Falha ao gerar a substituição do systemd"
   },
   "Failed to hold job": {
     "Failed to hold job": "Falha ao segurar trabalho"
@@ -3071,14 +3074,11 @@
   "Failed to load clipboard configuration.": {
     "Failed to load clipboard configuration.": "Falha ao carregar configuração de área de transferência."
   },
-  "Failed to move job": {
-    "Failed to move job": "Falha ao mover trabalho"
-  },
   "Failed to move to trash": {
-    "Failed to move to trash": ""
+    "Failed to move to trash": "Falha ao mover para a lixeira"
   },
   "Failed to parse %1": {
-    "Failed to parse %1": ""
+    "Failed to parse %1": "Falha ao analisar %1"
   },
   "Failed to pause printer": {
     "Failed to pause printer": "Falha ao pausar impressora"
@@ -3090,25 +3090,22 @@
     "Failed to print test page": "Falha ao imprimir página de testes"
   },
   "Failed to read theme file: %1": {
-    "Failed to read theme file: %1": ""
+    "Failed to read theme file: %1": "Falha ao ler o arquivo de tema: %1"
   },
   "Failed to reject pairing": {
     "Failed to reject pairing": "Falha ao rejeitar pareamento"
   },
   "Failed to reload plugin: %1": {
-    "Failed to reload plugin: %1": ""
+    "Failed to reload plugin: %1": "Falha ao recarregar o plugin: %1"
   },
   "Failed to remove QR code at %1: %2": {
-    "Failed to remove QR code at %1: %2": ""
+    "Failed to remove QR code at %1: %2": "Falha ao remover o código QR em %1: %2"
   },
   "Failed to remove device": {
     "Failed to remove device": "Erro ao remover dispositivo"
   },
   "Failed to remove keybind": {
     "Failed to remove keybind": "Falha ao remover atalho"
-  },
-  "Failed to remove printer from class": {
-    "Failed to remove printer from class": "Falha ao remover impressora da classe"
   },
   "Failed to restart audio system": {
     "Failed to restart audio system": "Falha ao reiniciar o sistema de áudio"
@@ -3122,14 +3119,11 @@
   "Failed to ring device": {
     "Failed to ring device": "Falha ao tocar dispositivo"
   },
-  "Failed to run 'dms greeter status'. Ensure DMS is installed and dms is in PATH.": {
-    "Failed to run 'dms greeter status'. Ensure DMS is installed and dms is in PATH.": ""
-  },
   "Failed to run 'dms-greeter status'. Ensure the dms-greeter package is installed.": {
-    "Failed to run 'dms-greeter status'. Ensure the dms-greeter package is installed.": ""
+    "Failed to run 'dms-greeter status'. Ensure the dms-greeter package is installed.": "Falha ao executar 'dms-greeter status'. Certifique-se de que o pacote dms-greeter está instalado."
   },
   "Failed to save VPN credentials": {
-    "Failed to save VPN credentials": ""
+    "Failed to save VPN credentials": "Falha ao salvar as credenciais da VPN"
   },
   "Failed to save audio config": {
     "Failed to save audio config": "Falha ao salvar a configuração de áudio"
@@ -3141,10 +3135,10 @@
     "Failed to save keybind": "Falha ao salvar atalho"
   },
   "Failed to save profile": {
-    "Failed to save profile": ""
+    "Failed to save profile": "Falha ao salvar o perfil"
   },
   "Failed to send SMS": {
-    "Failed to send SMS": ""
+    "Failed to send SMS": "Falha ao enviar SMS"
   },
   "Failed to send clipboard": {
     "Failed to send clipboard": "Falha ao enviar área de transferência"
@@ -3168,7 +3162,7 @@
     "Failed to set night mode temperature": "Falha ao definir a temperatura do modo noturno"
   },
   "Failed to set power profile": {
-    "Failed to set power profile": ""
+    "Failed to set power profile": "Falha ao definir o perfil de energia"
   },
   "Failed to set profile image": {
     "Failed to set profile image": "Erro ao definir imagem de perfil"
@@ -3183,19 +3177,19 @@
     "Failed to start connection to %1": "Falha ao iniciar conexão com %1"
   },
   "Failed to start hotspot": {
-    "Failed to start hotspot": ""
+    "Failed to start hotspot": "Falha ao iniciar o hotspot"
   },
   "Failed to stop hotspot": {
-    "Failed to stop hotspot": ""
+    "Failed to stop hotspot": "Falha ao interromper o hotspot"
   },
   "Failed to switch codec": {
-    "Failed to switch codec": ""
+    "Failed to switch codec": "Falha ao alternar o codec"
   },
   "Failed to unpin entry": {
     "Failed to unpin entry": "Falha ao remover entrada"
   },
   "Failed to update %1: %2": {
-    "Failed to update %1: %2": ""
+    "Failed to update %1: %2": "Falha ao atualizar %1: %2"
   },
   "Failed to update VPN": {
     "Failed to update VPN": "Falha ao atualizar VPN"
@@ -3204,28 +3198,19 @@
     "Failed to update autoconnect": "Erro ao atualizar conexão automática"
   },
   "Failed to update clipboard": {
-    "Failed to update clipboard": ""
-  },
-  "Failed to update description": {
-    "Failed to update description": "Falha ao atualizar descrição"
-  },
-  "Failed to update location": {
-    "Failed to update location": "Falha ao atualizar localização"
-  },
-  "Failed to update sharing": {
-    "Failed to update sharing": "Falha ao atualizar compartilhamento"
+    "Failed to update clipboard": "Falha ao atualizar a área de transferência"
   },
   "Failed to write autostart entry": {
-    "Failed to write autostart entry": ""
+    "Failed to write autostart entry": "Falha ao gravar a entrada de inicialização"
   },
   "Failed to write outputs config.": {
-    "Failed to write outputs config.": ""
+    "Failed to write outputs config.": "Falha ao gravar a configuração de saídas."
   },
   "Failed to write temp file for validation": {
     "Failed to write temp file for validation": "Falha ao salvar arquivo temporário para validação"
   },
   "Failed: %1": {
-    "Failed: %1": ""
+    "Failed: %1": "Falhou: %1"
   },
   "Features": {
     "Features": "Recursos"
@@ -3249,22 +3234,22 @@
     "File": "Arquivo"
   },
   "File Manager": {
-    "File Manager": ""
+    "File Manager": "Gerenciador de Arquivos"
   },
   "File changed on disk": {
-    "File changed on disk": ""
+    "File changed on disk": "O arquivo foi alterado no disco"
   },
   "File manager used to open the trash. Pick \"custom\" to enter your own command.": {
-    "File manager used to open the trash. Pick \"custom\" to enter your own command.": ""
+    "File manager used to open the trash. Pick \"custom\" to enter your own command.": "Gerenciador de arquivos usado para abrir a lixeira. Escolha \"personalizado\" para inserir seu próprio comando."
   },
   "File received from %1": {
-    "File received from %1": ""
+    "File received from %1": "Arquivo recebido de %1"
   },
   "File search requires dsearch\nInstall from github.com/AvengeMedia/danksearch": {
     "File search requires dsearch\nInstall from github.com/AvengeMedia/danksearch": "Pesquisa de arquivo requer dsearch\nInstalar de github.com/morelazers/dsearch"
   },
   "File search unavailable": {
-    "File search unavailable": ""
+    "File search unavailable": "Pesquisa de arquivos indisponível"
   },
   "Files": {
     "Files": "Arquivos"
@@ -3276,13 +3261,13 @@
     "Fill": "Preenchimento"
   },
   "Fill Mode": {
-    "Fill Mode": ""
+    "Fill Mode": "Modo de Preenchimento"
   },
   "Filter": {
-    "Filter": ""
+    "Filter": "Filtro"
   },
   "Filter by type": {
-    "Filter by type": ""
+    "Filter by type": "Filtrar por tipo"
   },
   "Find in Text": {
     "Find in Text": "Procurar no Texto"
@@ -3291,22 +3276,22 @@
     "Find in note...": "Procurar na nota..."
   },
   "Fine-tune the space reserved for the bar from the screen edge": {
-    "Fine-tune the space reserved for the bar from the screen edge": ""
+    "Fine-tune the space reserved for the bar from the screen edge": "Ajuste fino do espaço reservado para a barra a partir da borda da tela"
   },
   "Fingerprint availability could not be confirmed": {
-    "Fingerprint availability could not be confirmed": ""
+    "Fingerprint availability could not be confirmed": "Não foi possível confirmar a disponibilidade da impressão digital"
   },
   "Fingerprint error": {
-    "Fingerprint error": ""
+    "Fingerprint error": "Erro de impressão digital"
   },
   "Fingerprint not recognized (%1/%2). Please try again or use password.": {
-    "Fingerprint not recognized (%1/%2). Please try again or use password.": ""
+    "Fingerprint not recognized (%1/%2). Please try again or use password.": "Impressão digital não reconhecida (%1/%2). Tente novamente ou use a senha."
   },
   "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and enroll later.": {
-    "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and enroll later.": ""
+    "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and enroll later.": "Leitor de impressão digital detectado, mas nenhuma impressão cadastrada ainda. Você pode ativar isso agora e cadastrar depois."
   },
   "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and run Sync later.": {
-    "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and run Sync later.": ""
+    "Fingerprint reader detected, but no prints are enrolled yet. You can enable this now and run Sync later.": "Leitor de impressão digital detectado, mas nenhuma impressão cadastrada ainda. Você pode ativar isso agora e executar Sync depois."
   },
   "Finish": {
     "Finish": "Concluir"
@@ -3324,13 +3309,13 @@
     "Flags": "Bandeiras"
   },
   "Flat": {
-    "Flat": ""
+    "Flat": "Plano"
   },
   "Flat uses constant speed; Adaptive scales with movement speed": {
-    "Flat uses constant speed; Adaptive scales with movement speed": ""
+    "Flat uses constant speed; Adaptive scales with movement speed": "Plano usa velocidade constante; Adaptativo escala com a velocidade do movimento"
   },
   "Flatpak": {
-    "Flatpak": ""
+    "Flatpak": "Flatpak"
   },
   "Flipped": {
     "Flipped": "Invertido"
@@ -3348,46 +3333,46 @@
     "Float": "Flutuante"
   },
   "Float Anchor": {
-    "Float Anchor": ""
+    "Float Anchor": "Âncora Flutuante"
   },
   "Float X": {
-    "Float X": ""
+    "Float X": "Flutuar X"
   },
   "Float Y": {
-    "Float Y": ""
+    "Float Y": "Flutuar Y"
   },
   "Floating": {
-    "Floating": ""
+    "Floating": "Flutuante"
   },
   "Floating Position": {
-    "Floating Position": ""
+    "Floating Position": "Posição Flutuante"
   },
   "Floating Windows": {
-    "Floating Windows": ""
+    "Floating Windows": "Janelas Flutuantes"
   },
   "Floating windows follow Surface Styling settings": {
-    "Floating windows follow Surface Styling settings": ""
+    "Floating windows follow Surface Styling settings": "As janelas flutuantes seguem as configurações de Estilo de Superfície"
   },
   "Fluent": {
-    "Fluent": ""
+    "Fluent": "Fluent"
   },
   "Fluent: Smooth cubic deceleration in, quick snap out — clean, elegant curves.": {
-    "Fluent: Smooth cubic deceleration in, quick snap out — clean, elegant curves.": ""
+    "Fluent: Smooth cubic deceleration in, quick snap out — clean, elegant curves.": "Fluent: desaceleração cúbica suave ao entrar, ajuste rápido ao sair — curvas limpas e elegantes."
   },
   "Focus": {
     "Focus": "Foco"
   },
   "Focus Ring Color": {
-    "Focus Ring Color": ""
+    "Focus Ring Color": "Cor do Anel de Foco"
   },
   "Focus Ring Off": {
-    "Focus Ring Off": ""
+    "Focus Ring Off": "Anel de Foco Desligado"
   },
   "Focus at Startup": {
     "Focus at Startup": "Foco no Iniciar"
   },
   "Focused": {
-    "Focused": ""
+    "Focused": "Focado"
   },
   "Focused Border": {
     "Focused Border": "Borda em Foco"
@@ -3396,10 +3381,10 @@
     "Focused Color": "Cor em Foco"
   },
   "Focused Display": {
-    "Focused Display": ""
+    "Focused Display": "Monitor Focado"
   },
   "Focused Monitor Only": {
-    "Focused Monitor Only": ""
+    "Focused Monitor Only": "Somente Monitor Focado"
   },
   "Focused Window": {
     "Focused Window": "Janela Focada"
@@ -3414,7 +3399,7 @@
     "Folders": "Pastas"
   },
   "Follow DMS background color": {
-    "Follow DMS background color": ""
+    "Follow DMS background color": "Seguir a cor de fundo do DMS"
   },
   "Follow Monitor Focus": {
     "Follow Monitor Focus": "Seguir Foco do Monitor"
@@ -3423,7 +3408,7 @@
     "Follow focus": "Seguir foco"
   },
   "Follows the default launcher choice selected above.": {
-    "Follows the default launcher choice selected above.": ""
+    "Follows the default launcher choice selected above.": "Segue a escolha do inicializador padrão selecionada acima."
   },
   "Font": {
     "Font": "Fonte"
@@ -3441,7 +3426,7 @@
     "Font Weight": "Peso da Fonte"
   },
   "Font used for the clock and date on the lock screen": {
-    "Font used for the clock and date on the lock screen": ""
+    "Font used for the clock and date on the lock screen": "Fonte usada para o relógio e a data na tela de bloqueio"
   },
   "Font used on the login screen": {
     "Font used on the login screen": "Fonte usada na tela de login"
@@ -3462,7 +3447,7 @@
     "For 8 hours": "Por 8 horas"
   },
   "For editing plain text files": {
-    "For editing plain text files": ""
+    "For editing plain text files": "Para editar arquivos de texto simples"
   },
   "Force HDR": {
     "Force HDR": "Forçar HDR"
@@ -3471,10 +3456,10 @@
     "Force Kill (SIGKILL)": "Forçar Encerramento (SIGKILL)"
   },
   "Force Padding": {
-    "Force Padding": ""
+    "Force Padding": "Forçar Preenchimento"
   },
   "Force RGBX": {
-    "Force RGBX": ""
+    "Force RGBX": "Forçar RGBX"
   },
   "Force Wide Color": {
     "Force Wide Color": "Forçar Cor Ampla"
@@ -3492,13 +3477,13 @@
     "Forecast Not Available": "Previsão do Tempo não Disponível"
   },
   "Forecast and conditions": {
-    "Forecast and conditions": ""
+    "Forecast and conditions": "Previsão e condições"
   },
   "Foreground Layers": {
-    "Foreground Layers": ""
+    "Foreground Layers": "Camadas de Primeiro Plano"
   },
   "Foreground Opacity": {
-    "Foreground Opacity": ""
+    "Foreground Opacity": "Opacidade do Primeiro Plano"
   },
   "Forever": {
     "Forever": "Para sempre"
@@ -3522,25 +3507,25 @@
     "Format Legend": "Formatar Legenda"
   },
   "Format the date on the login screen": {
-    "Format the date on the login screen": ""
+    "Format the date on the login screen": "Formatar a data na tela de login"
   },
   "Forward 10s": {
-    "Forward 10s": ""
+    "Forward 10s": "Avançar 10s"
   },
   "Frame": {
-    "Frame": ""
+    "Frame": "Frame"
   },
   "Frame Blur": {
-    "Frame Blur": ""
+    "Frame Blur": "Desfoque do Frame"
   },
   "Frame Blur follows Background Blur in Theme & Colors": {
-    "Frame Blur follows Background Blur in Theme & Colors": ""
+    "Frame Blur follows Background Blur in Theme & Colors": "O desfoque do Frame segue o Desfoque de Fundo em Tema e Cores"
   },
   "Frame Border Color": {
-    "Frame Border Color": ""
+    "Frame Border Color": "Cor da Borda do Frame"
   },
   "Frame Xray": {
-    "Frame Xray": ""
+    "Frame Xray": "Xray do Frame"
   },
   "Free VRAM/memory when the launcher is closed. May cause a slight delay when reopening.": {
     "Free VRAM/memory when the launcher is closed. May cause a slight delay when reopening.": "Liberar VRAM/memória quando o lançador estiver fechado. Pode causar um pequeno atraso ao reabrir."
@@ -3555,7 +3540,7 @@
     "Fruit Salad": "Salada de Frutas"
   },
   "Full": {
-    "Full": ""
+    "Full": "Completo"
   },
   "Full Command:": {
     "Full Command:": "Comando Completo:"
@@ -3567,10 +3552,10 @@
     "Full Day & Month": "Dia e Mês Completo"
   },
   "Full Size": {
-    "Full Size": ""
+    "Full Size": "Tamanho Total"
   },
   "Full command to execute": {
-    "Full command to execute": ""
+    "Full command to execute": "Comando completo para executar"
   },
   "Full with Year": {
     "Full with Year": "Completo com Ano"
@@ -3597,10 +3582,10 @@
     "GPU Temperature": "Temperatura da GPU"
   },
   "GPU temperature display": {
-    "GPU temperature display": ""
+    "GPU temperature display": "Exibição da temperatura da GPU"
   },
   "GTK colors applied successfully": {
-    "GTK colors applied successfully": ""
+    "GTK colors applied successfully": "Cores GTK aplicadas com sucesso"
   },
   "GTK, Qt, IDEs, more": {
     "GTK, Qt, IDEs, more": "GTK, Qt, IDEs, mais"
@@ -3615,25 +3600,25 @@
     "Gamma control not available. Requires DMS API v6+.": "Controle de gama não disponível. Necessário DMS API v6+."
   },
   "Gap between the end widgets and the bar ends (0 = edge-to-edge)": {
-    "Gap between the end widgets and the bar ends (0 = edge-to-edge)": ""
+    "Gap between the end widgets and the bar ends (0 = edge-to-edge)": "Lacuna entre os widgets finais e as extremidades da barra (0 = ponta a ponta)"
   },
   "Gaps": {
-    "Gaps": ""
+    "Gaps": "Lacunas"
   },
   "General": {
-    "General": ""
+    "General": "Geral"
   },
   "Generate Override": {
-    "Generate Override": ""
+    "Generate Override": "Gerar Substituição"
   },
   "Generate baseline GTK3/4 or QT5/QT6 (requires qt6ct-kde) configurations to follow DMS colors. Only needed once.<br /><br />It is recommended to configure %1 prior to applying GTK themes.": {
-    "Generate baseline GTK3/4 or QT5/QT6 (requires qt6ct-kde) configurations to follow DMS colors. Only needed once.<br /><br />It is recommended to configure %1 prior to applying GTK themes.": ""
+    "Generate baseline GTK3/4 or QT5/QT6 (requires qt6ct-kde) configurations to follow DMS colors. Only needed once.<br /><br />It is recommended to configure %1 prior to applying GTK themes.": "Gerar configurações base de GTK3/4 ou QT5/QT6 (requer qt6ct-kde) para seguir as cores do DMS. Necessário apenas uma vez.<br /><br />É recomendado configurar %1 antes de aplicar temas GTK."
   },
   "Generic": {
     "Generic": "Genérico"
   },
   "Geometric Centering": {
-    "Geometric Centering": ""
+    "Geometric Centering": "Centralização Geométrica"
   },
   "Get Started": {
     "Get Started": "Começar"
@@ -3642,10 +3627,10 @@
     "GitHub": "GitHub"
   },
   "Global fonts can be configured in Settings → Personalization": {
-    "Global fonts can be configured in Settings → Personalization": ""
+    "Global fonts can be configured in Settings → Personalization": "As fontes globais podem ser configuradas em Configurações → Personalização"
   },
   "Globally": {
-    "Globally": ""
+    "Globally": "Globalmente"
   },
   "Globally scale all animation durations": {
     "Globally scale all animation durations": "Dimensionar globalmente todas as durações de animação"
@@ -3669,16 +3654,16 @@
     "Gradually fade the screen before turning off monitors with a configurable grace period": "Desaparecer gradualmente a tela antes de desligar monitores com um período de carência configurável"
   },
   "Grant": {
-    "Grant": ""
+    "Grant": "Conceder"
   },
   "Grant administrator privileges": {
-    "Grant administrator privileges": ""
+    "Grant administrator privileges": "Conceder privilégios de administrador"
   },
   "Granted administrator privileges": {
-    "Granted administrator privileges": ""
+    "Granted administrator privileges": "Privilégios de administrador concedidos"
   },
   "Granted greeter login access": {
-    "Granted greeter login access": ""
+    "Granted greeter login access": "Acesso de login do greeter concedido"
   },
   "Graph Time Range": {
     "Graph Time Range": "Intervalo de Tempo do Gráfico"
@@ -3687,25 +3672,22 @@
     "Graphics": "Gráficos"
   },
   "Greeter": {
-    "Greeter": ""
+    "Greeter": "Greeter"
   },
   "Greeter activated. greetd is now enabled.": {
-    "Greeter activated. greetd is now enabled.": ""
+    "Greeter activated. greetd is now enabled.": "Greeter ativado. O greetd agora está habilitado."
   },
   "Greeter font": {
-    "Greeter font": ""
-  },
-  "Greeter group members can sync their login-screen theme with dms greeter sync --profile after logging out and back in.": {
-    "Greeter group members can sync their login-screen theme with dms greeter sync --profile after logging out and back in.": ""
+    "Greeter font": "Fonte do greeter"
   },
   "Greeter group members can sync their login-screen theme with dms-greeter sync --profile after logging out and back in.": {
-    "Greeter group members can sync their login-screen theme with dms-greeter sync --profile after logging out and back in.": ""
+    "Greeter group members can sync their login-screen theme with dms-greeter sync --profile after logging out and back in.": "Os membros do grupo do greeter podem sincronizar o tema da tela de login com dms-greeter sync --profile após sair e entrar novamente."
   },
   "Greeter group:": {
-    "Greeter group:": ""
+    "Greeter group:": "Grupo do greeter:"
   },
   "Greeter sync complete": {
-    "Greeter sync complete": ""
+    "Greeter sync complete": "Sincronização do greeter concluída"
   },
   "Grid": {
     "Grid": "Grade"
@@ -3723,7 +3705,7 @@
     "Group": "Grupo"
   },
   "Group Active Workspace": {
-    "Group Active Workspace": ""
+    "Group Active Workspace": "Agrupar Espaço de Trabalho Ativo"
   },
   "Group Workspace Apps": {
     "Group Workspace Apps": "Agrupar Aplicativos da Área de Trabalho"
@@ -3744,7 +3726,7 @@
     "Groups": "Grupos"
   },
   "H": {
-    "H": ""
+    "H": "H"
   },
   "HDR (EDID)": {
     "HDR (EDID)": "HDR (EDID)"
@@ -3759,19 +3741,19 @@
     "HSV": "HSV"
   },
   "HSV %1 copied": {
-    "HSV %1 copied": ""
+    "HSV %1 copied": "HSV %1 copiado"
   },
   "HTML copied to clipboard": {
     "HTML copied to clipboard": "HTML copiado para a área de transferência"
   },
   "Handles geo: location links": {
-    "Handles geo: location links": ""
+    "Handles geo: location links": "Lida com links de localização geo:"
   },
   "Handles links and opens HTML files": {
-    "Handles links and opens HTML files": ""
+    "Handles links and opens HTML files": "Lida com links e abre arquivos HTML"
   },
   "Handles mailto links": {
-    "Handles mailto links": ""
+    "Handles mailto links": "Lida com links mailto"
   },
   "Health": {
     "Health": "Saúde"
@@ -3797,8 +3779,11 @@
   "Hex": {
     "Hex": "Hex"
   },
+  "Hibernate": {
+    "Hibernate": "Hibernar"
+  },
   "Hibernate failed": {
-    "Hibernate failed": ""
+    "Hibernate failed": "Falha ao hibernar"
   },
   "Hidden": {
     "Hidden": "Oculto"
@@ -3813,7 +3798,7 @@
     "Hidden apps won't appear in the launcher. Right-click an app and select 'Hide App' to hide it.": "Aplicativos ocultos não aparecerão no launcher. Clique com o botão direito em um aplicativo e selecione 'Ocultar Aplicativo' para ocultá-lo."
   },
   "Hidden until weather is enabled": {
-    "Hidden until weather is enabled": ""
+    "Hidden until weather is enabled": "Oculto até o clima ser ativado"
   },
   "Hide": {
     "Hide": "Ocultar"
@@ -3849,7 +3834,7 @@
     "Hide device": "Ocultar dispositivo"
   },
   "Hide installed": {
-    "Hide installed": ""
+    "Hide installed": "Ocultar instalados"
   },
   "Hide notification content until expanded": {
     "Hide notification content until expanded": "Ocultar conteúdo da notificação até expandir"
@@ -3861,25 +3846,25 @@
     "Hide on Touch": "Ocultar no Toque"
   },
   "Hide the bar when the pointer leaves even if a popout is still open": {
-    "Hide the bar when the pointer leaves even if a popout is still open": ""
+    "Hide the bar when the pointer leaves even if a popout is still open": "Ocultar a barra quando o ponteiro sair mesmo que um popout ainda esteja aberto"
   },
   "Hide when no updates: OFF": {
-    "Hide when no updates: OFF": ""
+    "Hide when no updates: OFF": "Ocultar quando não houver atualizações: DESLIGADO"
   },
   "Hide when no updates: ON": {
-    "Hide when no updates: ON": ""
+    "Hide when no updates: ON": "Ocultar quando não houver atualizações: LIGADO"
   },
   "High": {
-    "High": ""
+    "High": "Alto"
   },
   "High-fidelity palette that preserves source hues.": {
     "High-fidelity palette that preserves source hues.": "Paleta de alta fidelidade que preserva tons da fonte."
   },
   "Highlight Active Workspace App": {
-    "Highlight Active Workspace App": ""
+    "Highlight Active Workspace App": "Destacar Aplicativo do Espaço de Trabalho Ativo"
   },
   "Highlight the currently focused app inside workspace indicators": {
-    "Highlight the currently focused app inside workspace indicators": ""
+    "Highlight the currently focused app inside workspace indicators": "Destacar o aplicativo atualmente focado dentro dos indicadores de espaço de trabalho"
   },
   "History": {
     "History": "Histórico"
@@ -3896,14 +3881,23 @@
   "Hold Duration": {
     "Hold Duration": "Duração do Pressionamento"
   },
+  "Hold longer to confirm": {
+    "Hold longer to confirm": "Mantenha pressionado por mais tempo para confirmar"
+  },
   "Hold to Confirm Power Actions": {
     "Hold to Confirm Power Actions": "Manter Pressionado para Confirmar Ações de Energia"
   },
+  "Hold to confirm (%1 ms)": {
+    "Hold to confirm (%1 ms)": "Segure para confirmar (%1 ms)"
+  },
+  "Hold to confirm (%1s)": {
+    "Hold to confirm (%1s)": "Manter pressionado para confirmar (%1s)"
+  },
   "Horizontal and vertical bar thickness": {
-    "Horizontal and vertical bar thickness": ""
+    "Horizontal and vertical bar thickness": "Espessura horizontal e vertical da barra"
   },
   "Host": {
-    "Host": ""
+    "Host": "Host"
   },
   "Hostname": {
     "Hostname": "Nome do host"
@@ -3915,22 +3909,22 @@
     "Hotkey overlay title (optional)": "Título da sobreposição de atalhos"
   },
   "Hotspot": {
-    "Hotspot": ""
+    "Hotspot": "Hotspot"
   },
   "Hotspot activation failed.": {
-    "Hotspot activation failed.": ""
+    "Hotspot activation failed.": "Falha na ativação do hotspot."
   },
   "Hotspot name": {
-    "Hotspot name": ""
+    "Hotspot name": "Nome do hotspot"
   },
   "Hotspot saved": {
-    "Hotspot saved": ""
+    "Hotspot saved": "Hotspot salvo"
   },
   "Hotspot started": {
-    "Hotspot started": ""
+    "Hotspot started": "Hotspot iniciado"
   },
   "Hotspot stopped": {
-    "Hotspot stopped": ""
+    "Hotspot stopped": "Hotspot interrompido"
   },
   "Hour": {
     "Hour": "Hora"
@@ -3942,13 +3936,13 @@
     "Hourly Forecast Count": "Contagem de Previsão por Hora"
   },
   "Hover Popouts": {
-    "Hover Popouts": ""
+    "Hover Popouts": "Popouts ao Passar o Mouse"
   },
   "How layout changes are remembered across apps": {
-    "How layout changes are remembered across apps": ""
+    "How layout changes are remembered across apps": "Como as alterações de layout são lembradas entre os aplicativos"
   },
   "How often the server polls for new updates.": {
-    "How often the server polls for new updates.": ""
+    "How often the server polls for new updates.": "Com que frequência o servidor verifica novas atualizações."
   },
   "How often to change wallpaper": {
     "How often to change wallpaper": "Tempo entre papéis de parede"
@@ -3957,28 +3951,28 @@
     "How the background image is scaled": "Como a imagem de fundo é dimensionada"
   },
   "How the wallpaper is scaled to fit the screen": {
-    "How the wallpaper is scaled to fit the screen": ""
+    "How the wallpaper is scaled to fit the screen": "Como o papel de parede é dimensionado para caber na tela"
   },
   "Humidity": {
     "Humidity": "Umidade"
   },
   "Hyprland Discord Server": {
-    "Hyprland Discord Server": ""
+    "Hyprland Discord Server": "Servidor Discord do Hyprland"
   },
   "Hyprland Options": {
     "Hyprland Options": "Opções do Hyprland"
   },
   "Hyprland Website": {
-    "Hyprland Website": ""
+    "Hyprland Website": "Site do Hyprland"
   },
   "Hyprland conf mode": {
-    "Hyprland conf mode": ""
+    "Hyprland conf mode": "Modo de configuração do Hyprland"
   },
   "Hyprland conf mode is read-only in Settings": {
-    "Hyprland conf mode is read-only in Settings": ""
+    "Hyprland conf mode is read-only in Settings": "O modo de configuração do Hyprland é somente leitura nas Configurações"
   },
   "Hyprland config include missing": {
-    "Hyprland config include missing": ""
+    "Hyprland config include missing": "Include da configuração do Hyprland ausente"
   },
   "I Understand": {
     "I Understand": "Entendi"
@@ -3993,7 +3987,7 @@
     "IP address or hostname": "Endereço de IP ou nome do host"
   },
   "IP sharing setup failed. Check that dnsmasq is installed.": {
-    "IP sharing setup failed. Check that dnsmasq is installed.": ""
+    "IP sharing setup failed. Check that dnsmasq is installed.": "Falha na configuração do compartilhamento de IP. Verifique se o dnsmasq está instalado."
   },
   "ISO Date": {
     "ISO Date": "Data ISO"
@@ -4014,22 +4008,22 @@
     "Icon Theme": "Tema de Ícones"
   },
   "Icon theme changed outside DMS; switched to System Default": {
-    "Icon theme changed outside DMS; switched to System Default": ""
+    "Icon theme changed outside DMS; switched to System Default": "Tema de ícones alterado fora do DMS; alternado para Padrão do Sistema"
   },
   "Identical alerts show as one popup instead of stacking": {
-    "Identical alerts show as one popup instead of stacking": ""
+    "Identical alerts show as one popup instead of stacking": "Alertas idênticos aparecem como um único popup em vez de empilhar"
   },
   "Identical alerts stack as separate notification cards": {
-    "Identical alerts stack as separate notification cards": ""
+    "Identical alerts stack as separate notification cards": "Alertas idênticos empilham como cartões de notificação separados"
   },
   "Identify": {
-    "Identify": ""
+    "Identify": "Identificar"
   },
   "Idle": {
     "Idle": "Em espera"
   },
   "Idle Inhibit": {
-    "Idle Inhibit": ""
+    "Idle Inhibit": "Inibição de Inatividade"
   },
   "Idle Inhibitor": {
     "Idle Inhibitor": "Inibitor de inatividade"
@@ -4038,40 +4032,40 @@
     "Idle Settings": "Configurações de inatividade"
   },
   "If autostart app icons don't appear in the system tray, generate a systemd override to ensure DMS starts before autostart apps": {
-    "If autostart app icons don't appear in the system tray, generate a systemd override to ensure DMS starts before autostart apps": ""
+    "If autostart app icons don't appear in the system tray, generate a systemd override to ensure DMS starts before autostart apps": "Se os ícones dos aplicativos de inicialização não aparecerem na bandeja do sistema, gere uma substituição do systemd para garantir que o DMS inicie antes dos aplicativos de inicialização"
   },
   "If the field is hidden, it will appear as soon as a key is pressed.": {
     "If the field is hidden, it will appear as soon as a key is pressed.": "Se o campo está escondido, ele aparecerá no momento que uma tecla e pressionada."
   },
   "Ignore App-Requested Timeout": {
-    "Ignore App-Requested Timeout": ""
+    "Ignore App-Requested Timeout": "Ignorar Tempo Limite Solicitado pelo Aplicativo"
   },
   "Ignore Completely": {
     "Ignore Completely": "Ignorar Completamente"
   },
   "Ignore package": {
-    "Ignore package": ""
+    "Ignore package": "Ignorar pacote"
   },
   "Ignore this package": {
-    "Ignore this package": ""
+    "Ignore this package": "Ignorar este pacote"
   },
   "Ignored (%1)": {
-    "Ignored (%1)": ""
+    "Ignored (%1)": "Ignorado (%1)"
   },
   "Ignored Packages": {
-    "Ignored Packages": ""
+    "Ignored Packages": "Pacotes Ignorados"
   },
   "Ignored packages are hidden from the updater and skipped by 'Update All'.": {
-    "Ignored packages are hidden from the updater and skipped by 'Update All'.": ""
+    "Ignored packages are hidden from the updater and skipped by 'Update All'.": "Os pacotes ignorados ficam ocultos do atualizador e são ignorados por 'Atualizar Tudo'."
   },
   "Ignored packages only apply to the built-in updater. Your custom command controls its own exclusions.": {
-    "Ignored packages only apply to the built-in updater. Your custom command controls its own exclusions.": ""
+    "Ignored packages only apply to the built-in updater. Your custom command controls its own exclusions.": "Os pacotes ignorados se aplicam apenas ao atualizador integrado. Seu comando personalizado controla suas próprias exclusões."
   },
   "Image": {
     "Image": "Imagem"
   },
   "Image Viewer": {
-    "Image Viewer": ""
+    "Image Viewer": "Visualizador de Imagens"
   },
   "Image copied to clipboard": {
     "Image copied to clipboard": "Imagem copiada para a área de trabalho"
@@ -4086,16 +4080,16 @@
     "Inactive Monitor Color": "Cor do Monitor Inativo"
   },
   "Include AUR updates": {
-    "Include AUR updates": ""
+    "Include AUR updates": "Incluir atualizações AUR"
   },
   "Include Files in All Tab": {
-    "Include Files in All Tab": ""
+    "Include Files in All Tab": "Incluir Arquivos na Aba Todos"
   },
   "Include Flatpak updates": {
-    "Include Flatpak updates": ""
+    "Include Flatpak updates": "Incluir atualizações Flatpak"
   },
   "Include Folders in All Tab": {
-    "Include Folders in All Tab": ""
+    "Include Folders in All Tab": "Incluir Pastas na Aba Todos"
   },
   "Include Transitions": {
     "Include Transitions": "Incluir Transições"
@@ -4110,10 +4104,10 @@
     "Incorrect password": "Senha incorreta"
   },
   "Incorrect password - try again": {
-    "Incorrect password - try again": ""
+    "Incorrect password - try again": "Senha incorreta - tente novamente"
   },
   "Index Centering": {
-    "Index Centering": ""
+    "Index Centering": "Centralização do Índice"
   },
   "Indicator Style": {
     "Indicator Style": "Estilo de Indicador"
@@ -4131,22 +4125,22 @@
     "Inherit": "Herdar"
   },
   "Inherit Global (Default)": {
-    "Inherit Global (Default)": ""
+    "Inherit Global (Default)": "Herdar Global (Padrão)"
   },
   "Inhibitable": {
     "Inhibitable": "Inibível"
   },
   "Initial position for floating windows. Set both X and Y; anchor controls which corner/edge they're relative to.": {
-    "Initial position for floating windows. Set both X and Y; anchor controls which corner/edge they're relative to.": ""
+    "Initial position for floating windows. Set both X and Y; anchor controls which corner/edge they're relative to.": "Posição inicial das janelas flutuantes. Defina X e Y; a âncora controla a que canto/borda elas são relativas."
   },
   "Initialised": {
-    "Initialised": ""
+    "Initialised": "Inicializado"
   },
   "Inner Gaps": {
-    "Inner Gaps": ""
+    "Inner Gaps": "Lacunas Internas"
   },
   "Inner padding applied to each widget": {
-    "Inner padding applied to each widget": ""
+    "Inner padding applied to each widget": "Preenchimento interno aplicado a cada widget"
   },
   "Input Devices": {
     "Input Devices": "Dispositivos de Entrada"
@@ -4155,10 +4149,10 @@
     "Input Volume Slider": "Controle deslizante de volume de entrada"
   },
   "Insert your security key...": {
-    "Insert your security key...": ""
+    "Insert your security key...": "Insira sua chave de segurança..."
   },
   "Inset the Notepad from screen edges using the compositor's configured gaps": {
-    "Inset the Notepad from screen edges using the compositor's configured gaps": ""
+    "Inset the Notepad from screen edges using the compositor's configured gaps": "Recuar o Bloco de Notas das bordas da tela usando as lacunas configuradas do compositor"
   },
   "Install": {
     "Install": "Instalar"
@@ -4176,10 +4170,10 @@
     "Install color themes from the DMS theme registry": "Instalar temas de cor do registro de temas DMS"
   },
   "Install complete. Greeter has been installed.": {
-    "Install complete. Greeter has been installed.": ""
+    "Install complete. Greeter has been installed.": "Instalação concluída. O Greeter foi instalado."
   },
   "Install dsearch to search files.": {
-    "Install dsearch to search files.": ""
+    "Install dsearch to search files.": "Instale o dsearch para pesquisar arquivos."
   },
   "Install failed: %1": {
     "Install failed: %1": "Instalação falhou: %1"
@@ -4194,19 +4188,19 @@
     "Install plugins from the DMS plugin registry": "Instale plugins a partir do registro de plugins do DMS"
   },
   "Install the DMS greeter? A terminal will open for sudo authentication.": {
-    "Install the DMS greeter? A terminal will open for sudo authentication.": ""
+    "Install the DMS greeter? A terminal will open for sudo authentication.": "Instalar o greeter do DMS? Um terminal abrirá para autenticação sudo."
   },
   "Install theme '%1' from the DMS registry?": {
     "Install theme '%1' from the DMS registry?": "Instalar tema '%1' do registro DMS?"
   },
   "Installation and PAM setup are documented in the ": {
-    "Installation and PAM setup are documented in the ": ""
+    "Installation and PAM setup are documented in the ": "A instalação e a configuração do PAM estão documentadas no "
   },
   "Installed": {
     "Installed": "Instalado"
   },
   "Installed first": {
-    "Installed first": ""
+    "Installed first": "Instalados primeiro"
   },
   "Installed: %1": {
     "Installed: %1": "Instalado: %1"
@@ -4215,7 +4209,7 @@
     "Installing: %1": "Instalando: %1"
   },
   "Integrations": {
-    "Integrations": ""
+    "Integrations": "Integrações"
   },
   "Intelligent Auto-hide": {
     "Intelligent Auto-hide": "Ocultação Automática Inteligente"
@@ -4236,16 +4230,13 @@
     "Interval": "Intervalo"
   },
   "Invalid JSON format: %1": {
-    "Invalid JSON format: %1": ""
+    "Invalid JSON format: %1": "Formato JSON inválido: %1"
   },
   "Invalid configuration": {
     "Invalid configuration": "Configuração inválida"
   },
   "Invalid package name — letters, digits and @._+:- only.": {
-    "Invalid package name — letters, digits and @._+:- only.": ""
-  },
-  "Invalid password for %1": {
-    "Invalid password for %1": ""
+    "Invalid package name — letters, digits and @._+:- only.": "Nome de pacote inválido — apenas letras, dígitos e @._+:-."
   },
   "Invalid username": {
     "Invalid username": "Nome de usuário inválido"
@@ -4254,7 +4245,7 @@
     "Invert on mode change": "Inverter na mudança de modo"
   },
   "Invert touchpad scroll direction": {
-    "Invert touchpad scroll direction": ""
+    "Invert touchpad scroll direction": "Inverter a direção de rolagem do touchpad"
   },
   "Iris Bloom": {
     "Iris Bloom": "Íris em Flor"
@@ -4266,13 +4257,13 @@
     "Jobs": "Trabalhos"
   },
   "Join video call": {
-    "Join video call": ""
+    "Join video call": "Entrar na chamada de vídeo"
   },
   "Jump to page": {
-    "Jump to page": ""
+    "Jump to page": "Ir para a página"
   },
   "Jump to page (1 - %1)": {
-    "Jump to page (1 - %1)": ""
+    "Jump to page (1 - %1)": "Ir para a página (1 - %1)"
   },
   "Keep Awake": {
     "Keep Awake": "Manter Ligado"
@@ -4281,19 +4272,19 @@
     "Keep Changes": "Manter Alterações"
   },
   "Keep My Edits": {
-    "Keep My Edits": ""
+    "Keep My Edits": "Manter Minhas Edições"
   },
   "Keep dragging when finger is briefly lifted": {
-    "Keep dragging when finger is briefly lifted": ""
+    "Keep dragging when finger is briefly lifted": "Continuar arrastando quando o dedo for levantado brevemente"
   },
   "Keep in Bar": {
-    "Keep in Bar": ""
+    "Keep in Bar": "Manter na Barra"
   },
   "Keep the clipboard type filter when reopening history": {
-    "Keep the clipboard type filter when reopening history": ""
+    "Keep the clipboard type filter when reopening history": "Manter o filtro de tipo da área de transferência ao reabrir o histórico"
   },
   "Keep typing": {
-    "Keep typing": ""
+    "Keep typing": "Continue digitando"
   },
   "Keeping Awake": {
     "Keeping Awake": "Mantendo Ligado"
@@ -4305,7 +4296,7 @@
     "Key": "Tecla"
   },
   "Key combination": {
-    "Key combination": ""
+    "Key combination": "Combinação de teclas"
   },
   "Keybind Sources": {
     "Keybind Sources": "Fontes de Combinações de Teclas"
@@ -4320,31 +4311,31 @@
     "Keybinds shown alongside regular search results": "Combinações de teclas mostradas junto com resultados de pesquisa regulares"
   },
   "Keyboard": {
-    "Keyboard": ""
+    "Keyboard": "Teclado"
   },
   "Keyboard Behavior": {
-    "Keyboard Behavior": ""
+    "Keyboard Behavior": "Comportamento do Teclado"
   },
   "Keyboard Layout Name": {
     "Keyboard Layout Name": "Nome de Layout do Teclado"
   },
   "Keyboard Layouts": {
-    "Keyboard Layouts": ""
+    "Keyboard Layouts": "Layouts de Teclado"
   },
   "Keyboard Model": {
-    "Keyboard Model": ""
+    "Keyboard Model": "Modelo do Teclado"
   },
   "Keyboard Shortcuts": {
     "Keyboard Shortcuts": "Atalhos do Teclado"
   },
   "Keyboard Variant": {
-    "Keyboard Variant": ""
+    "Keyboard Variant": "Variante do Teclado"
   },
   "Keyboard shortcut to start security key unlock": {
-    "Keyboard shortcut to start security key unlock": ""
+    "Keyboard shortcut to start security key unlock": "Atalho de teclado para iniciar o desbloqueio por chave de segurança"
   },
   "Keymap File Path": {
-    "Keymap File Path": ""
+    "Keymap File Path": "Caminho do Arquivo de Mapa de Teclas"
   },
   "Keys": {
     "Keys": "Teclas"
@@ -4365,10 +4356,10 @@
     "LED device": "Dispositivo LED"
   },
   "LabWC IRC Channel": {
-    "LabWC IRC Channel": ""
+    "LabWC IRC Channel": "Canal IRC do LabWC"
   },
   "LabWC Website": {
-    "LabWC Website": ""
+    "LabWC Website": "Site do LabWC"
   },
   "Large": {
     "Large": "Grande"
@@ -4425,10 +4416,10 @@
     "Launcher Button Logo": "Logo do botão do Lançador"
   },
   "Launcher Emerge Side": {
-    "Launcher Emerge Side": ""
+    "Launcher Emerge Side": "Lado de Surgimento do Inicializador"
   },
   "Layer Outline Opacity": {
-    "Layer Outline Opacity": ""
+    "Layer Outline Opacity": "Opacidade do Contorno da Camada"
   },
   "Layout": {
     "Layout": "Layout"
@@ -4446,10 +4437,10 @@
     "Left Section": "Seção da Esquerda"
   },
   "Left-Handed Mode": {
-    "Left-Handed Mode": ""
+    "Left-Handed Mode": "Modo Canhoto"
   },
   "Light": {
-    "Light": ""
+    "Light": "Claro"
   },
   "Light Direction": {
     "Light Direction": "Direção da Luz"
@@ -4458,7 +4449,7 @@
     "Light Mode": "Modo Claro"
   },
   "Light Mode Icon Theme": {
-    "Light Mode Icon Theme": ""
+    "Light Mode Icon Theme": "Tema de Ícones do Modo Claro"
   },
   "Light Rain": {
     "Light Rain": "Chuva Leve"
@@ -4470,22 +4461,22 @@
     "Light Snow Showers": "Nevascas Leves"
   },
   "Light mode base": {
-    "Light mode base": ""
+    "Light mode base": "Base do modo claro"
   },
   "Light mode harmony": {
-    "Light mode harmony": ""
+    "Light mode harmony": "Harmonia do modo claro"
   },
   "Limit set to %1%": {
-    "Limit set to %1%": ""
+    "Limit set to %1%": "Limite definido em %1%"
   },
   "Limit the maximum battery charge level to extend lifespan.": {
-    "Limit the maximum battery charge level to extend lifespan.": ""
+    "Limit the maximum battery charge level to extend lifespan.": "Limitar o nível máximo de carga da bateria para prolongar sua vida útil."
   },
   "Line": {
     "Line": "Linha"
   },
   "Line: %1": {
-    "Line: %1": ""
+    "Line: %1": "Linha: %1"
   },
   "Linear": {
     "Linear": "Linear"
@@ -4518,10 +4509,10 @@
     "Local": "Local"
   },
   "Local Weather": {
-    "Local Weather": ""
+    "Local Weather": "Clima Local"
   },
   "Locale": {
-    "Locale": ""
+    "Locale": "Localidade"
   },
   "Location": {
     "Location": "Localização"
@@ -4548,13 +4539,16 @@
     "Lock fade grace period": "Período de carência de fade de bloqueio"
   },
   "Lock screen font": {
-    "Lock screen font": ""
+    "Lock screen font": "Fonte da tela de bloqueio"
   },
   "Locked": {
     "Locked": "Bloqueado"
   },
+  "Log Out": {
+    "Log Out": "Sair"
+  },
   "Login": {
-    "Login": ""
+    "Login": "Login"
   },
   "Long": {
     "Long": "Longo"
@@ -4569,43 +4563,43 @@
     "Longitude": "Longitude"
   },
   "Low": {
-    "Low": ""
+    "Low": "Baixo"
   },
   "Low Battery": {
-    "Low Battery": ""
+    "Low Battery": "Bateria Baixa"
   },
   "Low Battery Notifications": {
-    "Low Battery Notifications": ""
+    "Low Battery Notifications": "Notificações de Bateria Baixa"
   },
   "Low Battery Threshold": {
-    "Low Battery Threshold": ""
+    "Low Battery Threshold": "Limite de Bateria Baixa"
   },
   "Low Priority": {
     "Low Priority": "Baixa Prioridade"
   },
   "Lower display refresh rate on battery": {
-    "Lower display refresh rate on battery": ""
+    "Lower display refresh rate on battery": "Reduzir a taxa de atualização do monitor na bateria"
   },
   "MAC": {
     "MAC": "MAC"
   },
   "MIT License": {
-    "MIT License": ""
+    "MIT License": "Licença MIT"
   },
   "MTU": {
     "MTU": "MTU"
   },
   "Mail": {
-    "Mail": ""
+    "Mail": "Correio"
   },
   "Make admin": {
-    "Make admin": ""
+    "Make admin": "Tornar administrador"
   },
   "Make sure KDE Connect or Valent is running on your other devices": {
     "Make sure KDE Connect or Valent is running on your other devices": "Certifique-se de que o KDE Connect ou Valent esteja em execução em seus outros dispositivos"
   },
   "Make the bar background fully transparent": {
-    "Make the bar background fully transparent": ""
+    "Make the bar background fully transparent": "Tornar o fundo da barra totalmente transparente"
   },
   "Manage and configure plugins for extending DMS functionality": {
     "Manage and configure plugins for extending DMS functionality": "Gerencia e configure plugins para extender funcionalidades do DMS"
@@ -4614,28 +4608,25 @@
     "Manage up to 4 independent bar configurations. Each bar has its own position, widgets, styling, and display assignment.": "Gerencie até 4 configurações de barras independentes. Cada barra possui sua própria posição, widgets, estilo e atribuição de telas."
   },
   "Managed by Frame": {
-    "Managed by Frame": ""
+    "Managed by Frame": "Gerenciado pelo Frame"
   },
   "Managed by Frame in Connected Mode": {
-    "Managed by Frame in Connected Mode": ""
+    "Managed by Frame in Connected Mode": "Gerenciado pelo Frame no Modo Conectado"
   },
   "Managed by the primary PAM source": {
-    "Managed by the primary PAM source": ""
-  },
-  "Managed by the primary PAM source.": {
-    "Managed by the primary PAM source.": ""
+    "Managed by the primary PAM source": "Gerenciado pela fonte PAM principal"
   },
   "Management": {
     "Management": "Gerenciamento"
   },
   "Manages files and directories": {
-    "Manages files and directories": ""
+    "Manages files and directories": "Gerencia arquivos e diretórios"
   },
   "Mango Options": {
-    "Mango Options": ""
+    "Mango Options": "Opções Mango"
   },
   "Mango service not available": {
-    "Mango service not available": ""
+    "Mango service not available": "Serviço Mango indisponível"
   },
   "Manual": {
     "Manual": "Manual"
@@ -4650,19 +4641,19 @@
     "Manual Gap Size": "Espaçamento Manual"
   },
   "Manual Gaps": {
-    "Manual Gaps": ""
+    "Manual Gaps": "Lacunas Manuais"
   },
   "Manual Show/Hide": {
     "Manual Show/Hide": "Mostrar/Esconder Manualmente"
   },
   "Manual config": {
-    "Manual config": ""
+    "Manual config": "Configuração manual"
   },
   "Map window class names to icon names for proper icon display": {
     "Map window class names to icon names for proper icon display": "Mapear nomes de classe de janela para nomes de ícones para exibição adequada do ícone"
   },
   "Maps": {
-    "Maps": ""
+    "Maps": "Mapas"
   },
   "Margin": {
     "Margin": "Margem"
@@ -4680,19 +4671,19 @@
     "Marker Waste Full": "Coletor de Resíduos Cheio"
   },
   "Match (%1)": {
-    "Match (%1)": ""
+    "Match (%1)": "Correspondência (%1)"
   },
   "Match Conditions": {
-    "Match Conditions": ""
+    "Match Conditions": "Condições de Correspondência"
   },
   "Match Criteria": {
     "Match Criteria": "Critérios de Correspondência"
   },
   "Material": {
-    "Material": ""
+    "Material": "Material"
   },
   "Material Battery Style": {
-    "Material Battery Style": ""
+    "Material Battery Style": "Estilo de Bateria Material"
   },
   "Material Colors": {
     "Material Colors": "Cores Material"
@@ -4704,13 +4695,13 @@
     "Material colors generated from wallpaper": "Cores materiais geradas a partir do papel de parede"
   },
   "Material inspired shadows and elevation on modals, popouts, and dialogs": {
-    "Material inspired shadows and elevation on modals, popouts, and dialogs": ""
+    "Material inspired shadows and elevation on modals, popouts, and dialogs": "Sombras e elevação inspiradas em Material em modais, popouts e diálogos"
   },
   "Material: Material Design 3 Expressive bezier curves. The DMS default feel.": {
-    "Material: Material Design 3 Expressive bezier curves. The DMS default feel.": ""
+    "Material: Material Design 3 Expressive bezier curves. The DMS default feel.": "Material: curvas bezier Expressivas do Material Design 3. A sensação padrão do DMS."
   },
   "Matugen Contrast": {
-    "Matugen Contrast": ""
+    "Matugen Contrast": "Contraste do Matugen"
   },
   "Matugen Missing": {
     "Matugen Missing": "Matugen Ausente"
@@ -4743,7 +4734,7 @@
     "Max Running Apps (0 = Unlimited)": "Máximo de Aplicativos em Execução (0 = Ilimitado)"
   },
   "Max Visible": {
-    "Max Visible": ""
+    "Max Visible": "Máximo Visível"
   },
   "Max Volume": {
     "Max Volume": "Volume Máximo"
@@ -4779,7 +4770,7 @@
     "Maximum Pinned Entries": "Máximo de Entradas Fixadas"
   },
   "Maximum fingerprint attempts reached. Please use password.": {
-    "Maximum fingerprint attempts reached. Please use password.": ""
+    "Maximum fingerprint attempts reached. Please use password.": "Número máximo de tentativas de impressão digital atingido. Use a senha."
   },
   "Maximum number of clipboard entries to keep": {
     "Maximum number of clipboard entries to keep": "Número máximo de entradas da área de transferência para guardar"
@@ -4792,6 +4783,9 @@
   },
   "Maximum pinned entries reached": {
     "Maximum pinned entries reached": "Máximo de entradas fixadas alcançado"
+  },
+  "Media": {
+    "Media": "Mídia"
   },
   "Media Controls": {
     "Media Controls": "Controles de Mídia"
@@ -4836,10 +4830,10 @@
     "Memory usage indicator": "Indicador de uso de memória"
   },
   "Merge indexed file results into the All tab (requires dsearch).": {
-    "Merge indexed file results into the All tab (requires dsearch).": ""
+    "Merge indexed file results into the All tab (requires dsearch).": "Mesclar resultados de arquivos indexados na aba Todos (requer dsearch)."
   },
   "Merge indexed folder results into the All tab (requires dsearch).": {
-    "Merge indexed folder results into the All tab (requires dsearch).": ""
+    "Merge indexed folder results into the All tab (requires dsearch).": "Mesclar resultados de pastas indexadas na aba Todos (requer dsearch)."
   },
   "Message": {
     "Message": "Mensagem"
@@ -4863,7 +4857,7 @@
     "Microphone volume control": "Controle de volume de microfone"
   },
   "Middle Click Emulation": {
-    "Middle Click Emulation": ""
+    "Middle Click Emulation": "Emulação do Clique do Meio"
   },
   "Middle Section": {
     "Middle Section": "Seção do Meio"
@@ -4890,7 +4884,7 @@
     "Modal Background": "Fundo Modal"
   },
   "Modal Shadows": {
-    "Modal Shadows": ""
+    "Modal Shadows": "Sombras de Modais"
   },
   "Modals": {
     "Modals": "Modais"
@@ -4900,6 +4894,9 @@
   },
   "Model": {
     "Model": "Modelo"
+  },
+  "Modified": {
+    "Modified": "Modificado"
   },
   "Modular widget bar": {
     "Modular widget bar": "Barra de widgets modular"
@@ -4917,7 +4914,7 @@
     "Monitor whose wallpaper drives dynamic theming colors": "Monitor o qual papel de parede controla cores de tema dinâmicas"
   },
   "Monitors in \"%1\":": {
-    "Monitors in \"%1\":": ""
+    "Monitors in \"%1\":": "Monitores em \"%1\":"
   },
   "Monochrome": {
     "Monochrome": "Monocromático"
@@ -4935,19 +4932,19 @@
     "Morning": "Manhã"
   },
   "Motion Effects": {
-    "Motion Effects": ""
+    "Motion Effects": "Efeitos de Movimento"
   },
   "Mount Points": {
     "Mount Points": "Pontos de Montagem"
   },
   "Mouse & Touchpad": {
-    "Mouse & Touchpad": ""
+    "Mouse & Touchpad": "Mouse e Touchpad"
   },
   "Mouse Settings": {
-    "Mouse Settings": ""
+    "Mouse Settings": "Configurações do Mouse"
   },
   "Mouse clicks pass through the bar to windows behind it": {
-    "Mouse clicks pass through the bar to windows behind it": ""
+    "Mouse clicks pass through the bar to windows behind it": "Cliques do mouse passam pela barra para as janelas atrás dela"
   },
   "Mouse pointer appearance": {
     "Mouse pointer appearance": "Aparência do ponteiro do mouse"
@@ -4965,19 +4962,19 @@
     "Multi-Monitor": "Multi-Monitor"
   },
   "Multimedia": {
-    "Multimedia": ""
+    "Multimedia": "Multimídia"
   },
   "Multiplexer Type": {
-    "Multiplexer Type": ""
+    "Multiplexer Type": "Tipo de Multiplexador"
   },
   "Multiplexers": {
-    "Multiplexers": ""
+    "Multiplexers": "Multiplexadores"
   },
   "Music Player": {
-    "Music Player": ""
+    "Music Player": "Reprodutor de Música"
   },
   "Mute During Playback": {
-    "Mute During Playback": ""
+    "Mute During Playback": "Silenciar Durante a Reprodução"
   },
   "Mute Popups": {
     "Mute Popups": "Silenciar Popups"
@@ -4995,28 +4992,31 @@
     "Muted palette with subdued, calming tones.": "Paleta suave com tons sutis e calmantes."
   },
   "My Online": {
-    "My Online": ""
+    "My Online": "Meu Online"
   },
   "NM not supported": {
     "NM not supported": "NM não suportado"
+  },
+  "Name": {
+    "Name": "Nome"
   },
   "Named Workspace Icons": {
     "Named Workspace Icons": "Ícones de Áreas de Trabalho Nomeadas"
   },
   "Native": {
-    "Native": ""
+    "Native": "Nativo"
   },
   "Native: platform renderer (FreeType).": {
-    "Native: platform renderer (FreeType).": ""
+    "Native: platform renderer (FreeType).": "Nativo: renderizador de plataforma (FreeType)."
   },
   "Natural Scrolling": {
-    "Natural Scrolling": ""
+    "Natural Scrolling": "Rolagem Natural"
   },
   "Natural Touchpad Scrolling": {
-    "Natural Touchpad Scrolling": ""
+    "Natural Touchpad Scrolling": "Rolagem Natural no Touchpad"
   },
   "Navigate": {
-    "Navigate": ""
+    "Navigate": "Navegar"
   },
   "Network": {
     "Network": "Rede"
@@ -5037,13 +5037,10 @@
     "Network Speed Monitor": "Monitor de Velocidade da Rede"
   },
   "Network Type": {
-    "Network Type": ""
+    "Network Type": "Tipo de Rede"
   },
   "Network download and upload speed display": {
     "Network download and upload speed display": "Monitor de velocidades de download e upload da rede"
-  },
-  "Network not found": {
-    "Network not found": ""
   },
   "Neutral": {
     "Neutral": "Neutro"
@@ -5052,7 +5049,7 @@
     "Never": "Nunca"
   },
   "Never used": {
-    "Never used": ""
+    "Never used": "Nunca usado"
   },
   "New": {
     "New": "Novo"
@@ -5076,7 +5073,7 @@
     "New York, NY": "Nova York, NY"
   },
   "New event": {
-    "New event": ""
+    "New event": "Novo evento"
   },
   "New group name...": {
     "New group name...": "Novo nome de grupo..."
@@ -5088,7 +5085,7 @@
     "Next Transition": "Próxima Transição"
   },
   "Next page": {
-    "Next page": ""
+    "Next page": "Próxima página"
   },
   "Night": {
     "Night": "Noite"
@@ -5103,13 +5100,10 @@
     "Night mode & gamma": "Modo noturno e gama"
   },
   "Night mode failed: DMS gamma control not available": {
-    "Night mode failed: DMS gamma control not available": ""
+    "Night mode failed: DMS gamma control not available": "Falha no modo noturno: controle de gama do DMS indisponível"
   },
   "Niri Integration": {
     "Niri Integration": "Integração com niri"
-  },
-  "Niri compositor actions (focus, move, etc.)": {
-    "Niri compositor actions (focus, move, etc.)": "Ações do compositor Niri (focar, mover, etc.)"
   },
   "No": {
     "No": "Não"
@@ -5160,7 +5154,7 @@
     "No Rounding": "Sem Arredondamento"
   },
   "No Scroll": {
-    "No Scroll": ""
+    "No Scroll": "Sem Rolagem"
   },
   "No Shadow": {
     "No Shadow": "Sem Sombra"
@@ -5169,7 +5163,7 @@
     "No VPN profiles": "Sem perfis de VPN"
   },
   "No Weather": {
-    "No Weather": ""
+    "No Weather": "Sem Clima"
   },
   "No Weather Data": {
     "No Weather Data": "Sem Dados Meteorológicos"
@@ -5181,10 +5175,10 @@
     "No action": "Nenhuma ação"
   },
   "No active %1 sessions": {
-    "No active %1 sessions": ""
+    "No active %1 sessions": "Nenhuma sessão %1 ativa"
   },
   "No active session found for %1": {
-    "No active session found for %1": ""
+    "No active session found for %1": "Nenhuma sessão ativa encontrada para %1"
   },
   "No adapter": {
     "No adapter": "Sem adaptador"
@@ -5196,7 +5190,7 @@
     "No app customizations.": "Sem personalizações de aplicativo."
   },
   "No application selected": {
-    "No application selected": ""
+    "No application selected": "Nenhum aplicativo selecionado"
   },
   "No apps found": {
     "No apps found": "Nenhum aplicativo encontrado"
@@ -5208,7 +5202,7 @@
     "No apps muted. Right-click a notification and choose \"Mute popups\" to add one here.": "Nenhum aplicativo silenciado. Clique com o botão direito em uma notificação e escolha \"Silenciar popups\" para adicionar um aqui."
   },
   "No autostart entries": {
-    "No autostart entries": ""
+    "No autostart entries": "Nenhuma entrada de inicialização"
   },
   "No battery": {
     "No battery": "Sem bateria"
@@ -5217,7 +5211,7 @@
     "No brightness devices available": "Nenhum dispositivo de brilho disponível"
   },
   "No calendar source available": {
-    "No calendar source available": ""
+    "No calendar source available": "Nenhuma fonte de calendário disponível"
   },
   "No changes": {
     "No changes": "Nenhuma alteração"
@@ -5226,7 +5220,7 @@
     "No checks passed": "Nenhuma verificação passou"
   },
   "No codecs found": {
-    "No codecs found": ""
+    "No codecs found": "Nenhum codec encontrado"
   },
   "No custom theme file": {
     "No custom theme file": "Nenhum arquivo de tema personalizado"
@@ -5244,7 +5238,7 @@
     "No disk data available": "Nenhum dado de disco disponível"
   },
   "No display profiles found. Create them in Settings > Displays.": {
-    "No display profiles found. Create them in Settings > Displays.": ""
+    "No display profiles found. Create them in Settings > Displays.": "Nenhum perfil de monitor encontrado. Crie-os em Configurações > Monitores."
   },
   "No drivers found": {
     "No drivers found": "Nenhum driver encontrado"
@@ -5253,7 +5247,7 @@
     "No errors": "Sem erros"
   },
   "No excluded players configured": {
-    "No excluded players configured": ""
+    "No excluded players configured": "Nenhum reprodutor excluído configurado"
   },
   "No features enabled": {
     "No features enabled": "Nenhum recurso ativado"
@@ -5262,7 +5256,7 @@
     "No files found": "Nenhum arquivo encontrado"
   },
   "No fingerprint reader detected": {
-    "No fingerprint reader detected": ""
+    "No fingerprint reader detected": "Nenhum leitor de impressão digital detectado"
   },
   "No folders found": {
     "No folders found": "Nenhuma pasta encontrada"
@@ -5271,10 +5265,10 @@
     "No hidden apps.": "Sem aplicativos ocultos."
   },
   "No human user accounts found.": {
-    "No human user accounts found.": ""
+    "No human user accounts found.": "Nenhuma conta de usuário humana encontrada."
   },
   "No images found": {
-    "No images found": ""
+    "No images found": "Nenhuma imagem encontrada"
   },
   "No info items": {
     "No info items": "Nenhum item de informação"
@@ -5304,7 +5298,7 @@
     "No matches": "Nenhuma correspondência"
   },
   "No matching devices": {
-    "No matching devices": ""
+    "No matching devices": "Nenhum dispositivo correspondente"
   },
   "No matching processes": {
     "No matching processes": "Nenhum processo correspondente"
@@ -5316,7 +5310,7 @@
     "No mount points found": "Nenhum ponto de montagem encontrado"
   },
   "No other active sessions on this seat": {
-    "No other active sessions on this seat": ""
+    "No other active sessions on this seat": "Nenhuma outra sessão ativa neste assento"
   },
   "No output device": {
     "No output device": "Sem dispositivo de saída"
@@ -5325,10 +5319,10 @@
     "No output devices found": "Nenhum dispositivo de saída encontrado"
   },
   "No packages ignored. Add one here or hover an update in the popout and click the hide button.": {
-    "No packages ignored. Add one here or hover an update in the popout and click the hide button.": ""
+    "No packages ignored. Add one here or hover an update in the popout and click the hide button.": "Nenhum pacote ignorado. Adicione um aqui ou passe o mouse sobre uma atualização no popout e clique no botão de ocultar."
   },
   "No peers found": {
-    "No peers found": ""
+    "No peers found": "Nenhum par encontrado"
   },
   "No plugin results": {
     "No plugin results": "Sem resultados de plugin"
@@ -5352,10 +5346,10 @@
     "No recent clipboard entries found": "Nenhuma entrada recente de área de transferência encontrada"
   },
   "No reminder": {
-    "No reminder": ""
+    "No reminder": "Sem lembrete"
   },
   "No results": {
-    "No results": ""
+    "No results": "Nenhum resultado"
   },
   "No results found": {
     "No results found": "Nenhum resultado encontrado"
@@ -5364,7 +5358,7 @@
     "No saved clipboard entries": "Nenhuma entrada de área de transferência salva"
   },
   "No screenshot provided": {
-    "No screenshot provided": ""
+    "No screenshot provided": "Nenhuma captura de tela fornecida"
   },
   "No session selected": {
     "No session selected": "Nenhuma sessão selecionada"
@@ -5373,10 +5367,10 @@
     "No sessions found": "Nenhuma sessão localizada"
   },
   "No status output.": {
-    "No status output.": ""
+    "No status output.": "Nenhuma saída de status."
   },
   "No supported package manager found.": {
-    "No supported package manager found.": ""
+    "No supported package manager found.": "Nenhum gerenciador de pacotes compatível encontrado."
   },
   "No themes found": {
     "No themes found": "Nenhum tema encontrado"
@@ -5388,10 +5382,10 @@
     "No trigger": "Sem gatilho"
   },
   "No updates available.": {
-    "No updates available.": ""
+    "No updates available.": "Nenhuma atualização disponível."
   },
   "No user specified": {
-    "No user specified": ""
+    "No user specified": "Nenhum usuário especificado"
   },
   "No video found in folder": {
     "No video found in folder": "Nenhum vídeo encontrado na pasta"
@@ -5421,16 +5415,16 @@
     "No window rules configured": "Nenhuma regra de janela configurada"
   },
   "No writable calendar available": {
-    "No writable calendar available": ""
+    "No writable calendar available": "Nenhum calendário gravável disponível"
   },
   "Noise": {
-    "Noise": ""
+    "Noise": "Ruído"
   },
   "None": {
     "None": "Nenhum"
   },
   "None active": {
-    "None active": ""
+    "None active": "Nenhum ativo"
   },
   "Normal": {
     "Normal": "Normal"
@@ -5445,19 +5439,19 @@
     "Not available": "Indisponível"
   },
   "Not available - install fprintd and pam_fprintd": {
-    "Not available - install fprintd and pam_fprintd": ""
+    "Not available - install fprintd and pam_fprintd": "Não disponível - instale fprintd e pam_fprintd"
   },
   "Not available - install or configure pam_u2f": {
-    "Not available - install or configure pam_u2f": ""
+    "Not available - install or configure pam_u2f": "Não disponível - instale ou configure pam_u2f"
   },
   "Not available — install fprintd and pam_fprintd, or configure greetd PAM.": {
-    "Not available — install fprintd and pam_fprintd, or configure greetd PAM.": ""
+    "Not available — install fprintd and pam_fprintd, or configure greetd PAM.": "Não disponível — instale fprintd e pam_fprintd ou configure o PAM do greetd."
   },
   "Not available — install or configure pam_u2f, or configure greetd PAM.": {
-    "Not available — install or configure pam_u2f, or configure greetd PAM.": ""
+    "Not available — install or configure pam_u2f, or configure greetd PAM.": "Não disponível — instale ou configure pam_u2f ou configure o PAM do greetd."
   },
   "Not bound": {
-    "Not bound": ""
+    "Not bound": "Não vinculado"
   },
   "Not connected": {
     "Not connected": "Não conectado"
@@ -5475,13 +5469,13 @@
     "Notepad": "Bloco de Nota"
   },
   "Notepad Settings": {
-    "Notepad Settings": ""
+    "Notepad Settings": "Configurações do Bloco de Notas"
   },
   "Notepad Slideout": {
     "Notepad Slideout": "Blocos de Notas Deslizante"
   },
   "Notes": {
-    "Notes": ""
+    "Notes": "Notas"
   },
   "Nothing": {
     "Nothing": "Nada"
@@ -5490,7 +5484,7 @@
     "Nothing to see here": "Nada para ver aqui"
   },
   "Notification": {
-    "Notification": ""
+    "Notification": "Notificação"
   },
   "Notification Center": {
     "Notification Center": "Centro de Notificações"
@@ -5508,7 +5502,7 @@
     "Notification Settings": "Configurações de Notificação"
   },
   "Notification Type": {
-    "Notification Type": ""
+    "Notification Type": "Tipo de Notificação"
   },
   "Notification toast popups": {
     "Notification toast popups": "Pop-ups de notificações toast"
@@ -5517,10 +5511,10 @@
     "Notifications": "Notificações"
   },
   "Notify when limit is reached": {
-    "Notify when limit is reached": ""
+    "Notify when limit is reached": "Notificar quando o limite for atingido"
   },
   "Now playing and media controls": {
-    "Now playing and media controls": ""
+    "Now playing and media controls": "Reproduzindo agora e controles de mídia"
   },
   "Numeric (D/M)": {
     "Numeric (D/M)": "Numérico (D/M)"
@@ -5559,10 +5553,10 @@
     "On": "Ligado"
   },
   "On Button Down": {
-    "On Button Down": ""
+    "On Button Down": "Ao Pressionar o Botão"
   },
   "On indefinitely": {
-    "On indefinitely": ""
+    "On indefinitely": "Indefinidamente"
   },
   "On-Demand": {
     "On-Demand": "Por Demanda"
@@ -5571,7 +5565,7 @@
     "On-screen Displays": "Exibições OSD"
   },
   "Once a day": {
-    "Once a day": ""
+    "Once a day": "Uma vez por dia"
   },
   "Online": {
     "Online": "Online"
@@ -5580,10 +5574,10 @@
     "Only adjust gamma based on time or location rules.": "Apenas ajustar gama baseada em regras de tempo ou localização."
   },
   "Only continue if you recognize this server certificate fingerprint.": {
-    "Only continue if you recognize this server certificate fingerprint.": ""
+    "Only continue if you recognize this server certificate fingerprint.": "Continue somente se reconhecer a impressão digital deste certificado de servidor."
   },
   "Only on Battery": {
-    "Only on Battery": ""
+    "Only on Battery": "Somente na Bateria"
   },
   "Only show windows from the current monitor on each dock": {
     "Only show windows from the current monitor on each dock": "Mostrar apenas janelas do monitor atual em cada dock"
@@ -5595,13 +5589,13 @@
     "Opacity": "Opacidade"
   },
   "Opacity of cards and nested surfaces inside floating windows": {
-    "Opacity of cards and nested surfaces inside floating windows": ""
+    "Opacity of cards and nested surfaces inside floating windows": "Opacidade de cartões e superfícies aninhadas dentro de janelas flutuantes"
   },
   "Opacity of floating DMS windows like Settings, Notepad, and authentication prompts": {
-    "Opacity of floating DMS windows like Settings, Notepad, and authentication prompts": ""
+    "Opacity of floating DMS windows like Settings, Notepad, and authentication prompts": "Opacidade de janelas flutuantes do DMS como Configurações, Bloco de Notas e solicitações de autenticação"
   },
   "Opacity of foreground cards and nested surfaces on shell panels": {
-    "Opacity of foreground cards and nested surfaces on shell panels": ""
+    "Opacity of foreground cards and nested surfaces on shell panels": "Opacidade de cartões de primeiro plano e superfícies aninhadas nos painéis do shell"
   },
   "Opaque": {
     "Opaque": "Opaco"
@@ -5613,40 +5607,40 @@
     "Open App": "Abrir Aplicativo"
   },
   "Open DMS windows floating instead of tiled": {
-    "Open DMS windows floating instead of tiled": ""
+    "Open DMS windows floating instead of tiled": "Abrir janelas do DMS flutuantes em vez de lado a lado"
   },
   "Open Delay": {
-    "Open Delay": ""
+    "Open Delay": "Atraso de Abertura"
   },
   "Open Dir": {
-    "Open Dir": ""
+    "Open Dir": "Abrir Diretório"
   },
   "Open Frame": {
-    "Open Frame": ""
+    "Open Frame": "Abrir Frame"
   },
   "Open From": {
-    "Open From": ""
+    "Open From": "Abrir de"
   },
   "Open Notepad File": {
     "Open Notepad File": "Abrir Arquivo do Bloco de Notas"
   },
   "Open Trash": {
-    "Open Trash": ""
+    "Open Trash": "Abrir Lixeira"
   },
   "Open Trash With": {
-    "Open Trash With": ""
+    "Open Trash With": "Abrir Lixeira Com"
   },
   "Open Windows Floating": {
-    "Open Windows Floating": ""
+    "Open Windows Floating": "Abrir Janelas Flutuantes"
   },
   "Open a new note": {
     "Open a new note": "Abrir uma nova nota"
   },
   "Open a terminal and run a custom command instead of the in-shell upgrade flow.": {
-    "Open a terminal and run a custom command instead of the in-shell upgrade flow.": ""
+    "Open a terminal and run a custom command instead of the in-shell upgrade flow.": "Abra um terminal e execute um comando personalizado em vez do fluxo de atualização dentro do shell."
   },
   "Open as window": {
-    "Open as window": ""
+    "Open as window": "Abrir como janela"
   },
   "Open folder": {
     "Open folder": "Abrir pasta"
@@ -5658,16 +5652,16 @@
     "Open in terminal": "Abrir no terminal"
   },
   "Open network": {
-    "Open network": ""
+    "Open network": "Abrir rede"
   },
   "Open search bar to find text": {
     "Open search bar to find text": "Abrir barra de pesquisa e encontrar texto"
   },
   "Open the launcher by hovering the emerge edge (when free of bar and dock)": {
-    "Open the launcher by hovering the emerge edge (when free of bar and dock)": ""
+    "Open the launcher by hovering the emerge edge (when free of bar and dock)": "Abrir o inicializador passando o mouse na borda de surgimento (quando livre de barra e dock)"
   },
   "Open widget popouts by hovering over the bar. Moving to another widget switches the popout.": {
-    "Open widget popouts by hovering over the bar. Moving to another widget switches the popout.": ""
+    "Open widget popouts by hovering over the bar. Moving to another widget switches the popout.": "Abrir popouts de widgets passando o mouse sobre a barra. Mover para outro widget alterna o popout."
   },
   "Open with...": {
     "Open with...": "Abrir com..."
@@ -5682,13 +5676,13 @@
     "Opening terminal: ": "Abrindo o terminal: "
   },
   "Opens a picker of other active sessions on this seat": {
-    "Opens a picker of other active sessions on this seat": ""
+    "Opens a picker of other active sessions on this seat": "Abre um seletor de outras sessões ativas neste assento"
   },
   "Opens the connected launcher in Connected Frame Mode.": {
-    "Opens the connected launcher in Connected Frame Mode.": ""
+    "Opens the connected launcher in Connected Frame Mode.": "Abre o inicializador conectado no Modo Frame Conectado."
   },
   "Optional": {
-    "Optional": ""
+    "Optional": "Opcional"
   },
   "Optional description": {
     "Optional description": "Descrição opcional"
@@ -5697,10 +5691,10 @@
     "Optional location": "Localização opcional"
   },
   "Optional state-based conditions applied to the first match.": {
-    "Optional state-based conditions applied to the first match.": ""
+    "Optional state-based conditions applied to the first match.": "Condições opcionais baseadas em estado aplicadas à primeira correspondência."
   },
   "Optional; leave blank for open hotspot": {
-    "Optional; leave blank for open hotspot": ""
+    "Optional; leave blank for open hotspot": "Opcional; deixe em branco para hotspot aberto"
   },
   "Options": {
     "Options": "Opções"
@@ -5715,13 +5709,13 @@
     "Other": "Outro"
   },
   "Outer Gaps": {
-    "Outer Gaps": ""
+    "Outer Gaps": "Lacunas Externas"
   },
   "Outline": {
     "Outline": "Contorno"
   },
   "Outline around shell surfaces": {
-    "Outline around shell surfaces": ""
+    "Outline around shell surfaces": "Contorno ao redor das superfícies do shell"
   },
   "Output": {
     "Output": "Saída"
@@ -5745,7 +5739,7 @@
     "Overflow": "Estouro"
   },
   "Overlay": {
-    "Overlay": ""
+    "Overlay": "Sobreposição"
   },
   "Overridden by config": {
     "Overridden by config": "Substituído pela config"
@@ -5760,22 +5754,19 @@
     "Override Corner Radius": "Sobrescrever Arredondamento"
   },
   "Override floating window transparency for Notepad": {
-    "Override floating window transparency for Notepad": ""
+    "Override floating window transparency for Notepad": "Substituir a transparência das janelas flutuantes para o Bloco de Notas"
   },
   "Override global layout settings for this output": {
     "Override global layout settings for this output": "Substituir configurações de layout global para esta saída"
   },
-  "Override global transparency for Notepad": {
-    "Override global transparency for Notepad": ""
-  },
   "Override terminal with a custom command or script": {
-    "Override terminal with a custom command or script": ""
+    "Override terminal with a custom command or script": "Substituir o terminal por um comando ou script personalizado"
   },
   "Override the global shadow with per-bar settings": {
-    "Override the global shadow with per-bar settings": ""
+    "Override the global shadow with per-bar settings": "Substituir a sombra global com configurações por barra"
   },
   "Override the popup gap size when auto is disabled": {
-    "Override the popup gap size when auto is disabled": ""
+    "Override the popup gap size when auto is disabled": "Substituir o tamanho da lacuna do popup quando o modo automático estiver desativado"
   },
   "Overrides": {
     "Overrides": "Sobrescritas"
@@ -5787,22 +5778,22 @@
     "Overview of your network connections": "Visão geral das suas conexões de rede"
   },
   "Owner: %1": {
-    "Owner: %1": ""
+    "Owner: %1": "Proprietário: %1"
   },
   "PAM already provides fingerprint auth. Enable this to show it at login.": {
-    "PAM already provides fingerprint auth. Enable this to show it at login.": ""
+    "PAM already provides fingerprint auth. Enable this to show it at login.": "O PAM já fornece autenticação por impressão digital. Ative isso para mostrá-la no login."
   },
   "PAM already provides security-key auth. Enable this to show it at login.": {
-    "PAM already provides security-key auth. Enable this to show it at login.": ""
+    "PAM already provides security-key auth. Enable this to show it at login.": "O PAM já fornece autenticação por chave de segurança. Ative isso para mostrá-la no login."
   },
   "PDF Reader": {
-    "PDF Reader": ""
+    "PDF Reader": "Leitor de PDF"
   },
   "PIN": {
     "PIN": "PIN"
   },
   "Package name (e.g., docker)": {
-    "Package name (e.g., docker)": ""
+    "Package name (e.g., docker)": "Nome do pacote (ex.: docker)"
   },
   "Pad": {
     "Pad": "Pad"
@@ -5826,7 +5817,7 @@
     "Pairing failed": "Erro ao emparelhar"
   },
   "Pairing request from %1": {
-    "Pairing request from %1": ""
+    "Pairing request from %1": "Solicitação de pareamento de %1"
   },
   "Pairing request sent": {
     "Pairing request sent": "Solicitação de pareamento enviada"
@@ -5838,7 +5829,7 @@
     "Pairing...": "Pareando..."
   },
   "Partial": {
-    "Partial": ""
+    "Partial": "Parcial"
   },
   "Partly Cloudy": {
     "Partly Cloudy": "Parcialmente Nublado"
@@ -5853,25 +5844,25 @@
     "Password cannot be empty": "A senha não pode estar vazia"
   },
   "Password change failed (exit %1)": {
-    "Password change failed (exit %1)": ""
+    "Password change failed (exit %1)": "Falha na alteração da senha (saída %1)"
   },
   "Password set": {
-    "Password set": ""
+    "Password set": "Senha definida"
   },
   "Password updated": {
     "Password updated": "Senha atualizada"
   },
   "Passwords do not match.": {
-    "Passwords do not match.": ""
+    "Passwords do not match.": "As senhas não coincidem."
   },
   "Paste": {
     "Paste": "Colar"
   },
   "Paste failed: %1": {
-    "Paste failed: %1": ""
+    "Paste failed: %1": "Falha ao colar: %1"
   },
   "Path copied to clipboard": {
-    "Path copied to clipboard": ""
+    "Path copied to clipboard": "Caminho copiado para a área de transferência"
   },
   "Path to a video file or folder containing videos": {
     "Path to a video file or folder containing videos": "Caminho para um arquivo de vídeo ou pasta de vídeos"
@@ -5895,7 +5886,7 @@
     "Pending Discharge": "Descarga Pendente"
   },
   "Per Window": {
-    "Per Window": ""
+    "Per Window": "Por Janela"
   },
   "Per-Mode Wallpapers": {
     "Per-Mode Wallpapers": "Papéis de Parede por Modo"
@@ -5913,7 +5904,7 @@
     "Performance": "Desempenho"
   },
   "Permanently delete %1 item(s)? This cannot be undone.": {
-    "Permanently delete %1 item(s)? This cannot be undone.": ""
+    "Permanently delete %1 item(s)? This cannot be undone.": "Excluir permanentemente %1 item(ns)? Isso não pode ser desfeito."
   },
   "Permission denied to set profile image.": {
     "Permission denied to set profile image.": "Permissão negada ao definir imagem de perfil."
@@ -5928,13 +5919,13 @@
     "Phone number": "Número de telefone"
   },
   "Pick a different file manager in Settings → Dock → Trash.": {
-    "Pick a different file manager in Settings → Dock → Trash.": ""
+    "Pick a different file manager in Settings → Dock → Trash.": "Escolha um gerenciador de arquivos diferente em Configurações → Dock → Lixeira."
   },
   "Pick a different random video each time from the same folder": {
-    "Pick a different random video each time from the same folder": ""
+    "Pick a different random video each time from the same folder": "Escolher um vídeo aleatório diferente a cada vez da mesma pasta"
   },
   "Pick how long to pause notifications": {
-    "Pick how long to pause notifications": ""
+    "Pick how long to pause notifications": "Escolha por quanto tempo pausar as notificações"
   },
   "Pin": {
     "Pin": "Fixar"
@@ -5946,7 +5937,7 @@
     "Ping": "Ping"
   },
   "Ping sent to %1": {
-    "Ping sent to %1": ""
+    "Ping sent to %1": "Ping enviado para %1"
   },
   "Pinned": {
     "Pinned": "Fixado"
@@ -5958,7 +5949,7 @@
     "Pixelate": "Pixelizar"
   },
   "Place a trash bin at the end of the dock": {
-    "Place a trash bin at the end of the dock": ""
+    "Place a trash bin at the end of the dock": "Colocar uma lixeira no final do dock"
   },
   "Place plugin directories here. Each plugin should have a plugin.json manifest file.": {
     "Place plugin directories here. Each plugin should have a plugin.json manifest file.": "Use este local para os diretórios de plugin. Cada plugin deve ter um arquivo de manifesto plugin.json."
@@ -5967,19 +5958,19 @@
     "Place plugins in %1": "Coloque plugins em %1"
   },
   "Place the bar on the Wayland overlay layer": {
-    "Place the bar on the Wayland overlay layer": ""
+    "Place the bar on the Wayland overlay layer": "Colocar a barra na camada de sobreposição do Wayland"
   },
   "Place the dock on the Wayland overlay layer": {
-    "Place the dock on the Wayland overlay layer": ""
+    "Place the dock on the Wayland overlay layer": "Colocar o dock na camada de sobreposição do Wayland"
   },
   "Play": {
-    "Play": ""
+    "Play": "Reproduzir"
   },
   "Play a video when the screen locks.": {
-    "Play a video when the screen locks.": ""
+    "Play a video when the screen locks.": "Reproduzir um vídeo quando a tela for bloqueada."
   },
   "Play sound after logging in": {
-    "Play sound after logging in": ""
+    "Play sound after logging in": "Reproduzir som após entrar"
   },
   "Play sound when new notification arrives": {
     "Play sound when new notification arrives": "Reproduzir som ao conectar o cabo de energia"
@@ -5994,10 +5985,10 @@
     "Playback": "Reprodução"
   },
   "Playback error: ": {
-    "Playback error: ": ""
+    "Playback error: ": "Erro de reprodução: "
   },
   "Plays audio files": {
-    "Plays audio files": ""
+    "Plays audio files": "Reproduz arquivos de áudio"
   },
   "Please wait...": {
     "Please wait...": "Aguarde..."
@@ -6021,25 +6012,25 @@
     "Plugin Visibility": "Visibilidade do Plugin"
   },
   "Plugin dependency missing": {
-    "Plugin dependency missing": ""
+    "Plugin dependency missing": "Dependência do plugin ausente"
   },
   "Plugin disabled: %1": {
-    "Plugin disabled: %1": ""
+    "Plugin disabled: %1": "Plugin desativado: %1"
   },
   "Plugin enabled: %1": {
-    "Plugin enabled: %1": ""
+    "Plugin enabled: %1": "Plugin ativado: %1"
   },
   "Plugin is disabled - enable in Plugins settings to use": {
     "Plugin is disabled - enable in Plugins settings to use": "Plugin está desativado - ative em configurações de Plugins para usar"
   },
   "Plugin reloaded: %1": {
-    "Plugin reloaded: %1": ""
+    "Plugin reloaded: %1": "Plugin recarregado: %1"
   },
   "Plugin uninstalled: %1": {
-    "Plugin uninstalled: %1": ""
+    "Plugin uninstalled: %1": "Plugin desinstalado: %1"
   },
   "Plugin updated: %1": {
-    "Plugin updated: %1": ""
+    "Plugin updated: %1": "Plugin atualizado: %1"
   },
   "Plugins": {
     "Plugins": "Plugins"
@@ -6048,16 +6039,16 @@
     "Pointer": "Ponteiro"
   },
   "Pointer Speed": {
-    "Pointer Speed": ""
+    "Pointer Speed": "Velocidade do Ponteiro"
   },
   "Polkit integration is disabled. User management requires Polkit to elevate privileges.": {
-    "Polkit integration is disabled. User management requires Polkit to elevate privileges.": ""
+    "Polkit integration is disabled. User management requires Polkit to elevate privileges.": "A integração com o Polkit está desativada. O gerenciamento de usuários requer o Polkit para elevar privilégios."
   },
   "Popout": {
-    "Popout": ""
+    "Popout": "Popout"
   },
   "Popout Shadows": {
-    "Popout Shadows": ""
+    "Popout Shadows": "Sombras de Popout"
   },
   "Popouts": {
     "Popouts": "Popouts"
@@ -6078,10 +6069,10 @@
     "Popup behavior, position": "Comportamento de pop-up, posição"
   },
   "Popups": {
-    "Popups": ""
+    "Popups": "Popups"
   },
   "Port": {
-    "Port": ""
+    "Port": "Porta"
   },
   "Portal": {
     "Portal": "Portal"
@@ -6111,7 +6102,10 @@
     "Power Menu Customization": "Customização do Menu de Energia"
   },
   "Power Mode": {
-    "Power Mode": ""
+    "Power Mode": "Modo de Energia"
+  },
+  "Power Off": {
+    "Power Off": "Desligar"
   },
   "Power Profile": {
     "Power Profile": "Perfil de Energia"
@@ -6120,7 +6114,7 @@
     "Power Profile Degradation": "Degradação do Perfil de Energia"
   },
   "Power Profiles & Saving": {
-    "Power Profiles & Saving": ""
+    "Power Profiles & Saving": "Perfis de Energia e Economia"
   },
   "Power Saver": {
     "Power Saver": "Economia de Energia"
@@ -6135,10 +6129,10 @@
     "Power source": "Fonte de energia"
   },
   "Pre-fill the last successful username on the greeter": {
-    "Pre-fill the last successful username on the greeter": ""
+    "Pre-fill the last successful username on the greeter": "Preencher previamente o último nome de usuário bem-sucedido no greeter"
   },
   "Pre-select the last used session on the greeter": {
-    "Pre-select the last used session on the greeter": ""
+    "Pre-select the last used session on the greeter": "Pré-selecionar a última sessão usada no greeter"
   },
   "Precip": {
     "Precip": "Precipitação"
@@ -6156,10 +6150,10 @@
     "Preset Widths (%)": "Larguras Predefinidas (%)"
   },
   "Press Ctrl+N or click 'New Session' to create one": {
-    "Press Ctrl+N or click 'New Session' to create one": ""
+    "Press Ctrl+N or click 'New Session' to create one": "Pressione Ctrl+N ou clique em 'Nova Sessão' para criar uma"
   },
   "Press Ctrl+key to set. Esc cancels.": {
-    "Press Ctrl+key to set. Esc cancels.": ""
+    "Press Ctrl+key to set. Esc cancels.": "Pressione Ctrl+tecla para definir. Esc cancela."
   },
   "Press Enter and the audio system will restart to apply the change": {
     "Press Enter and the audio system will restart to apply the change": "Pressione Enter e o sistema de áudio reiniciará para aplicar a mudança"
@@ -6174,25 +6168,25 @@
     "Pressure": "Pressão"
   },
   "Prevent accidental cursor jumps while typing": {
-    "Prevent accidental cursor jumps while typing": ""
+    "Prevent accidental cursor jumps while typing": "Evitar saltos acidentais do cursor ao digitar"
   },
   "Prevent screen timeout": {
     "Prevent screen timeout": "Impedir suspensão da tela"
   },
   "Prevent specific applications from displaying in the media controllers (e.g., browser audio streams, background tools). Matches player identity or desktop file name case-insensitively.": {
-    "Prevent specific applications from displaying in the media controllers (e.g., browser audio streams, background tools). Matches player identity or desktop file name case-insensitively.": ""
+    "Prevent specific applications from displaying in the media controllers (e.g., browser audio streams, background tools). Matches player identity or desktop file name case-insensitively.": "Impedir que aplicativos específicos apareçam nos controladores de mídia (ex.: fluxos de áudio do navegador, ferramentas em segundo plano). Corresponde à identidade do reprodutor ou ao nome do arquivo .desktop sem diferenciar maiúsculas e minúsculas."
   },
   "Preview": {
     "Preview": "Pré-visualização"
   },
   "Preview: %1": {
-    "Preview: %1": ""
+    "Preview: %1": "Visualizar: %1"
   },
   "Previous": {
-    "Previous": ""
+    "Previous": "Anterior"
   },
   "Previous page": {
-    "Previous page": ""
+    "Previous page": "Página anterior"
   },
   "Primary": {
     "Primary": "Primário"
@@ -6222,7 +6216,7 @@
     "Printer name (no spaces)": "Nome da impressora (sem espaços)"
   },
   "Printer reachable": {
-    "Printer reachable": ""
+    "Printer reachable": "Impressora acessível"
   },
   "Printers": {
     "Printers": "Impressoras"
@@ -6246,7 +6240,7 @@
     "Process Count": "Contador de Processos"
   },
   "Process exited with code %1": {
-    "Process exited with code %1": ""
+    "Process exited with code %1": "O processo foi encerrado com o código %1"
   },
   "Processes": {
     "Processes": "Processos"
@@ -6276,43 +6270,43 @@
     "Profile not found": "Perfil não encontrado"
   },
   "Profile not found in monitors.json": {
-    "Profile not found in monitors.json": ""
+    "Profile not found in monitors.json": "Perfil não encontrado em monitors.json"
   },
   "Profile saved: %1": {
     "Profile saved: %1": "Perfil salvo: %1"
   },
   "Profile when Plugged In (AC)": {
-    "Profile when Plugged In (AC)": ""
+    "Profile when Plugged In (AC)": "Perfil quando Conectado (AC)"
   },
   "Profile when on Battery": {
-    "Profile when on Battery": ""
+    "Profile when on Battery": "Perfil na Bateria"
   },
   "Protection": {
-    "Protection": ""
+    "Protection": "Proteção"
   },
   "Protocol": {
     "Protocol": "Protocolo"
   },
   "QR Generator": {
-    "QR Generator": ""
+    "QR Generator": "Gerador de QR"
   },
   "Qt": {
-    "Qt": ""
+    "Qt": "Qt"
   },
   "Qt colors applied successfully": {
-    "Qt colors applied successfully": ""
+    "Qt colors applied successfully": "Cores Qt aplicadas com sucesso"
   },
   "Qt: distance-field renderer.": {
-    "Qt: distance-field renderer.": ""
+    "Qt: distance-field renderer.": "Qt: renderizador de campo de distância."
   },
   "QtMultimedia is not available": {
     "QtMultimedia is not available": "QtMultimedia não está disponível"
   },
   "QtMultimedia is not available - video screensaver requires qt multimedia services": {
-    "QtMultimedia is not available - video screensaver requires qt multimedia services": ""
+    "QtMultimedia is not available - video screensaver requires qt multimedia services": "QtMultimedia não está disponível - o protetor de tela de vídeo requer os serviços multimídia do Qt"
   },
   "Quality": {
-    "Quality": ""
+    "Quality": "Qualidade"
   },
   "Quick access to application launcher": {
     "Quick access to application launcher": "Acesso rápido ao lançador de aplicativos"
@@ -6348,40 +6342,43 @@
     "Random": "Aleatório"
   },
   "Random Order": {
-    "Random Order": ""
+    "Random Order": "Ordem Aleatória"
   },
   "Rate": {
     "Rate": "Taxa"
   },
   "Re-enter password": {
-    "Re-enter password": ""
+    "Re-enter password": "Digite a senha novamente"
   },
   "Re-enter the password before saving.": {
-    "Re-enter the password before saving.": ""
+    "Re-enter the password before saving.": "Digite a senha novamente antes de salvar."
   },
   "Reach local network devices while using an exit node": {
-    "Reach local network devices while using an exit node": ""
+    "Reach local network devices while using an exit node": "Alcançar dispositivos da rede local ao usar um nó de saída"
   },
   "Read-only legacy config": {
-    "Read-only legacy config": ""
+    "Read-only legacy config": "Configuração legada somente leitura"
   },
   "Read:": {
     "Read:": "Leitura:"
   },
   "Ready": {
-    "Ready": ""
+    "Ready": "Pronto"
   },
   "Reason": {
     "Reason": "Razão"
   },
+  "Reboot": {
+    "Reboot": "Reiniciar"
+  },
   "Recent": {
-    "Recent": ""
+    "Recent": "Recentes"
   },
   "Recent Colors": {
     "Recent Colors": "Cores Recentes"
   },
   "Recent Images": {
-    "Recent Images": ""
+    "Recent Images": "Imagens Recentes"
   },
   "Recently Used Apps": {
     "Recently Used Apps": "Apps Usados Recentemente"
@@ -6396,16 +6393,16 @@
     "Refresh Weather": "Atualizar Clima"
   },
   "Refreshing...": {
-    "Refreshing...": ""
+    "Refreshing...": "Atualizando..."
   },
   "Regex": {
     "Regex": "Regex"
   },
   "Registries": {
-    "Registries": ""
+    "Registries": "Registros"
   },
   "Regular": {
-    "Regular": ""
+    "Regular": "Regular"
   },
   "Reject": {
     "Reject": "Rejeitar"
@@ -6414,16 +6411,16 @@
     "Reject Jobs": "Rejeitar Trabalhos"
   },
   "Related: %1": {
-    "Related: %1": ""
+    "Related: %1": "Relacionado: %1"
   },
   "Release": {
     "Release": "Soltar"
   },
   "Release to confirm": {
-    "Release to confirm": ""
+    "Release to confirm": "Solte para confirmar"
   },
   "Reload From Disk": {
-    "Reload From Disk": ""
+    "Reload From Disk": "Recarregar do Disco"
   },
   "Reload Plugin": {
     "Reload Plugin": "Reiniciar Plugin"
@@ -6435,16 +6432,16 @@
     "Remaining / Total": "Restante / Total"
   },
   "Remember Last Mode": {
-    "Remember Last Mode": ""
+    "Remember Last Mode": "Lembrar Último Modo"
   },
   "Remember Last Query": {
-    "Remember Last Query": ""
+    "Remember Last Query": "Lembrar Última Consulta"
   },
   "Remember Layout": {
-    "Remember Layout": ""
+    "Remember Layout": "Lembrar Layout"
   },
   "Remember Type Filter": {
-    "Remember Type Filter": ""
+    "Remember Type Filter": "Lembrar Filtro de Tipo"
   },
   "Remember last session": {
     "Remember last session": "Lembrar última sessão"
@@ -6453,13 +6450,13 @@
     "Remember last user": "Lembrar último usuário"
   },
   "Reminder": {
-    "Reminder": ""
+    "Reminder": "Lembrete"
   },
   "Remove": {
     "Remove": "Remover"
   },
   "Remove \"%1\" from the %2 group?": {
-    "Remove \"%1\" from the %2 group?": ""
+    "Remove \"%1\" from the %2 group?": "Remover \"%1\" do grupo %2?"
   },
   "Remove Shortcut?": {
     "Remove Shortcut?": "Remover Atalho?"
@@ -6468,37 +6465,37 @@
     "Remove Widget Padding": "Remover Preenchimento de Widgets"
   },
   "Remove admin": {
-    "Remove admin": ""
+    "Remove admin": "Remover administrador"
   },
   "Remove corner rounding from the bar": {
-    "Remove corner rounding from the bar": ""
+    "Remove corner rounding from the bar": "Remover o arredondamento dos cantos da barra"
   },
   "Remove gaps and border when windows are maximized": {
     "Remove gaps and border when windows are maximized": "Remover espaçámentos e borda quando janelas estão maximizadas"
   },
   "Remove greeter access?": {
-    "Remove greeter access?": ""
+    "Remove greeter access?": "Remover o acesso ao greeter?"
   },
   "Remove greeter login access": {
-    "Remove greeter login access": ""
+    "Remove greeter login access": "Remover acesso de login do greeter"
   },
   "Remove inner padding from all widgets": {
-    "Remove inner padding from all widgets": ""
+    "Remove inner padding from all widgets": "Remover o preenchimento interno de todos os widgets"
   },
   "Remove match": {
-    "Remove match": ""
+    "Remove match": "Remover correspondência"
   },
   "Remove the shortcut %1?": {
-    "Remove the shortcut %1?": ""
+    "Remove the shortcut %1?": "Remover o atalho %1?"
   },
   "Remove the shortcut %1? An unbind entry will be saved to dms/binds-user.lua so it stays removed across DMS updates.": {
-    "Remove the shortcut %1? An unbind entry will be saved to dms/binds-user.lua so it stays removed across DMS updates.": ""
+    "Remove the shortcut %1? An unbind entry will be saved to dms/binds-user.lua so it stays removed across DMS updates.": "Remover o atalho %1? Uma entrada de desvinculação será salva em dms/binds-user.lua para que permaneça removido nas atualizações do DMS."
   },
   "Removed administrator privileges": {
-    "Removed administrator privileges": ""
+    "Removed administrator privileges": "Privilégios de administrador removidos"
   },
   "Removed greeter login access": {
-    "Removed greeter login access": ""
+    "Removed greeter login access": "Acesso de login do greeter removido"
   },
   "Rename": {
     "Rename": "Renomear"
@@ -6510,16 +6507,16 @@
     "Rename Workspace": "Renomear Espaço de Trabalho"
   },
   "Reorder & Group": {
-    "Reorder & Group": ""
+    "Reorder & Group": "Reordenar e Agrupar"
   },
   "Repeat": {
     "Repeat": "Repetir"
   },
   "Repeat Delay": {
-    "Repeat Delay": ""
+    "Repeat Delay": "Atraso de Repetição"
   },
   "Repeat Rate": {
-    "Repeat Rate": ""
+    "Repeat Rate": "Taxa de Repetição"
   },
   "Replacement": {
     "Replacement": "Substituição"
@@ -6546,25 +6543,25 @@
     "Requires DMS %1": "Requer DMS %1"
   },
   "Requires DMS server with sysupdate capability": {
-    "Requires DMS server with sysupdate capability": ""
+    "Requires DMS server with sysupdate capability": "Requer servidor DMS com capacidade de atualização do sistema"
   },
   "Requires MangoWC compositor": {
-    "Requires MangoWC compositor": ""
+    "Requires MangoWC compositor": "Requer o compositor MangoWC"
   },
   "Requires a newer version of Quickshell": {
-    "Requires a newer version of Quickshell": ""
+    "Requires a newer version of Quickshell": "Requer uma versão mais recente do Quickshell"
   },
   "Requires greetd, dms-greeter, and your user in the greeter group (plus fprintd/pam_fprintd for fingerprint, pam_u2f for security keys).": {
-    "Requires greetd, dms-greeter, and your user in the greeter group (plus fprintd/pam_fprintd for fingerprint, pam_u2f for security keys).": ""
+    "Requires greetd, dms-greeter, and your user in the greeter group (plus fprintd/pam_fprintd for fingerprint, pam_u2f for security keys).": "Requer greetd, dms-greeter e seu usuário no grupo do greeter (além de fprintd/pam_fprintd para impressão digital e pam_u2f para chaves de segurança)."
   },
   "Requires night mode support": {
     "Requires night mode support": "Requer suporte a modo noturno"
   },
   "Requires remembering the last user and session. Enable those options first.": {
-    "Requires remembering the last user and session. Enable those options first.": ""
+    "Requires remembering the last user and session. Enable those options first.": "Requer lembrar o último usuário e sessão. Ative essas opções primeiro."
   },
   "Requires the DMS Theme extension from the editor marketplace": {
-    "Requires the DMS Theme extension from the editor marketplace": ""
+    "Requires the DMS Theme extension from the editor marketplace": "Requer a extensão DMS Theme do mercado do editor"
   },
   "Reset": {
     "Reset": "Resetar"
@@ -6576,7 +6573,7 @@
     "Reset Size": "Restaurar Tamanho"
   },
   "Reset to default": {
-    "Reset to default": ""
+    "Reset to default": "Redefinir para o padrão"
   },
   "Reset to default name": {
     "Reset to default name": "Redefinir para o nome padrão"
@@ -6585,10 +6582,10 @@
     "Resize Widget": "Redimensionar Widget"
   },
   "Resize on Border": {
-    "Resize on Border": ""
+    "Resize on Border": "Redimensionar na Borda"
   },
   "Resize windows by dragging their edges with the mouse": {
-    "Resize windows by dragging their edges with the mouse": ""
+    "Resize windows by dragging their edges with the mouse": "Redimensionar janelas arrastando suas bordas com o mouse"
   },
   "Resolution & Refresh": {
     "Resolution & Refresh": "Resolução & Taxa de Atualização"
@@ -6603,31 +6600,31 @@
     "Restart the DankMaterialShell": "Reinicie o DankMaterialShell"
   },
   "Restart userspace without rebooting the kernel, requires systemd": {
-    "Restart userspace without rebooting the kernel, requires systemd": ""
+    "Restart userspace without rebooting the kernel, requires systemd": "Reiniciar o espaço do usuário sem reiniciar o kernel, requer systemd"
   },
   "Restarting audio system...": {
     "Restarting audio system...": "Reiniciando sistema de áudio..."
   },
   "Restore Special Workspace Windows": {
-    "Restore Special Workspace Windows": ""
+    "Restore Special Workspace Windows": "Restaurar Janelas de Espaço de Trabalho Especial"
   },
   "Restore the last selected mode (tab) when the launcher is opened": {
-    "Restore the last selected mode (tab) when the launcher is opened": ""
+    "Restore the last selected mode (tab) when the launcher is opened": "Restaurar o último modo (aba) selecionado quando o inicializador for aberto"
   },
   "Resume": {
     "Resume": "Resumir"
   },
   "Reveal the arcs where surfaces meet the frame": {
-    "Reveal the arcs where surfaces meet the frame": ""
+    "Reveal the arcs where surfaces meet the frame": "Revelar os arcos onde as superfícies encontram o frame"
   },
   "Reverse Scrolling Direction": {
     "Reverse Scrolling Direction": "Inverter Direção do Scroll"
   },
   "Reverse mouse wheel scrolling direction": {
-    "Reverse mouse wheel scrolling direction": ""
+    "Reverse mouse wheel scrolling direction": "Inverter a direção de rolagem da roda do mouse"
   },
   "Reverse two-finger scrolling direction": {
-    "Reverse two-finger scrolling direction": ""
+    "Reverse two-finger scrolling direction": "Inverter a direção de rolagem com dois dedos"
   },
   "Reverse workspace switch direction when scrolling over the bar": {
     "Reverse workspace switch direction when scrolling over the bar": "Inverter direção de troca de área de trabalho ao rolar sobre a barra"
@@ -6636,7 +6633,7 @@
     "Revert": "Reverter"
   },
   "Rewind 10s": {
-    "Rewind 10s": ""
+    "Rewind 10s": "Voltar 10s"
   },
   "Right": {
     "Right": "Direita"
@@ -6663,7 +6660,7 @@
     "Ring": "Tocar"
   },
   "Ringing %1...": {
-    "Ringing %1...": ""
+    "Ringing %1...": "Chamando %1..."
   },
   "Ripple Effects": {
     "Ripple Effects": "Efeitos de Ondulação"
@@ -6678,19 +6675,19 @@
     "Rule": "Regra"
   },
   "Rule %1": {
-    "Rule %1": ""
+    "Rule %1": "Regra %1"
   },
   "Rule Name": {
     "Rule Name": "Nome da Regra"
   },
   "Rules": {
-    "Rules": ""
+    "Rules": "Regras"
   },
   "Rules (%1)": {
     "Rules (%1)": "Regras (%1)"
   },
   "Rules found in your compositor config. These are read-only here, use Convert to DMS to make an editable copy.": {
-    "Rules found in your compositor config. These are read-only here, use Convert to DMS to make an editable copy.": ""
+    "Rules found in your compositor config. These are read-only here, use Convert to DMS to make an editable copy.": "Regras encontradas na configuração do seu compositor. Aqui são somente leitura; use Converter para DMS para fazer uma cópia editável."
   },
   "Run Again": {
     "Run Again": "Executar Novamente"
@@ -6708,10 +6705,10 @@
     "Run a shell command (e.g., notify-send)": "Rodar um comando do shell (ex. notify-send)"
   },
   "Run paru/yay with AUR enabled when 'Update All' is clicked.": {
-    "Run paru/yay with AUR enabled when 'Update All' is clicked.": ""
+    "Run paru/yay with AUR enabled when 'Update All' is clicked.": "Executar paru/yay com AUR ativado quando 'Atualizar Tudo' for clicado."
   },
   "Running": {
-    "Running": ""
+    "Running": "Em execução"
   },
   "Running Apps": {
     "Running Apps": "Apps Em Execução"
@@ -6720,10 +6717,10 @@
     "Running Apps Settings": "Configurações de Apps em Execução"
   },
   "Running greeter sync...": {
-    "Running greeter sync...": ""
+    "Running greeter sync...": "Executando sincronização do greeter..."
   },
   "Running in terminal": {
-    "Running in terminal": ""
+    "Running in terminal": "Executando no terminal"
   },
   "SDR Brightness": {
     "SDR Brightness": "Brilho SDR"
@@ -6735,16 +6732,19 @@
     "SMS": "SMS"
   },
   "SMS sent successfully": {
-    "SMS sent successfully": ""
+    "SMS sent successfully": "SMS enviado com sucesso"
   },
   "SSID": {
-    "SSID": ""
+    "SSID": "SSID"
   },
   "Saturation": {
-    "Saturation": ""
+    "Saturation": "Saturação"
+  },
+  "Save": {
+    "Save": "Salvar"
   },
   "Save & Start": {
-    "Save & Start": ""
+    "Save & Start": "Salvar e Iniciar"
   },
   "Save Notepad File": {
     "Save Notepad File": "Salvar Arquivo do Bloco de Notas"
@@ -6762,7 +6762,7 @@
     "Save and switch between display configurations": "Salvar e alternar entre configurações de exibição"
   },
   "Save credentials": {
-    "Save credentials": ""
+    "Save credentials": "Salvar credenciais"
   },
   "Save critical priority notifications to history": {
     "Save critical priority notifications to history": "Salvar notificações de prioridade crítica no histórico"
@@ -6786,7 +6786,7 @@
     "Saved Configurations": "Configurações Salvas"
   },
   "Saved Networks": {
-    "Saved Networks": ""
+    "Saved Networks": "Redes Salvas"
   },
   "Saved Note": {
     "Saved Note": "Nota Salva"
@@ -6825,7 +6825,7 @@
     "Screen sharing": "Compartilhamento de tela"
   },
   "Screenshot unavailable": {
-    "Screenshot unavailable": ""
+    "Screenshot unavailable": "Captura de tela indisponível"
   },
   "Scroll": {
     "Scroll": "Rolagem"
@@ -6834,10 +6834,10 @@
     "Scroll Factor": "Fator de Rolagem"
   },
   "Scroll GitHub": {
-    "Scroll GitHub": ""
+    "Scroll GitHub": "Rolar GitHub"
   },
   "Scroll Method": {
-    "Scroll Method": ""
+    "Scroll Method": "Método de Rolagem"
   },
   "Scroll Wheel": {
     "Scroll Wheel": "Roda de Rolagem"
@@ -6855,7 +6855,7 @@
     "Scrolling": "Scrolling"
   },
   "Scrolling Speed": {
-    "Scrolling Speed": ""
+    "Scrolling Speed": "Velocidade de Rolagem"
   },
   "Search App Actions": {
     "Search App Actions": "Pesquisar Ações do Aplicativo"
@@ -6864,16 +6864,16 @@
     "Search Options": "Opções de Pesquisa"
   },
   "Search applications...": {
-    "Search applications...": ""
+    "Search applications...": "Pesquisar aplicativos..."
   },
   "Search by key combo, description, or action name.\n\nDefault action copies the keybind to clipboard.\nRight-click or press Right Arrow to pin frequently used keybinds - they'll appear at the top when not searching.": {
     "Search by key combo, description, or action name.\n\nDefault action copies the keybind to clipboard.\nRight-click or press Right Arrow to pin frequently used keybinds - they'll appear at the top when not searching.": "Buscar por combinação de teclas, descrição ou nome de ação.\n\nA ação padrão copia o atalho para a área de transferência.\nClique com o botão direito ou pressione Seta para a Direita para fixar atalhos usados com frequência - eles aparecerão no topo quando não estiver pesquisando."
   },
   "Search devices...": {
-    "Search devices...": ""
+    "Search devices...": "Pesquisar dispositivos..."
   },
   "Search installed plugins...": {
-    "Search installed plugins...": ""
+    "Search installed plugins...": "Pesquisar plugins instalados..."
   },
   "Search keybinds...": {
     "Search keybinds...": "Pesquisar atalhos..."
@@ -6888,7 +6888,7 @@
     "Search processes...": "Buscar processos..."
   },
   "Search sessions...": {
-    "Search sessions...": ""
+    "Search sessions...": "Pesquisar sessões..."
   },
   "Search themes...": {
     "Search themes...": "Pesquisar temas..."
@@ -6896,17 +6896,20 @@
   "Search widgets...": {
     "Search widgets...": "Procurar widgets..."
   },
+  "Search...": {
+    "Search...": "Buscar..."
+  },
   "Searching...": {
     "Searching...": "Pesquisando..."
   },
   "Second Factor (AND)": {
-    "Second Factor (AND)": ""
+    "Second Factor (AND)": "Segundo Fator (E)"
   },
   "Secondary": {
     "Secondary": "Secundário"
   },
   "Secondary Container": {
-    "Secondary Container": ""
+    "Secondary Container": "Contêiner Secundário"
   },
   "Secured": {
     "Secured": "Seguro"
@@ -6918,25 +6921,25 @@
     "Security & privacy": "Segurança e privacidade"
   },
   "Security Key PAM Source": {
-    "Security Key PAM Source": ""
+    "Security Key PAM Source": "Fonte PAM da Chave de Segurança"
   },
   "Security key": {
-    "Security key": ""
+    "Security key": "Chave de segurança"
   },
   "Security key (%1)": {
-    "Security key (%1)": ""
+    "Security key (%1)": "Chave de segurança (%1)"
   },
   "Security key mode": {
-    "Security key mode": ""
+    "Security key mode": "Modo de chave de segurança"
   },
   "Security key shortcut": {
-    "Security key shortcut": ""
+    "Security key shortcut": "Atalho da chave de segurança"
   },
   "Security-key availability could not be confirmed": {
-    "Security-key availability could not be confirmed": ""
+    "Security-key availability could not be confirmed": "Não foi possível confirmar a disponibilidade da chave de segurança"
   },
   "Security-key support was detected, but no registered key was found yet. You can enable this now and register one later.": {
-    "Security-key support was detected, but no registered key was found yet. You can enable this now and register one later.": ""
+    "Security-key support was detected, but no registered key was found yet. You can enable this now and register one later.": "O suporte a chave de segurança foi detectado, mas nenhuma chave registrada foi encontrada ainda. Você pode ativar isso agora e registrar uma depois."
   },
   "Select": {
     "Select": "Selecionar"
@@ -6963,7 +6966,7 @@
     "Select Profile Image": "Selecionar Imagem de Perfil"
   },
   "Select Video or Folder": {
-    "Select Video or Folder": ""
+    "Select Video or Folder": "Selecionar Vídeo ou Pasta"
   },
   "Select Wallpaper": {
     "Select Wallpaper": "Selecionar Papel de Parede"
@@ -6975,10 +6978,10 @@
     "Select a color from the palette or use custom sliders": "Escolha uma cor na paleta ou use controles deslizantes"
   },
   "Select a desktop application": {
-    "Select a desktop application": ""
+    "Select a desktop application": "Selecionar um aplicativo da área de trabalho"
   },
   "Select a random wallpaper instead of cycling in alphabetical order": {
-    "Select a random wallpaper instead of cycling in alphabetical order": ""
+    "Select a random wallpaper instead of cycling in alphabetical order": "Selecionar um papel de parede aleatório em vez de percorrer em ordem alfabética"
   },
   "Select a widget to add to your desktop. Each widget is a separate instance with its own settings.": {
     "Select a widget to add to your desktop. Each widget is a separate instance with its own settings.": "Selecione um widget para adicionar à sua área de trabalho. Cada widget é uma instância separada com suas próprias configurações."
@@ -6990,7 +6993,7 @@
     "Select a window...": "Selecionar uma janela..."
   },
   "Select an active session to switch to. The current session stays running in the background.": {
-    "Select an active session to switch to. The current session stays running in the background.": ""
+    "Select an active session to switch to. The current session stays running in the background.": "Selecione uma sessão ativa para alternar. A sessão atual permanece em execução em segundo plano."
   },
   "Select an image file...": {
     "Select an image file...": "Selecione um arquivo de imagem..."
@@ -6999,7 +7002,7 @@
     "Select at least one provider": "Selecione pelo menos um provedor"
   },
   "Select background image": {
-    "Select background image": ""
+    "Select background image": "Selecionar imagem de fundo"
   },
   "Select device": {
     "Select device": "Selecionar dispositivo"
@@ -7014,10 +7017,10 @@
     "Select font weight for UI text": "Selecione a espessura da fonte para o texto da UI"
   },
   "Select greeter background image": {
-    "Select greeter background image": ""
+    "Select greeter background image": "Selecionar imagem de fundo do greeter"
   },
   "Select lock screen background image": {
-    "Select lock screen background image": ""
+    "Select lock screen background image": "Selecionar imagem de fundo da tela de bloqueio"
   },
   "Select monospace font for process list and technical displays": {
     "Select monospace font for process list and technical displays": "Selecionar fonte monoespaçada para a lista de processos e telas técnicas"
@@ -7053,19 +7056,19 @@
     "Send SMS": "Enviar SMS"
   },
   "Sending %1...": {
-    "Sending %1...": ""
+    "Sending %1...": "Enviando %1..."
   },
   "Separate": {
-    "Separate": ""
+    "Separate": "Separado"
   },
   "Separate Appearance for Unfocused Display(s)": {
-    "Separate Appearance for Unfocused Display(s)": ""
+    "Separate Appearance for Unfocused Display(s)": "Aparência Separada para Monitor(es) Não Focado(s)"
   },
   "Separate Light & Dark Themes": {
-    "Separate Light & Dark Themes": ""
+    "Separate Light & Dark Themes": "Temas Claro e Escuro Separados"
   },
   "Separate appearance for unfocused displays is not supported on this compositor.": {
-    "Separate appearance for unfocused displays is not supported on this compositor.": ""
+    "Separate appearance for unfocused displays is not supported on this compositor.": "Aparência separada para monitores não focados não é compatível neste compositor."
   },
   "Separator": {
     "Separator": "Separador"
@@ -7074,7 +7077,7 @@
     "Server": "Servidor"
   },
   "Session Filter": {
-    "Session Filter": ""
+    "Session Filter": "Filtro de Sessão"
   },
   "Set Custom Device Name": {
     "Set Custom Device Name": "Definir Nome de Dispositivo Personalizado"
@@ -7095,7 +7098,7 @@
     "Set different wallpapers for light and dark mode": "Use papéis de parede diferentes para modos claro e escuro"
   },
   "Set initial password": {
-    "Set initial password": ""
+    "Set initial password": "Definir senha inicial"
   },
   "Set key and action to save": {
     "Set key and action to save": "Definir chave e ação para salvar"
@@ -7104,31 +7107,31 @@
     "Set notification rules": "Definir regras de notificação"
   },
   "Set the font size for notification body text (htmlBody)": {
-    "Set the font size for notification body text (htmlBody)": ""
+    "Set the font size for notification body text (htmlBody)": "Definir o tamanho da fonte para o texto do corpo das notificações (htmlBody)"
   },
   "Set the percentage at which the battery is considered low.": {
-    "Set the percentage at which the battery is considered low.": ""
+    "Set the percentage at which the battery is considered low.": "Defina o percentual em que a bateria é considerada baixa."
   },
   "Set up a WiFi hotspot for sharing this connection.": {
-    "Set up a WiFi hotspot for sharing this connection.": ""
+    "Set up a WiFi hotspot for sharing this connection.": "Configurar um hotspot WiFi para compartilhar esta conexão."
   },
   "Set up hotspot": {
-    "Set up hotspot": ""
+    "Set up hotspot": "Configurar hotspot"
   },
   "Set up hotspot in Settings": {
-    "Set up hotspot in Settings": ""
+    "Set up hotspot in Settings": "Configurar hotspot nas Configurações"
   },
   "Setting": {
-    "Setting": ""
+    "Setting": "Configuração"
   },
   "Setting up...": {
-    "Setting up...": ""
+    "Setting up...": "Configurando..."
   },
   "Settings": {
     "Settings": "Configurações"
   },
   "Settings Search": {
-    "Settings Search": ""
+    "Settings Search": "Pesquisa de Configurações"
   },
   "Settings are read-only. Changes will not persist.": {
     "Settings are read-only. Changes will not persist.": "Configurações são somente leitura. Mudanças não serão mantidas."
@@ -7146,19 +7149,19 @@
     "Shadow Opacity": "Opacidade da Sombra"
   },
   "Shadow Override": {
-    "Shadow Override": ""
+    "Shadow Override": "Substituição de Sombra"
   },
   "Shadow blur radius in pixels": {
-    "Shadow blur radius in pixels": ""
+    "Shadow blur radius in pixels": "Raio de desfoque da sombra em pixels"
   },
   "Shadow elevation on bars and panels": {
-    "Shadow elevation on bars and panels": ""
+    "Shadow elevation on bars and panels": "Elevação da sombra em barras e painéis"
   },
   "Shadow elevation on modals and dialogs": {
-    "Shadow elevation on modals and dialogs": ""
+    "Shadow elevation on modals and dialogs": "Elevação da sombra em modais e diálogos"
   },
   "Shadow elevation on popouts, OSDs, and dropdowns": {
-    "Shadow elevation on popouts, OSDs, and dropdowns": ""
+    "Shadow elevation on popouts, OSDs, and dropdowns": "Elevação da sombra em popouts, OSDs e menus suspensos"
   },
   "Shadows": {
     "Shadows": "Sombras"
@@ -7176,7 +7179,7 @@
     "Shell": "Shell"
   },
   "Shift+Enter to copy": {
-    "Shift+Enter to copy": ""
+    "Shift+Enter to copy": "Shift+Enter para copiar"
   },
   "Shift+Enter to paste": {
     "Shift+Enter to paste": "Shift+Enter para colar"
@@ -7185,10 +7188,10 @@
     "Short": "Curto"
   },
   "Shortcut (%1)": {
-    "Shortcut (%1)": ""
+    "Shortcut (%1)": "Atalho (%1)"
   },
   "Shortcut that opens this settings window": {
-    "Shortcut that opens this settings window": ""
+    "Shortcut that opens this settings window": "Atalho que abre esta janela de configurações"
   },
   "Shortcuts": {
     "Shortcuts": "Atalhos"
@@ -7200,7 +7203,7 @@
     "Show": "Mostrar"
   },
   "Show \"config reloaded\" Toast": {
-    "Show \"config reloaded\" Toast": ""
+    "Show \"config reloaded\" Toast": "Mostrar aviso \"configuração recarregada\""
   },
   "Show 3rd Party": {
     "Show 3rd Party": "Mostrar Terceiros"
@@ -7209,7 +7212,7 @@
     "Show All Tags": "Mostrar Todas as Tags"
   },
   "Show All, Apps, Files, and Plugins chips beside the Spotlight Bar input.": {
-    "Show All, Apps, Files, and Plugins chips beside the Spotlight Bar input.": ""
+    "Show All, Apps, Files, and Plugins chips beside the Spotlight Bar input.": "Mostrar chips de Todos, Aplicativos, Arquivos e Plugins ao lado da entrada da Barra Spotlight."
   },
   "Show Badge": {
     "Show Badge": "Mostrar Distintivo"
@@ -7236,7 +7239,7 @@
     "Show Feels Like Temperature": "Mostrar Temperatura Aparente"
   },
   "Show Flatpak, Snap, AppImage, or Nix badge icons on launcher items.": {
-    "Show Flatpak, Snap, AppImage, or Nix badge icons on launcher items.": ""
+    "Show Flatpak, Snap, AppImage, or Nix badge icons on launcher items.": "Mostrar ícones de distintivo de Flatpak, Snap, AppImage ou Nix nos itens do inicializador."
   },
   "Show Footer": {
     "Show Footer": "Mostrar Rodapé"
@@ -7263,7 +7266,7 @@
     "Show Humidity": "Mostrar Umidade"
   },
   "Show Icon": {
-    "Show Icon": ""
+    "Show Icon": "Mostrar Ícone"
   },
   "Show Launcher Button": {
     "Show Launcher Button": "Mostrar Botão do Launcher"
@@ -7296,7 +7299,7 @@
     "Show Memory in GB": "Exibir a Memória em GB"
   },
   "Show Mode Chips": {
-    "Show Mode Chips": ""
+    "Show Mode Chips": "Mostrar Chips de Modo"
   },
   "Show Network": {
     "Show Network": "Mostrar Rede"
@@ -7311,13 +7314,13 @@
     "Show Overflow Badge Count": "Mostrar Contagem de Distintivo de Estouro"
   },
   "Show Package Source Badges": {
-    "Show Package Source Badges": ""
+    "Show Package Source Badges": "Mostrar Distintivos de Origem do Pacote"
   },
   "Show Password Field": {
     "Show Password Field": "Mostrar Campo de Senha"
   },
   "Show Percentage": {
-    "Show Percentage": ""
+    "Show Percentage": "Mostrar Percentual"
   },
   "Show Power Actions": {
     "Show Power Actions": "Mostrar Ações de Energia"
@@ -7338,7 +7341,7 @@
     "Show Reboot": "Mostrar Reiniciar"
   },
   "Show Remaining Time": {
-    "Show Remaining Time": ""
+    "Show Remaining Time": "Mostrar Tempo Restante"
   },
   "Show Restart DMS": {
     "Show Restart DMS": "Mostrar Reiniciar DMS"
@@ -7350,7 +7353,7 @@
     "Show Seconds": "Mostrar Segundos"
   },
   "Show Soft Reboot": {
-    "Show Soft Reboot": ""
+    "Show Soft Reboot": "Mostrar Reinicialização Suave"
   },
   "Show Sunrise/Sunset": {
     "Show Sunrise/Sunset": "Mostrar Nascer/Pôr do Sol"
@@ -7359,10 +7362,10 @@
     "Show Suspend": "Mostrar Suspender"
   },
   "Show Swap": {
-    "Show Swap": ""
+    "Show Swap": "Mostrar Swap"
   },
   "Show Switch User": {
-    "Show Switch User": ""
+    "Show Switch User": "Mostrar Trocar Usuário"
   },
   "Show System Date": {
     "Show System Date": "Mostrar Data do Sistema"
@@ -7395,25 +7398,25 @@
     "Show Workspace Apps": "Mostrar Aplicativos da Área de Trabalho Virtual"
   },
   "Show a bar that drains as the popup's auto-dismiss timer runs": {
-    "Show a bar that drains as the popup's auto-dismiss timer runs": ""
+    "Show a bar that drains as the popup's auto-dismiss timer runs": "Mostrar uma barra que se esvazia conforme o temporizador de dispensa automática do popup"
   },
   "Show a notification when battery reaches the charge limit.": {
-    "Show a notification when battery reaches the charge limit.": ""
+    "Show a notification when battery reaches the charge limit.": "Mostrar uma notificação quando a bateria atingir o limite de carga."
   },
   "Show a toast when the compositor config is reloaded": {
-    "Show a toast when the compositor config is reloaded": ""
+    "Show a toast when the compositor config is reloaded": "Mostrar um aviso quando a configuração do compositor for recarregada"
   },
   "Show a warning popup when battery is running low.": {
-    "Show a warning popup when battery is running low.": ""
+    "Show a warning popup when battery is running low.": "Mostrar um popup de aviso quando a bateria estiver baixa."
   },
   "Show all 9 tags instead of only occupied tags": {
-    "Show all 9 tags instead of only occupied tags": ""
+    "Show all 9 tags instead of only occupied tags": "Mostrar todas as 9 tags em vez de apenas as tags ocupadas"
   },
   "Show an outline ring around the focused workspace indicator": {
     "Show an outline ring around the focused workspace indicator": "Mostrar um anel de contorno ao redor do indicador de espaço de trabalho em foco"
   },
   "Show an urgent alert when battery reaches critical level.": {
-    "Show an urgent alert when battery reaches critical level.": ""
+    "Show an urgent alert when battery reaches critical level.": "Mostrar um alerta urgente quando a bateria atingir o nível crítico."
   },
   "Show cava audio visualizer in media widget": {
     "Show cava audio visualizer in media widget": "Exibir a visualização cava no widget de mídia"
@@ -7428,19 +7431,19 @@
     "Show dock when floating windows don't overlap its area": "Mostrar dock quando janelas flutuantes não se sobrepõem à sua área"
   },
   "Show drop shadow on notification popups. Requires M3 Elevation to be enabled in Theme & Colors.": {
-    "Show drop shadow on notification popups. Requires M3 Elevation to be enabled in Theme & Colors.": ""
+    "Show drop shadow on notification popups. Requires M3 Elevation to be enabled in Theme & Colors.": "Mostrar sombra projetada em popups de notificação. Requer que a Elevação M3 esteja ativada em Tema e Cores."
   },
   "Show during Niri overview": {
-    "Show during Niri overview": ""
+    "Show during Niri overview": "Mostrar durante a visão geral do Niri"
   },
   "Show foreground surfaces on cards inside floating windows": {
-    "Show foreground surfaces on cards inside floating windows": ""
+    "Show foreground surfaces on cards inside floating windows": "Mostrar superfícies de primeiro plano em cartões dentro de janelas flutuantes"
   },
   "Show foreground surfaces on notification cards": {
-    "Show foreground surfaces on notification cards": ""
+    "Show foreground surfaces on notification cards": "Mostrar superfícies de primeiro plano em cartões de notificação"
   },
   "Show foreground surfaces on panels for stronger contrast": {
-    "Show foreground surfaces on panels for stronger contrast": ""
+    "Show foreground surfaces on panels for stronger contrast": "Mostrar superfícies de primeiro plano em painéis para contraste mais forte"
   },
   "Show in GB": {
     "Show in GB": "Exibir em GB"
@@ -7449,13 +7452,13 @@
     "Show launcher overlay when typing in Niri overview. Disable to use another launcher.": "Mostrar sobreposição do iniciador ao digitar na visão geral do Niri. Desative para usar outro iniciador."
   },
   "Show looping video album artwork from Apple Music when available. Sends the playing artist and album name to Apple.": {
-    "Show looping video album artwork from Apple Music when available. Sends the playing artist and album name to Apple.": ""
+    "Show looping video album artwork from Apple Music when available. Sends the playing artist and album name to Apple.": "Mostrar a arte do álbum em vídeo em loop do Apple Music quando disponível. Envia o artista e o álbum em reprodução para a Apple."
   },
   "Show mode tabs and keyboard hints at the bottom.": {
     "Show mode tabs and keyboard hints at the bottom.": "Mostrar guias de modo e dicas de teclado na parte inferior."
   },
   "Show mount path": {
-    "Show mount path": ""
+    "Show mount path": "Mostrar caminho de montagem"
   },
   "Show on Last Display": {
     "Show on Last Display": "Mostrar na Última Tela"
@@ -7473,10 +7476,10 @@
     "Show on screens:": "Mostrar nas telas:"
   },
   "Show the bar only when no windows are open": {
-    "Show the bar only when no windows are open": ""
+    "Show the bar only when no windows are open": "Mostrar a barra somente quando nenhuma janela estiver aberta"
   },
   "Show the bar when niri overview is active": {
-    "Show the bar when niri overview is active": ""
+    "Show the bar when niri overview is active": "Mostrar a barra quando a visão geral do niri estiver ativa"
   },
   "Show weather information in top bar and control center": {
     "Show weather information in top bar and control center": "Mostrar informação de clima na barra superior e na central de controle"
@@ -7503,7 +7506,7 @@
     "Shows when microphone, camera, or screen sharing is active": "Mostra quando microfone, câmera, ou compartilhamento de tela está ativado"
   },
   "Shrink the media widget to fit shorter song titles while still respecting the configured maximum size": {
-    "Shrink the media widget to fit shorter song titles while still respecting the configured maximum size": ""
+    "Shrink the media widget to fit shorter song titles while still respecting the configured maximum size": "Encolher o widget de mídia para caber títulos de música mais curtos respeitando ainda o tamanho máximo configurado"
   },
   "Shutdown": {
     "Shutdown": "Desligar"
@@ -7512,7 +7515,7 @@
     "Signal": "Sinal"
   },
   "Signal Strength": {
-    "Signal Strength": ""
+    "Signal Strength": "Intensidade do Sinal"
   },
   "Silence for a while": {
     "Silence for a while": "Silenciar por um tempo"
@@ -7521,10 +7524,13 @@
     "Silence notifications": "Silenciar notificações"
   },
   "Silence system sounds while media is playing": {
-    "Silence system sounds while media is playing": ""
+    "Silence system sounds while media is playing": "Silenciar os sons do sistema enquanto a mídia está sendo reproduzida"
   },
   "Single-Line Popup": {
-    "Single-Line Popup": ""
+    "Single-Line Popup": "Popup de Uma Linha"
+  },
+  "Size": {
+    "Size": "Tamanho"
   },
   "Size Constraints": {
     "Size Constraints": "Restrições de Tamanho"
@@ -7545,10 +7551,10 @@
     "Skip setup": "Pular configuração"
   },
   "Skip the greeter password after boot until you sign out. Lock screen unlock is unchanged. Takes effect on the next reboot after sync.": {
-    "Skip the greeter password after boot until you sign out. Lock screen unlock is unchanged. Takes effect on the next reboot after sync.": ""
+    "Skip the greeter password after boot until you sign out. Lock screen unlock is unchanged. Takes effect on the next reboot after sync.": "Pular a senha do greeter após a inicialização até você sair. O desbloqueio da tela de bloqueio permanece inalterado. Entra em vigor no próximo reinício após a sincronização."
   },
   "Slideout": {
-    "Slideout": ""
+    "Slideout": "Slideout"
   },
   "Small": {
     "Small": "Pequeno"
@@ -7563,7 +7569,7 @@
     "Snow": "Neve"
   },
   "Soft Reboot": {
-    "Soft Reboot": ""
+    "Soft Reboot": "Reinicialização Suave"
   },
   "Some plugins require a newer version of DMS:": {
     "Some plugins require a newer version of DMS:": "Alguns plugins requerem uma versão mais recente do DMS:"
@@ -7571,8 +7577,11 @@
   "Sort Alphabetically": {
     "Sort Alphabetically": "Ordenar Alfabeticamente"
   },
+  "Sort By": {
+    "Sort By": "Ordenar Por"
+  },
   "Sort wallpapers": {
-    "Sort wallpapers": ""
+    "Sort wallpapers": "Ordenar papéis de parede"
   },
   "Sorting & Layout": {
     "Sorting & Layout": "Classificação e Layout"
@@ -7584,19 +7593,19 @@
     "Sounds": "Sons"
   },
   "Source: %1": {
-    "Source: %1": ""
+    "Source: %1": "Origem: %1"
   },
   "Sources for plugins and themes. Registries are git repositories with a plugins/ or themes/ directory.": {
-    "Sources for plugins and themes. Registries are git repositories with a plugins/ or themes/ directory.": ""
+    "Sources for plugins and themes. Registries are git repositories with a plugins/ or themes/ directory.": "Origens de plugins e temas. Os registros são repositórios git com um diretório plugins/ ou themes/."
   },
   "Space between the bar and screen edges": {
-    "Space between the bar and screen edges": ""
+    "Space between the bar and screen edges": "Espaço entre a barra e as bordas da tela"
   },
   "Space between windows": {
     "Space between windows": "Espaço entre janelas"
   },
   "Space between windows and screen edges": {
-    "Space between windows and screen edges": ""
+    "Space between windows and screen edges": "Espaço entre as janelas e as bordas da tela"
   },
   "Spacer": {
     "Spacer": "Espaçador"
@@ -7614,16 +7623,16 @@
     "Spool Area Full": "Área de Spool Cheia"
   },
   "Spotlight": {
-    "Spotlight": ""
+    "Spotlight": "Spotlight"
   },
   "Spotlight Bar": {
-    "Spotlight Bar": ""
+    "Spotlight Bar": "Barra Spotlight"
   },
   "Spotlight Bar Shortcut": {
-    "Spotlight Bar Shortcut": ""
+    "Spotlight Bar Shortcut": "Atalho da Barra Spotlight"
   },
   "Spotlight Search": {
-    "Spotlight Search": ""
+    "Spotlight Search": "Pesquisa Spotlight"
   },
   "Square Corners": {
     "Square Corners": "Cantos Retos"
@@ -7635,13 +7644,13 @@
     "Standard": "Padrão"
   },
   "Standard: Classic Material Design 3 — panels rise from below with a subtle scale. The DMS default.": {
-    "Standard: Classic Material Design 3 — panels rise from below with a subtle scale. The DMS default.": ""
+    "Standard: Classic Material Design 3 — panels rise from below with a subtle scale. The DMS default.": "Padrão: Material Design 3 clássico — os painéis sobem de baixo com uma escala sutil. O padrão do DMS."
   },
   "Start": {
     "Start": "Iniciar"
   },
   "Start Hotspot?": {
-    "Start Hotspot?": ""
+    "Start Hotspot?": "Iniciar Hotspot?"
   },
   "Start KDE Connect or Valent to use this plugin": {
     "Start KDE Connect or Valent to use this plugin": "Inicie o KDE Connect ou Valent para usar este plugin"
@@ -7650,22 +7659,25 @@
     "Start typing your notes here...": "Comece a digitar suas anotações aqui..."
   },
   "Starting hotspot...": {
-    "Starting hotspot...": ""
+    "Starting hotspot...": "Iniciando hotspot..."
   },
   "Starting the hotspot will disconnect WiFi from \"%1\" — the radio can't do both at once. Sharing internet then requires another connection, such as Ethernet.": {
-    "Starting the hotspot will disconnect WiFi from \"%1\" — the radio can't do both at once. Sharing internet then requires another connection, such as Ethernet.": ""
+    "Starting the hotspot will disconnect WiFi from \"%1\" — the radio can't do both at once. Sharing internet then requires another connection, such as Ethernet.": "Iniciar o hotspot desconectará o WiFi de \"%1\" — o rádio não pode fazer os dois ao mesmo tempo. Compartilhar a internet exigirá então outra conexão, como Ethernet."
   },
   "Starting...": {
-    "Starting...": ""
+    "Starting...": "Iniciando..."
   },
   "State": {
     "State": "Estado"
   },
+  "Status": {
+    "Status": "Status"
+  },
   "Stop": {
-    "Stop": ""
+    "Stop": "Parar"
   },
   "Stop ignoring %1": {
-    "Stop ignoring %1": ""
+    "Stop ignoring %1": "Parar de ignorar %1"
   },
   "Stopped": {
     "Stopped": "Parado"
@@ -7680,13 +7692,13 @@
     "Stretch": "Esticar"
   },
   "Stretch widget icons to fill the available bar height": {
-    "Stretch widget icons to fill the available bar height": ""
+    "Stretch widget icons to fill the available bar height": "Esticar os ícones dos widgets para preencher a altura disponível da barra"
   },
   "Stretch widget text to fill the available bar height": {
-    "Stretch widget text to fill the available bar height": ""
+    "Stretch widget text to fill the available bar height": "Esticar o texto dos widgets para preencher a altura disponível da barra"
   },
   "Strict auto-hide": {
-    "Strict auto-hide": ""
+    "Strict auto-hide": "Ocultação automática estrita"
   },
   "Stripes": {
     "Stripes": "Listras"
@@ -7695,7 +7707,7 @@
     "Summary": "Resumo"
   },
   "Summary Font Size": {
-    "Summary Font Size": ""
+    "Summary Font Size": "Tamanho da Fonte do Resumo"
   },
   "Sunrise": {
     "Sunrise": "Nascer do Sol"
@@ -7704,10 +7716,10 @@
     "Sunset": "Pôr do Sol"
   },
   "Super + Space": {
-    "Super + Space": ""
+    "Super + Space": "Super + Espaço"
   },
   "Suppress Duplicate Notifications": {
-    "Suppress Duplicate Notifications": ""
+    "Suppress Duplicate Notifications": "Suprimir Notificações Duplicadas"
   },
   "Suppress notification popups while enabled": {
     "Suppress notification popups while enabled": "Suprimir pop-ups de notificação enquanto ativado"
@@ -7716,43 +7728,46 @@
     "Surface": "Superfície"
   },
   "Surface Behavior": {
-    "Surface Behavior": ""
+    "Surface Behavior": "Comportamento da Superfície"
   },
   "Surface Border Color": {
-    "Surface Border Color": ""
+    "Surface Border Color": "Cor da Borda da Superfície"
   },
   "Surface Border Opacity": {
-    "Surface Border Opacity": ""
+    "Surface Border Opacity": "Opacidade da Borda da Superfície"
   },
   "Surface Border Outline": {
-    "Surface Border Outline": ""
+    "Surface Border Outline": "Contorno da Borda da Superfície"
   },
   "Surface Container": {
-    "Surface Container": ""
+    "Surface Container": "Contêiner de Superfície"
   },
   "Surface High": {
-    "Surface High": ""
+    "Surface High": "Superfície Alta"
   },
   "Surface Highest": {
-    "Surface Highest": ""
+    "Surface Highest": "Superfície Mais Alta"
   },
   "Surface Opacity": {
-    "Surface Opacity": ""
+    "Surface Opacity": "Opacidade da Superfície"
   },
   "Surface Styling": {
-    "Surface Styling": ""
+    "Surface Styling": "Estilo de Superfície"
   },
   "Surface Text": {
-    "Surface Text": ""
+    "Surface Text": "Texto de Superfície"
   },
   "Surface Variant": {
     "Surface Variant": "Variante de Superfície"
   },
   "Surfaces emerge flush from the bar": {
-    "Surfaces emerge flush from the bar": ""
+    "Surfaces emerge flush from the bar": "As superfícies emergem rentes à barra"
   },
   "Surfaces float independently of the frame": {
-    "Surfaces float independently of the frame": ""
+    "Surfaces float independently of the frame": "As superfícies flutuam independentemente do frame"
+  },
+  "Suspend": {
+    "Suspend": "Suspender"
   },
   "Suspend behavior": {
     "Suspend behavior": "Comportamento de suspensão"
@@ -7764,19 +7779,22 @@
     "Suspend then Hibernate": "Suspender e Hibernar"
   },
   "Swap primary and secondary mouse buttons": {
-    "Swap primary and secondary mouse buttons": ""
+    "Swap primary and secondary mouse buttons": "Alternar os botões primário e secundário do mouse"
   },
   "Sway Website": {
-    "Sway Website": ""
+    "Sway Website": "Site do Sway"
   },
   "Switch Layout Shortcut": {
-    "Switch Layout Shortcut": ""
+    "Switch Layout Shortcut": "Atalho de Alternância de Layout"
+  },
+  "Switch User": {
+    "Switch User": "Trocar Usuário"
   },
   "Switch between display configurations": {
-    "Switch between display configurations": ""
+    "Switch between display configurations": "Alternar entre configurações de monitor"
   },
   "Switch displays with an available 60 Hz mode to 60 Hz on battery and restore the previous mode on AC. Skips displays with VRR enabled.": {
-    "Switch displays with an available 60 Hz mode to 60 Hz on battery and restore the previous mode on AC. Skips displays with VRR enabled.": ""
+    "Switch displays with an available 60 Hz mode to 60 Hz on battery and restore the previous mode on AC. Skips displays with VRR enabled.": "Alternar monitores com modo de 60 Hz disponível para 60 Hz na bateria e restaurar o modo anterior no AC. Ignora monitores com VRR ativado."
   },
   "Switch to power profile": {
     "Switch to power profile": "Trocar para perfil de energia"
@@ -7785,7 +7803,7 @@
     "Sync": "Sincronização"
   },
   "Sync Bar Inset Padding": {
-    "Sync Bar Inset Padding": ""
+    "Sync Bar Inset Padding": "Sincronizar Preenchimento Interno da Barra"
   },
   "Sync Mode with Portal": {
     "Sync Mode with Portal": "Sincronizar Modo Com Portal"
@@ -7796,11 +7814,8 @@
   "Sync Position Across Screens": {
     "Sync Position Across Screens": "Sincronizar Posição entre Telas"
   },
-  "Sync applies your theme and settings to the login screen. Shared users should run dms greeter sync --profile instead of a primary user sync.": {
-    "Sync applies your theme and settings to the login screen. Shared users should run dms greeter sync --profile instead of a primary user sync.": ""
-  },
   "Sync applies your theme and settings to the login screen. Shared users should run dms-greeter sync --profile instead of a primary user sync.": {
-    "Sync applies your theme and settings to the login screen. Shared users should run dms-greeter sync --profile instead of a primary user sync.": ""
+    "Sync applies your theme and settings to the login screen. Shared users should run dms-greeter sync --profile instead of a primary user sync.": "A sincronização aplica seu tema e configurações à tela de login. Usuários compartilhados devem executar dms-greeter sync --profile em vez de uma sincronização de usuário primário."
   },
   "Sync completed successfully.": {
     "Sync completed successfully.": "A sincronização foi concluída com sucesso."
@@ -7809,19 +7824,22 @@
     "Sync dark mode with settings portals for system-wide theme hints": "Sincronize o modo escuro com os portais de configurações para ter indicações de temas em todo o sistema"
   },
   "Sync failed in background mode. Trying terminal mode so you can authenticate interactively.": {
-    "Sync failed in background mode. Trying terminal mode so you can authenticate interactively.": ""
+    "Sync failed in background mode. Trying terminal mode so you can authenticate interactively.": "A sincronização falhou no modo de segundo plano. Tentando o modo de terminal para que você possa autenticar interativamente."
   },
   "Sync needs sudo authentication. Opening terminal so you can use password or fingerprint.": {
-    "Sync needs sudo authentication. Opening terminal so you can use password or fingerprint.": ""
+    "Sync needs sudo authentication. Opening terminal so you can use password or fingerprint.": "A sincronização precisa de autenticação sudo. Abrindo o terminal para que você possa usar senha ou impressão digital."
   },
   "Sync to apply": {
-    "Sync to apply": ""
+    "Sync to apply": "Sincronizar para aplicar"
   },
   "Sync with Global Settings": {
-    "Sync with Global Settings": ""
+    "Sync with Global Settings": "Sincronizar com as Configurações Globais"
   },
   "Syncing...": {
-    "Syncing...": ""
+    "Syncing...": "Sincronizando..."
+  },
+  "System": {
+    "System": "Sistema"
   },
   "System App Theming": {
     "System App Theming": "Tema de Apps do Sistema"
@@ -7848,7 +7866,7 @@
     "System Tray": "Bandeja do Sistema"
   },
   "System Tray Icon Tint": {
-    "System Tray Icon Tint": ""
+    "System Tray Icon Tint": "Tom dos Ícones da Bandeja do Sistema"
   },
   "System Update": {
     "System Update": "Atualização do Sistema"
@@ -7872,70 +7890,67 @@
     "System toast notifications": "Notificações toast do sistema"
   },
   "Systemd Override generated": {
-    "Systemd Override generated": ""
+    "Systemd Override generated": "Substituição do systemd gerada"
   },
   "Tab": {
     "Tab": "Aba"
   },
   "Tags": {
-    "Tags": ""
+    "Tags": "Tags"
   },
   "Tags: %1": {
-    "Tags: %1": ""
+    "Tags: %1": "Tags: %1"
   },
   "Tailscale": {
-    "Tailscale": ""
+    "Tailscale": "Tailscale"
   },
   "Tailscale Network": {
-    "Tailscale Network": ""
+    "Tailscale Network": "Rede Tailscale"
   },
   "Tailscale action failed": {
-    "Tailscale action failed": ""
+    "Tailscale action failed": "Falha na ação do Tailscale"
   },
   "Tailscale not available": {
-    "Tailscale not available": ""
+    "Tailscale not available": "Tailscale indisponível"
   },
   "Tap and Drag": {
-    "Tap and Drag": ""
+    "Tap and Drag": "Tocar e Arrastar"
   },
   "Tap and drag on the touchpad to move items": {
-    "Tap and drag on the touchpad to move items": ""
+    "Tap and drag on the touchpad to move items": "Tocar e arrastar no touchpad para mover itens"
   },
   "Tap the touchpad surface to trigger left click clicks": {
-    "Tap the touchpad surface to trigger left click clicks": ""
+    "Tap the touchpad surface to trigger left click clicks": "Tocar na superfície do touchpad para acionar cliques de botão esquerdo"
   },
   "Tap to Click": {
-    "Tap to Click": ""
+    "Tap to Click": "Tocar para Clicar"
   },
   "Terminal": {
-    "Terminal": ""
+    "Terminal": "Terminal"
   },
   "Terminal additional parameters": {
-    "Terminal additional parameters": ""
+    "Terminal additional parameters": "Parâmetros adicionais do terminal"
   },
   "Terminal fallback failed. Install a supported terminal emulator or run 'dms auth sync' manually.": {
-    "Terminal fallback failed. Install a supported terminal emulator or run 'dms auth sync' manually.": ""
-  },
-  "Terminal fallback failed. Install one of the supported terminal emulators or run 'dms greeter sync' manually.": {
-    "Terminal fallback failed. Install one of the supported terminal emulators or run 'dms greeter sync' manually.": ""
+    "Terminal fallback failed. Install a supported terminal emulator or run 'dms auth sync' manually.": "Falha no fallback do terminal. Instale um emulador de terminal compatível ou execute 'dms auth sync' manualmente."
   },
   "Terminal fallback failed. Install one of the supported terminal emulators or run 'dms-greeter sync' manually.": {
-    "Terminal fallback failed. Install one of the supported terminal emulators or run 'dms-greeter sync' manually.": ""
+    "Terminal fallback failed. Install one of the supported terminal emulators or run 'dms-greeter sync' manually.": "Falha no fallback do terminal. Instale um dos emuladores de terminal compatíveis ou execute 'dms-greeter sync' manualmente."
   },
   "Terminal fallback opened. Complete authentication there; it will close automatically when done.": {
-    "Terminal fallback opened. Complete authentication there; it will close automatically when done.": ""
+    "Terminal fallback opened. Complete authentication there; it will close automatically when done.": "Fallback do terminal aberto. Complete a autenticação lá; ele fechará automaticamente quando concluído."
   },
   "Terminal opened. Complete authentication there; it will close automatically when done.": {
-    "Terminal opened. Complete authentication there; it will close automatically when done.": ""
+    "Terminal opened. Complete authentication there; it will close automatically when done.": "Terminal aberto. Complete a autenticação lá; ele fechará automaticamente quando concluído."
   },
   "Terminals - Always use Dark Theme": {
     "Terminals - Always use Dark Theme": "Terminais - Sempre usar Tema Escuro"
   },
   "Tertiary": {
-    "Tertiary": ""
+    "Tertiary": "Terciário"
   },
   "Tertiary Container": {
-    "Tertiary Container": ""
+    "Tertiary Container": "Contêiner Terciário"
   },
   "Test Connection": {
     "Test Connection": "Testar a conexão"
@@ -7956,10 +7971,10 @@
     "Text Color": "Cor do Texto"
   },
   "Text Editor": {
-    "Text Editor": ""
+    "Text Editor": "Editor de Texto"
   },
   "Text Rendering": {
-    "Text Rendering": ""
+    "Text Rendering": "Renderização de Texto"
   },
   "The 'dgop' tool is required for system monitoring.\nPlease install dgop to use this feature.": {
     "The 'dgop' tool is required for system monitoring.\nPlease install dgop to use this feature.": "A ferramenta 'dgop' é necessária para monitoramento do sistema.\nPor favor, instale o dgop para usar este recurso."
@@ -7968,22 +7983,22 @@
     "The DMS_SOCKET environment variable is not set or the socket is unavailable. Automated plugin management requires the DMS_SOCKET.": "A variável de ambiente DMS_SOCKET não está definida ou o socket está indisponível. O gerenciamento automático de plugins requer a DMS_SOCKET."
   },
   "The WiFi adapter could not start access point mode.": {
-    "The WiFi adapter could not start access point mode.": ""
+    "The WiFi adapter could not start access point mode.": "O adaptador WiFi não conseguiu iniciar o modo de ponto de acesso."
   },
   "The below settings will modify your GTK and Qt settings. If you wish to preserve your current configurations, please back them up (qt5ct.conf|qt6ct.conf and ~/.config/gtk-3.0|gtk-4.0).": {
     "The below settings will modify your GTK and Qt settings. If you wish to preserve your current configurations, please back them up (qt5ct.conf|qt6ct.conf and ~/.config/gtk-3.0|gtk-4.0).": "As configurações abaixo vão modificar suas configurações GTK e Qt. Se você deseja preservá-las, por favor faça um back up (qt5ct.conf|qt6ct.conf and ~/.config/gtk-3.0|gtk-4.0)."
   },
   "The custom command used when attaching to sessions (receives the session name as the first argument)": {
-    "The custom command used when attaching to sessions (receives the session name as the first argument)": ""
+    "The custom command used when attaching to sessions (receives the session name as the first argument)": "O comando personalizado usado ao anexar a sessões (recebe o nome da sessão como primeiro argumento)"
   },
   "The job queue of this printer is empty": {
     "The job queue of this printer is empty": "A fila de trabalhos dessa impressora está vazia"
   },
   "The rule applies to any window matching one of these.": {
-    "The rule applies to any window matching one of these.": ""
+    "The rule applies to any window matching one of these.": "A regra se aplica a qualquer janela que corresponda a um destes."
   },
   "The server certificate has changed since it was last trusted. Only continue if you recognize the new fingerprint.": {
-    "The server certificate has changed since it was last trusted. Only continue if you recognize the new fingerprint.": ""
+    "The server certificate has changed since it was last trusted. Only continue if you recognize the new fingerprint.": "O certificado do servidor mudou desde que foi confiado pela última vez. Continue somente se reconhecer a nova impressão digital."
   },
   "Theme & Colors": {
     "Theme & Colors": "Tema & Cores"
@@ -7995,25 +8010,25 @@
     "Theme Registry": "Registro de Tema"
   },
   "Theme color used for the border": {
-    "Theme color used for the border": ""
+    "Theme color used for the border": "Cor do tema usada para a borda"
   },
   "Theme color used for the widget outline": {
-    "Theme color used for the widget outline": ""
+    "Theme color used for the widget outline": "Cor do tema usada para o contorno do widget"
   },
   "Theme worker failed (%1)": {
-    "Theme worker failed (%1)": ""
+    "Theme worker failed (%1)": "Falha no worker de tema (%1)"
   },
   "Themes": {
     "Themes": "Temas"
   },
   "These add entries to the XDG autostart directory (~/.config/autostart/*.desktop)": {
-    "These add entries to the XDG autostart directory (~/.config/autostart/*.desktop)": ""
+    "These add entries to the XDG autostart directory (~/.config/autostart/*.desktop)": "Eles adicionam entradas ao diretório de inicialização XDG (~/.config/autostart/*.desktop)"
   },
   "Thickness": {
     "Thickness": "Espessura"
   },
   "Thin": {
-    "Thin": ""
+    "Thin": "Fino"
   },
   "Third-Party Plugin Warning": {
     "Third-Party Plugin Warning": "Aviso Sobre Plugins de Terceiros"
@@ -8025,16 +8040,16 @@
     "This bind is overridden by config.kdl": "Esta vinculação é substituída pela configuração do config.kdl"
   },
   "This device": {
-    "This device": ""
+    "This device": "Este dispositivo"
   },
   "This install is still using hyprland.conf. Run dms setup to migrate before changing these settings.": {
-    "This install is still using hyprland.conf. Run dms setup to migrate before changing these settings.": ""
+    "This install is still using hyprland.conf. Run dms setup to migrate before changing these settings.": "Esta instalação ainda está usando hyprland.conf. Execute dms setup para migrar antes de alterar essas configurações."
   },
   "This may take a few seconds": {
     "This may take a few seconds": "Isso pode levar alguns segundos"
   },
   "This output is disabled in the current profile": {
-    "This output is disabled in the current profile": ""
+    "This output is disabled in the current profile": "Esta saída está desativada no perfil atual"
   },
   "This plugin does not have 'settings_write' permission.\n\nAdd \"permissions\": [\"settings_read\", \"settings_write\"] to plugin.json": {
     "This plugin does not have 'settings_write' permission.\n\nAdd \"permissions\": [\"settings_read\", \"settings_write\"] to plugin.json": "Este plugin não possui permissão de 'settings_write'.\n\nAdicione \"permissions\": [\"settings_read\", \"settings_write\"] ao plugin.json"
@@ -8046,7 +8061,7 @@
     "This will delete all unpinned entries. %1 pinned entries will be kept.": "Isso excluirá todas as entradas não fixadas. %1 entradas fixadas serão mantidas."
   },
   "This will disconnect WiFi from \"%1\" — the radio can't host a hotspot and stay connected at the same time. Internet sharing will need another connection, such as Ethernet.": {
-    "This will disconnect WiFi from \"%1\" — the radio can't host a hotspot and stay connected at the same time. Internet sharing will need another connection, such as Ethernet.": ""
+    "This will disconnect WiFi from \"%1\" — the radio can't host a hotspot and stay connected at the same time. Internet sharing will need another connection, such as Ethernet.": "Isso desconectará o WiFi de \"%1\" — o rádio não pode hospedar um hotspot e permanecer conectado ao mesmo tempo. O compartilhamento de internet precisará de outra conexão, como Ethernet."
   },
   "This will permanently delete all clipboard history.": {
     "This will permanently delete all clipboard history.": "Isso vai apagar permanentemetne todo o histórico da área de transferência."
@@ -8064,10 +8079,10 @@
     "Tile": "Azulejo"
   },
   "Tile Horizontally": {
-    "Tile Horizontally": ""
+    "Tile Horizontally": "Lado a lado na Horizontal"
   },
   "Tile Vertically": {
-    "Tile Vertically": ""
+    "Tile Vertically": "Lado a lado na Vertical"
   },
   "Tiled": {
     "Tiled": "Em Mosaico"
@@ -8082,7 +8097,7 @@
     "Time": "Tempo"
   },
   "Time & Date Locale": {
-    "Time & Date Locale": ""
+    "Time & Date Locale": "Localidade de Hora e Data"
   },
   "Time & Weather": {
     "Time & Weather": "Hora & Clima"
@@ -8094,10 +8109,10 @@
     "Time remaining: %1": "Tempo restante: %1"
   },
   "Time to rest on a widget before its popout opens": {
-    "Time to rest on a widget before its popout opens": ""
+    "Time to rest on a widget before its popout opens": "Tempo de permanência em um widget antes de seu popout abrir"
   },
   "Time to wait before hiding after the pointer leaves": {
-    "Time to wait before hiding after the pointer leaves": ""
+    "Time to wait before hiding after the pointer leaves": "Tempo de espera antes de ocultar após o ponteiro sair"
   },
   "Time until full: %1": {
     "Time until full: %1": "Tempo até o carregamento completo: %1"
@@ -8106,25 +8121,25 @@
     "Timed Out": "Tempo Limite Esgotado"
   },
   "Timeout Progress Bar": {
-    "Timeout Progress Bar": ""
+    "Timeout Progress Bar": "Barra de Progresso de Tempo Limite"
   },
   "Timeouts": {
-    "Timeouts": ""
+    "Timeouts": "Tempos Limites"
   },
   "Tint Saturation": {
-    "Tint Saturation": ""
+    "Tint Saturation": "Saturação do Tom"
   },
   "Tint Strength": {
-    "Tint Strength": ""
+    "Tint Strength": "Intensidade do Tom"
   },
   "Title": {
     "Title": "Título"
   },
   "Title (optional)": {
-    "Title (optional)": ""
+    "Title (optional)": "Título (opcional)"
   },
   "Title is required": {
-    "Title is required": ""
+    "Title is required": "O título é obrigatório"
   },
   "Title regex (optional)": {
     "Title regex (optional)": "Regex de Título (opcional)"
@@ -8133,7 +8148,7 @@
     "To Full": "Para completar"
   },
   "To sign in as a different user, log out and pick the account from the greeter. Creating a fresh session in parallel needs a multi-session greeter (greetd-flexiserver / GDM / LightDM).": {
-    "To sign in as a different user, log out and pick the account from the greeter. Creating a fresh session in parallel needs a multi-session greeter (greetd-flexiserver / GDM / LightDM).": ""
+    "To sign in as a different user, log out and pick the account from the greeter. Creating a fresh session in parallel needs a multi-session greeter (greetd-flexiserver / GDM / LightDM).": "Para entrar como um usuário diferente, saia e escolha a conta no greeter. Criar uma sessão nova em paralelo requer um greeter de múltiplas sessões (greetd-flexiserver / GDM / LightDM)."
   },
   "To update, run the following command:": {
     "To update, run the following command:": "Para atualizar, execute o seguinte comando:"
@@ -8142,7 +8157,7 @@
     "To use this DMS bind, remove or change the keybind in your config.kdl": "Para usar este vinculo de DMS, remova ou altere o keybind no seu config.kdl"
   },
   "Toast": {
-    "Toast": ""
+    "Toast": "Aviso"
   },
   "Toast Messages": {
     "Toast Messages": "Mensagens Toast"
@@ -8151,10 +8166,10 @@
     "Today": "Hoje"
   },
   "Toggle bar visibility manually via IPC": {
-    "Toggle bar visibility manually via IPC": ""
+    "Toggle bar visibility manually via IPC": "Alternar a visibilidade da barra manualmente via IPC"
   },
   "Toggle fonts": {
-    "Toggle fonts": ""
+    "Toggle fonts": "Alternar fontes"
   },
   "Toggle visibility of this bar configuration": {
     "Toggle visibility of this bar configuration": "Alternar visibilidade dessa configuração de barra"
@@ -8175,7 +8190,7 @@
     "Toner Low": "Toner Baixo"
   },
   "Too many attempts - locked out": {
-    "Too many attempts - locked out": ""
+    "Too many attempts - locked out": "Muitas tentativas - bloqueado"
   },
   "Tools": {
     "Tools": "Ferramentas"
@@ -8184,7 +8199,7 @@
     "Top": "Topo"
   },
   "Top (Default)": {
-    "Top (Default)": ""
+    "Top (Default)": "Superior (Padrão)"
   },
   "Top Bar Format": {
     "Top Bar Format": "Formato da Barra Superior"
@@ -8205,19 +8220,19 @@
     "Top Section": "Seção do topo"
   },
   "Total": {
-    "Total": ""
+    "Total": "Total"
   },
   "Total Jobs": {
     "Total Jobs": "Total de Trabalhos"
   },
   "Touch your security key...": {
-    "Touch your security key...": ""
+    "Touch your security key...": "Toque sua chave de segurança..."
   },
   "Touchpad Settings": {
-    "Touchpad Settings": ""
+    "Touchpad Settings": "Configurações do Touchpad"
   },
   "Touchpad Speed": {
-    "Touchpad Speed": ""
+    "Touchpad Speed": "Velocidade do Touchpad"
   },
   "Transform": {
     "Transform": "Transformar"
@@ -8232,10 +8247,10 @@
     "Trash": "Lixeira"
   },
   "Trash command failed (exit %1)": {
-    "Trash command failed (exit %1)": ""
+    "Trash command failed (exit %1)": "Falha no comando da lixeira (saída %1)"
   },
   "Tray Icon Fix": {
-    "Tray Icon Fix": ""
+    "Tray Icon Fix": "Correção do Ícone da Bandeja"
   },
   "Trending GIFs": {
     "Trending GIFs": "GIFs em alta"
@@ -8259,7 +8274,7 @@
     "Try a different search": "Tente uma pesquisa diferente"
   },
   "Try a different search or switch filters.": {
-    "Try a different search or switch filters.": ""
+    "Try a different search or switch filters.": "Tente uma pesquisa diferente ou alterne os filtros."
   },
   "Turn off": {
     "Turn off": "Desativar"
@@ -8274,19 +8289,22 @@
     "Turn off monitors after": "Desligar monitores depois de"
   },
   "Turn off monitors after lock": {
-    "Turn off monitors after lock": ""
+    "Turn off monitors after lock": "Desligar os monitores após o bloqueio"
   },
   "Turn off now": {
-    "Turn off now": ""
+    "Turn off now": "Desligar agora"
   },
   "Two Finger": {
-    "Two Finger": ""
+    "Two Finger": "Dois Dedos"
+  },
+  "Type": {
+    "Type": "Tipo"
   },
   "Type at least 2 characters": {
     "Type at least 2 characters": "Digite pelo menos 2 caracteres"
   },
   "Type at least 2 characters to search files.": {
-    "Type at least 2 characters to search files.": ""
+    "Type at least 2 characters to search files.": "Digite pelo menos 2 caracteres para pesquisar arquivos."
   },
   "Type this prefix to search keybinds": {
     "Type this prefix to search keybinds": "Digite este prefixo para pesquisar combinações de teclas"
@@ -8301,19 +8319,19 @@
     "Typography & Motion": "Tipografia & Movimento"
   },
   "URI": {
-    "URI": ""
+    "URI": "URI"
   },
   "Unavailable": {
     "Unavailable": "Indisponível"
   },
   "Uncategorized": {
-    "Uncategorized": ""
+    "Uncategorized": "Sem categoria"
   },
   "Unfocused Color": {
     "Unfocused Color": "Cor sem Foco"
   },
   "Unfocused Display(s)": {
-    "Unfocused Display(s)": ""
+    "Unfocused Display(s)": "Monitor(es) Não Focado(s)"
   },
   "Ungrouped": {
     "Ungrouped": "Sem Grupo"
@@ -8321,20 +8339,11 @@
   "Uninstall": {
     "Uninstall": "Desinstalar"
   },
-  "Uninstall Greeter": {
-    "Uninstall Greeter": "Desinstalar o Greeter"
-  },
   "Uninstall Plugin": {
     "Uninstall Plugin": "Desinstalar Plugin"
   },
-  "Uninstall complete. Greeter has been removed.": {
-    "Uninstall complete. Greeter has been removed.": "Desinstalação concluída. O Greeter foi removido."
-  },
   "Uninstall failed: %1": {
     "Uninstall failed: %1": "Desinstalação falhou: %1"
-  },
-  "Uninstall the DMS greeter? This will remove configuration and restore your previous display manager. A terminal will open for sudo authentication.": {
-    "Uninstall the DMS greeter? This will remove configuration and restore your previous display manager. A terminal will open for sudo authentication.": ""
   },
   "Uninstalled: %1": {
     "Uninstalled: %1": "Desinstalado: %1"
@@ -8361,7 +8370,7 @@
     "Unknown GPU": "GPU Desconhecida"
   },
   "Unknown Model": {
-    "Unknown Model": ""
+    "Unknown Model": "Modelo Desconhecido"
   },
   "Unknown Monitor": {
     "Unknown Monitor": "Monitor Desconhecido"
@@ -8373,7 +8382,7 @@
     "Unknown Title": "Título Desconhecido"
   },
   "Unknown Track": {
-    "Unknown Track": ""
+    "Unknown Track": "Faixa Desconhecida"
   },
   "Unload on Close": {
     "Unload on Close": "Descarregar ao Fechar"
@@ -8403,19 +8412,19 @@
     "Unsaved changes": "Mudanças não salvas"
   },
   "Unset": {
-    "Unset": ""
+    "Unset": "Não definido"
   },
   "Until %1": {
-    "Until %1": ""
+    "Until %1": "Até %1"
   },
   "Until 8 AM": {
-    "Until 8 AM": ""
+    "Until 8 AM": "Até às 8 da manhã"
   },
   "Until I turn it off": {
-    "Until I turn it off": ""
+    "Until I turn it off": "Até eu desligar"
   },
   "Until tomorrow, 8:00 AM": {
-    "Until tomorrow, 8:00 AM": ""
+    "Until tomorrow, 8:00 AM": "Até amanhã, às 8:00"
   },
   "Untitled": {
     "Untitled": "Sem título"
@@ -8424,10 +8433,10 @@
     "Untrust": "Deixar de confiar"
   },
   "Untrusted VPN certificate": {
-    "Untrusted VPN certificate": ""
+    "Untrusted VPN certificate": "Certificado VPN não confiável"
   },
   "Up to date": {
-    "Up to date": ""
+    "Up to date": "Atualizado"
   },
   "Update": {
     "Update": "Atualizar"
@@ -8439,22 +8448,22 @@
     "Update Plugin": "Atualizar Plugin"
   },
   "Update failed: %1": {
-    "Update failed: %1": ""
+    "Update failed: %1": "Falha na atualização: %1"
   },
   "Updating %1...": {
-    "Updating %1...": ""
+    "Updating %1...": "Atualizando %1..."
   },
   "Updating plugins...": {
-    "Updating plugins...": ""
+    "Updating plugins...": "Atualizando plugins..."
   },
   "Upgrading...": {
-    "Upgrading...": ""
+    "Upgrading...": "Atualizando..."
   },
   "Uptime": {
     "Uptime": "Tempo de Atividade"
   },
   "Urgent": {
-    "Urgent": ""
+    "Urgent": "Urgente"
   },
   "Urgent Color": {
     "Urgent Color": "Cor Urgente"
@@ -8472,7 +8481,7 @@
     "Use Grid Layout": "Usar Layout em Grade"
   },
   "Use HH:MM time format": {
-    "Use HH:MM time format": ""
+    "Use HH:MM time format": "Usar formato de hora HH:MM"
   },
   "Use IP Location": {
     "Use IP Location": "Usar Localização do Endereço IP"
@@ -8484,34 +8493,34 @@
     "Use Imperial units (°F, mph, inHg) instead of Metric (°C, km/h, hPa)": "Usar unidades Imperiais (°F, mph, inHg) ao invés de Métricas (°C, km/h, hPa)"
   },
   "Use Inline Expansion": {
-    "Use Inline Expansion": ""
+    "Use Inline Expansion": "Usar Expansão Inline"
   },
   "Use Monospace Font": {
     "Use Monospace Font": "Usar Fonte Monoespaçada"
   },
   "Use Overlay Layer": {
-    "Use Overlay Layer": ""
+    "Use Overlay Layer": "Usar Camada de Sobreposição"
   },
   "Use System Theme": {
     "Use System Theme": "Usar Tema do Sistema"
   },
   "Use a custom image for the lock screen, or leave empty to use your desktop wallpaper.": {
-    "Use a custom image for the lock screen, or leave empty to use your desktop wallpaper.": ""
+    "Use a custom image for the lock screen, or leave empty to use your desktop wallpaper.": "Use uma imagem personalizada para a tela de bloqueio ou deixe vazio para usar o papel de parede da área de trabalho."
   },
   "Use a custom image for the login screen, or leave empty to use desktop wallpaper": {
-    "Use a custom image for the login screen, or leave empty to use desktop wallpaper": ""
+    "Use a custom image for the login screen, or leave empty to use desktop wallpaper": "Use uma imagem personalizada para a tela de login ou deixe vazio para usar o papel de parede da área de trabalho"
   },
   "Use a custom radius for goth corner cutouts": {
-    "Use a custom radius for goth corner cutouts": ""
+    "Use a custom radius for goth corner cutouts": "Use um raio personalizado para os recortes de canto goth"
   },
   "Use a fixed shadow direction for this bar": {
-    "Use a fixed shadow direction for this bar": ""
+    "Use a fixed shadow direction for this bar": "Use uma direção de sombra fixa para esta barra"
   },
   "Use a security key for lock screen authentication": {
-    "Use a security key for lock screen authentication": ""
+    "Use a security key for lock screen authentication": "Usar uma chave de segurança para autenticação da tela de bloqueio"
   },
   "Use album art accent": {
-    "Use album art accent": ""
+    "Use album art accent": "Usar destaque da arte do álbum"
   },
   "Use an external wallpaper manager like swww, hyprpaper, or swaybg.": {
     "Use an external wallpaper manager like swww, hyprpaper, or swaybg.": "Use um gerenciador de papel de parede externo como swww, hyprpaper ou swaybg."
@@ -8520,7 +8529,7 @@
     "Use animated wave progress bars for media playback": "Usar barras de progresso de ondas animadas para reprodução de mídia"
   },
   "Use colors extracted from album art instead of system theme colors": {
-    "Use colors extracted from album art instead of system theme colors": ""
+    "Use colors extracted from album art instead of system theme colors": "Usar cores extraídas da arte do álbum em vez das cores do tema do sistema"
   },
   "Use custom border/focus-ring width": {
     "Use custom border/focus-ring width": "Usar largura de borda/anel de foco personalizada"
@@ -8529,19 +8538,19 @@
     "Use custom window radius instead of theme radius": "Usar raio de janela personalizado em vez do raio do tema"
   },
   "Use desktop wallpaper": {
-    "Use desktop wallpaper": ""
+    "Use desktop wallpaper": "Usar papel de parede da área de trabalho"
   },
   "Use different icon themes for light and dark mode": {
-    "Use different icon themes for light and dark mode": ""
+    "Use different icon themes for light and dark mode": "Usar temas de ícones diferentes para os modos claro e escuro"
   },
   "Use different workspace colors on displays that are not focused": {
-    "Use different workspace colors on displays that are not focused": ""
+    "Use different workspace colors on displays that are not focused": "Usar cores de espaço de trabalho diferentes em monitores que não estão focados"
   },
   "Use fingerprint authentication for the lock screen": {
-    "Use fingerprint authentication for the lock screen": ""
+    "Use fingerprint authentication for the lock screen": "Usar autenticação por impressão digital para a tela de bloqueio"
   },
   "Use keys 1-3 or arrows, Enter/Space to select": {
-    "Use keys 1-3 or arrows, Enter/Space to select": ""
+    "Use keys 1-3 or arrows, Enter/Space to select": "Use as teclas 1-3 ou setas, Enter/Espaço para selecionar"
   },
   "Use light theme instead of dark theme": {
     "Use light theme instead of dark theme": "Usar tema claro em vez de escuro"
@@ -8550,7 +8559,7 @@
     "Use meters per second instead of km/h for wind speed": "Usar metros por segundo em vez de km/h para velocidade do vento"
   },
   "Use one inset value for every bar": {
-    "Use one inset value for every bar": ""
+    "Use one inset value for every bar": "Usar um único valor de recuo para todas as barras"
   },
   "Use smaller notification cards": {
     "Use smaller notification cards": "Usar cartões de notificação menores"
@@ -8559,10 +8568,10 @@
     "Use sound theme from system settings": "Usar tema de som das configurações do sistema"
   },
   "Use system PAM authentication": {
-    "Use system PAM authentication": ""
+    "Use system PAM authentication": "Usar autenticação PAM do sistema"
   },
   "Use the extended surface for launcher content": {
-    "Use the extended surface for launcher content": ""
+    "Use the extended surface for launcher content": "Usar a superfície estendida para o conteúdo do inicializador"
   },
   "Use the same position and size on all displays": {
     "Use the same position and size on all displays": "Usar a mesma posição e tamanho em todos os monitores"
@@ -8571,7 +8580,7 @@
     "Use trigger prefix to activate": "Usar prefixo de gatilho para ativar"
   },
   "Used for xdg-terminal-exec": {
-    "Used for xdg-terminal-exec": ""
+    "Used for xdg-terminal-exec": "Usado para xdg-terminal-exec"
   },
   "Used when accent color is set to Custom": {
     "Used when accent color is set to Custom": "Usado quando a cor de destaque é definida como Personalizada"
@@ -8580,7 +8589,7 @@
     "User": "Usuário"
   },
   "User Window Rules (%1)": {
-    "User Window Rules (%1)": ""
+    "User Window Rules (%1)": "Regras de Janela do Usuário (%1)"
   },
   "User already exists": {
     "User already exists": "Usuário já existe"
@@ -8589,7 +8598,7 @@
     "User created": "Usuário criado"
   },
   "User created with administrator and greeter login access": {
-    "User created with administrator and greeter login access": ""
+    "User created with administrator and greeter login access": "Usuário criado com acesso de administrador e login do greeter"
   },
   "User created with administrator privileges": {
     "User created with administrator privileges": "Usuário criado com privilégios de administrador"
@@ -8607,7 +8616,7 @@
     "Username": "Nome de usuário"
   },
   "Username must start with a lowercase letter or underscore and contain only lowercase letters, digits, hyphens, or underscores.": {
-    "Username must start with a lowercase letter or underscore and contain only lowercase letters, digits, hyphens, or underscores.": ""
+    "Username must start with a lowercase letter or underscore and contain only lowercase letters, digits, hyphens, or underscores.": "O nome de usuário deve começar com uma letra minúscula ou sublinhado e conter apenas letras minúsculas, dígitos, hífens ou sublinhados."
   },
   "Users": {
     "Users": "Usuários"
@@ -8619,16 +8628,16 @@
     "Uses sunrise/sunset times to automatically adjust night mode based on your location.": "Usa o tempo de nascer e pôr do sol para ajustar automaticamente o modo noturno baseado na sua localização."
   },
   "Uses the spotlight-bar IPC action and always opens the minimal bar.": {
-    "Uses the spotlight-bar IPC action and always opens the minimal bar.": ""
+    "Uses the spotlight-bar IPC action and always opens the minimal bar.": "Usa a ação IPC da barra spotlight e sempre abre a barra mínima."
   },
   "Using DankCalendar%1": {
-    "Using DankCalendar%1": ""
+    "Using DankCalendar%1": "Usando DankCalendar%1"
   },
   "Using global monospace font from Settings → Personalization": {
-    "Using global monospace font from Settings → Personalization": ""
+    "Using global monospace font from Settings → Personalization": "Usando a fonte monoespaçada global de Configurações → Personalização"
   },
   "Using khal": {
-    "Using khal": ""
+    "Using khal": "Usando khal"
   },
   "Using shared settings from Gamma Control": {
     "Using shared settings from Gamma Control": "Usando configurações compartilhadas do Gamma Control"
@@ -8646,7 +8655,7 @@
     "VPN configuration updated": "Configuração da VPN atualizada"
   },
   "VPN credentials saved": {
-    "VPN credentials saved": ""
+    "VPN credentials saved": "Credenciais da VPN salvas"
   },
   "VPN deleted": {
     "VPN deleted": "VPN excluída"
@@ -8691,7 +8700,7 @@
     "Vertical Tiling": "Tiling Vertical"
   },
   "Very High": {
-    "Very High": ""
+    "Very High": "Muito Alto"
   },
   "Vibrant": {
     "Vibrant": "Vibrante"
@@ -8700,13 +8709,13 @@
     "Vibrant palette with playful saturation.": "Paleta vibrante com saturação divertida."
   },
   "Video Path": {
-    "Video Path": ""
+    "Video Path": "Caminho do Vídeo"
   },
   "Video Player": {
-    "Video Player": ""
+    "Video Player": "Reprodutor de Vídeo"
   },
   "Video Screensaver": {
-    "Video Screensaver": ""
+    "Video Screensaver": "Protetor de Tela de Vídeo"
   },
   "View Mode": {
     "View Mode": "Modo de Visualização"
@@ -8715,7 +8724,7 @@
     "Visibility": "Visibilidade"
   },
   "Visible Entry Actions": {
-    "Visible Entry Actions": ""
+    "Visible Entry Actions": "Ações de Entrada Visíveis"
   },
   "Visual Effects": {
     "Visual Effects": "Efeitos Visuais"
@@ -8739,19 +8748,16 @@
     "Volume, brightness, and other system OSDs": "Volume, brilho, e outros OSDs do sistema"
   },
   "Votes": {
-    "Votes": ""
+    "Votes": "Votos"
   },
   "W": {
-    "W": ""
-  },
-  "WCAG %1 body": {
-    "WCAG %1 body": ""
+    "W": "W"
   },
   "WPA/WPA2": {
     "WPA/WPA2": "WPA/WPA2"
   },
   "WPA2 password": {
-    "WPA2 password": ""
+    "WPA2 password": "Senha WPA2"
   },
   "Wallpaper": {
     "Wallpaper": "Papel de parede"
@@ -8763,7 +8769,7 @@
     "Wallpaper Monitor": "Monitor do Papel de Parede"
   },
   "Wallpaper fill mode": {
-    "Wallpaper fill mode": ""
+    "Wallpaper fill mode": "Modo de preenchimento do papel de parede"
   },
   "Wallpaper processing failed": {
     "Wallpaper processing failed": "Processamento de papel de parede falhou"
@@ -8793,7 +8799,7 @@
     "Weather Widget": "Widget de Clima"
   },
   "Web Browser": {
-    "Web Browser": ""
+    "Web Browser": "Navegador Web"
   },
   "Welcome": {
     "Welcome": "Boas-vindas"
@@ -8802,22 +8808,22 @@
     "Welcome to DankMaterialShell": "Bem-vindo ao DankMaterialShell"
   },
   "When clicking a dock window in a Hyprland special workspace, bring that special workspace back before focusing the window": {
-    "When clicking a dock window in a Hyprland special workspace, bring that special workspace back before focusing the window": ""
+    "When clicking a dock window in a Hyprland special workspace, bring that special workspace back before focusing the window": "Ao clicar em uma janela do dock em um espaço de trabalho especial do Hyprland, traga esse espaço de trabalho especial de volta antes de focar a janela"
   },
   "When enabled, apps are sorted alphabetically. When disabled, apps are sorted by usage frequency.": {
     "When enabled, apps are sorted alphabetically. When disabled, apps are sorted by usage frequency.": "Quando ativado, apps são ordenados alfabeticamente. Quando desativado, apps são ordenados por frequência de uso."
   },
   "When enabled, checks updates on startup. When disabled, only the interval above or a manual refresh runs a check.": {
-    "When enabled, checks updates on startup. When disabled, only the interval above or a manual refresh runs a check.": ""
+    "When enabled, checks updates on startup. When disabled, only the interval above or a manual refresh runs a check.": "Quando ativado, verifica atualizações na inicialização. Quando desativado, apenas o intervalo acima ou uma atualização manual executa uma verificação."
   },
   "When locked": {
     "When locked": "Quando bloqueado"
   },
   "Which PAM service the lock screen uses to authenticate": {
-    "Which PAM service the lock screen uses to authenticate": ""
+    "Which PAM service the lock screen uses to authenticate": "Qual serviço PAM a tela de bloqueio usa para autenticar"
   },
   "White": {
-    "White": ""
+    "White": "Branco"
   },
   "Wi-Fi and Ethernet connection": {
     "Wi-Fi and Ethernet connection": "Conexão Wi-Fi e Ethernet"
@@ -8841,10 +8847,10 @@
     "WiFi enabled": "Wifi ativado"
   },
   "WiFi is disabled": {
-    "WiFi is disabled": ""
+    "WiFi is disabled": "WiFi desativado"
   },
   "WiFi is disabled. You can still edit and save hotspot settings, but starting the hotspot requires WiFi to be enabled.": {
-    "WiFi is disabled. You can still edit and save hotspot settings, but starting the hotspot requires WiFi to be enabled.": ""
+    "WiFi is disabled. You can still edit and save hotspot settings, but starting the hotspot requires WiFi to be enabled.": "WiFi desativado. Você ainda pode editar e salvar as configurações do hotspot, mas iniciar o hotspot requer que o WiFi esteja ativado."
   },
   "WiFi is off": {
     "WiFi is off": "WiFi desligado"
@@ -8862,7 +8868,7 @@
     "Widget Management": "Gerenciamento de Widgets"
   },
   "Widget Opacity": {
-    "Widget Opacity": ""
+    "Widget Opacity": "Opacidade do Widget"
   },
   "Widget Outline": {
     "Widget Outline": "Borda de Widgets"
@@ -8871,7 +8877,7 @@
     "Widget Styling": "Estilo dos Widgets"
   },
   "Widget Text Style": {
-    "Widget Text Style": ""
+    "Widget Text Style": "Estilo de Texto do Widget"
   },
   "Widget added": {
     "Widget added": "Widget adicionado"
@@ -8883,7 +8889,7 @@
     "Widgets": "Widgets"
   },
   "Widgets & Notifications": {
-    "Widgets & Notifications": ""
+    "Widgets & Notifications": "Widgets e Notificações"
   },
   "Widgets, layout, style": {
     "Widgets, layout, style": "Widgets, layout, estilo"
@@ -8892,19 +8898,19 @@
     "Width": "Largura"
   },
   "Width of the border in pixels": {
-    "Width of the border in pixels": ""
+    "Width of the border in pixels": "Largura da borda em pixels"
   },
   "Width of the widget outline in pixels": {
-    "Width of the widget outline in pixels": ""
+    "Width of the widget outline in pixels": "Largura do contorno do widget em pixels"
   },
   "Width of window border": {
-    "Width of window border": ""
+    "Width of window border": "Largura da borda da janela"
   },
   "Width of window border and focus ring": {
     "Width of window border and focus ring": "Largura da borda da janela e anel de foco"
   },
-  "Will disconnect \"%1": {
-    "Will disconnect \"%1\"": ""
+  "Will disconnect \"%1\"": {
+    "Will disconnect \"%1\"": "Desconectará \"%1\""
   },
   "Wind": {
     "Wind": "Vento"
@@ -8928,7 +8934,7 @@
     "Window Height": "Altura da Janela"
   },
   "Window Opacity": {
-    "Window Opacity": ""
+    "Window Opacity": "Opacidade da Janela"
   },
   "Window Opening": {
     "Window Opening": "Abertura de Janela"
@@ -8940,7 +8946,10 @@
     "Wipe": "Limpar"
   },
   "Working...": {
-    "Working...": ""
+    "Working...": "Trabalhando..."
+  },
+  "Workspace": {
+    "Workspace": "Espaço de Trabalho"
   },
   "Workspace Index Numbers": {
     "Workspace Index Numbers": "Índices das Áreas de Trabalho"
@@ -8961,37 +8970,37 @@
     "Workspaces": "Áreas de Trabalho"
   },
   "Wrap the app command. %command% is replaced with the actual executable": {
-    "Wrap the app command. %command% is replaced with the actual executable": ""
+    "Wrap the app command. %command% is replaced with the actual executable": "Envolver o comando do aplicativo. %command% é substituído pelo executável real"
   },
   "Write:": {
     "Write:": "Escrita:"
   },
   "X": {
-    "X": ""
+    "X": "X"
   },
   "X Axis": {
     "X Axis": "Eixo X"
   },
   "X-Ray": {
-    "X-Ray": ""
+    "X-Ray": "X-Ray"
   },
   "XKB Options": {
-    "XKB Options": ""
+    "XKB Options": "Opções XKB"
   },
   "XWayland": {
-    "XWayland": ""
+    "XWayland": "XWayland"
   },
   "Xray Blur Effect": {
-    "Xray Blur Effect": ""
+    "Xray Blur Effect": "Efeito de Desfoque Xray"
   },
   "Xray blurs only the wallpaper (efficient) and is the default when Blur is on. Set Xray to Off for regular full blur of everything beneath the window (more expensive).": {
-    "Xray blurs only the wallpaper (efficient) and is the default when Blur is on. Set Xray to Off for regular full blur of everything beneath the window (more expensive).": ""
+    "Xray blurs only the wallpaper (efficient) and is the default when Blur is on. Set Xray to Off for regular full blur of everything beneath the window (more expensive).": "Xray desfoca apenas o papel de parede (eficiente) e é o padrão quando o Desfoque está ativado. Defina Xray como Desligado para desfoque total regular de tudo sob a janela (mais caro)."
   },
   "Xray options are in Compositor → Layout": {
-    "Xray options are in Compositor → Layout": ""
+    "Xray options are in Compositor → Layout": "As opções de Xray estão em Compositor → Layout"
   },
   "Y": {
-    "Y": ""
+    "Y": "Y"
   },
   "Y Axis": {
     "Y Axis": "Eixo Y"
@@ -9009,64 +9018,64 @@
     "You need to set either:\nQT_QPA_PLATFORMTHEME=gtk3 OR\nQT_QPA_PLATFORMTHEME=qt6ct\nas environment variables, and then restart the shell.\n\nqt6ct requires qt6ct-kde to be installed.": "Você precisa definir um dos seguintes:\nQT_QPA_PLATFORMTHEME=gtk3 OU\nQT_QPA_PLATFORMTHEME=qt6ct\ncomo variáveis de ambiente, e então reiniciar o shell.\n\nqt6ct requer qt6ct-kde para ser instalado."
   },
   "You'll enter your password at the greeter after the next reboot.": {
-    "You'll enter your password at the greeter after the next reboot.": ""
+    "You'll enter your password at the greeter after the next reboot.": "Você inserirá sua senha no greeter após o próximo reinício."
   },
   "You'll skip the greeter password after the next reboot. The lock screen and signing out still require your password.": {
-    "You'll skip the greeter password after the next reboot. The lock screen and signing out still require your password.": ""
+    "You'll skip the greeter password after the next reboot. The lock screen and signing out still require your password.": "Você pulará a senha do greeter após o próximo reinício. A tela de bloqueio e a saída ainda exigem sua senha."
   },
   "You're All Set!": {
     "You're All Set!": "Tudo Pronto!"
   },
   "Your compositor does not support background blur (ext-background-effect-v1)": {
-    "Your compositor does not support background blur (ext-background-effect-v1)": ""
+    "Your compositor does not support background blur (ext-background-effect-v1)": "Seu compositor não suporta desfoque de fundo (ext-background-effect-v1)"
   },
   "Your hotspot is running.": {
-    "Your hotspot is running.": ""
+    "Your hotspot is running.": "Seu hotspot está em execução."
   },
   "Your hotspot profile is saved and ready to start.": {
-    "Your hotspot profile is saved and ready to start.": ""
+    "Your hotspot profile is saved and ready to start.": "Seu perfil de hotspot está salvo e pronto para iniciar."
   },
   "Your system is up to date!": {
-    "Your system is up to date!": ""
+    "Your system is up to date!": "Seu sistema está atualizado!"
   },
   "admin": {
-    "admin": ""
+    "admin": "admin"
   },
   "attached": {
-    "attached": ""
+    "attached": "anexado"
   },
   "below AA": {
-    "below AA": ""
+    "below AA": "abaixo de AA"
   },
   "brandon": {
     "brandon": "brandon"
   },
   "broken": {
-    "broken": ""
+    "broken": "quebrado"
   },
   "by %1": {
     "by %1": "por %1"
   },
   "checked %1d ago": {
-    "checked %1d ago": ""
+    "checked %1d ago": "verificado há %1d"
   },
   "checked %1h ago": {
-    "checked %1h ago": ""
+    "checked %1h ago": "verificado há %1h"
   },
   "checked %1m ago": {
-    "checked %1m ago": ""
+    "checked %1m ago": "verificado há %1m"
   },
   "checked just now": {
-    "checked just now": ""
+    "checked just now": "verificado agora mesmo"
   },
   "days": {
     "days": "dias"
   },
   "deprecated": {
-    "deprecated": ""
+    "deprecated": "obsoleto"
   },
   "detached": {
-    "detached": ""
+    "detached": "desanexado"
   },
   "device": {
     "device": "dispositivo"
@@ -9075,22 +9084,19 @@
     "dgop not available": "dgop não disponível"
   },
   "direct": {
-    "direct": ""
+    "direct": "direto"
   },
   "discuss": {
-    "discuss": ""
-  },
-  "display rotation option": {
-    "Normal": ""
+    "discuss": "discutir"
   },
   "e.g. /usr/bin/my-script --flag": {
-    "e.g. /usr/bin/my-script --flag": ""
+    "e.g. /usr/bin/my-script --flag": "ex.: /usr/bin/my-script --flag"
   },
   "e.g. My Script": {
-    "e.g. My Script": ""
+    "e.g. My Script": "ex.: Meu Script"
   },
   "e.g. alice": {
-    "e.g. alice": ""
+    "e.g. alice": "ex.: alice"
   },
   "e.g., firefox, kitty --title foo": {
     "e.g., firefox, kitty --title foo": "ex. firefox, kitty --title foo"
@@ -9099,13 +9105,13 @@
     "e.g., focus-workspace 3, resize-column -10": "ex. focus-workspace 3, resize-column -10"
   },
   "e.g., hl.dsp.focus({ workspace = \"3\" })": {
-    "e.g., hl.dsp.focus({ workspace = \"3\" })": ""
+    "e.g., hl.dsp.focus({ workspace = \"3\" })": "ex.: hl.dsp.focus({ workspace = \"3\" })"
   },
   "e.g., notify-send 'Hello' && sleep 1": {
     "e.g., notify-send 'Hello' && sleep 1": "por exemplo, notify-send 'Olá' && sleep 1"
   },
   "e.g., scratch, /^tmp_.*/, build": {
-    "e.g., scratch, /^tmp_.*/, build": ""
+    "e.g., scratch, /^tmp_.*/, build": "ex.: scratch, /^tmp_.*/, build"
   },
   "ext": {
     "ext": "ext"
@@ -9114,34 +9120,34 @@
     "featured": "em destaque"
   },
   "khal": {
-    "khal": ""
+    "khal": "khal"
   },
   "last seen %1": {
-    "last seen %1": ""
+    "last seen %1": "visto por último há %1"
   },
   "leave empty for default": {
     "leave empty for default": "deixe vazio por padrão"
   },
   "loginctl activate failed (exit %1)": {
-    "loginctl activate failed (exit %1)": ""
+    "loginctl activate failed (exit %1)": "Falha ao ativar com loginctl (saída %1)"
   },
   "loginctl not available - lock integration requires DMS socket connection": {
     "loginctl not available - lock integration requires DMS socket connection": "loginctl não disponível - integração com bloqueio requer conexão de socket DMS"
   },
   "mango: config reloaded": {
-    "mango: config reloaded": ""
+    "mango: config reloaded": "mango: configuração recarregada"
   },
   "mango: failed to reload config": {
-    "mango: failed to reload config": ""
+    "mango: failed to reload config": "mango: falha ao recarregar a configuração"
   },
   "mangowc Discord Server": {
-    "mangowc Discord Server": ""
+    "mangowc Discord Server": "Servidor Discord do mangowc"
   },
   "mangowc GitHub": {
-    "mangowc GitHub": ""
+    "mangowc GitHub": "GitHub do mangowc"
   },
   "matugen not available or disabled - cannot apply %1 colors": {
-    "matugen not available or disabled - cannot apply %1 colors": ""
+    "matugen not available or disabled - cannot apply %1 colors": "matugen indisponível ou desativado - não é possível aplicar cores de %1"
   },
   "matugen not found - install matugen package for dynamic theming": {
     "matugen not found - install matugen package for dynamic theming": "matugen não encontrado - instale o pacote matugen para tematização dinâmica"
@@ -9155,26 +9161,23 @@
   "nav": {
     "nav": "nav"
   },
-  "network security type": {
-    "Open": ""
-  },
   "niri GitHub": {
-    "niri GitHub": ""
+    "niri GitHub": "GitHub do niri"
   },
   "niri Matrix Chat": {
-    "niri Matrix Chat": ""
+    "niri Matrix Chat": "Chat Matrix do niri"
   },
   "niri shortcuts config": {
     "niri shortcuts config": "configuração de atalhos do niri"
   },
   "niri/dms Discord": {
-    "niri/dms Discord": ""
+    "niri/dms Discord": "Discord niri/dms"
   },
   "niri: config reloaded": {
-    "niri: config reloaded": ""
+    "niri: config reloaded": "niri: configuração recarregada"
   },
   "niri: failed to load config": {
-    "niri: failed to load config": ""
+    "niri: failed to load config": "niri: falha ao carregar a configuração"
   },
   "now": {
     "now": "agora"
@@ -9201,46 +9204,43 @@
     "on Sway": "no Sway"
   },
   "power-profiles-daemon not available": {
-    "power-profiles-daemon not available": ""
-  },
-  "primary network connection label": {
-    "Primary": ""
+    "power-profiles-daemon not available": "power-profiles-daemon indisponível"
   },
   "procs": {
     "procs": "processos"
   },
   "r/niri Subreddit": {
-    "r/niri Subreddit": ""
+    "r/niri Subreddit": "Subreddit r/niri"
   },
   "relay: %1": {
-    "relay: %1": ""
+    "relay: %1": "relay: %1"
   },
   "remote": {
-    "remote": ""
+    "remote": "remoto"
   },
   "reviewed": {
-    "reviewed": ""
+    "reviewed": "revisado"
   },
   "seconds": {
     "seconds": "segundos"
   },
   "session %1": {
-    "session %1": ""
+    "session %1": "sessão %1"
   },
   "source": {
     "source": "fonte"
   },
   "the Qt 6 Multimedia QML module": {
-    "the Qt 6 Multimedia QML module": ""
+    "the Qt 6 Multimedia QML module": "o módulo QML Qt 6 Multimedia"
   },
   "this app": {
     "this app": "este aplicativo"
   },
   "unmaintained": {
-    "unmaintained": ""
+    "unmaintained": "sem manutenção"
   },
   "until %1": {
-    "until %1": ""
+    "until %1": "até %1"
   },
   "up": {
     "up": "cima"
@@ -9249,13 +9249,13 @@
     "update dms for NM integration.": "atualize dms para integração com o NM."
   },
   "useradd failed (exit %1)": {
-    "useradd failed (exit %1)": ""
+    "useradd failed (exit %1)": "falha no useradd (saída %1)"
   },
   "userdel failed (exit %1)": {
-    "userdel failed (exit %1)": ""
+    "userdel failed (exit %1)": "falha no userdel (saída %1)"
   },
   "usermod failed (exit %1)": {
-    "usermod failed (exit %1)": ""
+    "usermod failed (exit %1)": "falha no usermod (saída %1)"
   },
   "v%1 by %2": {
     "v%1 by %2": "v%1 por %2"
@@ -9303,9 +9303,9 @@
     "↑/↓: Nav • Space: Expand • Enter: Action/Expand • E: Text": "↑/↓: Navegar • Espaço: Expandir • Enter: Ação/Expandir • E: Texto"
   },
   "↑/↓: Navigate • Enter/Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": {
-    "↑/↓: Navigate • Enter/Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": ""
+    "↑/↓: Navigate • Enter/Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": "↑/↓: Navegar • Enter/Ctrl+C: Copiar • Del: Excluir • Ctrl+E: Editar • Ctrl+S: Fixar/Desfixar • F10: Ajuda"
   },
   "↑/↓: Navigate • Enter: Paste • Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": {
-    "↑/↓: Navigate • Enter: Paste • Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": ""
+    "↑/↓: Navigate • Enter: Paste • Ctrl+C: Copy • Del: Delete • Ctrl+E: Edit • Ctrl+S: Pin/Unpin • F10: Help": "↑/↓: Navegar • Enter: Colar • Ctrl+C: Copiar • Del: Excluir • Ctrl+E: Editar • Ctrl+S: Fixar/Desfixar • F10: Ajuda"
   }
 }


### PR DESCRIPTION
Fill in 1155 previously empty or missing Portuguese (pt-BR) translation strings across the quickshell UI.

## Description

Completes the Portuguese (Brazil) localization of the quickshell UI. The `pt.json` translation file had 1155 terms that were either empty placeholders or entirely missing compared to the English base (`en.json`).

This PR fills every one of them with proper pt-BR translations, so the quickshell user interface no longer falls back to English (or shows blank text) for those strings. No source behavior changes; only the translation catalog is updated.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

None.

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

No visual change; this only supplies the missing translated strings used by the existing `I18n.tr()` calls.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs