### PR TITLE
readme: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ For documentation contributions, see [DankLinux-Docs](https://github.com/AvengeM
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=AvengeMedia/DankMaterialShell&type=date&legend=top-left)](https://www.star-history.com/#AvengeMedia/DankMaterialShell&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=AvengeMedia/DankMaterialShell&type=date&legend=top-left)](https://star-history.dera.page/#AvengeMedia/DankMaterialShell&type=date&legend=top-left)
 
 ## License
 


### PR DESCRIPTION
The Star History chart in the README no longer renders because the upstream service is broken due to GitHub stargazer API restrictions. This switches the chart to a working mirror that uses a different data source requiring no API token, so the chart is displayed again.