### PR TITLE
fix(typography): use monospace for dynamic numeric values

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/Battery.qml
+++ b/quickshell/Modules/DankBar/Widgets/Battery.qml
@@ -151,6 +151,7 @@ BasePill {
 
                 StyledText {
                     text: battery.verticalDisplayText
+                    isMonospace: true
                     font.pixelSize: Theme.barTextSize(battery.barThickness, battery.barConfig?.fontScale, battery.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
                     horizontalAlignment: Text.AlignHCenter
@@ -197,6 +198,7 @@ BasePill {
 
                 StyledText {
                     text: battery.horizontalSideText
+                    isMonospace: true
                     font.pixelSize: Theme.barTextSize(battery.barThickness, battery.barConfig?.fontScale, battery.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
                     anchors.verticalCenter: parent.verticalCenter

--- a/quickshell/Modules/DankBar/Widgets/CpuMonitor.qml
+++ b/quickshell/Modules/DankBar/Widgets/CpuMonitor.qml
@@ -59,6 +59,7 @@ BasePill {
 
                         return DgopService.cpuUsage.toFixed(0);
                     }
+                    isMonospace: true
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -101,12 +102,14 @@ BasePill {
 
                     StyledTextMetrics {
                         id: cpuBaseline
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         text: "100%"
                     }
 
                     StyledTextMetrics {
                         id: cpuCurrent
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         text: cpuText.text
                     }
@@ -120,6 +123,7 @@ BasePill {
                             }
                             return v.toFixed(0) + "%";
                         }
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         color: Theme.widgetTextColor
 

--- a/quickshell/Modules/DankBar/Widgets/CpuTemperature.qml
+++ b/quickshell/Modules/DankBar/Widgets/CpuTemperature.qml
@@ -59,6 +59,7 @@ BasePill {
 
                         return Math.round(DgopService.cpuTemperature).toString();
                     }
+                    isMonospace: true
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -101,6 +102,7 @@ BasePill {
 
                     StyledTextMetrics {
                         id: tempBaseline
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         text: "88°"
                     }
@@ -114,6 +116,7 @@ BasePill {
 
                             return Math.round(DgopService.cpuTemperature) + "°";
                         }
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         color: Theme.widgetTextColor
 

--- a/quickshell/Modules/DankBar/Widgets/DiskUsage.qml
+++ b/quickshell/Modules/DankBar/Widgets/DiskUsage.qml
@@ -148,6 +148,7 @@ BasePill {
                             return root.diskUsagePercent.toFixed(0);
                         }
                     }
+                    isMonospace: true
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -208,6 +209,7 @@ BasePill {
 
                     StyledTextMetrics {
                         id: diskBaseline
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         text: {
                             switch (root.diskUsageMode) {
@@ -224,6 +226,7 @@ BasePill {
 
                     StyledTextMetrics {
                         id: diskCurrent
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         text: diskText.text
                     }
@@ -247,6 +250,7 @@ BasePill {
                                 return root.diskUsagePercent.toFixed(0) + "%";
                             }
                         }
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         color: Theme.widgetTextColor
 

--- a/quickshell/Modules/DankBar/Widgets/GpuTemperature.qml
+++ b/quickshell/Modules/DankBar/Widgets/GpuTemperature.qml
@@ -127,6 +127,7 @@ BasePill {
 
                         return Math.round(root.displayTemp).toString();
                     }
+                    isMonospace: true
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -169,6 +170,7 @@ BasePill {
 
                     StyledTextMetrics {
                         id: gpuTempBaseline
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         text: "88°"
                     }
@@ -182,6 +184,7 @@ BasePill {
 
                             return Math.round(root.displayTemp) + "°";
                         }
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         color: Theme.widgetTextColor
 

--- a/quickshell/Modules/DankBar/Widgets/NetworkMonitor.qml
+++ b/quickshell/Modules/DankBar/Widgets/NetworkMonitor.qml
@@ -42,6 +42,7 @@ BasePill {
                             return (rate / 1024).toFixed(0) + "K";
                         return (rate / (1024 * 1024)).toFixed(0) + "M";
                     }
+                    isMonospace: true
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     color: Theme.info
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -56,6 +57,7 @@ BasePill {
                             return (rate / 1024).toFixed(0) + "K";
                         return (rate / (1024 * 1024)).toFixed(0) + "M";
                     }
+                    isMonospace: true
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     color: Theme.error
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -87,6 +89,7 @@ BasePill {
 
                     StyledText {
                         text: DgopService.networkRxRate > 0 ? Format.formatRate(DgopService.networkRxRate, 1) : "0 B/s"
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         color: Theme.widgetTextColor
                         anchors.verticalCenter: parent.verticalCenter
@@ -96,6 +99,7 @@ BasePill {
 
                         StyledTextMetrics {
                             id: rxBaseline
+                            isMonospace: true
                             font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                             text: "88.8 MB/s"
                         }
@@ -116,6 +120,7 @@ BasePill {
 
                     StyledText {
                         text: DgopService.networkTxRate > 0 ? Format.formatRate(DgopService.networkTxRate, 1) : "0 B/s"
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         color: Theme.widgetTextColor
                         anchors.verticalCenter: parent.verticalCenter
@@ -125,6 +130,7 @@ BasePill {
 
                         StyledTextMetrics {
                             id: txBaseline
+                            isMonospace: true
                             font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                             text: "88.8 MB/s"
                         }

--- a/quickshell/Modules/DankBar/Widgets/RamMonitor.qml
+++ b/quickshell/Modules/DankBar/Widgets/RamMonitor.qml
@@ -66,6 +66,7 @@ BasePill {
 
                         return DgopService.memoryUsage.toFixed(0);
                     }
+                    isMonospace: true
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -74,6 +75,7 @@ BasePill {
                 StyledText {
                     visible: root.showSwap && DgopService.totalSwapKB > 0
                     text: root.swapUsage.toFixed(0)
+                    isMonospace: true
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     color: Theme.surfaceVariantText
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -116,6 +118,7 @@ BasePill {
 
                     StyledTextMetrics {
                         id: ramBaseline
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         text: {
                             let baseText = root.showInGb ? "88.8 GB" : "88%";
@@ -148,6 +151,7 @@ BasePill {
                             }
                             return ramText;
                         }
+                        isMonospace: true
                         font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                         color: Theme.widgetTextColor
 

--- a/quickshell/Modules/DankBar/Widgets/Weather.qml
+++ b/quickshell/Modules/DankBar/Widgets/Weather.qml
@@ -44,6 +44,7 @@ BasePill {
                         const temp = SettingsData.useFahrenheit ? WeatherService.weather.tempF : WeatherService.weather.temp;
                         return temp;
                     }
+                    isMonospace: true
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -65,6 +66,7 @@ BasePill {
 
                 StyledText {
                     text: WeatherService.currentTempText(false)
+                    isMonospace: true
                     font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
                     anchors.verticalCenter: parent.verticalCenter

--- a/quickshell/Widgets/BatteryMeter.qml
+++ b/quickshell/Widgets/BatteryMeter.qml
@@ -67,6 +67,7 @@ Item {
 
         font.pixelSize: Math.max(1, root.baseTextSize)
         font.weight: Font.Bold
+        isMonospace: true
         text: root.numberText
     }
 
@@ -127,6 +128,7 @@ Item {
             y: root.textBaseline - baselineOffset
             text: root.numberText
             color: glyphs.glyphColor
+            isMonospace: true
             font.pixelSize: Math.max(1, root.textSize)
             font.weight: Font.Bold
         }


### PR DESCRIPTION
## Description

The CPU temperature kept changing width and making the bar jump around, which was pretty distracting.
This switches dynamic numbers in DankBar to the configured monospace font so the layout stays stable.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

None.

## Screenshots / video

<!-- Add before/after screenshots here -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] QML changes: ran `make lint-qml` with no new warnings