### PR TITLE
fix(processlist): stop polling when the popout is closed

### DIFF
--- a/quickshell/Common/Ref.qml
+++ b/quickshell/Common/Ref.qml
@@ -3,7 +3,18 @@ import Quickshell
 
 QtObject {
     required property Singleton service
+    property bool active: true
 
-    Component.onCompleted: service.refCount++
-    Component.onDestruction: service.refCount--
+    property bool _held: false
+
+    function sync(wanted) {
+        if (wanted === _held)
+            return;
+        _held = wanted;
+        service.refCount += wanted ? 1 : -1;
+    }
+
+    onActiveChanged: sync(active)
+    Component.onCompleted: sync(active)
+    Component.onDestruction: sync(false)
 }

--- a/quickshell/Modules/ProcessList/ProcessListPopout.qml
+++ b/quickshell/Modules/ProcessList/ProcessListPopout.qml
@@ -62,6 +62,7 @@ DankPopout {
 
     Ref {
         service: DgopService
+        active: processListPopout.shouldBeVisible
     }
 
     ProcessContextMenu {
@@ -378,6 +379,7 @@ DankPopout {
                         id: processesView
                         anchors.fill: parent
                         anchors.margins: Theme.spacingS
+                        active: processListPopout.shouldBeVisible
                         searchText: processListPopout.searchText
                         expandedPid: processListPopout.expandedPid
                         processFilter: processListPopout.processFilter

--- a/quickshell/Modules/ProcessList/ProcessListPopout.qml
+++ b/quickshell/Modules/ProcessList/ProcessListPopout.qml
@@ -379,7 +379,7 @@ DankPopout {
                         id: processesView
                         anchors.fill: parent
                         anchors.margins: Theme.spacingS
-                        active: processListPopout.shouldBeVisible
+                        active: processListPopout.shouldBeVisible || processListPopout.isClosing
                         searchText: processListPopout.searchText
                         expandedPid: processListPopout.expandedPid
                         processFilter: processListPopout.processFilter

--- a/quickshell/Modules/ProcessList/ProcessesView.qml
+++ b/quickshell/Modules/ProcessList/ProcessesView.qml
@@ -12,6 +12,7 @@ Item {
     property string expandedPid: ""
     property var contextMenu: null
     property string processFilter: "all" // "all", "user", "system"
+    property bool active: true
 
     property int selectedIndex: -1
     property bool keyboardNavigationActive: false
@@ -250,14 +251,27 @@ Item {
         }
     }
 
+    readonly property var dgopModules: ["processes", "cpu", "memory", "system"]
+    property bool _dgopHeld: false
+
+    function syncDgopRef(wanted) {
+        if (wanted === _dgopHeld)
+            return;
+        _dgopHeld = wanted;
+        if (wanted)
+            DgopService.addRef(dgopModules);
+        else
+            DgopService.removeRef(dgopModules);
+    }
+
+    onActiveChanged: syncDgopRef(active)
+
     Component.onCompleted: {
-        DgopService.addRef(["processes", "cpu", "memory", "system"]);
+        syncDgopRef(active);
         cachedProcesses = filteredProcesses;
     }
 
-    Component.onDestruction: {
-        DgopService.removeRef(["processes", "cpu", "memory", "system"]);
-    }
+    Component.onDestruction: syncDgopRef(false)
 
     ColumnLayout {
         anchors.fill: parent


### PR DESCRIPTION
## Description

<!-- What does this PR do and why? -->
The popout's content loader deliberately stays warm across close so re-opening is instant, and PopoutService only defers the actual unload until session lock or monitors-off. But both DgopService references were bound to component lifetime rather than presentation, so after closing the popout refCount stayed above zero: dgop kept sampling the full process list every 3s until the shell restarted or the session was locked and unlocked.


Gate both references on shouldBeVisible instead. Ref grows an `active` property (defaulting to true, so every other call site is unchanged) and ProcessesView grows an `active` property that hosts keeping it loaded while hidden can drive. ProcessListModal is unaffected — its tab loaders already destroy the view when the window hides.


## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->
Closes  #3046 

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvenjkgeMedia/DankLinux-Docs
