### PR TITLE
launcher: pass badgeLabel through for external plugin items

### DIFF
--- a/quickshell/Modals/DankLauncherV2/ItemTransformers.js
+++ b/quickshell/Modals/DankLauncherV2/ItemTransformers.js
@@ -238,6 +238,7 @@ function transformPluginItem(item, pluginId, selectLabel) {
         type: "plugin",
         name: item.name || "",
         subtitle: item.comment || item.description || "",
+        badgeLabel: item.badgeLabel || "",
         icon: icon,
         iconType: iconType,
         section: "plugin_" + pluginId,


### PR DESCRIPTION
Both launcher row widgets (`SpotlightResultRow` and `ResultItem`) check `item.badgeLabel` before falling back to the generic "Plugin" type chip, and `transformBuiltInLauncherItem` already forwards the field — but `transformPluginItem` never copied it, so items returned by external launcher plugins can't customize their badge and always show "Plugin".

This forwards `badgeLabel` for external plugin items the same way the built-in transformer does. Behavior is unchanged for plugins that don't set it (empty string falls through to the existing type-label switch).

Use case: a plugin listing projects across several machines can put the machine name in the badge instead of the redundant "Plugin" label.