### PR TITLE
SystemTrayBar: add configurable icon spacing

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -521,6 +521,7 @@ Singleton {
     property bool trayAutoOverflow: true
     property bool trayPopupSingleLine: true
     property int trayMaxVisibleItems: 0
+    property real trayIconSpacing: 0
     property bool appsDockHideIndicators: false
     property bool appsDockColorizeActive: false
     property string appsDockActiveColorMode: "primary"

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -240,6 +240,7 @@ var SPEC = {
     trayAutoOverflow: { def: true },
     trayPopupSingleLine: { def: true },
     trayMaxVisibleItems: { def: 0 },
+    trayIconSpacing: { def: 0 },
     appsDockHideIndicators: { def: false },
     appsDockColorizeActive: { def: false },
     appsDockActiveColorMode: { def: "primary" },

--- a/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
+++ b/quickshell/Modules/DankBar/Widgets/SystemTrayBar.qml
@@ -24,6 +24,7 @@ BasePill {
     property bool useSingleLineOverflowPopup: widgetData?.trayPopupSingleLine ?? SettingsData.trayPopupSingleLine
     property bool useAutomaticOverflow: widgetData?.trayAutoOverflow ?? SettingsData.trayAutoOverflow
     property int configuredMaxVisibleItems: widgetData?.trayMaxVisibleItems ?? SettingsData.trayMaxVisibleItems
+    property real configuredIconSpacing: Math.max(0, widgetData?.trayIconSpacing ?? SettingsData.trayIconSpacing)
     property real sectionAvailablePrimarySize: 0
     readonly property var hiddenTrayIds: {
         const envValue = Quickshell.env("DMS_HIDE_TRAYIDS") || "";
@@ -178,7 +179,7 @@ BasePill {
         const sectionPrimary = root.sectionAvailablePrimarySize > 0 ? root.sectionAvailablePrimarySize : (root.isVerticalOrientation ? (root.parentScreen?.height || 0) : (root.parentScreen?.width || 0));
         const logicalPrimary = sectionPrimary > 0 ? (sectionPrimary / scale) : 640;
         const maxTrayShare = root.isVerticalOrientation ? 0.55 : 0.50;
-        const itemSize = Math.max(1, root.trayItemSize);
+        const itemSize = Math.max(1, root.trayItemSize + root.configuredIconSpacing);
         const slots = Math.floor((logicalPrimary * maxTrayShare) / itemSize);
         return Math.max(2, Math.min(10, Math.min(root.visibleSortedTrayItems.length, slots)));
     }
@@ -320,7 +321,7 @@ BasePill {
     }
 
     function updateMainDrag(axisOffset, visualIndex, reversed) {
-        const itemSize = root.trayItemSize;
+        const itemSize = root.trayItemSize + root.configuredIconSpacing;
         const slotOffset = Math.round(axisOffset / itemSize);
         const visualTargetIndex = Math.max(0, Math.min(root.mainBarItems.length - 1, visualIndex + slotOffset));
         const newTargetIndex = reversed ? (root.mainBarItems.length - 1 - visualTargetIndex) : visualTargetIndex;
@@ -468,7 +469,7 @@ BasePill {
     Component {
         id: rowComp
         Row {
-            spacing: 0
+            spacing: root.configuredIconSpacing
             layoutDirection: root.reverseInlineHorizontal ? Qt.RightToLeft : Qt.LeftToRight
 
             Repeater {
@@ -487,7 +488,7 @@ BasePill {
                     height: root.barThickness
                     z: dragHandler.dragging ? 100 : 0
 
-                    property real shiftOffset: root.dragShiftOffset(index, root.draggedIndex, root.dropTargetIndex, root.trayItemSize)
+                    property real shiftOffset: root.dragShiftOffset(index, root.draggedIndex, root.dropTargetIndex, root.trayItemSize + root.configuredIconSpacing)
 
                     transform: Translate {
                         x: delegateRoot.shiftOffset
@@ -706,7 +707,7 @@ BasePill {
 
             width: root.isVerticalOrientation ? root.barThickness : (root.inlineExpanded ? root.trayItemSize : 0)
             height: root.isVerticalOrientation ? (root.inlineExpanded ? root.trayItemSize : 0) : root.barThickness
-            visible: width > 0 || height > 0
+            visible: width > 0 && height > 0
 
             Behavior on width {
                 enabled: !root.isVerticalOrientation
@@ -819,7 +820,7 @@ BasePill {
             height: root.trayItemSize
             z: dragHandler.dragging ? 100 : 0
 
-            property real shiftOffset: root.dragShiftOffset(index, root.draggedIndex, root.dropTargetIndex, root.trayItemSize)
+            property real shiftOffset: root.dragShiftOffset(index, root.draggedIndex, root.dropTargetIndex, root.trayItemSize + root.configuredIconSpacing)
 
             transform: Translate {
                 y: shiftOffset
@@ -975,7 +976,7 @@ BasePill {
     Component {
         id: columnComp
         Column {
-            spacing: 0
+            spacing: root.configuredIconSpacing
 
             // Column lacks layoutDirection, so we use four repeaters with mutually exclusive models to control whether main items or expanded items appear above/ below the toggle button.
             // When reverseInlineVertical is true the first and third repeaters are empty and the second and fourth are active, and vice-versa.

--- a/quickshell/Modules/Settings/WidgetsTab.qml
+++ b/quickshell/Modules/Settings/WidgetsTab.qml
@@ -1088,6 +1088,8 @@ Item {
                     item.trayAutoOverflow = widget.trayAutoOverflow;
                 if (widget.trayMaxVisibleItems !== undefined)
                     item.trayMaxVisibleItems = widget.trayMaxVisibleItems;
+                if (widget.trayIconSpacing !== undefined)
+                    item.trayIconSpacing = widget.trayIconSpacing;
                 if (widget.hideWhenIdle !== undefined)
                     item.hideWhenIdle = widget.hideWhenIdle;
             }

--- a/quickshell/Modules/Settings/WidgetsTabSection.qml
+++ b/quickshell/Modules/Settings/WidgetsTabSection.qml
@@ -1723,6 +1723,86 @@ Column {
                         acceptedButtons: Qt.NoButton
                     }
                 }
+
+                Rectangle {
+                    width: parent.width
+                    height: 36
+                    radius: Theme.cornerRadius
+                    color: trayIconSpacingArea.containsMouse ? Theme.primaryHover : Theme.withAlpha(Theme.primaryHover, 0)
+
+                    Row {
+                        anchors.left: parent.left
+                        anchors.leftMargin: Theme.spacingS
+                        anchors.right: trayIconSpacingButtons.left
+                        anchors.rightMargin: Theme.spacingXS
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Theme.spacingS
+                        clip: true
+
+                        DankIcon {
+                            name: "open_in_full"
+                            size: 16
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+
+                        StyledText {
+                            text: I18n.tr("Icon Spacing")
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            font.weight: Font.Normal
+                            anchors.verticalCenter: parent.verticalCenter
+                            maximumLineCount: 1
+                        }
+
+                        StyledText {
+                            text: {
+                                const value = Math.max(0, trayContextMenu.currentWidgetData?.trayIconSpacing ?? SettingsData.trayIconSpacing);
+                                return `${value}px`;
+                            }
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceTextMedium
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+
+                    Row {
+                        id: trayIconSpacingButtons
+                        anchors.right: parent.right
+                        anchors.rightMargin: Theme.spacingXS
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Theme.spacingXXS
+
+                        DankActionButton {
+                            buttonSize: 28
+                            iconName: "remove"
+                            iconSize: 16
+                            iconColor: Theme.surfaceText
+                            onClicked: {
+                                const current = Math.max(0, trayContextMenu.currentWidgetData?.trayIconSpacing ?? SettingsData.trayIconSpacing);
+                                root.overflowSettingChanged(trayContextMenu.sectionId, trayContextMenu.widgetIndex, "trayIconSpacing", Math.max(0, current - 1));
+                            }
+                        }
+
+                        DankActionButton {
+                            buttonSize: 28
+                            iconName: "add"
+                            iconSize: 16
+                            iconColor: Theme.surfaceText
+                            onClicked: {
+                                const current = Math.max(0, trayContextMenu.currentWidgetData?.trayIconSpacing ?? SettingsData.trayIconSpacing);
+                                root.overflowSettingChanged(trayContextMenu.sectionId, trayContextMenu.widgetIndex, "trayIconSpacing", Math.min(20, current + 1));
+                            }
+                        }
+                    }
+
+                    MouseArea {
+                        id: trayIconSpacingArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        acceptedButtons: Qt.NoButton
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

Adds a user-configurable spacing between system tray icons in the DankBar.

The spacing is available per widget instance through the tray widget context
menu in Settings > Widgets ("Icon Spacing" stepper, 0–20px), falling back to a
global default (`trayIconSpacing`, default 0 = current behavior).

It is applied to both horizontal (Row) and vertical (Column) bar orientations,
and is accounted for in auto-overflow slot estimation and drag-and-drop slot
math (shift offsets and target index calculation) so reordering stays accurate
when spacing is non-zero.

### Changes

- `Common/SettingsData.qml` / `Common/settings/SettingsSpec.js`: new
  `trayIconSpacing` setting (default 0)
- `Modules/DankBar/Widgets/SystemTrayBar.qml`: new `configuredIconSpacing`
  property (`widgetData ?? SettingsData`) applied to the Row/Column layouts,
  auto-overflow estimation, and drag-and-drop math
- `Modules/Settings/WidgetsTabSection.qml`: "Icon Spacing" stepper in the tray
  widget context menu, following the existing "Max Visible" pattern
- `Modules/Settings/WidgetsTab.qml`: keep `trayIconSpacing` when restoring
  per-widget data


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues


## Screenshots / video

<img width="447" height="120" alt="Screenshot from 2026-08-26 09-52-23" src="https://github.com/user-attachments/assets/6586cf7e-dd04-4eb9-9ce6-30d2d54f3b17" />
<img width="564" height="254" alt="Screenshot from 2026-08-26 09-52-47" src="https://github.com/user-attachments/assets/57fe4234-c1e1-4eef-a416-a6b0ebf1d8b1" />

## Checklist

- [X] My code follows the conventions in CONTRIBUTING.md
- [X] I have tested my changes locally
- [X] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [X] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
