### PR TITLE
feat(dankbar): corner style & bar length padding

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1029,6 +1029,7 @@ Singleton {
             "innerPadding": 4,
             "barInsetPadding": -1,
             "bottomGap": 0,
+            "attachToScreenEdge": false,
             "transparency": 1.0,
             "widgetTransparency": 1.0,
             "squareCorners": false,

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1806,6 +1806,7 @@ Singleton {
         return {
             "shadowIntensity": config?.shadowIntensity ?? 0,
             "squareCorners": config?.squareCorners ?? false,
+            "attachToScreenEdge": config?.attachToScreenEdge ?? false,
             "gothCornersEnabled": config?.gothCornersEnabled ?? false,
             "borderEnabled": config?.borderEnabled ?? false
         };
@@ -1879,7 +1880,7 @@ Singleton {
             updateBarConfigs();
     }
 
-    // Zeroes out connected-mode-hostile fields (shadow, square/goth corners, border).
+    // Zeroes out connected-mode-hostile fields (shadow, square/goth corners, edge attach, border).
     // Returns { configs, changed } — `configs` is the same ref when no change.
     function _sanitizeBarConfigsForConnectedFrame(configs) {
         if (!connectedFrameModeActive || !Array.isArray(configs))
@@ -1900,6 +1901,10 @@ Singleton {
             }
             if (s.squareCorners ?? false) {
                 s.squareCorners = false;
+                dirty = true;
+            }
+            if (s.attachToScreenEdge ?? false) {
+                s.attachToScreenEdge = false;
                 dirty = true;
             }
             if (s.gothCornersEnabled ?? false) {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1028,6 +1028,7 @@ Singleton {
             "spacing": 4,
             "innerPadding": 4,
             "barInsetPadding": -1,
+            "barLengthPadding": 0,
             "bottomGap": 0,
             "attachToScreenEdge": false,
             "transparency": 1.0,

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -577,6 +577,7 @@ var SPEC = {
             rightWidgets: ["systemTray", "clipboard", "cpuUsage", "memUsage", "notificationButton", "battery", "controlCenterButton"],
             spacing: 4,
             innerPadding: 4,
+            barLengthPadding: 0,
             bottomGap: 0,
             attachToScreenEdge: false,
             transparency: 1.0,

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -578,6 +578,7 @@ var SPEC = {
             spacing: 4,
             innerPadding: 4,
             bottomGap: 0,
+            attachToScreenEdge: false,
             transparency: 1.0,
             widgetTransparency: 1.0,
             squareCorners: false,

--- a/quickshell/Modules/DankBar/BarCanvas.qml
+++ b/quickshell/Modules/DankBar/BarCanvas.qml
@@ -29,6 +29,7 @@ Item {
     readonly property bool isBottom: barPos === SettingsData.Position.Bottom
     readonly property bool isLeft: barPos === SettingsData.Position.Left
     readonly property bool isRight: barPos === SettingsData.Position.Right
+    readonly property bool edgeAttached: (barConfig?.attachToScreenEdge ?? false) && !frameShapesBar
 
     property real wing: gothEnabled ? barWindow._wingR : 0
 
@@ -204,10 +205,10 @@ Item {
         // wing-side body corners are square where the gothic fillets attach;
         // rounding the shadow there leaves a shadow-filled notch under the
         // translucent bar fill (#2975)
-        topLeftRadius: root.gothEnabled && (root.isBottom || root.isRight) ? 0 : root.rt
-        topRightRadius: root.gothEnabled && (root.isBottom || root.isLeft) ? 0 : root.rt
-        bottomLeftRadius: root.gothEnabled && (root.isTop || root.isRight) ? 0 : root.rt
-        bottomRightRadius: root.gothEnabled && (root.isTop || root.isLeft) ? 0 : root.rt
+        topLeftRadius: root.edgeAttached && (root.isTop || root.isLeft) ? 0 : (root.gothEnabled && (root.isBottom || root.isRight) ? 0 : root.rt)
+        topRightRadius: root.edgeAttached && (root.isTop || root.isRight) ? 0 : (root.gothEnabled && (root.isBottom || root.isLeft) ? 0 : root.rt)
+        bottomLeftRadius: root.edgeAttached && (root.isBottom || root.isLeft) ? 0 : (root.gothEnabled && (root.isTop || root.isRight) ? 0 : root.rt)
+        bottomRightRadius: root.edgeAttached && (root.isBottom || root.isRight) ? 0 : (root.gothEnabled && (root.isTop || root.isLeft) ? 0 : root.rt)
         // barShape below is the sole painter of the bar; a fill here doubles
         // the alpha of translucent bars while the wings stay single-painted
         targetColor: "transparent"
@@ -298,7 +299,7 @@ Item {
         h = h - wing;
         const r = wing;
         const cr = rt;
-        const crE = frameShapesBar ? 0 : cr;
+        const crE = frameShapesBar || edgeAttached ? 0 : cr;
 
         let d = `M ${crE} 0`;
         d += ` L ${w - crE} 0`;
@@ -329,7 +330,7 @@ Item {
         h = h - wing;
         const r = wing;
         const cr = rt;
-        const crE = frameShapesBar ? 0 : cr;
+        const crE = frameShapesBar || edgeAttached ? 0 : cr;
 
         let d = `M ${crE} ${fullH}`;
         d += ` L ${w - crE} ${fullH}`;
@@ -359,7 +360,7 @@ Item {
         w = w - wing;
         const r = wing;
         const cr = rt;
-        const crE = frameShapesBar ? 0 : cr;
+        const crE = frameShapesBar || edgeAttached ? 0 : cr;
 
         let d = `M 0 ${crE}`;
         d += ` L 0 ${h - crE}`;
@@ -390,7 +391,7 @@ Item {
         w = w - wing;
         const r = wing;
         const cr = rt;
-        const crE = frameShapesBar ? 0 : cr;
+        const crE = frameShapesBar || edgeAttached ? 0 : cr;
 
         let d = `M ${fullW} ${crE}`;
         d += ` L ${fullW} ${h - crE}`;
@@ -514,11 +515,12 @@ Item {
         if (isTop) {
             const w = fullW - i * 2;
             const h = fullH - wing - i * 2;
+            const crE = edgeAttached ? 0 : cr;
 
-            let d = `M ${i + cr} ${i}`;
-            d += ` L ${i + w - cr} ${i}`;
-            if (cr > 0)
-                d += ` A ${cr} ${cr} 0 0 1 ${i + w} ${i + cr}`;
+            let d = `M ${i + crE} ${i}`;
+            d += ` L ${i + w - crE} ${i}`;
+            if (crE > 0)
+                d += ` A ${crE} ${crE} 0 0 1 ${i + w} ${i + crE}`;
             if (r > 0) {
                 d += ` L ${i + w} ${fullH - i}`;
                 d += ` A ${r} ${r} 0 0 0 ${i + w - r} ${i + h}`;
@@ -532,9 +534,9 @@ Item {
                 if (cr > 0)
                     d += ` A ${cr} ${cr} 0 0 1 ${i} ${i + h - cr}`;
             }
-            d += ` L ${i} ${i + cr}`;
-            if (cr > 0)
-                d += ` A ${cr} ${cr} 0 0 1 ${i + cr} ${i}`;
+            d += ` L ${i} ${i + crE}`;
+            if (crE > 0)
+                d += ` A ${crE} ${crE} 0 0 1 ${i + crE} ${i}`;
             d += " Z";
             return d;
         }
@@ -542,11 +544,12 @@ Item {
         if (isBottom) {
             const w = fullW - i * 2;
             const h = fullH - wing - i * 2;
+            const crE = edgeAttached ? 0 : cr;
 
-            let d = `M ${i + cr} ${fullH - i}`;
-            d += ` L ${i + w - cr} ${fullH - i}`;
-            if (cr > 0)
-                d += ` A ${cr} ${cr} 0 0 0 ${i + w} ${fullH - i - cr}`;
+            let d = `M ${i + crE} ${fullH - i}`;
+            d += ` L ${i + w - crE} ${fullH - i}`;
+            if (crE > 0)
+                d += ` A ${crE} ${crE} 0 0 0 ${i + w} ${fullH - i - crE}`;
             if (r > 0) {
                 d += ` L ${i + w} ${i}`;
                 d += ` A ${r} ${r} 0 0 1 ${i + w - r} ${i + r}`;
@@ -560,9 +563,9 @@ Item {
                 if (cr > 0)
                     d += ` A ${cr} ${cr} 0 0 0 ${i} ${i + cr}`;
             }
-            d += ` L ${i} ${fullH - i - cr}`;
-            if (cr > 0)
-                d += ` A ${cr} ${cr} 0 0 0 ${i + cr} ${fullH - i}`;
+            d += ` L ${i} ${fullH - i - crE}`;
+            if (crE > 0)
+                d += ` A ${crE} ${crE} 0 0 0 ${i + crE} ${fullH - i}`;
             d += " Z";
             return d;
         }
@@ -570,11 +573,12 @@ Item {
         if (isLeft) {
             const w = fullW - wing - i * 2;
             const h = fullH - i * 2;
+            const crE = edgeAttached ? 0 : cr;
 
-            let d = `M ${i} ${i + cr}`;
-            d += ` L ${i} ${i + h - cr}`;
-            if (cr > 0)
-                d += ` A ${cr} ${cr} 0 0 0 ${i + cr} ${i + h}`;
+            let d = `M ${i} ${i + crE}`;
+            d += ` L ${i} ${i + h - crE}`;
+            if (crE > 0)
+                d += ` A ${crE} ${crE} 0 0 0 ${i + crE} ${i + h}`;
             if (r > 0) {
                 d += ` L ${fullW - i} ${i + h}`;
                 d += ` A ${r} ${r} 0 0 1 ${i + w} ${i + h - r}`;
@@ -588,9 +592,9 @@ Item {
                 if (cr > 0)
                     d += ` A ${cr} ${cr} 0 0 0 ${i + w - cr} ${i}`;
             }
-            d += ` L ${i + cr} ${i}`;
-            if (cr > 0)
-                d += ` A ${cr} ${cr} 0 0 0 ${i} ${i + cr}`;
+            d += ` L ${i + crE} ${i}`;
+            if (crE > 0)
+                d += ` A ${crE} ${crE} 0 0 0 ${i} ${i + crE}`;
             d += " Z";
             return d;
         }
@@ -598,11 +602,12 @@ Item {
         if (isRight) {
             const w = fullW - wing - i * 2;
             const h = fullH - i * 2;
+            const crE = edgeAttached ? 0 : cr;
 
-            let d = `M ${fullW - i} ${i + cr}`;
-            d += ` L ${fullW - i} ${i + h - cr}`;
-            if (cr > 0)
-                d += ` A ${cr} ${cr} 0 0 1 ${fullW - i - cr} ${i + h}`;
+            let d = `M ${fullW - i} ${i + crE}`;
+            d += ` L ${fullW - i} ${i + h - crE}`;
+            if (crE > 0)
+                d += ` A ${crE} ${crE} 0 0 1 ${fullW - i - crE} ${i + h}`;
             if (r > 0) {
                 d += ` L ${i} ${i + h}`;
                 d += ` A ${r} ${r} 0 0 0 ${i + r} ${i + h - r}`;
@@ -616,9 +621,9 @@ Item {
                 if (cr > 0)
                     d += ` A ${cr} ${cr} 0 0 1 ${wing + i + cr} ${i}`;
             }
-            d += ` L ${fullW - i - cr} ${i}`;
-            if (cr > 0)
-                d += ` A ${cr} ${cr} 0 0 1 ${fullW - i} ${i + cr}`;
+            d += ` L ${fullW - i - crE} ${i}`;
+            if (crE > 0)
+                d += ` A ${crE} ${crE} 0 0 1 ${fullW - i} ${i + crE}`;
             d += " Z";
             return d;
         }

--- a/quickshell/Modules/DankBar/DankBarBody.qml
+++ b/quickshell/Modules/DankBar/DankBarBody.qml
@@ -571,6 +571,7 @@ Item {
 
     readonly property int notificationCount: NotificationService.notifications.length
     readonly property real effectiveBarThickness: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? SettingsData.frameBarSize : Theme.snap(Math.max(barWindow.widgetThickness + (barConfig?.innerPadding ?? 4) + 4, Theme.barHeight - 4 - (8 - (barConfig?.innerPadding ?? 4))), _dpr)
+    readonly property real effectiveBarLengthPadding: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? 0 : Math.max(0, barConfig?.barLengthPadding ?? 0)
     readonly property bool effectiveOpenOnOverview: FrameTransitionState.effectiveFrameEnabled ? SettingsData.frameShowOnOverview : (barConfig?.openOnOverview ?? false)
     readonly property real widgetThickness: Theme.snap(Math.max(20, 26 + (barConfig?.innerPadding ?? 4) * 0.6), _dpr)
 
@@ -1074,11 +1075,12 @@ Item {
                 Item {
                     id: barUnitInset
                     property int spacingPx: Theme.px(barWindow.effectiveSpacing, barWindow._dpr)
+                    property int lengthPaddingPx: Theme.px(barWindow.effectiveBarLengthPadding, barWindow._dpr)
                     anchors.fill: parent
-                    anchors.leftMargin: !barWindow.isVertical ? spacingPx : (axis.edge === "left" ? spacingPx : 0)
-                    anchors.rightMargin: !barWindow.isVertical ? spacingPx : (axis.edge === "right" ? spacingPx : 0)
-                    anchors.topMargin: barWindow.isVertical ? (barWindow.hasAdjacentTopBar ? 0 : spacingPx) : (axis.outerVisualEdge() === "bottom" ? 0 : spacingPx)
-                    anchors.bottomMargin: barWindow.isVertical ? (barWindow.hasAdjacentBottomBar ? 0 : spacingPx) : (axis.outerVisualEdge() === "bottom" ? spacingPx : 0)
+                    anchors.leftMargin: !barWindow.isVertical ? spacingPx + lengthPaddingPx : (axis.edge === "left" ? spacingPx : 0)
+                    anchors.rightMargin: !barWindow.isVertical ? spacingPx + lengthPaddingPx : (axis.edge === "right" ? spacingPx : 0)
+                    anchors.topMargin: barWindow.isVertical ? (barWindow.hasAdjacentTopBar ? 0 : spacingPx) + lengthPaddingPx : (axis.outerVisualEdge() === "bottom" ? 0 : spacingPx)
+                    anchors.bottomMargin: barWindow.isVertical ? (barWindow.hasAdjacentBottomBar ? 0 : spacingPx) + lengthPaddingPx : (axis.outerVisualEdge() === "bottom" ? spacingPx : 0)
 
                     BarCanvas {
                         id: barBackground

--- a/quickshell/Modules/DankBar/DankBarBody.qml
+++ b/quickshell/Modules/DankBar/DankBarBody.qml
@@ -559,7 +559,8 @@ Item {
         shouldHideForWindows = filtered.length > 0;
     }
 
-    property real effectiveSpacing: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? 0 : ((flattenForMaximizedWindow && hasMaximizedToplevel) ? 0 : (barConfig?.spacing ?? 4))
+    readonly property bool edgeAttached: (barConfig?.attachToScreenEdge ?? false) && !(FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome)
+    property real effectiveSpacing: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? 0 : ((edgeAttached || (flattenForMaximizedWindow && hasMaximizedToplevel)) ? 0 : (barConfig?.spacing ?? 4))
 
     Behavior on effectiveSpacing {
         enabled: barWindow.hostWindow?.visible ?? false
@@ -571,7 +572,13 @@ Item {
 
     readonly property int notificationCount: NotificationService.notifications.length
     readonly property real effectiveBarThickness: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? SettingsData.frameBarSize : Theme.snap(Math.max(barWindow.widgetThickness + (barConfig?.innerPadding ?? 4) + 4, Theme.barHeight - 4 - (8 - (barConfig?.innerPadding ?? 4))), _dpr)
-    readonly property real effectiveBarLengthPadding: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? 0 : Math.max(0, barConfig?.barLengthPadding ?? 0)
+    readonly property real effectiveBarLengthPadding: {
+        if ((FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) || (flattenForMaximizedWindow && hasMaximizedToplevel))
+            return 0;
+        const pad = Math.max(0, barConfig?.barLengthPadding ?? 0);
+        const length = isVertical ? height : width;
+        return length > 0 ? Math.min(pad, Math.max(0, length / 2 - effectiveSpacing)) : pad;
+    }
     readonly property bool effectiveOpenOnOverview: FrameTransitionState.effectiveFrameEnabled ? SettingsData.frameShowOnOverview : (barConfig?.openOnOverview ?? false)
     readonly property real widgetThickness: Theme.snap(Math.max(20, 26 + (barConfig?.innerPadding ?? 4) * 0.6), _dpr)
 
@@ -767,6 +774,7 @@ Item {
         id: inputMask
 
         readonly property int barThickness: Theme.px(barWindow.effectiveBarThickness + barWindow.effectiveSpacing, barWindow._dpr)
+        readonly property int lengthPaddingPx: Theme.px(barWindow.effectiveBarLengthPadding, barWindow._dpr)
 
         readonly property bool inOverviewWithShow: CompositorService.isNiri && NiriService.inOverview && barWindow.effectiveOpenOnOverview
         readonly property bool effectiveVisible: (barConfig?.visible ?? true) || inOverviewWithShow
@@ -776,7 +784,7 @@ Item {
 
         x: {
             if (!axis.isVertical) {
-                return 0;
+                return lengthPaddingPx;
             } else {
                 switch (barPos) {
                 case SettingsData.Position.Left:
@@ -790,7 +798,7 @@ Item {
         }
         y: {
             if (axis.isVertical) {
-                return 0;
+                return lengthPaddingPx;
             } else {
                 switch (barPos) {
                 case SettingsData.Position.Top:
@@ -802,8 +810,8 @@ Item {
                 }
             }
         }
-        width: axis.isVertical ? maskThickness : parent.width
-        height: axis.isVertical ? parent.height : maskThickness
+        width: axis.isVertical ? maskThickness : parent.width - lengthPaddingPx * 2
+        height: axis.isVertical ? parent.height - lengthPaddingPx * 2 : maskThickness
     }
 
     readonly property bool clickThroughEnabled: barConfig?.clickThrough ?? false

--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -1040,7 +1040,7 @@ Item {
                     tags: ["bar", "length", "padding", "size", "shorter"]
                     unit: "px"
                     minimum: 0
-                    maximum: 128
+                    maximum: 512
                     defaultValue: 0
                     value: selectedBarConfig?.barLengthPadding ?? 0
                     onSliderDragFinished: finalValue => SettingsData.updateBarConfig(selectedBarId, {

--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -1044,8 +1044,8 @@ Item {
                     defaultValue: 0
                     value: selectedBarConfig?.barLengthPadding ?? 0
                     onSliderDragFinished: finalValue => SettingsData.updateBarConfig(selectedBarId, {
-                        barLengthPadding: finalValue
-                    })
+                            barLengthPadding: finalValue
+                        })
 
                     Binding {
                         target: barLengthPaddingSlider
@@ -1250,7 +1250,7 @@ Item {
                     text: I18n.tr("Corner Style")
                     description: I18n.tr("Choose how the bar meets the screen edge")
                     visible: !SettingsData.frameEnabled
-                    model: [I18n.tr("Rounded"), I18n.tr("Flush"), I18n.tr("Square")]
+                    model: [I18n.tr("Rounded", "bar corner style option"), I18n.tr("Flush", "bar corner style option"), I18n.tr("Square", "bar corner style option")]
                     currentIndex: {
                         if (selectedBarConfig?.squareCorners ?? false)
                             return 2;

--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -137,6 +137,7 @@ Item {
             spacing: defaultBar.spacing ?? 4,
             innerPadding: defaultBar.innerPadding ?? 4,
             bottomGap: defaultBar.bottomGap ?? 0,
+            attachToScreenEdge: defaultBar.attachToScreenEdge ?? false,
             transparency: defaultBar.transparency ?? 1.0,
             widgetTransparency: defaultBar.widgetTransparency ?? 1.0,
             squareCorners: defaultBar.squareCorners ?? false,
@@ -1175,6 +1176,18 @@ Item {
                     checked: selectedBarConfig?.squareCorners ?? false
                     onToggled: checked => SettingsData.updateBarConfig(selectedBarId, {
                             squareCorners: checked
+                        })
+                }
+
+                SettingsToggleRow {
+                    settingKey: "barAttachToScreenEdge"
+                    tags: ["attach", "edge", "screen", "flush", "bar"]
+                    text: I18n.tr("Attach to Screen Edge")
+                    description: I18n.tr("Align the outer bar edge with the screen while keeping the inner edge rounded")
+                    visible: !SettingsData.frameEnabled
+                    checked: selectedBarConfig?.attachToScreenEdge ?? false
+                    onToggled: checked => SettingsData.updateBarConfig(selectedBarId, {
+                            attachToScreenEdge: checked
                         })
                 }
 

--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -1192,30 +1192,6 @@ Item {
                     reason: I18n.tr("Managed by Frame")
                 }
 
-                SettingsButtonGroupRow {
-                    settingKey: "barCornerStyle"
-                    tags: ["rounded", "attached", "square", "corners", "edge", "screen", "flush"]
-                    text: I18n.tr("Corner Style")
-                    description: I18n.tr("Choose how the bar meets the screen edge")
-                    visible: !SettingsData.frameEnabled
-                    model: [I18n.tr("Rounded"), I18n.tr("Flush"), I18n.tr("Square")]
-                    currentIndex: {
-                        if (selectedBarConfig?.squareCorners ?? false)
-                            return 2;
-                        if (selectedBarConfig?.attachToScreenEdge ?? false)
-                            return 1;
-                        return 0;
-                    }
-                    onSelectionChanged: (index, selected) => {
-                        if (!selected)
-                            return;
-                        SettingsData.updateBarConfig(selectedBarId, {
-                            squareCorners: index === 2,
-                            attachToScreenEdge: index === 1
-                        });
-                    }
-                }
-
                 SettingsToggleRow {
                     settingKey: "barNoBackground"
                     tags: ["transparent", "background", "invisible"]
@@ -1266,6 +1242,30 @@ Item {
                     height: 1
                     color: Theme.outline
                     opacity: 0.15
+                }
+
+                SettingsButtonGroupRow {
+                    settingKey: "barCornerStyle"
+                    tags: ["rounded", "attached", "square", "corners", "edge", "screen", "flush"]
+                    text: I18n.tr("Corner Style")
+                    description: I18n.tr("Choose how the bar meets the screen edge")
+                    visible: !SettingsData.frameEnabled
+                    model: [I18n.tr("Rounded"), I18n.tr("Flush"), I18n.tr("Square")]
+                    currentIndex: {
+                        if (selectedBarConfig?.squareCorners ?? false)
+                            return 2;
+                        if (selectedBarConfig?.attachToScreenEdge ?? false)
+                            return 1;
+                        return 0;
+                    }
+                    onSelectionChanged: (index, selected) => {
+                        if (!selected)
+                            return;
+                        SettingsData.updateBarConfig(selectedBarId, {
+                            squareCorners: index === 2,
+                            attachToScreenEdge: index === 1
+                        });
+                    }
                 }
 
                 SettingsToggleRow {

--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -1192,28 +1192,28 @@ Item {
                     reason: I18n.tr("Managed by Frame")
                 }
 
-                SettingsToggleRow {
-                    settingKey: "barSquareCorners"
-                    tags: ["square", "corners", "rounding"]
-                    text: I18n.tr("Square Corners")
-                    description: I18n.tr("Remove corner rounding from the bar")
+                SettingsButtonGroupRow {
+                    settingKey: "barCornerStyle"
+                    tags: ["rounded", "attached", "square", "corners", "edge", "screen", "flush"]
+                    text: I18n.tr("Corner Style")
+                    description: I18n.tr("Choose how the bar meets the screen edge")
                     visible: !SettingsData.frameEnabled
-                    checked: selectedBarConfig?.squareCorners ?? false
-                    onToggled: checked => SettingsData.updateBarConfig(selectedBarId, {
-                            squareCorners: checked
-                        })
-                }
-
-                SettingsToggleRow {
-                    settingKey: "barAttachToScreenEdge"
-                    tags: ["attach", "edge", "screen", "flush", "bar"]
-                    text: I18n.tr("Attach to Screen Edge")
-                    description: I18n.tr("Align the outer bar edge with the screen while keeping the inner edge rounded")
-                    visible: !SettingsData.frameEnabled
-                    checked: selectedBarConfig?.attachToScreenEdge ?? false
-                    onToggled: checked => SettingsData.updateBarConfig(selectedBarId, {
-                            attachToScreenEdge: checked
-                        })
+                    model: [I18n.tr("Rounded"), I18n.tr("Attached"), I18n.tr("Square")]
+                    currentIndex: {
+                        if (selectedBarConfig?.squareCorners ?? false)
+                            return 2;
+                        if (selectedBarConfig?.attachToScreenEdge ?? false)
+                            return 1;
+                        return 0;
+                    }
+                    onSelectionChanged: (index, selected) => {
+                        if (!selected)
+                            return;
+                        SettingsData.updateBarConfig(selectedBarId, {
+                            squareCorners: index === 2,
+                            attachToScreenEdge: index === 1
+                        });
+                    }
                 }
 
                 SettingsToggleRow {

--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -1198,7 +1198,7 @@ Item {
                     text: I18n.tr("Corner Style")
                     description: I18n.tr("Choose how the bar meets the screen edge")
                     visible: !SettingsData.frameEnabled
-                    model: [I18n.tr("Rounded"), I18n.tr("Attached"), I18n.tr("Square")]
+                    model: [I18n.tr("Rounded"), I18n.tr("Flush"), I18n.tr("Square")]
                     currentIndex: {
                         if (selectedBarConfig?.squareCorners ?? false)
                             return 2;

--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -136,6 +136,7 @@ Item {
             rightWidgets: defaultBar.rightWidgets || [],
             spacing: defaultBar.spacing ?? 4,
             innerPadding: defaultBar.innerPadding ?? 4,
+            barLengthPadding: defaultBar.barLengthPadding ?? 0,
             bottomGap: defaultBar.bottomGap ?? 0,
             attachToScreenEdge: defaultBar.attachToScreenEdge ?? false,
             transparency: defaultBar.transparency ?? 1.0,
@@ -1026,6 +1027,30 @@ Item {
                         target: barInsetPaddingSlider
                         property: "value"
                         value: dankBarTab.insetPadDisplayValue
+                        restoreMode: Binding.RestoreBinding
+                    }
+                }
+
+                SettingsSliderRow {
+                    id: barLengthPaddingSlider
+                    settingKey: "barLengthPadding"
+                    visible: !SettingsData.frameEnabled
+                    text: I18n.tr("Bar Length Padding")
+                    description: I18n.tr("Reduce the visible bar length from both ends")
+                    tags: ["bar", "length", "padding", "size", "shorter"]
+                    unit: "px"
+                    minimum: 0
+                    maximum: 128
+                    defaultValue: 0
+                    value: selectedBarConfig?.barLengthPadding ?? 0
+                    onSliderDragFinished: finalValue => SettingsData.updateBarConfig(selectedBarId, {
+                        barLengthPadding: finalValue
+                    })
+
+                    Binding {
+                        target: barLengthPaddingSlider
+                        property: "value"
+                        value: selectedBarConfig?.barLengthPadding ?? 0
                         restoreMode: Binding.RestoreBinding
                     }
                 }

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -763,6 +763,31 @@
     "conditionKey": "keybindsAvailable"
   },
   {
+    "section": "barAttachToScreenEdge",
+    "label": "Attach to Screen Edge",
+    "tabIndex": 3,
+    "category": "Dank Bar",
+    "keywords": [
+      "align",
+      "attach",
+      "bar",
+      "dank",
+      "edge",
+      "flush",
+      "inner",
+      "keeping",
+      "outer",
+      "panel",
+      "rounded",
+      "screen",
+      "statusbar",
+      "taskbar",
+      "topbar",
+      "while"
+    ],
+    "description": "Align the outer bar edge with the screen while keeping the inner edge rounded"
+  },
+  {
     "section": "barAutoHide",
     "label": "Auto-hide",
     "tabIndex": 3,

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -2451,27 +2451,24 @@
     "tabIndex": 6,
     "category": "Dank Bar",
     "keywords": [
-      "attached",
       "background",
       "bar",
-      "choose",
       "corners",
       "dank",
-      "edge",
-      "flush",
-      "meets",
+      "fully",
+      "invisible",
+      "make",
       "panel",
       "radius",
       "round",
       "rounded",
-      "screen",
-      "square",
       "statusbar",
       "taskbar",
-      "topbar"
+      "topbar",
+      "transparent"
     ],
     "icon": "rounded_corner",
-    "description": "Choose how the bar meets the screen edge"
+    "description": "Make the bar background fully transparent"
   },
   {
     "section": "barAppearance",

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -763,31 +763,6 @@
     "conditionKey": "keybindsAvailable"
   },
   {
-    "section": "barAttachToScreenEdge",
-    "label": "Attach to Screen Edge",
-    "tabIndex": 3,
-    "category": "Dank Bar",
-    "keywords": [
-      "align",
-      "attach",
-      "bar",
-      "dank",
-      "edge",
-      "flush",
-      "inner",
-      "keeping",
-      "outer",
-      "panel",
-      "rounded",
-      "screen",
-      "statusbar",
-      "taskbar",
-      "topbar",
-      "while"
-    ],
-    "description": "Align the outer bar edge with the screen while keeping the inner edge rounded"
-  },
-  {
     "section": "barAutoHide",
     "label": "Auto-hide",
     "tabIndex": 3,
@@ -878,6 +853,34 @@
       "topbar"
     ],
     "icon": "dashboard"
+  },
+  {
+    "section": "barCornerStyle",
+    "label": "Corner Style",
+    "tabIndex": 3,
+    "category": "Dank Bar",
+    "keywords": [
+      "attached",
+      "bar",
+      "choose",
+      "corner",
+      "corners",
+      "dank",
+      "edge",
+      "flush",
+      "meets",
+      "panel",
+      "radius",
+      "round",
+      "rounded",
+      "screen",
+      "square",
+      "statusbar",
+      "style",
+      "taskbar",
+      "topbar"
+    ],
+    "description": "Choose how the bar meets the screen edge"
   },
   {
     "section": "barDisplay",
@@ -1246,29 +1249,6 @@
       "topbar"
     ],
     "description": "Adjust the bar height via inner padding"
-  },
-  {
-    "section": "barSquareCorners",
-    "label": "Square Corners",
-    "tabIndex": 3,
-    "category": "Dank Bar",
-    "keywords": [
-      "bar",
-      "corner",
-      "corners",
-      "dank",
-      "panel",
-      "radius",
-      "remove",
-      "round",
-      "rounded",
-      "rounding",
-      "square",
-      "statusbar",
-      "taskbar",
-      "topbar"
-    ],
-    "description": "Remove corner rounding from the bar"
   },
   {
     "section": "barAutoHideStrict",
@@ -2471,24 +2451,27 @@
     "tabIndex": 6,
     "category": "Dank Bar",
     "keywords": [
+      "attached",
       "background",
       "bar",
-      "corner",
+      "choose",
       "corners",
       "dank",
+      "edge",
+      "flush",
+      "meets",
       "panel",
       "radius",
-      "remove",
       "round",
       "rounded",
-      "rounding",
+      "screen",
       "square",
       "statusbar",
       "taskbar",
       "topbar"
     ],
     "icon": "rounded_corner",
-    "description": "Remove corner rounding from the bar"
+    "description": "Choose how the bar meets the screen edge"
   },
   {
     "section": "barAppearance",

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -813,6 +813,29 @@
     "description": "Automatically hide the bar when the pointer moves away"
   },
   {
+    "section": "barLengthPadding",
+    "label": "Bar Length Padding",
+    "tabIndex": 3,
+    "category": "Dank Bar",
+    "keywords": [
+      "bar",
+      "both",
+      "dank",
+      "ends",
+      "length",
+      "padding",
+      "panel",
+      "reduce",
+      "shorter",
+      "size",
+      "statusbar",
+      "taskbar",
+      "topbar",
+      "visible"
+    ],
+    "description": "Reduce the visible bar length from both ends"
+  },
+  {
     "section": "barClickThrough",
     "label": "Click Through",
     "tabIndex": 3,


### PR DESCRIPTION
## Description

Add two opt-in Dank Bar appearance settings:

- `Corner Style` groups `Rounded`, `Flush`, and `Square` corner behavior. `Flush` makes the outer bar edge align with the screen while keeping the inner edge rounded.
- `Bar Length Padding` shortens the visible bar from both ends without changing widget padding.

Both settings default to the current behavior and are disabled in Frame mode.

## Type of change

- [x] New feature

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<img width="3840" height="808" alt="dms_capture_1786892813006" src="https://github.com/user-attachments/assets/716e1d1c-9af6-4cda-89d5-353c39a629b9" />

<img width="3840" height="794" alt="dms_capture_1786892860597" src="https://github.com/user-attachments/assets/fd55597e-0ce3-457e-8be6-82561d70c530" />

<img width="322" height="1080" alt="1786893016225120817" src="https://github.com/user-attachments/assets/23702c61-1c32-4154-9ad0-b7f57120dcfa" />

<img width="322" height="1080" alt="dms_capture_1786892938068" src="https://github.com/user-attachments/assets/91dfa353-bf82-4079-bd49-15d98d1ec58d" />

<img width="2130" height="1198" alt="dms_capture_1786926585323" src="https://github.com/user-attachments/assets/99cbbcc7-625c-40bb-ac43-8e0eb8c88a70" />
