### PR TITLE
feat(greeter): auto-start external auth for howdy face recognition

### DIFF
--- a/quickshell/Modules/Greetd/GreeterContent.qml
+++ b/quickshell/Modules/Greetd/GreeterContent.qml
@@ -72,8 +72,9 @@ Item {
     // Falls back to PAM-only detection until the fprintd D-Bus probe completes.
     readonly property bool greeterPamHasFprint: greeterPamStackHasFprint && (!fprintdProbeComplete || fprintdHasDevice)
     readonly property bool greeterPamHasU2f: greeterPamStackHasModule("pam_u2f")
-    readonly property bool greeterExternalAuthAvailable: (greeterPamHasFprint && GreetdSettings.greeterEnableFprint) || (greeterPamHasU2f && GreetdSettings.greeterEnableU2f)
-    readonly property bool greeterPamHasExternalAuth: greeterPamHasFprint || greeterPamHasU2f
+    readonly property bool greeterPamHasHowdy: greeterPamStackHasModule("pam_howdy")
+    readonly property bool greeterExternalAuthAvailable: (greeterPamHasFprint && GreetdSettings.greeterEnableFprint) || (greeterPamHasU2f && GreetdSettings.greeterEnableU2f) || greeterPamHasHowdy
+    readonly property bool greeterPamHasExternalAuth: greeterPamHasFprint || greeterPamHasU2f || greeterPamHasHowdy
     readonly property bool externalAuthInProgress: awaitingExternalAuth || (Greetd.state !== GreetdState.Inactive && passwordSubmitRequested && greeterPamHasExternalAuth && !pendingPasswordResponse)
     readonly property string externalAuthStatusMessage: {
         if (!externalAuthInProgress)
@@ -82,6 +83,8 @@ Item {
             return I18n.tr("Awaiting fingerprint or security key authentication");
         if (greeterPamHasFprint)
             return I18n.tr("Awaiting fingerprint authentication");
+        if (greeterPamHasHowdy)
+            return I18n.tr("Awaiting face authentication");
         return I18n.tr("Awaiting security key authentication");
     }
     readonly property string authDisplayMessage: authFeedbackMessage || authSuccessMessage || externalAuthStatusMessage


### PR DESCRIPTION
## Problem

The greeter auto-starts PAM external authentication (via `maybeAutoStartExternalAuth`) only for fingerprint (`pam_fprintd`) and security keys (`pam_u2f`). When [howdy](https://github.com/boltgolt/howdy) face recognition (`pam_howdy.so`) is in the greetd PAM stack, the camera stays off until the user presses Enter once — defeating the purpose of face login.

## Change

Treat `pam_howdy` like the other external auth modules:

- `greeterPamHasHowdy` detects `pam_howdy` in the effective PAM stack (reusing `greeterPamStackHasModule`)
- Included in `greeterExternalAuthAvailable` / `greeterPamHasExternalAuth`, so `maybeAutoStartExternalAuth()` fires and the camera activates as soon as the password view is shown
- Status message "Awaiting face authentication" while howdy runs

No settings toggle is added: presence of `pam_howdy.so` in the PAM stack is an explicit admin choice, same as the module ordering. Unlike fprint, howdy has no D-Bus probe equivalent, so PAM-stack detection is authoritative (howdy exits quickly with `PAM_AUTHINFO_UNAVAIL` when disabled via its own config).

## Testing

- Arch Linux, greetd + niri, [howdy-next](https://codeberg.org/nathawat/howdy) 3.4.0 (`pam_howdy.so`), `auth sufficient pam_howdy.so` in `/etc/pam.d/greetd`
- Before: camera only activated after pressing Enter
- After: camera LED turns on automatically when the password view appears; face match completes login without keyboard input; password entry still works as fallback; `qmllint` clean
