### PR TITLE
fix(tailscale): back off when the IPN bus read fails

### DIFF
--- a/core/internal/server/tailscale/manager.go
+++ b/core/internal/server/tailscale/manager.go
@@ -112,17 +112,13 @@ func (m *Manager) watchLoop(ctx context.Context) {
 				m.updateState(&TailscaleState{Connected: false, BackendState: "Unreachable"})
 				unreachableSent = true
 			}
-			select {
-			case <-ctx.Done():
+			if !sleepBackoff(ctx, &backoff) {
 				return
-			case <-time.After(backoff):
 			}
-			backoff = min(backoff*2, 30*time.Second)
 			continue
 		}
 
 		unreachableSent = false
-		backoff = time.Second
 		log.Info("[Tailscale] Connected to IPN bus")
 		m.markAvailable()
 
@@ -132,6 +128,8 @@ func (m *Manager) watchLoop(ctx context.Context) {
 				log.Warnf("[Tailscale] IPN bus error: %v", err)
 				break
 			}
+
+			backoff = time.Second
 
 			if notify.State == nil && notify.NetMap == nil { //nolint:staticcheck // NetMap is deprecated upstream but still the only activity signal on some platforms
 				continue
@@ -143,7 +141,21 @@ func (m *Manager) watchLoop(ctx context.Context) {
 		}
 
 		watcher.Close()
+
+		if !sleepBackoff(ctx, &backoff) {
+			return
+		}
 	}
+}
+
+func sleepBackoff(ctx context.Context, backoff *time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(*backoff):
+	}
+	*backoff = min(*backoff*2, 30*time.Second)
+	return true
 }
 
 // debounceLoop coalesces rapid bus notifications into a single Status RPC

--- a/core/internal/server/tailscale/manager_test.go
+++ b/core/internal/server/tailscale/manager_test.go
@@ -214,6 +214,29 @@ func TestWatchLoop_Reconnect(t *testing.T) {
 	}, 3*time.Second, 50*time.Millisecond)
 }
 
+func TestWatchLoop_BacksOffOnPersistentBusError(t *testing.T) {
+	var watchCalls atomic.Int32
+
+	client := &mockClient{
+		watchFn: func(ctx context.Context, mask ipn.NotifyWatchOpt) (ipnBusWatcher, error) {
+			watchCalls.Add(1)
+			return newMockWatcher(ctx, nil, fmt.Errorf("json: cannot unmarshal object")), nil
+		},
+		statusFn: func(ctx context.Context) (*ipnstate.Status, error) {
+			return runningStatus(), nil
+		},
+	}
+
+	m := newManager(client)
+	defer m.Close()
+
+	time.Sleep(300 * time.Millisecond)
+
+	calls := watchCalls.Load()
+	assert.LessOrEqual(t, int(calls), 3,
+		"a persistent bus read error should back off, not reconnect in a hot loop; got %d attempts in 300ms", calls)
+}
+
 func TestManager_Subscribe(t *testing.T) {
 	client := &mockClient{
 		watchFn: func(ctx context.Context, mask ipn.NotifyWatchOpt) (ipnBusWatcher, error) {


### PR DESCRIPTION
## Description

Makes the IPN bus watch loop back off when a read fails rather than only when a connection fails, so a permanently undecodable netmap can't hammer tailscaled at ~3000 reconnects/sec (or journal at ~340,000 lines/min :sob:)

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
