### PR TITLE
feat(resize-api): add runtime resize functionality for desktop widgets

### DIFF
--- a/quickshell/Modules/Plugins/DesktopPluginComponent.qml
+++ b/quickshell/Modules/Plugins/DesktopPluginComponent.qml
@@ -14,6 +14,9 @@ Item {
     property real minWidth: 100
     property real minHeight: 100
 
+    property var requestResize: null
+    property var clearResize: null
+
     readonly property bool isInstance: instanceId !== "" && instanceData !== null
     readonly property var instanceConfig: instanceData?.config ?? {}
 

--- a/quickshell/Modules/Plugins/DesktopPluginWrapper.qml
+++ b/quickshell/Modules/Plugins/DesktopPluginWrapper.qml
@@ -231,6 +231,20 @@ Item {
         dragOverrideH = -1;
     }
 
+    function requestResize(width, height) {
+        if (width < minWidth || height < minHeight)
+            return;
+        if (width > screenWidth || height > screenHeight)
+            return;
+        dragOverrideW = width;
+        dragOverrideH = height;
+    }
+
+    function clearResize() {
+        dragOverrideW = -1;
+        dragOverrideH = -1;
+    }
+
     property real minWidth: contentLoader.item?.minWidth ?? 100
     property real minHeight: contentLoader.item?.minHeight ?? 100
     property bool forceSquare: contentLoader.item?.forceSquare ?? false
@@ -442,6 +456,10 @@ Item {
                     item.widgetHeight = Qt.binding(() => contentLoader.height);
                 if (item.screen !== undefined)
                     item.screen = Qt.binding(() => root.screen);
+                if (item.requestResize !== undefined)
+                    item.requestResize = root.requestResize;
+                if (item.clearResize !== undefined)
+                    item.clearResize = root.clearResize;
             }
         }
 

--- a/quickshell/PLUGINS/README.md
+++ b/quickshell/PLUGINS/README.md
@@ -1651,6 +1651,43 @@ Define these properties on your widget to customize behavior:
 - `minWidth`: Minimum allowed width (default: 100)
 - `minHeight`: Minimum allowed height (default: 100)
 
+### Runtime Resize API
+
+Desktop widgets can resize their live surface at runtime without saving the new size to disk.
+
+The wrapper exposes two functions on the widget instance:
+
+- `requestResize(width, height)`: Applies a temporary surface size override
+- `clearResize()`: Clears the temporary override and restores the normal persisted size
+
+These are available as properties on `DesktopPluginComponent` and are passed through by `DesktopPluginWrapper` automatically.
+
+```qml
+import QtQuick
+import qs.Common
+
+Item {
+    id: root
+
+    function expandPreview() {
+        if (requestResize) {
+            requestResize(420, 260)
+        }
+    }
+
+    function resetPreview() {
+        if (clearResize) {
+            clearResize()
+        }
+    }
+}
+```
+
+Notes:
+- This is a transient runtime resize only; it does not persist to `settings.json`
+- The requested size must stay within the screen bounds and above `minWidth` / `minHeight`
+- Use `clearResize()` when you want to return to the saved widget dimensions
+
 ### Loading and Saving Data
 
 Use the injected `pluginService` to persist widget-specific data:


### PR DESCRIPTION
## Description
Adds a transient surface resize API for Desktop Widgets.

Before the only way to resize a widget was to update the widget settings, which writes to the disk. But the `DesktopPluginWrapper` internally used `dragOverrideW/H` to represent a transient width/height when the user drags and resizes the widget, it was simply not exposed to the plugins.

This patch allows setting a size to the surface without writing it to the disk from the plugins. A possible use case could be a compact widget, that expands when hovered to show more information, and collapses back when hover removed.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [x] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
