### PR TITLE
feat(battery): show estimated end time

### DIFF
--- a/quickshell/Modules/DankBar/Popouts/BatteryPopout.qml
+++ b/quickshell/Modules/DankBar/Popouts/BatteryPopout.qml
@@ -175,7 +175,9 @@ DankPopout {
                                 return I18n.tr("Power profile management available");
                             const time = BatteryService.formatTimeRemaining();
                             if (time !== "Unknown") {
-                                return BatteryService.isCharging ? I18n.tr("Time until full: %1").arg(time) : I18n.tr("Time remaining: %1").arg(time);
+                                const estimated = BatteryService.formatEstimatedTime();
+                                const timeText = estimated ? `${time} (${estimated})` : time;
+                                return BatteryService.isCharging ? I18n.tr("Time until full: %1").arg(timeText) : I18n.tr("Time remaining: %1").arg(timeText);
                             }
                             return "";
                         }

--- a/quickshell/Services/BatteryService.qml
+++ b/quickshell/Services/BatteryService.qml
@@ -405,21 +405,37 @@ Singleton {
         return btDevices;
     }
 
-    // Format time remaining for charge/discharge
-    function formatTimeRemaining() {
-        if (!batteryAvailable) {
-            return "Unknown";
-        }
+    function estimatedSeconds() {
+        if (!batteryAvailable)
+            return 0;
 
         const rate = _smoothedChangeRate > 0 ? _smoothedChangeRate : changeRate;
         const totalTime = (isCharging) ? ((batteryCapacity - batteryEnergy) / rate) : (batteryEnergy / rate);
-        const avgTime = Math.abs(totalTime * 3600);
-        if (!avgTime || avgTime <= 0 || avgTime > 86400)
+        const seconds = Math.abs(totalTime * 3600);
+        if (!seconds || seconds <= 0 || seconds > 86400)
+            return 0;
+        return seconds;
+    }
+
+    // Format time remaining for charge/discharge
+    function formatTimeRemaining() {
+        const seconds = estimatedSeconds();
+        if (!seconds)
             return "Unknown";
 
-        const hours = Math.floor(avgTime / 3600);
-        const minutes = Math.floor((avgTime % 3600) / 60);
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
         return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+    }
+
+    function formatEstimatedTime() {
+        const seconds = estimatedSeconds();
+        if (!seconds)
+            return "";
+
+        const target = new Date(Date.now() + seconds * 1000);
+        const use24Hour = SettingsData.use24HourClock !== false;
+        return target.toLocaleTimeString(Qt.locale(), use24Hour ? "HH:mm" : "h:mm AP");
     }
 
     function getBatteryIcon() {


### PR DESCRIPTION
## Description

In battery popout, show the estimated end time after the estimated duration (e.g., 1h 35m (10:00)). This small change helps users do less mental calculation.

## Screenshots / video

<img width="780" height="594" alt="image" src="https://github.com/user-attachments/assets/15b266e7-9464-49f2-90a7-00016cff9f3c" />

