### PR TITLE
fix(frame): preserve connected popout chrome

### DIFF
--- a/quickshell/Widgets/DankPopout.qml
+++ b/quickshell/Widgets/DankPopout.qml
@@ -226,7 +226,9 @@ Item {
     }
 
     function _triggerBarUsesOverlayLayer(targetScreen, barConfig) {
-        return LayerShell.envUsesOverlay("DMS_DANKBAR_LAYER", (barConfig?.useOverlayLayer ?? false) || CompositorService.framePeerSurfacesUseOverlayForScreen(targetScreen));
+        const frameHostsBar = CompositorService.frameHostsBarForConfig(targetScreen, barConfig);
+        const frameRequiresOverlay = CompositorService.framePeerSurfacesUseOverlayForScreen(targetScreen) && !frameHostsBar;
+        return LayerShell.envUsesOverlay("DMS_DANKBAR_LAYER", (barConfig?.useOverlayLayer ?? false) || frameRequiresOverlay);
     }
 
     function setTriggerPosition(x, y, width, section, targetScreen, barPosition, barThickness, barSpacing, barConfig) {


### PR DESCRIPTION
Fix a regression from #3039 that caused a gap between connected-mode popouts and their widgets.
Before:
<img width="815" height="239" alt="image" src="https://github.com/user-attachments/assets/98ca854b-4878-4ac2-8c23-973a6766bc2e" />
After:
<img width="942" height="330" alt="dms_capture_1787003076334" src="https://github.com/user-attachments/assets/252d53d1-9154-4c23-b29f-918c955184bc" />
