### PR TITLE
feat(spotlight): align tab navigation with full launcher

### DIFF
--- a/quickshell/Modals/DankLauncherV2/ActionPanel.qml
+++ b/quickshell/Modals/DankLauncherV2/ActionPanel.qml
@@ -225,10 +225,9 @@ Rectangle {
 
     function cycleAction(reverse = false) {
         if (actions.length > 0) {
-            if (!reverse)
-                selectedActionIndex = (selectedActionIndex + 1) % actions.length;
-            else
-                selectedActionIndex = (selectedActionIndex - 1) % actions.length;
+            selectedActionIndex = reverse
+                ? (selectedActionIndex - 1 + actions.length) % actions.length
+                : (selectedActionIndex + 1) % actions.length;
             ensureSelectedVisible();
         }
     }

--- a/quickshell/Modals/DankLauncherV2/SpotlightLauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/SpotlightLauncherContent.qml
@@ -22,6 +22,7 @@ FocusScope {
     readonly property real _searchBarH: 56
     readonly property real _searchAreaH: _searchBarH
     readonly property alias searchAreaHeight: root._searchAreaH
+    readonly property real actionPanelHeight: actionPanel.height
     readonly property real _statusH: 92
     readonly property real _rowH: 64
     readonly property real _maxResultsH: root.maxResultsHeight > 0 ? root.maxResultsHeight : Math.min(430, (parentModal?.screenHeight ?? 900) * 0.55)
@@ -283,6 +284,11 @@ FocusScope {
 
     Connections {
         target: root.controller
+
+        function onSelectedItemChanged() {
+            if (actionPanel.expanded)
+                actionPanel.hide();
+        }
 
         function onItemExecuted() {
             root.parentModal?.hide();

--- a/quickshell/Modals/DankLauncherV2/SpotlightLauncherContent.qml
+++ b/quickshell/Modals/DankLauncherV2/SpotlightLauncherContent.qml
@@ -47,7 +47,7 @@ FocusScope {
         return Theme.surfaceContainer;
     }
 
-    implicitHeight: _searchAreaH + resultsContainer.height
+    implicitHeight: _searchAreaH + resultsContainer.height + actionPanel.height
 
     property bool _animateResize: false
 
@@ -71,6 +71,7 @@ FocusScope {
 
     function closeTransientUi() {
         transientSurfaceTracker?.closeAll?.();
+        actionPanel.hide();
         root.enabled = true;
     }
 
@@ -117,6 +118,11 @@ FocusScope {
 
         switch (event.key) {
         case Qt.Key_Escape:
+            if (actionPanel.expanded) {
+                actionPanel.hide();
+                event.accepted = true;
+                return;
+            }
             if (root.controller.clearPluginFilter()) {
                 event.accepted = true;
                 return;
@@ -169,17 +175,29 @@ FocusScope {
             }
             break;
         case Qt.Key_Tab:
-            _cycleCategory(false);
+            if (hasCtrl) {
+                actionPanel.hide();
+                _cycleCategory(false);
+            } else if (actionPanel.hasActions) {
+                actionPanel.expanded ? actionPanel.cycleAction() : actionPanel.show();
+            }
             event.accepted = true;
             return;
         case Qt.Key_Backtab:
-            _cycleCategory(true);
+            if (hasCtrl) {
+                actionPanel.hide();
+                _cycleCategory(true);
+            } else if (actionPanel.hasActions) {
+                actionPanel.expanded ? actionPanel.cycleAction(true) : actionPanel.show();
+            }
             event.accepted = true;
             return;
         case Qt.Key_Return:
         case Qt.Key_Enter:
             if (event.modifiers & Qt.ShiftModifier) {
                 root.controller.pasteSelected();
+            } else if (actionPanel.expanded && actionPanel.selectedActionIndex > 0) {
+                actionPanel.executeSelectedAction();
             } else {
                 root.controller.executeSelected();
             }
@@ -411,6 +429,7 @@ FocusScope {
                 onTextChanged: {
                     if (root.suspendSearchUpdates)
                         return;
+                    actionPanel.hide();
                     if (text.length > 0) {
                         root.controller.setSearchQuery(text);
                     } else {
@@ -455,6 +474,15 @@ FocusScope {
                 root._showContextMenu(item, sceneX, sceneY, false);
             }
         }
+    }
+
+    ActionPanel {
+        id: actionPanel
+        anchors.top: resultsContainer.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        selectedItem: root.controller.selectedItem
+        controller: root.controller
     }
 
     readonly property var _categoryModel: [

--- a/quickshell/Modules/DankIsland/Activities/LauncherExpanded.qml
+++ b/quickshell/Modules/DankIsland/Activities/LauncherExpanded.qml
@@ -79,7 +79,7 @@ FocusScope {
         controllerOverride: root.launcherController
         transientSurfaceTracker: root.transientSurfaceTracker
         showResultsWithoutQuery: true
-        maxResultsHeight: Math.max(120, root.controller.launcherExpandedTarget.height - Theme.spacingM - root.bottomInset - launcherContent.searchAreaHeight)
+        maxResultsHeight: Math.max(120, root.controller.launcherExpandedTarget.height - Theme.spacingM - root.bottomInset - launcherContent.searchAreaHeight - launcherContent.actionPanelHeight)
     }
 
     onActiveFocusChanged: root.controller.launcherInputFocused = activeFocus


### PR DESCRIPTION
Please review PR #3204 first.

Align Spotlight keyboard navigation with Full Launcher. `Tab` and `Shift+Tab` navigate the action panel, while `Ctrl+Tab` and `Ctrl+Shift+Tab` cycle launcher categories.

Closes #3172
