### PR TITLE
test(plugins): isolate git config in the real git client test

### DIFF
--- a/core/internal/plugins/registry_test.go
+++ b/core/internal/plugins/registry_test.go
@@ -84,6 +84,9 @@ func TestGetCacheDir(t *testing.T) {
 }
 
 func TestRealGitClientRevisionCheckout(t *testing.T) {
+	t.Setenv("GIT_CONFIG_GLOBAL", "")
+	t.Setenv("GIT_CONFIG_SYSTEM", "")
+
 	repoPath := t.TempDir()
 	repo, err := git.PlainInit(repoPath, false)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

Isolates the go-git test from global git config, so having commit.gpgSign = true won't fail the suite.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
