### PR TITLE
fix(launcher): DankLauncherV2 was missing id and genericName search

### DIFF
--- a/quickshell/Modals/DankLauncherV2/Scorer.js
+++ b/quickshell/Modals/DankLauncherV2/Scorer.js
@@ -5,6 +5,9 @@ const Weights = {
     prefixMatch: 5000,
     wordBoundary: 3000,
     substring: 500,
+    genericPrefix: 800,
+    generic: 400,
+    id: 350,
     fuzzy: 100,
     frecency: 2000,
     typeBonus: {
@@ -128,6 +131,21 @@ function score(item, query, frecencyData) {
                 textScore = keywordScore * 0.3
                 break
             }
+        }
+    }
+
+    if (textScore === 0 && item.data && item.data.genericName) {
+        var genericLower = item.data.genericName.toLowerCase()
+        if (genericLower.startsWith(q))
+            textScore = Weights.genericPrefix
+        else if (genericLower.includes(q))
+            textScore = Weights.generic
+    }
+
+    if (textScore === 0 && item.id && item.type === "app") {
+        var id = item.id.toLowerCase().replace(/\.desktop$/, "")
+        if (id.includes(q)) {
+            textScore = Weights.id
         }
     }
 


### PR DESCRIPTION
## What this fixes

Almost every mainstream launcher matches by id, and most also support generic name. DankLauncherV2 didn't have it.

AppSearchService already matches apps by their desktop id and generic name, but DankLauncherV2's Scorer never picked those up. So when an app only matched on id or genericName, launcher just skipped it.

## What changed

- Match GenericName (prefix 800, contains 400).
- Match the desktop id (350), after dropping the `.desktop` suffix.
- These only run once name, subtitle, and keyword matches fail, so existing search results stay the same.

## Tested

I tested it on my own machine. Typing an app's id (org.kde.dolphin) or its generic name (Web Browser) now finds it in the V2 launcher.