### PR TITLE
feat(launcher): cycle modes with ctrl-tab

### DIFF
--- a/quickshell/Modals/DankLauncherV2/ActionPanel.qml
+++ b/quickshell/Modals/DankLauncherV2/ActionPanel.qml
@@ -225,10 +225,9 @@ Rectangle {
 
     function cycleAction(reverse = false) {
         if (actions.length > 0) {
-            if (!reverse)
-                selectedActionIndex = (selectedActionIndex + 1) % actions.length;
-            else
-                selectedActionIndex = (selectedActionIndex - 1) % actions.length;
+            selectedActionIndex = reverse
+                ? (selectedActionIndex - 1 + actions.length) % actions.length
+                : (selectedActionIndex + 1) % actions.length;
             ensureSelectedVisible();
         }
     }

--- a/quickshell/Modals/DankLauncherV2/LauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/LauncherContent.qml
@@ -212,13 +212,20 @@ FocusScope {
             event.accepted = false;
             return;
         case Qt.Key_Tab:
-            if (actionPanel.hasActions) {
+            if (hasCtrl) {
+                actionPanel.hide();
+                controller.cycleMode();
+            } else if (actionPanel.hasActions) {
                 actionPanel.expanded ? actionPanel.cycleAction() : actionPanel.show();
             }
             return;
         case Qt.Key_Backtab:
-            if (actionPanel.expanded)
+            if (hasCtrl) {
                 actionPanel.hide();
+                controller.cycleMode(true);
+            } else if (actionPanel.hasActions) {
+                actionPanel.expanded ? actionPanel.cycleAction(true) : actionPanel.show();
+            }
             return;
         case Qt.Key_Return:
         case Qt.Key_Enter:


### PR DESCRIPTION
Add `Ctrl+Tab` and `Ctrl+Shift+Tab` support to Full Launcher for cycling launcher modes, while keeping `Tab` and `Shift+Tab` for navigating action panel items.

This follows up on [#3172](https://github.com/AvengeMedia/DankMaterialShell/issues/3172) and prepares a follow-up PR to align keyboard behavior between Full Launcher and Spotlight.
