### PR TITLE
fix(clipboard): stack clear dialog above modal

### DIFF
--- a/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryModal.qml
@@ -97,6 +97,7 @@ DankModal {
         id: clearConfirmDialog
         confirmButtonText: I18n.tr("Clear All")
         confirmButtonColor: Theme.primary
+        useOverlayLayer: true
         onShouldBeVisibleChanged: {
             if (shouldBeVisible) {
                 clipboardHistoryModal.shouldHaveFocus = false;

--- a/quickshell/Modals/Clipboard/ClipboardHistoryPopout.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryPopout.qml
@@ -104,6 +104,7 @@ DankPopout {
         id: clearConfirmDialog
         confirmButtonText: I18n.tr("Clear All")
         confirmButtonColor: Theme.primary
+        useOverlayLayer: true
         onShouldBeVisibleChanged: {
             if (shouldBeVisible) {
                 root.customKeyboardFocus = WlrKeyboardFocus.None;


### PR DESCRIPTION
Move the Clipboard delete confirmation dialogs to the Wayland overlay layer so they render above the active Clipboard modal/popout and connected frame chrome.