### PR TITLE
feat(control-center): show Bluetooth battery in quick tile

### DIFF
--- a/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
+++ b/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
@@ -559,8 +559,18 @@ Column {
                                 }
                                 return null;
                             })();
-                        if (primaryDevice)
-                            return primaryDevice.name || primaryDevice.alias || primaryDevice.deviceName || I18n.tr("Connected Device", "bluetooth status");
+                        if (primaryDevice) {
+                            const name = primaryDevice.name || primaryDevice.alias || primaryDevice.deviceName || I18n.tr("Connected Device", "bluetooth status");
+                            // A reported 0% is valid; batteryAvailable distinguishes missing data.
+                            // https://quickshell.org/docs/v0.3.1/types/Quickshell.Bluetooth/BluetoothDevice/
+                            // https://bluez.readthedocs.io/en/latest/battery-api/
+                            if (primaryDevice.batteryAvailable)
+                                return `${name} • ${Math.round(primaryDevice.battery * 100)}%`;
+                            const btBattery = BatteryService.bluetoothDevices.find(dev => dev.name === name || dev.name.toLowerCase().includes(name.toLowerCase()) || name.toLowerCase().includes(dev.name.toLowerCase()));
+                            if (btBattery)
+                                return `${name} • ${btBattery.percentage}%`;
+                            return name;
+                        }
                         return I18n.tr("No devices", "bluetooth status");
                     }
                 case "audioOutput":

--- a/quickshell/Modules/ControlCenter/Details/BluetoothDetail.qml
+++ b/quickshell/Modules/ControlCenter/Details/BluetoothDetail.qml
@@ -362,7 +362,10 @@ Rectangle {
                                         return BatteryService.bluetoothDevices.find(dev => dev.name === name || dev.name.toLowerCase().includes(name.toLowerCase()) || name.toLowerCase().includes(dev.name.toLowerCase()));
                                     }
                                     text: {
-                                        if (pairedDelegate.modelData.batteryAvailable && pairedDelegate.modelData.battery > 0)
+                                        // A reported 0% is valid; batteryAvailable distinguishes missing data.
+                                        // https://quickshell.org/docs/v0.3.1/types/Quickshell.Bluetooth/BluetoothDevice/
+                                        // https://bluez.readthedocs.io/en/latest/battery-api/
+                                        if (pairedDelegate.modelData.batteryAvailable)
                                             return "• " + Math.round(pairedDelegate.modelData.battery * 100) + "%";
                                         if (btBattery)
                                             return "• " + btBattery.percentage + "%";


### PR DESCRIPTION
## Description

Shows the connected Bluetooth device battery level in the Control Center tile when available.

## Type of change

- [x] New feature

## Related issues

None.

## Screenshots / video

<img width="525" height="146" alt="Screenshot from 2026-08-23 20-33-48" src="https://github.com/user-attachments/assets/66e9abe0-4a25-47f0-bcd6-0b0562464f1e" />


## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] QML changes: ran `make lint-qml` with no new warnings