### PR TITLE
fix(system-update): apply saved updaterIntervalSeconds on daemon connect

### DIFF
--- a/quickshell/Services/SystemUpdateService.qml
+++ b/quickshell/Services/SystemUpdateService.qml
@@ -98,6 +98,10 @@ Singleton {
         if (has && !sysupdateAvailable) {
             sysupdateAvailable = true;
             requestState();
+            // The daemon always starts at defaultIntervalSeconds (30 min) and
+            // has no persistence of its own, so re-apply the saved interval
+            // on every fresh connection (daemon (re)start).
+            setInterval(SettingsData.updaterIntervalSeconds);
         } else if (!has) {
             sysupdateAvailable = false;
         }


### PR DESCRIPTION
Fixes #3092.

The daemon has no persistence and always starts at the 30min default; the saved interval was only ever pushed on manual Settings-UI interaction. Now it's re-applied on every fresh daemon connection.