### PR TITLE
fix(trash): keep tests off the machine's real per-mount trash dirs

### DIFF
--- a/core/internal/trash/trash.go
+++ b/core/internal/trash/trash.go
@@ -250,6 +250,10 @@ func Put(path string) (Entry, error) {
 	}, nil
 }
 
+// mountPoints is a variable so tests can keep the mount walk off the real
+// filesystem; HOME and XDG_DATA_HOME alone do not redirect it.
+var mountPoints = readMountPoints
+
 // allTrashDirs returns the home trash plus every per-mountpoint trash dir
 // that exists (and passes the spec's safety checks for $topdir/.Trash).
 func allTrashDirs() []string {
@@ -259,7 +263,7 @@ func allTrashDirs() []string {
 	}
 
 	uid := strconv.Itoa(os.Getuid())
-	for _, mount := range readMountPoints() {
+	for _, mount := range mountPoints() {
 		shared := filepath.Join(mount, ".Trash")
 		if isValidSharedTrash(shared) {
 			candidate := filepath.Join(shared, uid)

--- a/core/internal/trash/trash_test.go
+++ b/core/internal/trash/trash_test.go
@@ -17,6 +17,13 @@ func setupHomeTrash(t *testing.T) (homeRoot string, trashDir string) {
 	}
 	t.Setenv("XDG_DATA_HOME", xdg)
 	t.Setenv("HOME", homeRoot)
+
+	// Without this, Count() and Empty() reach the machine's real per-mount
+	// trash dirs, and Empty() deletes what it finds there.
+	prev := mountPoints
+	mountPoints = func() []string { return nil }
+	t.Cleanup(func() { mountPoints = prev })
+
 	trashDir = filepath.Join(xdg, "Trash")
 	return homeRoot, trashDir
 }


### PR DESCRIPTION
## Description

The `internal/trash` tests redirect the home trash with `t.Setenv("HOME", ...)` and `t.Setenv("XDG_DATA_HOME", ...)`, but `allTrashDirs()` also walks every mount point looking for `<mount>/.Trash/<uid>` and `<mount>/.Trash-<uid>`, and no environment variable redirects that walk. `Count()` and `Empty()` both iterate its result, so on any machine with a second mounted filesystem that has ever had a file trashed from it:

- `TestListAndCount` and `TestEmptyClearsAll` fail, because `Count()` returns the test's own three files plus whatever the real trash dirs hold.
- If those dirs hold only orphaned files (no matching `.trashinfo`), the count still matches, the test passes, and `Empty()` deletes them.

CI never hits either case because it runs on a single filesystem. The freedesktop spec requires a trashed file to stay on its own filesystem, so this affects anyone with a separate home and data partition.

This PR adds a `mountPoints` function variable that the tests point away from the real filesystem and restore with `t.Cleanup`. Production behavior is unchanged: 
it is initialized to `readMountPoints`. The seam sits in `trash.go` rather than in `mounts_linux.go` and `mounts_freebsd.go`, so one line covers both platforms.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

None

## Screenshots / video

## Validation

Measured on CachyOS with a second mount (`/run/user/1000`, tmpfs) holding a fabricated
`.Trash-1000`.

Two orphaned files, no `.trashinfo`, running `TestEmptyClearsAll`:

| | test result | the two files |
|---|---|---|
| before | ok | deleted |
| after | ok | intact |

One file with a matching `.trashinfo`, running both tests:

```
before:
--- FAIL: TestListAndCount (0.00s)
    trash_test.go:120: initial count = 1, want 0
    trash_test.go:137: count = 4, want 3
--- FAIL: TestEmptyClearsAll (0.00s)
    trash_test.go:164: pre-empty count = 4

after:
ok (2 passed), and the trashed file is still there
```

- `make fmt`, `make test` (2159 tests, 88 packages), `go mod tidy` clean
- `GOOS=freebsd GOARCH=amd64 go build ./...`
(END)

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
