### PR TITLE
feat(mpris): pin preferred media source

### DIFF
--- a/quickshell/Common/SessionData.qml
+++ b/quickshell/Common/SessionData.qml
@@ -214,6 +214,7 @@ Singleton {
     property string bluetoothAdapterOverride: ""
 
     property string lastPlayerIdentity: ""
+    property string pinnedPlayerIdentity: ""
 
     property var deviceMaxVolumes: ({})
     property var hiddenOutputDeviceNames: []

--- a/quickshell/Common/settings/SessionSpec.js
+++ b/quickshell/Common/settings/SessionSpec.js
@@ -84,6 +84,7 @@ var SPEC = {
     bluetoothAdapterOverride: { def: "" },
 
     lastPlayerIdentity: { def: "" },
+    pinnedPlayerIdentity: { def: "" },
 
     deviceMaxVolumes: { def: {} },
     hiddenOutputDeviceNames: { def: [] },

--- a/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
+++ b/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
@@ -556,7 +556,7 @@ Item {
                                 anchors.leftMargin: Theme.spacingM
                                 anchors.verticalCenter: parent.verticalCenter
                                 spacing: Theme.spacingM
-                                width: parent.width - Theme.spacingM * 2
+                                width: parent.width - Theme.spacingM * 2 - pinIndicator.width - Theme.spacingS
 
                                 DankIcon {
                                     name: "music_note"
@@ -596,12 +596,36 @@ Item {
                                 }
                             }
 
+                            Rectangle {
+                                id: pinIndicator
+                                readonly property bool pinned: !!modelData?.identity && MprisController.pinnedIdentity === modelData.identity
+                                anchors.right: parent.right
+                                anchors.rightMargin: Theme.spacingM
+                                anchors.verticalCenter: parent.verticalCenter
+                                width: 12
+                                height: 12
+                                radius: 6
+                                color: pinned ? Theme.primary : "transparent"
+                                border.color: pinned ? Theme.primary : Theme.outlineHeavy
+                                border.width: 2
+                            }
+
                             MouseArea {
                                 id: playerMouseArea
                                 anchors.fill: parent
                                 hoverEnabled: true
                                 cursorShape: Qt.PointingHandCursor
-                                onClicked: {
+                                acceptedButtons: Qt.LeftButton | Qt.RightButton
+                                onClicked: mouse => {
+                                    if (mouse.button === Qt.RightButton) {
+                                        if (modelData?.identity) {
+                                            if (MprisController.pinnedIdentity === modelData.identity)
+                                                MprisController.setPinned("");
+                                            else
+                                                MprisController.setPinned(modelData.identity);
+                                        }
+                                        return;
+                                    }
                                     if (modelData?.identity) {
                                         root.playerSelected(modelData);
                                     }

--- a/quickshell/Services/MprisController.qml
+++ b/quickshell/Services/MprisController.qml
@@ -43,6 +43,7 @@ Singleton {
         });
     }
     property MprisPlayer activePlayer: null
+    property string pinnedIdentity: SessionData.pinnedPlayerIdentity || ""
     property real activePlayerStableLength: 0
     // Chromium can report blank metadata between tracks
     property string stableTitle: ""
@@ -247,6 +248,13 @@ Singleton {
         if (playing.length === 0)
             return null;
 
+        if (pinnedIdentity !== "") {
+            const pinLower = pinnedIdentity.toLowerCase();
+            const pinned = playing.find(player => player.identity === pinnedIdentity) ?? playing.find(player => (player.identity || "").toLowerCase().includes(pinLower));
+            if (pinned)
+                return pinned;
+        }
+
         const controllable = playing.filter(player => player.canControl);
         if (activePlayer?.isPlaying) {
             if (activePlayer.canControl || controllable.length === 0)
@@ -299,6 +307,13 @@ Singleton {
         activePlayer = player;
         if (player)
             _persistIdentity(player.identity);
+    }
+
+    function setPinned(identity: string): void {
+        pinnedIdentity = identity;
+        if (SessionData.pinnedPlayerIdentity !== identity)
+            SessionData.set("pinnedPlayerIdentity", identity);
+        _resolveActivePlayer();
     }
 
     function _persistIdentity(identity: string): void {

--- a/quickshell/Services/MprisController.qml
+++ b/quickshell/Services/MprisController.qml
@@ -310,7 +310,6 @@ Singleton {
     }
 
     function setPinned(identity: string): void {
-        pinnedIdentity = identity;
         if (SessionData.pinnedPlayerIdentity !== identity)
             SessionData.set("pinnedPlayerIdentity", identity);
         _resolveActivePlayer();

--- a/quickshell/Services/MprisController.qml
+++ b/quickshell/Services/MprisController.qml
@@ -250,7 +250,9 @@ Singleton {
 
         if (pinnedIdentity !== "") {
             const pinLower = pinnedIdentity.toLowerCase();
-            const pinned = playing.find(player => player.identity === pinnedIdentity) ?? playing.find(player => (player.identity || "").toLowerCase().includes(pinLower));
+            const exact = playing.filter(player => player.identity === pinnedIdentity);
+            const matches = exact.length > 0 ? exact : playing.filter(player => (player.identity || "").toLowerCase().includes(pinLower));
+            const pinned = matches.find(player => player.canControl) ?? matches[0];
             if (pinned)
                 return pinned;
         }


### PR DESCRIPTION

<img width="983" height="568" alt="Screenshot example" src="https://github.com/user-attachments/assets/1ab11134-0638-4364-9c73-e4343be69a63" />


## Description
Add a minimal "pin media source" option so the bar media widget and OSD keep showing a preferred player (e.g. a music player) even when another source (e.g. YouTube in the browser) starts playing.
 - MprisController: new pinnedIdentity property + setPinned(identity); _bestPlayingPlayer() prefers a playing pinned player (exact identity match, then case-insensitive substring fallback). Existing behavior is unchanged when no pin is set.
- Persistence via SessionData.pinnedPlayerIdentity (spec entry added so SessionData.set() accepts the key); empty string clears the pin.
- MediaDropdownOverlay (Media Players panel): each player row gets a theme-colored circle indicator on the right. Empty circle = no pin (initial state). Right-click a row to make it the default source (circle fills); right-click another row to move the pin; right-click the pinned row again to clear (back to empty). Left-click behavior unchanged (selects the player).
<!-- What does this PR do and why? -->

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<img width="983" height="568" alt="Screenshot example" src="https://github.com/user-attachments/assets/1ab11134-0638-4364-9c73-e4343be69a63" />

## Checklist

- [X ] My code follows the conventions in CONTRIBUTING.md
- [X ] I have tested my changes locally
- [X ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ X] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [X ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
i'll do that last one next