### PR TITLE
feat(screenshot): drag region with ctrl

### DIFF
--- a/core/internal/screenshot/region.go
+++ b/core/internal/screenshot/region.go
@@ -121,6 +121,8 @@ type RegionSelector struct {
 	shiftHeld          bool
 	ctrlHeld           bool
 	movingSelection    bool
+	moveOffsetX        float64
+	moveOffsetY        float64
 
 	phase  selectorPhase
 	scroll *scrollSession

--- a/core/internal/screenshot/region_input.go
+++ b/core/internal/screenshot/region_input.go
@@ -135,7 +135,7 @@ func (r *RegionSelector) updateSelectionCurrent(os *OutputSurface, surfaceX, sur
 	curX := surfaceX + float64(os.output.x)
 	curY := surfaceY + float64(os.output.y)
 	if r.movingSelection {
-		r.updateMovedSelection(curX, curY)
+		r.updateMovedSelection(os, curX, curY)
 		return
 	}
 
@@ -185,7 +185,7 @@ func (r *RegionSelector) beginSelectionMove(pointerX, pointerY float64) bool {
 	return true
 }
 
-func (r *RegionSelector) updateMovedSelection(pointerX, pointerY float64) {
+func (r *RegionSelector) updateMovedSelection(activeSurface *OutputSurface, pointerX, pointerY float64) {
 	minX := math.Min(r.selection.anchorX, r.selection.currentX)
 	minY := math.Min(r.selection.anchorY, r.selection.currentY)
 	maxX := math.Max(r.selection.anchorX, r.selection.currentX)
@@ -195,7 +195,7 @@ func (r *RegionSelector) updateMovedSelection(pointerX, pointerY float64) {
 
 	newMinX := pointerX - r.moveOffsetX
 	newMinY := pointerY - r.moveOffsetY
-	newMinX, newMinY = r.clampMovedSelection(newMinX, newMinY, width, height)
+	newMinX, newMinY = r.clampMovedSelection(activeSurface, newMinX, newMinY, width, height)
 	deltaX := newMinX - minX
 	deltaY := newMinY - minY
 	r.selection.anchorX += deltaX
@@ -240,37 +240,48 @@ func (r *RegionSelector) rehomeSelectionSurface() {
 	}
 }
 
-func (r *RegionSelector) clampMovedSelection(x, y, width, height float64) (float64, float64) {
+func (r *RegionSelector) clampMovedSelection(activeSurface *OutputSurface, x, y, width, height float64) (float64, float64) {
 	var minX, minY, maxX, maxY float64
 	initialized := false
-	for _, surface := range r.surfaces {
-		if surface == nil || surface.output == nil || surface.logicalW <= 0 || surface.logicalH <= 0 {
-			continue
+	boundsSurface := r.selection.surface
+	if activeSurface != nil && activeSurface.output != nil && activeSurface.logicalW > 0 && activeSurface.logicalH > 0 {
+		minX = float64(activeSurface.output.x)
+		minY = float64(activeSurface.output.y)
+		maxX = minX + float64(activeSurface.logicalW)
+		maxY = minY + float64(activeSurface.logicalH)
+		initialized = true
+		boundsSurface = activeSurface
+	} else {
+		for _, surface := range r.surfaces {
+			if surface == nil || surface.output == nil || surface.logicalW <= 0 || surface.logicalH <= 0 {
+				continue
+			}
+			outputMinX := float64(surface.output.x)
+			outputMinY := float64(surface.output.y)
+			outputMaxX := outputMinX + float64(surface.logicalW)
+			outputMaxY := outputMinY + float64(surface.logicalH)
+			if !initialized {
+				minX, minY, maxX, maxY = outputMinX, outputMinY, outputMaxX, outputMaxY
+				initialized = true
+				continue
+			}
+			minX = math.Min(minX, outputMinX)
+			minY = math.Min(minY, outputMinY)
+			maxX = math.Max(maxX, outputMaxX)
+			maxY = math.Max(maxY, outputMaxY)
 		}
-		outputMinX := float64(surface.output.x)
-		outputMinY := float64(surface.output.y)
-		outputMaxX := outputMinX + float64(surface.logicalW)
-		outputMaxY := outputMinY + float64(surface.logicalH)
-		if !initialized {
-			minX, minY, maxX, maxY = outputMinX, outputMinY, outputMaxX, outputMaxY
-			initialized = true
-			continue
-		}
-		minX = math.Min(minX, outputMinX)
-		minY = math.Min(minY, outputMinY)
-		maxX = math.Max(maxX, outputMaxX)
-		maxY = math.Max(maxY, outputMaxY)
 	}
 	if !initialized {
 		return x, y
 	}
+
 	epsilonX, epsilonY := 1.0, 1.0
-	if surface := r.selection.surface; surface != nil && surface.screenBuf != nil {
-		if surface.logicalW > 0 && surface.screenBuf.Width > 0 {
-			epsilonX = float64(surface.logicalW) / float64(surface.screenBuf.Width)
+	if boundsSurface != nil && boundsSurface.screenBuf != nil {
+		if boundsSurface.logicalW > 0 && boundsSurface.screenBuf.Width > 0 {
+			epsilonX = float64(boundsSurface.logicalW) / float64(boundsSurface.screenBuf.Width)
 		}
-		if surface.logicalH > 0 && surface.screenBuf.Height > 0 {
-			epsilonY = float64(surface.logicalH) / float64(surface.screenBuf.Height)
+		if boundsSurface.logicalH > 0 && boundsSurface.screenBuf.Height > 0 {
+			epsilonY = float64(boundsSurface.logicalH) / float64(boundsSurface.screenBuf.Height)
 		}
 	}
 	return math.Max(minX, math.Min(maxX-width-epsilonX, x)),

--- a/core/internal/screenshot/region_input.go
+++ b/core/internal/screenshot/region_input.go
@@ -88,12 +88,21 @@ func (r *RegionSelector) setupPointerHandlers() {
 		case 0x110: // BTN_LEFT
 			switch e.State {
 			case 1: // pressed
+				pointerX := r.pointerX + float64(r.activeSurface.output.x)
+				pointerY := r.pointerY + float64(r.activeSurface.output.y)
+				if r.ctrlHeld && r.beginSelectionMove(pointerX, pointerY) {
+					r.selection.dragging = true
+					r.refreshCursor()
+					break
+				}
+
 				r.preSelect = Region{}
+				r.movingSelection = false
 				r.selection.hasSelection = true
 				r.selection.dragging = true
 				r.selection.surface = r.activeSurface
-				r.selection.anchorX = r.pointerX + float64(r.activeSurface.output.x)
-				r.selection.anchorY = r.pointerY + float64(r.activeSurface.output.y)
+				r.selection.anchorX = pointerX
+				r.selection.anchorY = pointerY
 				r.selection.currentX = r.selection.anchorX
 				r.selection.currentY = r.selection.anchorY
 				r.refreshCursor()
@@ -102,6 +111,7 @@ func (r *RegionSelector) setupPointerHandlers() {
 				}
 			case 0: // released
 				r.selection.dragging = false
+				r.movingSelection = false
 				r.refreshCursor()
 				for _, os := range r.surfaces {
 					r.redrawSurface(os)
@@ -124,6 +134,11 @@ func (r *RegionSelector) updateSelectionCurrent(os *OutputSurface, surfaceX, sur
 
 	curX := surfaceX + float64(os.output.x)
 	curY := surfaceY + float64(os.output.y)
+	if r.movingSelection {
+		r.updateMovedSelection(curX, curY)
+		return
+	}
+
 	if r.shiftHeld {
 		dx := curX - r.selection.anchorX
 		dy := curY - r.selection.anchorY
@@ -155,6 +170,79 @@ func (r *RegionSelector) updateSelectionCurrent(os *OutputSurface, surfaceX, sur
 	for _, surface := range r.surfaces {
 		r.redrawSurface(surface)
 	}
+}
+
+func (r *RegionSelector) beginSelectionMove(pointerX, pointerY float64) bool {
+	if !r.selection.hasSelection {
+		return false
+	}
+
+	minX := math.Min(r.selection.anchorX, r.selection.currentX)
+	minY := math.Min(r.selection.anchorY, r.selection.currentY)
+	r.moveOffsetX = pointerX - minX
+	r.moveOffsetY = pointerY - minY
+	r.movingSelection = true
+	return true
+}
+
+func (r *RegionSelector) updateMovedSelection(pointerX, pointerY float64) {
+	minX := math.Min(r.selection.anchorX, r.selection.currentX)
+	minY := math.Min(r.selection.anchorY, r.selection.currentY)
+	maxX := math.Max(r.selection.anchorX, r.selection.currentX)
+	maxY := math.Max(r.selection.anchorY, r.selection.currentY)
+	width := maxX - minX
+	height := maxY - minY
+
+	newMinX := pointerX - r.moveOffsetX
+	newMinY := pointerY - r.moveOffsetY
+	newMinX, newMinY = r.clampMovedSelection(newMinX, newMinY, width, height)
+	deltaX := newMinX - minX
+	deltaY := newMinY - minY
+	r.selection.anchorX += deltaX
+	r.selection.currentX += deltaX
+	r.selection.anchorY += deltaY
+	r.selection.currentY += deltaY
+
+	for _, surface := range r.surfaces {
+		r.redrawSurface(surface)
+	}
+}
+
+func (r *RegionSelector) clampMovedSelection(x, y, width, height float64) (float64, float64) {
+	var minX, minY, maxX, maxY float64
+	initialized := false
+	for _, surface := range r.surfaces {
+		if surface == nil || surface.output == nil || surface.logicalW <= 0 || surface.logicalH <= 0 {
+			continue
+		}
+		outputMinX := float64(surface.output.x)
+		outputMinY := float64(surface.output.y)
+		outputMaxX := outputMinX + float64(surface.logicalW)
+		outputMaxY := outputMinY + float64(surface.logicalH)
+		if !initialized {
+			minX, minY, maxX, maxY = outputMinX, outputMinY, outputMaxX, outputMaxY
+			initialized = true
+			continue
+		}
+		minX = math.Min(minX, outputMinX)
+		minY = math.Min(minY, outputMinY)
+		maxX = math.Max(maxX, outputMaxX)
+		maxY = math.Max(maxY, outputMaxY)
+	}
+	if !initialized {
+		return x, y
+	}
+	epsilonX, epsilonY := 1.0, 1.0
+	if surface := r.selection.surface; surface != nil && surface.screenBuf != nil {
+		if surface.logicalW > 0 && surface.screenBuf.Width > 0 {
+			epsilonX = float64(surface.logicalW) / float64(surface.screenBuf.Width)
+		}
+		if surface.logicalH > 0 && surface.screenBuf.Height > 0 {
+			epsilonY = float64(surface.logicalH) / float64(surface.screenBuf.Height)
+		}
+	}
+	return math.Max(minX, math.Min(maxX-width-epsilonX, x)),
+		math.Max(minY, math.Min(maxY-height-epsilonY, y))
 }
 
 func (r *RegionSelector) setupKeyboardHandlers() {

--- a/core/internal/screenshot/region_input.go
+++ b/core/internal/screenshot/region_input.go
@@ -223,15 +223,7 @@ func (r *RegionSelector) rehomeSelectionSurface() {
 		outputMinY := float64(surface.output.y)
 		outputMaxX := outputMinX + float64(surface.logicalW)
 		outputMaxY := outputMinY + float64(surface.logicalH)
-		epsilonX, epsilonY := 1.0, 1.0
-		if surface.screenBuf != nil {
-			if surface.screenBuf.Width > 0 {
-				epsilonX = float64(surface.logicalW) / float64(surface.screenBuf.Width)
-			}
-			if surface.screenBuf.Height > 0 {
-				epsilonY = float64(surface.logicalH) / float64(surface.screenBuf.Height)
-			}
-		}
+		epsilonX, epsilonY := surfaceEpsilon(surface)
 		if minX >= outputMinX && minY >= outputMinY &&
 			maxX <= outputMaxX-epsilonX && maxY <= outputMaxY-epsilonY {
 			r.selection.surface = surface
@@ -241,51 +233,72 @@ func (r *RegionSelector) rehomeSelectionSurface() {
 }
 
 func (r *RegionSelector) clampMovedSelection(activeSurface *OutputSurface, x, y, width, height float64) (float64, float64) {
-	var minX, minY, maxX, maxY float64
+	var unionMinX, unionMinY, unionMaxX, unionMaxY, unionEpsX, unionEpsY float64
 	initialized := false
-	boundsSurface := r.selection.surface
-	if activeSurface != nil && activeSurface.output != nil && activeSurface.logicalW > 0 && activeSurface.logicalH > 0 {
-		minX = float64(activeSurface.output.x)
-		minY = float64(activeSurface.output.y)
-		maxX = minX + float64(activeSurface.logicalW)
-		maxY = minY + float64(activeSurface.logicalH)
-		initialized = true
-		boundsSurface = activeSurface
-	} else {
-		for _, surface := range r.surfaces {
-			if surface == nil || surface.output == nil || surface.logicalW <= 0 || surface.logicalH <= 0 {
-				continue
-			}
-			outputMinX := float64(surface.output.x)
-			outputMinY := float64(surface.output.y)
-			outputMaxX := outputMinX + float64(surface.logicalW)
-			outputMaxY := outputMinY + float64(surface.logicalH)
-			if !initialized {
-				minX, minY, maxX, maxY = outputMinX, outputMinY, outputMaxX, outputMaxY
-				initialized = true
-				continue
-			}
-			minX = math.Min(minX, outputMinX)
-			minY = math.Min(minY, outputMinY)
-			maxX = math.Max(maxX, outputMaxX)
-			maxY = math.Max(maxY, outputMaxY)
+	for _, surface := range r.surfaces {
+		if surface == nil || surface.output == nil || surface.logicalW <= 0 || surface.logicalH <= 0 {
+			continue
 		}
+		outputMinX := float64(surface.output.x)
+		outputMinY := float64(surface.output.y)
+		outputMaxX := outputMinX + float64(surface.logicalW)
+		outputMaxY := outputMinY + float64(surface.logicalH)
+		epsilonX, epsilonY := surfaceEpsilon(surface)
+		if !initialized {
+			unionMinX, unionMinY, unionMaxX, unionMaxY = outputMinX, outputMinY, outputMaxX, outputMaxY
+			unionEpsX, unionEpsY = epsilonX, epsilonY
+			initialized = true
+			continue
+		}
+		unionMinX = math.Min(unionMinX, outputMinX)
+		unionMinY = math.Min(unionMinY, outputMinY)
+		unionMaxX = math.Max(unionMaxX, outputMaxX)
+		unionMaxY = math.Max(unionMaxY, outputMaxY)
+		unionEpsX = math.Max(unionEpsX, epsilonX)
+		unionEpsY = math.Max(unionEpsY, epsilonY)
 	}
 	if !initialized {
 		return x, y
 	}
 
-	epsilonX, epsilonY := 1.0, 1.0
-	if boundsSurface != nil && boundsSurface.screenBuf != nil {
-		if boundsSurface.logicalW > 0 && boundsSurface.screenBuf.Width > 0 {
-			epsilonX = float64(boundsSurface.logicalW) / float64(boundsSurface.screenBuf.Width)
-		}
-		if boundsSurface.logicalH > 0 && boundsSurface.screenBuf.Height > 0 {
-			epsilonY = float64(boundsSurface.logicalH) / float64(boundsSurface.screenBuf.Height)
-		}
+	minX, minY, maxX, maxY := unionMinX, unionMinY, unionMaxX, unionMaxY
+	epsilonX, epsilonY := unionEpsX, unionEpsY
+	if activeSurface != nil && activeSurface.output != nil && activeSurface.logicalW > 0 && activeSurface.logicalH > 0 {
+		minX = float64(activeSurface.output.x)
+		minY = float64(activeSurface.output.y)
+		maxX = minX + float64(activeSurface.logicalW)
+		maxY = minY + float64(activeSurface.logicalH)
+		epsilonX, epsilonY = surfaceEpsilon(activeSurface)
 	}
-	return math.Max(minX, math.Min(maxX-width-epsilonX, x)),
-		math.Max(minY, math.Min(maxY-height-epsilonY, y))
+
+	return clampMoveAxis(x, width, minX, maxX-epsilonX, unionMinX, unionMaxX-unionEpsX),
+		clampMoveAxis(y, height, minY, maxY-epsilonY, unionMinY, unionMaxY-unionEpsY)
+}
+
+// a region larger than the active output falls back to the output union so the clamp range cannot invert and freeze the drag
+func clampMoveAxis(pos, size, lo, hi, unionLo, unionHi float64) float64 {
+	if hi-size < lo {
+		lo, hi = unionLo, unionHi
+	}
+	upper := hi - size
+	if upper < lo {
+		lo, upper = upper, lo
+	}
+	return math.Max(lo, math.Min(upper, pos))
+}
+
+func surfaceEpsilon(surface *OutputSurface) (float64, float64) {
+	epsilonX, epsilonY := 1.0, 1.0
+	if surface.screenBuf == nil {
+		return epsilonX, epsilonY
+	}
+	if surface.logicalW > 0 && surface.screenBuf.Width > 0 {
+		epsilonX = float64(surface.logicalW) / float64(surface.screenBuf.Width)
+	}
+	if surface.logicalH > 0 && surface.screenBuf.Height > 0 {
+		epsilonY = float64(surface.logicalH) / float64(surface.screenBuf.Height)
+	}
+	return epsilonX, epsilonY
 }
 
 func (r *RegionSelector) setupKeyboardHandlers() {

--- a/core/internal/screenshot/region_input.go
+++ b/core/internal/screenshot/region_input.go
@@ -202,9 +202,41 @@ func (r *RegionSelector) updateMovedSelection(pointerX, pointerY float64) {
 	r.selection.currentX += deltaX
 	r.selection.anchorY += deltaY
 	r.selection.currentY += deltaY
+	r.rehomeSelectionSurface()
 
 	for _, surface := range r.surfaces {
 		r.redrawSurface(surface)
+	}
+}
+
+func (r *RegionSelector) rehomeSelectionSurface() {
+	minX := math.Min(r.selection.anchorX, r.selection.currentX)
+	minY := math.Min(r.selection.anchorY, r.selection.currentY)
+	maxX := math.Max(r.selection.anchorX, r.selection.currentX)
+	maxY := math.Max(r.selection.anchorY, r.selection.currentY)
+
+	for _, surface := range r.surfaces {
+		if surface == nil || surface.output == nil || surface.logicalW <= 0 || surface.logicalH <= 0 {
+			continue
+		}
+		outputMinX := float64(surface.output.x)
+		outputMinY := float64(surface.output.y)
+		outputMaxX := outputMinX + float64(surface.logicalW)
+		outputMaxY := outputMinY + float64(surface.logicalH)
+		epsilonX, epsilonY := 1.0, 1.0
+		if surface.screenBuf != nil {
+			if surface.screenBuf.Width > 0 {
+				epsilonX = float64(surface.logicalW) / float64(surface.screenBuf.Width)
+			}
+			if surface.screenBuf.Height > 0 {
+				epsilonY = float64(surface.logicalH) / float64(surface.screenBuf.Height)
+			}
+		}
+		if minX >= outputMinX && minY >= outputMinY &&
+			maxX <= outputMaxX-epsilonX && maxY <= outputMaxY-epsilonY {
+			r.selection.surface = surface
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
Add `Ctrl + left-drag` support for moving the current screenshot region.

The selection keeps its size and cursor offset while being moved, and is clamped to the available output bounds.