### PR TITLE
perf(ipc): call Quickshell directly

### DIFF
--- a/core/cmd/dms/shell.go
+++ b/core/cmd/dms/shell.go
@@ -138,17 +138,8 @@ func runShellIPCCommand(args []string) {
 	if args[0] != "call" {
 		args = append([]string{"call"}, args...)
 	}
-	if len(args) >= 3 {
-		if pid, ok := shellApp.SessionPID(); ok {
-			result, isVoid, err := qsipc.Call(qsipc.SocketPathForPID(pid), args[1], args[2], args[3:])
-			if err != nil {
-				log.Fatalf("Error running IPC command: %v", err)
-			}
-			if !isVoid {
-				fmt.Fprintln(os.Stdout, result)
-			}
-			return
-		}
+	if tryDirectIPCCall(args) {
+		return
 	}
 
 	baseArgs, err := buildQsIPCBaseArgs()
@@ -164,6 +155,27 @@ func runShellIPCCommand(args []string) {
 	if err := cmd.Run(); err != nil {
 		log.Fatalf("Error running IPC command: %v", err)
 	}
+}
+
+// tryDirectIPCCall invokes the shell over its IPC socket without spawning qs.
+// Any failure falls back to the qs child process path, which owns error output.
+func tryDirectIPCCall(args []string) bool {
+	if len(args) < 3 {
+		return false
+	}
+	pid, ok := shellApp.SessionPID()
+	if !ok {
+		return false
+	}
+	result, isVoid, err := qsipc.Call(qsipc.SocketPathForPID(pid), args[1], args[2], args[3:])
+	if err != nil {
+		log.Debugf("Direct Quickshell IPC failed, falling back to qs: %v", err)
+		return false
+	}
+	if !isVoid {
+		fmt.Println(result)
+	}
+	return true
 }
 
 func printIPCHelp() {

--- a/core/cmd/dms/shell.go
+++ b/core/cmd/dms/shell.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/log"
+	"github.com/AvengeMedia/DankMaterialShell/core/internal/qsipc"
 )
 
 type ipcTargets map[string]map[string][]string
@@ -136,6 +137,18 @@ func runShellIPCCommand(args []string) {
 
 	if args[0] != "call" {
 		args = append([]string{"call"}, args...)
+	}
+	if len(args) >= 3 {
+		if pid, ok := shellApp.SessionPID(); ok {
+			result, isVoid, err := qsipc.Call(qsipc.SocketPathForPID(pid), args[1], args[2], args[3:])
+			if err != nil {
+				log.Fatalf("Error running IPC command: %v", err)
+			}
+			if !isVoid {
+				fmt.Fprintln(os.Stdout, result)
+			}
+			return
+		}
 	}
 
 	baseArgs, err := buildQsIPCBaseArgs()

--- a/core/internal/qsipc/client.go
+++ b/core/internal/qsipc/client.go
@@ -27,9 +27,9 @@ const (
 )
 
 var (
-	ErrTargetNotFound      = errors.New("Quickshell IPC target not found")
-	ErrFunctionNotFound    = errors.New("Quickshell IPC function not found")
-	ErrArgumentMismatch    = errors.New("Quickshell IPC argument mismatch")
+	ErrTargetNotFound      = errors.New("quickshell IPC target not found")
+	ErrFunctionNotFound    = errors.New("quickshell IPC function not found")
+	ErrArgumentMismatch    = errors.New("quickshell IPC argument mismatch")
 	ErrUnsupportedResponse = errors.New("unsupported Quickshell IPC response")
 )
 

--- a/core/internal/qsipc/client.go
+++ b/core/internal/qsipc/client.go
@@ -16,11 +16,22 @@ import (
 
 const (
 	commandStringCall = 3
-	responseCompleted = 5
-	maxStringLength   = 1 << 20
+
+	// Keep these indexes in sync with quickshell-mirror/quickshell:
+	// https://github.com/quickshell-mirror/quickshell/blob/59e9c47/src/io/ipccomm.cpp#L126
+	responseTargetNotFound   = 2
+	responseFunctionNotFound = 3
+	responseArgumentMismatch = 4
+	responseCompleted        = 5
+	maxStringLength          = 1 << 20
 )
 
-var ErrUnsupportedResponse = errors.New("unsupported Quickshell IPC response")
+var (
+	ErrTargetNotFound      = errors.New("Quickshell IPC target not found")
+	ErrFunctionNotFound    = errors.New("Quickshell IPC function not found")
+	ErrArgumentMismatch    = errors.New("Quickshell IPC argument mismatch")
+	ErrUnsupportedResponse = errors.New("unsupported Quickshell IPC response")
+)
 
 // Call invokes a Quickshell IpcHandler without starting a qs child process.
 func Call(socketPath, target, function string, args []string) (string, bool, error) {
@@ -70,7 +81,16 @@ func readResponse(r io.Reader) (string, bool, error) {
 	if err := binary.Read(r, binary.BigEndian, &index); err != nil {
 		return "", false, fmt.Errorf("read Quickshell IPC response: %w", err)
 	}
-	if index != responseCompleted {
+	switch index {
+	case responseTargetNotFound:
+		return "", false, ErrTargetNotFound
+	case responseFunctionNotFound:
+		return "", false, ErrFunctionNotFound
+	case responseArgumentMismatch:
+		return "", false, ErrArgumentMismatch
+	case responseCompleted:
+		break
+	default:
 		return "", false, fmt.Errorf("%w: variant index %d", ErrUnsupportedResponse, index)
 	}
 

--- a/core/internal/qsipc/client.go
+++ b/core/internal/qsipc/client.go
@@ -1,0 +1,132 @@
+package qsipc
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+	"unicode/utf16"
+)
+
+const (
+	commandStringCall = 3
+	responseCompleted = 5
+	maxStringLength   = 1 << 20
+)
+
+var ErrUnsupportedResponse = errors.New("unsupported Quickshell IPC response")
+
+// Call invokes a Quickshell IpcHandler without starting a qs child process.
+func Call(socketPath, target, function string, args []string) (string, bool, error) {
+	conn, err := net.DialTimeout("unix", socketPath, 2*time.Second)
+	if err != nil {
+		return "", false, fmt.Errorf("connect to Quickshell IPC: %w", err)
+	}
+	defer conn.Close()
+
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	if err := writeCall(conn, target, function, args); err != nil {
+		return "", false, fmt.Errorf("write Quickshell IPC request: %w", err)
+	}
+
+	result, isVoid, err := readResponse(bufio.NewReader(conn))
+	if err != nil {
+		return "", false, err
+	}
+	return result, isVoid, nil
+}
+
+func writeCall(w io.Writer, target, function string, args []string) error {
+	var buf bytes.Buffer
+	if err := buf.WriteByte(commandStringCall); err != nil {
+		return err
+	}
+	if err := writeQString(&buf, target); err != nil {
+		return err
+	}
+	if err := writeQString(&buf, function); err != nil {
+		return err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, uint32(len(args))); err != nil {
+		return err
+	}
+	for _, arg := range args {
+		if err := writeQString(&buf, arg); err != nil {
+			return err
+		}
+	}
+	_, err := w.Write(buf.Bytes())
+	return err
+}
+
+func readResponse(r io.Reader) (string, bool, error) {
+	var index uint8
+	if err := binary.Read(r, binary.BigEndian, &index); err != nil {
+		return "", false, fmt.Errorf("read Quickshell IPC response: %w", err)
+	}
+	if index != responseCompleted {
+		return "", false, fmt.Errorf("%w: variant index %d", ErrUnsupportedResponse, index)
+	}
+
+	var isVoid uint8
+	if err := binary.Read(r, binary.BigEndian, &isVoid); err != nil {
+		return "", false, fmt.Errorf("read Quickshell IPC completion: %w", err)
+	}
+	value, err := readQString(r)
+	if err != nil {
+		return "", false, fmt.Errorf("read Quickshell IPC result: %w", err)
+	}
+	return value, isVoid != 0, nil
+}
+
+func writeQString(w io.Writer, value string) error {
+	encoded := utf16.Encode([]rune(value))
+	byteLength := len(encoded) * 2
+	if byteLength > maxStringLength {
+		return fmt.Errorf("QString is too large: %d bytes", byteLength)
+	}
+	if err := binary.Write(w, binary.BigEndian, uint32(byteLength)); err != nil {
+		return err
+	}
+	for _, codeUnit := range encoded {
+		if err := binary.Write(w, binary.BigEndian, codeUnit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readQString(r io.Reader) (string, error) {
+	var length uint32
+	if err := binary.Read(r, binary.BigEndian, &length); err != nil {
+		return "", err
+	}
+	if length == ^uint32(0) {
+		return "", nil
+	}
+	if length > maxStringLength || length%2 != 0 {
+		return "", fmt.Errorf("invalid QString length: %d bytes", length)
+	}
+	codeUnits := make([]uint16, length/2)
+	for i := range codeUnits {
+		if err := binary.Read(r, binary.BigEndian, &codeUnits[i]); err != nil {
+			return "", err
+		}
+	}
+	return string(utf16.Decode(codeUnits)), nil
+}
+
+// SocketPathForPID returns the instance IPC socket used by qs --pid.
+func SocketPathForPID(pid int) string {
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	if runtimeDir == "" {
+		runtimeDir = fmt.Sprintf("/run/user/%d", os.Getuid())
+	}
+	return filepath.Join(runtimeDir, "quickshell", "by-pid", fmt.Sprint(pid), "ipc.sock")
+}

--- a/core/internal/qsipc/client.go
+++ b/core/internal/qsipc/client.go
@@ -19,6 +19,7 @@ const (
 
 	// Keep these indexes in sync with quickshell-mirror/quickshell:
 	// https://github.com/quickshell-mirror/quickshell/blob/59e9c47/src/io/ipccomm.cpp#L126
+	responseNotReady         = 1
 	responseTargetNotFound   = 2
 	responseFunctionNotFound = 3
 	responseArgumentMismatch = 4
@@ -27,6 +28,7 @@ const (
 )
 
 var (
+	ErrNotReady            = errors.New("quickshell IPC not ready")
 	ErrTargetNotFound      = errors.New("quickshell IPC target not found")
 	ErrFunctionNotFound    = errors.New("quickshell IPC function not found")
 	ErrArgumentMismatch    = errors.New("quickshell IPC argument mismatch")
@@ -82,6 +84,8 @@ func readResponse(r io.Reader) (string, bool, error) {
 		return "", false, fmt.Errorf("read Quickshell IPC response: %w", err)
 	}
 	switch index {
+	case responseNotReady:
+		return "", false, ErrNotReady
 	case responseTargetNotFound:
 		return "", false, ErrTargetNotFound
 	case responseFunctionNotFound:

--- a/core/internal/qsipc/client_test.go
+++ b/core/internal/qsipc/client_test.go
@@ -1,0 +1,40 @@
+package qsipc
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestWriteCall(t *testing.T) {
+	var got bytes.Buffer
+	if err := writeCall(&got, "spotlight", "toggle", []string{"true", "é"}); err != nil {
+		t.Fatal(err)
+	}
+	want, err := hex.DecodeString("030000001200730070006f0074006c00690067006800740000000c0074006f00670067006c0065000000020000000800740072007500650000000200e9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got.Bytes(), want) {
+		for i := range got.Bytes() {
+			if got.Bytes()[i] != want[i] {
+				t.Fatalf("unexpected byte at %d: got %02x want %02x", i, got.Bytes()[i], want[i])
+			}
+		}
+		t.Fatal("unexpected wire bytes")
+	}
+}
+
+func TestReadResponse(t *testing.T) {
+	data, err := hex.DecodeString("050000000018007b0022006f006b0022003a00200074007200750065007d")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, isVoid, err := readResponse(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isVoid || value != `{"ok": true}` {
+		t.Fatalf("unexpected response: value=%q void=%v", value, isVoid)
+	}
+}

--- a/core/internal/qsipc/client_test.go
+++ b/core/internal/qsipc/client_test.go
@@ -17,12 +17,7 @@ func TestWriteCall(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(got.Bytes(), want) {
-		for i := range got.Bytes() {
-			if got.Bytes()[i] != want[i] {
-				t.Fatalf("unexpected byte at %d: got %02x want %02x", i, got.Bytes()[i], want[i])
-			}
-		}
-		t.Fatal("unexpected wire bytes")
+		t.Fatalf("unexpected wire bytes:\ngot  %x\nwant %x", got.Bytes(), want)
 	}
 }
 
@@ -46,6 +41,7 @@ func TestReadResponseErrors(t *testing.T) {
 		index byte
 		want  error
 	}{
+		{name: "not ready", index: responseNotReady, want: ErrNotReady},
 		{name: "target not found", index: responseTargetNotFound, want: ErrTargetNotFound},
 		{name: "function not found", index: responseFunctionNotFound, want: ErrFunctionNotFound},
 		{name: "argument mismatch", index: responseArgumentMismatch, want: ErrArgumentMismatch},

--- a/core/internal/qsipc/client_test.go
+++ b/core/internal/qsipc/client_test.go
@@ -3,6 +3,7 @@ package qsipc
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"testing"
 )
 
@@ -36,5 +37,26 @@ func TestReadResponse(t *testing.T) {
 	}
 	if isVoid || value != `{"ok": true}` {
 		t.Fatalf("unexpected response: value=%q void=%v", value, isVoid)
+	}
+}
+
+func TestReadResponseErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		index byte
+		want  error
+	}{
+		{name: "target not found", index: responseTargetNotFound, want: ErrTargetNotFound},
+		{name: "function not found", index: responseFunctionNotFound, want: ErrFunctionNotFound},
+		{name: "argument mismatch", index: responseArgumentMismatch, want: ErrArgumentMismatch},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := readResponse(bytes.NewReader([]byte{tt.index}))
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("readResponse() error = %v, want %v", err, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

Reduce `dms ipc` latency by calling the running Quickshell instance directly over its Unix IPC socket instead of spawning a `qs` process for every command.

This keeps the existing `dms ipc call <target> <function>` syntax and falls back to the existing path when no running session is available.

Benchmarking `spotlight toggle` locally reduced latency from approximately `336 ms ± 130ms` to `210.5 ms ± 88.7ms` by removing the intermediate `qs` process.

A separate lightweight IPC binary could reduce startup latency further, but is intentionally left out of this PR to preserve the existing command interface and keep the change focused.

## Type of change

- [x] Refactor / internal cleanup

## Related issues

#2060

## Screenshots / video

Not applicable.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
