### PR TITLE
feat(settings): search runtime plugins

### DIFF
--- a/quickshell/Modals/Settings/SettingsContent.qml
+++ b/quickshell/Modals/Settings/SettingsContent.qml
@@ -12,8 +12,27 @@ FocusScope {
 
     property int currentIndex: 0
     property var parentModal: null
+    property string pendingPluginId: ""
 
     focus: true
+
+    function openPluginSettings(pluginId) {
+        pendingPluginId = pluginId || "";
+        if (currentIndex === 12)
+            Qt.callLater(applyPendingPluginSettings);
+    }
+
+    function applyPendingPluginSettings() {
+        if (!pendingPluginId || !pluginsLoader.item)
+            return;
+        pluginsLoader.item.openPluginSettings(pendingPluginId);
+        pendingPluginId = "";
+    }
+
+    onCurrentIndexChanged: {
+        if (currentIndex === 12 && pendingPluginId)
+            Qt.callLater(applyPendingPluginSettings);
+    }
 
     Rectangle {
         anchors.fill: parent
@@ -379,6 +398,13 @@ FocusScope {
             onActiveChanged: {
                 if (active && item)
                     Qt.callLater(() => item.forceActiveFocus());
+                if (active)
+                    Qt.callLater(root.applyPendingPluginSettings);
+            }
+
+            onLoaded: {
+                if (visible)
+                    Qt.callLater(root.applyPendingPluginSettings);
             }
         }
 

--- a/quickshell/Modals/Settings/SettingsModal.qml
+++ b/quickshell/Modals/Settings/SettingsModal.qml
@@ -86,6 +86,11 @@ DankFloatingWindow {
         showWithTabName("keybinds");
     }
 
+    function openPluginSettings(pluginId: string) {
+        setTabIndex(12);
+        content.openPluginSettings(pluginId);
+    }
+
     function toggleMenu() {
         enableAnimations = true;
         menuVisible = !menuVisible;

--- a/quickshell/Modals/Settings/SettingsSidebar.qml
+++ b/quickshell/Modals/Settings/SettingsSidebar.qml
@@ -704,6 +704,8 @@ Rectangle {
         tabChangeRequested(result.tabIndex);
         autoCollapseIfNeeded(oldIndex, result.tabIndex);
         autoExpandForTab(result.tabIndex);
+        if (result.runtimeType === "plugin" && result.runtimeId && root.parentModal?.openPluginSettings)
+            root.parentModal.openPluginSettings(result.runtimeId);
         keyboardHighlightIndex = -1;
         Qt.callLater(searchField.forceActiveFocus);
     }

--- a/quickshell/Modules/Settings/PluginsTab.qml
+++ b/quickshell/Modules/Settings/PluginsTab.qml
@@ -38,6 +38,21 @@ FocusScope {
         });
     }
 
+    function openPluginSettings(pluginId) {
+        if (!pluginId)
+            return;
+        expandedPluginId = pluginId;
+        Qt.callLater(() => {
+            const index = filteredPlugins.findIndex(plugin => plugin.id === pluginId);
+            const item = index >= 0 ? pluginRepeater.itemAt(index) : null;
+            if (!item)
+                return;
+            const mapped = item.mapToItem(pluginFlickable.contentItem, 0, 0);
+            const maxY = Math.max(0, pluginFlickable.contentHeight - pluginFlickable.height);
+            pluginFlickable.contentY = Math.min(maxY, Math.max(0, mapped.y - Theme.spacingM));
+        });
+    }
+
     Connections {
         target: PluginService
         function onAvailablePluginsListChanged() {
@@ -52,6 +67,7 @@ FocusScope {
     }
 
     DankFlickable {
+        id: pluginFlickable
         anchors.fill: parent
         clip: true
         contentHeight: mainColumn.height + Theme.spacingXL

--- a/quickshell/Modules/Settings/PluginsTab.qml
+++ b/quickshell/Modules/Settings/PluginsTab.qml
@@ -41,6 +41,10 @@ FocusScope {
     function openPluginSettings(pluginId) {
         if (!pluginId)
             return;
+        searchQuery = "";
+        isSearchExpanded = false;
+        pluginSearchField.text = "";
+        updateFilteredPlugins();
         expandedPluginId = pluginId;
         Qt.callLater(() => {
             const index = filteredPlugins.findIndex(plugin => plugin.id === pluginId);

--- a/quickshell/Services/SettingsSearchService.qml
+++ b/quickshell/Services/SettingsSearchService.qml
@@ -150,14 +150,17 @@ Singleton {
     }
 
     function translateItem(item) {
+        const isRuntimePlugin = item.runtimeType === "plugin";
+        const label = isRuntimePlugin ? item.label : I18n.tr(item.label);
+        const description = isRuntimePlugin ? (item.description || "") : I18n.tr(item.description || "");
         return {
             section: item.section,
-            label: I18n.tr(item.label),
+            label: label,
             tabIndex: item.tabIndex,
             category: I18n.tr(item.category),
             keywords: item.keywords || [],
             icon: item.icon || "settings",
-            description: item.description ? I18n.tr(item.description) : "",
+            description: description,
             conditionKey: item.conditionKey,
             runtimeType: item.runtimeType || "",
             runtimeId: item.runtimeId || ""

--- a/quickshell/Services/SettingsSearchService.qml
+++ b/quickshell/Services/SettingsSearchService.qml
@@ -32,6 +32,14 @@ Singleton {
         }
     }
 
+    Connections {
+        target: PluginService
+
+        function onPluginListUpdated() {
+            root._refreshTranslatedCache();
+        }
+    }
+
     readonly property var conditionMap: ({
             "isNiri": () => CompositorService.isNiri,
             "isHyprland": () => CompositorService.isHyprland,
@@ -150,19 +158,22 @@ Singleton {
             keywords: item.keywords || [],
             icon: item.icon || "settings",
             description: item.description ? I18n.tr(item.description) : "",
-            conditionKey: item.conditionKey
+            conditionKey: item.conditionKey,
+            runtimeType: item.runtimeType || "",
+            runtimeId: item.runtimeId || ""
         };
     }
 
     function _rebuildTranslationCache() {
         var cache = [];
-        for (var i = 0; i < settingsIndex.length; i++) {
-            var item = settingsIndex[i];
+        var items = settingsIndex.concat(_runtimeSearchEntries());
+        for (var i = 0; i < items.length; i++) {
+            var item = items[i];
             var t = translateItem(item);
             var sourceDescription = item.description || "";
             var labelLower = _lowerVariants([item.label, t.label]);
             var categoryLower = _lowerVariants([item.category, t.category]);
-            var descriptionLower = _lowerVariants([sourceDescription, t.description]);
+            var descriptionLower = item.runtimeType === "plugin" ? [] : _lowerVariants([sourceDescription, t.description]);
             cache.push({
                 section: t.section,
                 label: t.label,
@@ -172,6 +183,8 @@ Singleton {
                 icon: t.icon,
                 description: t.description,
                 conditionKey: t.conditionKey,
+                runtimeType: t.runtimeType,
+                runtimeId: t.runtimeId,
                 isTab: String(t.section).startsWith("_tab_"),
                 labelSearch: labelLower,
                 categorySearch: categoryLower,
@@ -183,6 +196,27 @@ Singleton {
             });
         }
         _translatedCache = cache;
+    }
+
+    function _runtimeSearchEntries() {
+        var entries = [];
+        var plugins = PluginService.availablePluginsList || [];
+        for (var i = 0; i < plugins.length; i++) {
+            var plugin = plugins[i];
+            entries.push({
+                section: "",
+                label: plugin.name || plugin.id,
+                tabIndex: 12,
+                category: "Plugins",
+                keywords: [plugin.id || ""],
+                icon: plugin.icon || "extension",
+                description: plugin.description || "",
+                conditionKey: "",
+                runtimeType: "plugin",
+                runtimeId: plugin.id || ""
+            });
+        }
+        return entries;
     }
 
     function _lowerVariants(values) {
@@ -338,6 +372,10 @@ Singleton {
         }
 
         scored.sort((a, b) => {
+            const aRuntime = !!a.item.runtimeType;
+            const bRuntime = !!b.item.runtimeType;
+            if (aRuntime !== bRuntime)
+                return aRuntime ? 1 : -1;
             if (b.score !== a.score)
                 return b.score - a.score;
             if (b.labelScore !== a.labelScore)


### PR DESCRIPTION
## Description

Add installed runtime plugins to the Settings search, including plugins with a desktop surface. Selecting a plugin result opens the Plugins tab, expands the matching plugin, and scrolls it into view. Runtime plugin descriptions remain display-only and are not used for search ranking; static settings stay prioritized.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

Closes #2541

## Screenshots / video


https://github.com/user-attachments/assets/04f63825-5c04-4ae4-9bad-43fcb3e56efb

