### PR TITLE
fix(session): persist the idle inhibitor across shell restarts

### DIFF
--- a/quickshell/Common/SessionData.qml
+++ b/quickshell/Common/SessionData.qml
@@ -34,6 +34,7 @@ Singleton {
     property bool isLightMode: false
     property bool doNotDisturb: false
     property real doNotDisturbUntil: 0
+    property bool idleInhibited: false
     property string terminalOverride: ""
     property bool isSwitchingMode: false
     property bool suppressOSD: true
@@ -623,6 +624,14 @@ Singleton {
         const minutes = Number(durationMinutes) || 0;
         doNotDisturb = enabled;
         doNotDisturbUntil = (enabled && minutes > 0) ? Date.now() + minutes * 60 * 1000 : 0;
+        saveSettings();
+    }
+
+    function setIdleInhibited(enabled) {
+        const next = !!enabled;
+        if (idleInhibited === next)
+            return;
+        idleInhibited = next;
         saveSettings();
     }
 

--- a/quickshell/Common/settings/SessionSpec.js
+++ b/quickshell/Common/settings/SessionSpec.js
@@ -4,6 +4,7 @@ var SPEC = {
     isLightMode: { def: false },
     doNotDisturb: { def: false },
     doNotDisturbUntil: { def: 0 },
+    idleInhibited: { def: false },
     terminalOverride: { def: "" },
 
     wallpaperPath: { def: "" },

--- a/quickshell/Services/SessionService.qml
+++ b/quickshell/Services/SessionService.qml
@@ -488,10 +488,34 @@ Singleton {
     // * Idle Inhibitor
     signal inhibitorChanged
 
+    // The inhibitor is a state the user turns on explicitly, so it is persisted in the session
+    // like the other Control Center toggles (doNotDisturb, nightModeEnabled, ...). Without this
+    // it lived only in memory and every shell restart silently cleared it.
+    //
+    // Both entry points are needed because the two singletons are lazily created and the order is
+    // not fixed: onLoaded covers "service first, session file read later", the restore below
+    // covers "session already loaded by the time the service is instantiated". enableIdleInhibit
+    // is idempotent, so whichever runs second does nothing.
+    function _restoreIdleInhibit() {
+        if (SessionData.idleInhibited && !idleInhibited)
+            enableIdleInhibit();
+    }
+
+    Connections {
+        target: SessionData
+
+        function onLoaded() {
+            root._restoreIdleInhibit();
+        }
+    }
+
+    Component.onCompleted: _restoreIdleInhibit()
+
     function enableIdleInhibit() {
         if (idleInhibited)
             return;
         idleInhibited = true;
+        SessionData.setIdleInhibited(true);
         inhibitorChanged();
     }
 
@@ -499,6 +523,7 @@ Singleton {
         if (!idleInhibited)
             return;
         idleInhibited = false;
+        SessionData.setIdleInhibited(false);
         inhibitorChanged();
     }
 


### PR DESCRIPTION
## Description

The idle inhibitor ("Keep Awake") does not survive a shell restart. `SessionService` holds it as a plain in-memory property and nothing ever writes it out:

```qml
property bool idleInhibited: false
```

Every restart silently clears it. The user's explicit choice is dropped with no message — the pill disappears from the bar and the screen starts sleeping again mid-task.

Restarting is not an edge case: `dms restart` is a first-class CLI command, and `assets/systemd/dms.service` in this repo sets `Restart=on-failure` with `TimeoutStopSec=10`, so a shell that is slow to stop is killed and brought back automatically.

**Every other Control Center toggle already survives a restart.** Measured on upstream `master`, over the state read by `Modules/ControlCenter/Components/DragDropGrid.qml` and its neighbours:

| toggle | declared in `SessionSpec.js` |
| --- | --- |
| `doNotDisturb` | yes |
| `isLightMode` | yes |
| `nightModeEnabled` | yes |
| `wallpaperCyclingEnabled` | yes |
| **`idleInhibited`** | **no** |

So this follows the `doNotDisturb` idiom exactly rather than inventing a mechanism: one spec entry, one property, one setter that saves.

- `SessionSpec.js` — `idleInhibited: { def: false }`
- `SessionData.qml` — the property plus `setIdleInhibited(enabled)`
- `SessionService.qml` — `enableIdleInhibit()` / `disableIdleInhibit()` write through; the state is restored at startup

Restore goes through two entry points because the singletons are lazily created and their order is not fixed: `onLoaded` covers "service instantiated before the session file is read", `Component.onCompleted` covers the opposite. `enableIdleInhibit()` is idempotent, so whichever runs second is a no-op.

The default stays `false` and `SessionStore.toJson` omits defaults, so an untouched `session.json` gains no new key.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

None open for this. #1483 (configurable timer) is adjacent: the field added here has the same shape `doNotDisturb` uses alongside `doNotDisturbUntil`, so a later `idleInhibitedUntil` slots in beside it without another migration.

## Screenshots / video

No visual change. The bar pill already reflects `SessionService.idleInhibited`; it simply now shows the state the user left it in. Behaviour is shown as measurements below instead.

## How this was verified

In a nested niri with isolated `XDG_CONFIG_HOME`/`XDG_STATE_HOME`, so the bench could never touch the live session:

```
qs ipc --pid <nested> call inhibit enable
→ session.json:  "idleInhibited": true
kill <nested>                 # what systemd does at TimeoutStopSec
relaunch, then: qs ipc --pid <new> call inhibit status
→ Idle inhibit is enabled
```

Counter-test on the same `session.json`, with the patch reverted to plain upstream:

| | after the shell restarts |
| --- | --- |
| with this patch | `Idle inhibit is enabled` |
| upstream as-is | `Idle inhibit is disabled` |

Also exercised directly against `SessionStore.js` + `SessionSpec.js`: `parse({idleInhibited: true})` → `true`, `toJson` → `{"idleInhibited": true}`, and with the value at its default the key is omitted from the output.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` — n/a, this PR adds no user-facing strings
- [x] Go changes — n/a, QML/JS only
- [ ] QML changes: ran `make lint-qml` with no new warnings — **could not run locally**: the script requires the Quickshell tooling VFS (`quickshell/.qmlls.ini` + `<buildDir>/qs/qmldir`), and on quickshell 0.3.0 here the VFS directory only ever contains `tooling.lock`, so `lint-qml` refuses to start. The two touched QML files parse cleanly under `qmlformat`, and the pre-commit hooks that apply were run by hand (no trailing whitespace, single trailing newline, no `console.*`). Happy to re-run if you can point me at what generates the VFS.
- [x] Documentation: companion PR opened in dlx-docs: AvengeMedia/DankLinux-Docs#138
