### PR TITLE
fix(display): enforce at least one real monitor in profile application

### DIFF
--- a/quickshell/Modules/Settings/DisplayConfig/DisplayConfigState.qml
+++ b/quickshell/Modules/Settings/DisplayConfig/DisplayConfigState.qml
@@ -529,11 +529,20 @@ Singleton {
         const outputKeys = Object.keys(configEntry.outputs || {});
         if (outputKeys.length === 0)
             return false;
-        const hasEnabled = outputKeys.some(k => !configEntry.outputs[k].disabled);
-        if (hasEnabled)
+        const hasEnabledReal = outputKeys.some(k => {
+            const o = configEntry.outputs[k];
+            return !o.disabled && o.make && o.model;
+        });
+        if (hasEnabledReal)
             return false;
-        delete configEntry.outputs[outputKeys[0]].disabled;
-        return true;
+        for (const k of outputKeys) {
+            const o = configEntry.outputs[k];
+            if (o.make && o.model) {
+                delete o.disabled;
+                return true;
+            }
+        }
+        return false;
     }
 
     // Write compositor config from a neutral config entry and optionally reload
@@ -548,6 +557,20 @@ Singleton {
             return;
         }
         ensureEnabledOutput(configEntry);
+        const outputKeys = Object.keys(configEntry.outputs || {});
+        const hasRealOutput = outputKeys.some(k => {
+            const o = configEntry.outputs[k];
+            return o.make && o.model;
+        });
+        if (!hasRealOutput) {
+            backendWriteOutputsConfig({}, null, success => {
+                if (success) {
+                    SettingsData.setActiveDisplayProfile(CompositorService.compositor, configId);
+                    WlrOutputService.requestState();
+                }
+            });
+            return;
+        }
         // Capture the entry being applied so disabled-output settings fields can read
         // scale/position/transform back even when wlr reports no logical viewport.
         root.lastAppliedEntry = JSON.parse(JSON.stringify(configEntry));


### PR DESCRIPTION
## Problem

During hotplug transitions, Hyprland creates a virtual `FALLBACK` output (empty `make`/`model`). The auto-profile system captures this in `monitors.json`, creating profiles where all physical monitors are disabled and only `FALLBACK` is enabled. When such a stale profile is applied, the laptop display is left disabled with no way to recover without manual intervention.

## Root Cause

`ensureEnabledOutput` in `DisplayConfigState.qml` checked if **any** output was enabled — a virtual `FALLBACK` output counted as valid, so the guard never triggered.

## Fix

- `ensureEnabledOutput` now only considers outputs with both `make` and `model` set (real monitors). Virtual outputs like `FALLBACK` are ignored.
- `applyConfigEntry` writes an empty config when no real outputs exist, letting the compositor handle fallback via its default rules.