### PR TITLE
fix(doctor): explain Qt private API mismatch

### DIFF
--- a/core/cmd/dms/commands_doctor.go
+++ b/core/cmd/dms/commands_doctor.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -510,9 +511,8 @@ func checkVersions(qsMissingFeatures bool) []checkResult {
 		{catVersions, "DMS CLI", statusOK, formatVersion(Version), dmsCliDetails, doctorDocsURL + "#dms-cli"},
 	}
 
-	qsVersion, qsStatus, qsPath := getQuickshellVersionInfo(qsMissingFeatures)
-	qsDetails := ""
-	if doctorVerbose && qsPath != "" {
+	qsVersion, qsStatus, qsPath, qsDetails := getQuickshellVersionInfo(qsMissingFeatures)
+	if doctorVerbose && qsPath != "" && qsDetails == "" {
 		qsDetails = qsPath
 	}
 	results = append(results, checkResult{catVersions, "Quickshell", qsStatus, qsVersion, qsDetails, doctorDocsURL + "#quickshell"})
@@ -547,30 +547,43 @@ func getDMSShellVersion() (version, path string) {
 	return "", ""
 }
 
-func getQuickshellVersionInfo(missingFeatures bool) (string, status, string) {
+func getQuickshellVersionInfo(missingFeatures bool) (string, status, string, string) {
 	if !utils.CommandExists("qs") {
-		return "Not installed", statusError, ""
+		return "Not installed", statusError, "", ""
 	}
 
 	qsPath, _ := exec.LookPath("qs")
 
 	output, err := exec.Command("qs", "--version").Output()
 	if err != nil {
-		return "Installed (version check failed)", statusWarn, qsPath
+		details := "Run 'qs --version' to inspect the failure."
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			details = quickshellVersionFailureDetails(string(exitErr.Stderr))
+		}
+		return "Installed (version check failed)", statusWarn, qsPath, details
 	}
 
 	fullVersion := strings.TrimSpace(string(output))
 	if matches := quickshellVersionRegex.FindStringSubmatch(fullVersion); len(matches) >= 2 {
 		if version.CompareVersions(matches[1], "0.2.0") < 0 {
-			return fmt.Sprintf("%s (needs >= 0.2.0)", fullVersion), statusError, qsPath
+			return fmt.Sprintf("%s (needs >= 0.2.0)", fullVersion), statusError, qsPath, ""
 		}
 		if missingFeatures {
-			return fullVersion, statusWarn, qsPath
+			return fullVersion, statusWarn, qsPath, ""
 		}
-		return fullVersion, statusOK, qsPath
+		return fullVersion, statusOK, qsPath, ""
 	}
 
-	return fullVersion, statusWarn, qsPath
+	return fullVersion, statusWarn, qsPath, ""
+}
+
+func quickshellVersionFailureDetails(stderr string) string {
+	if strings.Contains(stderr, "undefined symbol:") && strings.Contains(stderr, "Qt_6_PRIVATE_API") {
+		return "Quickshell is incompatible with the installed Qt libraries. Rebuild or reinstall Quickshell against the current Qt version."
+	}
+
+	return "Run 'qs --version' to inspect the failure."
 }
 
 func checkDMSInstallation() []checkResult {

--- a/core/cmd/dms/commands_doctor_test.go
+++ b/core/cmd/dms/commands_doctor_test.go
@@ -2,6 +2,33 @@ package main
 
 import "testing"
 
+func TestQuickshellVersionFailureDetails(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		want   string
+	}{
+		{
+			name:   "Qt private API symbol mismatch",
+			stderr: "qs: symbol lookup error: qs: undefined symbol: _ZN23QUntypedPropertyBindingC1EP23QPropertyBindingPrivate, version Qt_6_PRIVATE_API",
+			want:   "Quickshell is incompatible with the installed Qt libraries. Rebuild or reinstall Quickshell against the current Qt version.",
+		},
+		{
+			name:   "other failure",
+			stderr: "qs: unsupported option --version",
+			want:   "Run 'qs --version' to inspect the failure.",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := quickshellVersionFailureDetails(tc.stderr); got != tc.want {
+				t.Fatalf("quickshellVersionFailureDetails(%q) = %q, want %q", tc.stderr, got, tc.want)
+			}
+		})
+	}
+}
+
 // Parsing a full property dump as a bare value would yield a bogus plugin root,
 // making the qtengine check warn at a user whose install is fine.
 func TestQtQueryValue(t *testing.T) {


### PR DESCRIPTION
## Description

When `qs --version` exits because the installed binary references a missing `Qt_6_PRIVATE_API` symbol, `dms doctor -v` currently reports only “Installed (version check failed)”.

This change recognizes that loader failure and reports that Quickshell must be rebuilt or reinstalled against the installed Qt libraries. Other version-check failures retain the existing command-level troubleshooting guidance.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

None.

## Screenshots / video

Not applicable; this is a CLI diagnostic improvement.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings follow the existing non-localized CLI diagnostic convention
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: not applicable
- [x] I have opened a corresponding pull request in dlx-docs to document the recovery path: https://github.com/AvengeMedia/DankLinux-Docs/pull/139
