### PR TITLE
fix(bar): prevent focused app overlap

### DIFF
--- a/quickshell/Modules/DankBar/DankBarContent.qml
+++ b/quickshell/Modules/DankBar/DankBarContent.qml
@@ -1040,8 +1040,19 @@ Item {
         id: focusedWindowComponent
 
         FocusedApp {
+            id: focusedWindowWidget
             axis: barWindow.axis
-            availableWidth: topBarContent.leftToMediaGap
+            availableWidth: {
+                const configuredWidth = focusedWindowWidget.maxWidth;
+                const focusedWidgetContainer = focusedWindowWidget.parent?.parent;
+                if (barWindow.axis?.isVertical || topBarContent.getWidgetSection(focusedWindowWidget) !== "left" || hCenterSection.contentSize <= 0 || !focusedWidgetContainer)
+                    return configuredWidth;
+
+                // Read Row coordinates directly so this binding tracks reflow.
+                const focusedWidgetLeft = hLeftSection.x + focusedWidgetContainer.x;
+                const centerContentLeft = hCenterSection.x + hCenterSection.contentStart;
+                return Math.max(0, centerContentLeft - focusedWidgetLeft);
+            }
             widgetThickness: barWindow.widgetThickness
             barThickness: barWindow.effectiveBarThickness
             barSpacing: barConfig?.spacing ?? 4

--- a/quickshell/Modules/DankBar/Widgets/FocusedApp.qml
+++ b/quickshell/Modules/DankBar/Widgets/FocusedApp.qml
@@ -29,6 +29,8 @@ BasePill {
         }
     }
     property int availableWidth: maxWidth
+    readonly property real effectiveHorizontalWidth: Math.max(0, Math.min(maxWidth, availableWidth))
+    readonly property real effectiveHorizontalInnerWidth: Math.max(0, effectiveHorizontalWidth - horizontalPadding * 2)
     property Toplevel activeWindow: null
     property var activeDesktopEntry: null
     property bool isHovered: mouseArea.containsMouse
@@ -200,9 +202,9 @@ BasePill {
         return activeWindow && (activeWindow.title || activeWindow.appId);
     }
 
-    width: hasWindowsOnCurrentWorkspace ? (isVerticalOrientation ? barThickness : visualWidth) : 0
+    width: hasWindowsOnCurrentWorkspace ? (isVerticalOrientation ? barThickness : (effectiveHorizontalInnerWidth > 0 ? visualWidth : 0)) : 0
     height: hasWindowsOnCurrentWorkspace ? (isVerticalOrientation ? visualHeight : barThickness) : 0
-    visible: hasWindowsOnCurrentWorkspace
+    visible: hasWindowsOnCurrentWorkspace && (isVerticalOrientation || effectiveHorizontalInnerWidth > 0)
 
     content: Component {
         Item {
@@ -211,10 +213,11 @@ BasePill {
                     return 0;
                 if (root.isVerticalOrientation)
                     return root.widgetThickness - root.horizontalPadding * 2;
-                return contentRow.implicitWidth;
+                return Math.min(contentRow.implicitWidth, root.effectiveHorizontalInnerWidth);
             }
+            width: root.isVerticalOrientation ? root.widgetThickness - root.horizontalPadding * 2 : Math.min(implicitWidth, root.effectiveHorizontalInnerWidth)
             implicitHeight: root.widgetThickness - root.horizontalPadding * 2
-            clip: false
+            clip: !root.isVerticalOrientation
 
             IconImage {
                 id: appIcon
@@ -263,7 +266,8 @@ BasePill {
 
             Row {
                 id: contentRow
-                anchors.centerIn: parent
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
                 spacing: Theme.spacingS
                 visible: !root.isVerticalOrientation
 
@@ -316,7 +320,16 @@ BasePill {
                     wrapMode: Text.NoWrap
                     elide: Text.ElideRight
                     maximumLineCount: 1
-                    width: Math.min(implicitWidth, compactMode ? 80 : 180)
+                    width: {
+                        const sp = contentRow.spacing;
+                        let used = 0;
+                        if (horizontalAppIcon.visible)
+                            used += horizontalAppIcon.width + sp;
+                        else if (horizontalSteamIcon.visible)
+                            used += horizontalSteamIcon.width + sp;
+                        const budget = Math.max(0, root.effectiveHorizontalInnerWidth - used);
+                        return Math.min(implicitWidth, compactMode ? 80 : 180, budget);
+                    }
                     visible: text.length > 0
                 }
 
@@ -368,7 +381,7 @@ BasePill {
                             used += appText.width + sp;
                         if (appSeparator.visible)
                             used += appSeparator.width + sp;
-                        const budget = root.maxWidth - root.horizontalPadding * 2 - used;
+                        const budget = root.effectiveHorizontalInnerWidth - used;
                         return Math.min(implicitWidth, Math.max(0, budget));
                     }
                     visible: text.length > 0


### PR DESCRIPTION
## Description

Prevents the focused app widget from overlapping centered bar content on constrained horizontal layouts.

The focused app now caps its width at the center section's actual content boundary and elides its label when space is limited. Compact media also stops reserving metadata text width while keeping its icon and playback controls visible.

Vertical bar behavior is unchanged.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Fixes #1369
Related #2342

## Screenshots / video

<img width="1305" height="175" alt="image" src="https://github.com/user-attachments/assets/44733731-af2f-48ad-8618-2544b86b9b1e" />
## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
