### PR TITLE
fix(notifications): keep popup above frame chrome

### DIFF
--- a/quickshell/Modules/Notifications/Popup/NotificationPopup.qml
+++ b/quickshell/Modules/Notifications/Popup/NotificationPopup.qml
@@ -191,7 +191,7 @@ PanelWindow {
 
     visible: !_finalized
     WlrLayershell.layer: {
-        const shouldUseOverlay = notificationData && (SettingsData.notificationOverlayEnabled || notificationData.urgency === NotificationUrgency.Critical);
+        const shouldUseOverlay = CompositorService.framePeerSurfacesUseOverlayForScreen(win.screen) || (notificationData && (SettingsData.notificationOverlayEnabled || notificationData.urgency === NotificationUrgency.Critical));
         const fallback = shouldUseOverlay ? WlrLayer.Overlay : WlrLayer.Top;
         return LayerShell.fromEnv("DMS_NOTIFICATION_LAYER", fallback);
     }


### PR DESCRIPTION
Fixes #3098

<img width="1142" height="528" alt="image" src="https://github.com/user-attachments/assets/76a07a95-e4de-460a-8cc0-1ab5792d3b4d" />
