### PR TITLE
control-center: route Bluetooth power toggles through DMS backend

### DIFF
--- a/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
+++ b/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
@@ -191,9 +191,7 @@ Column {
             }
         case "bluetooth":
             {
-                if (BluetoothService.available && BluetoothService.adapter) {
-                    BluetoothService.adapter.enabled = !BluetoothService.adapter.enabled;
-                }
+                BluetoothService.setBluetoothEnabled(!BluetoothService.enabled);
                 break;
             }
         case "audioOutput":

--- a/quickshell/Services/BluetoothService.qml
+++ b/quickshell/Services/BluetoothService.qml
@@ -11,6 +11,7 @@ import qs.Services
 Singleton {
     id: root
 
+    readonly property var log: Log.scoped("BluetoothService")
     readonly property BluetoothAdapter adapter: Bluetooth.defaultAdapter
     readonly property bool available: adapter !== null
     readonly property bool enabled: (adapter && adapter.enabled) ?? false
@@ -77,6 +78,21 @@ Singleton {
     Component.onCompleted: {
         detectWpexecProcess.running = true;
         maybeSubscribeCodecSignals();
+    }
+
+    function setBluetoothEnabled(enabled) {
+        if (DMSService.isConnected && DMSService.capabilities.includes("bluetooth")) {
+            DMSService.sendRequest("bluetooth.setPowered", {
+                "powered": enabled
+            }, response => {
+                if (response.error)
+                    log.warn("Failed to set Bluetooth powered state:", response.error);
+            });
+            return;
+        }
+
+        if (adapter)
+            adapter.enabled = enabled;
     }
 
     Connections {


### PR DESCRIPTION
## Description

The Control Center previously toggled `BluetoothService.adapter.enabled` directly, bypassing DMS’s Bluetooth backend.

This change routes Bluetooth power toggles through `bluetooth.setPowered` whenever the DMS Bluetooth capability is available. The backend already attempts soft-rfkill unblocking before enabling the BlueZ adapter, making recovery automatic and invisible to the user.

If the backend is unavailable, it falls back to the Quickshell Bluetooth adapter.

## What changed

- Added `BluetoothService.setBluetoothEnabled()`
- Routed the existing Control Center toggle through the DMS backend
- Logs backend failures
- Preserves the direct adapter fallback
- Adds no prompts, external commands, or visual changes

## Testing

- `make lint-qml` passes
- `git diff --check` passes
- Quickshell configuration loads without new errors
- Tested in the active DMS installation