### PR TITLE
fix(tray): prefer tooltip title in menu

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
+++ b/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
@@ -1890,10 +1890,10 @@ BasePill {
                                     anchors.leftMargin: Theme.spacingS
                                     anchors.verticalCenter: parent.verticalCenter
                                     text: {
-                                        const itemId = menuRoot.trayItem?.id || "Unknown";
+                                        const itemTitle = menuRoot.trayItem?.tooltipTitle || menuRoot.trayItem?.id || I18n.tr("Unknown");
                                         if (root.isAutoOverflowTrayItem(menuRoot.trayItem))
-                                            return itemId + " · " + I18n.tr("Keep in Bar");
-                                        return itemId;
+                                            return itemTitle + " · " + I18n.tr("Keep in Bar");
+                                        return itemTitle;
                                     }
                                     font.pixelSize: Theme.fontSizeSmall
                                     color: Theme.surfaceTextMedium


### PR DESCRIPTION
## Description

Use the tray item's tooltip title for the user-visible menu header, falling back to its ID and then `Unknown`.

This avoids showing Chromium/Electron IDs such as `chrome_status_icon_1` while preserving the existing technical identity and DBus lookup.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots / video

<img width="598" height="112" alt="image" src="https://github.com/user-attachments/assets/5855cdb1-3160-4d5c-acdb-5df10e751dbc" />
<img width="536" height="86" alt="image" src="https://github.com/user-attachments/assets/f201c80f-85f6-45d7-8ef0-1f0cd87d6882" />


## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] QML changes: ran `make lint-qml` with no new warnings
