### PR TITLE
feat(battery): show charge/discharge rate in the bar widget

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -810,6 +810,8 @@ Singleton {
     property bool showBatteryPercentOnlyOnBattery: false
     property bool showBatteryTime: false
     property bool showBatteryTimeOnlyOnBattery: false
+    property bool showBatteryPowerCharging: false
+    property bool showBatteryPowerDischarging: false
     property bool batteryPillStyle: false
     property bool lockBeforeSuspend: false
     property bool loginctlLockIntegration: true

--- a/quickshell/Common/settings/Lists.qml
+++ b/quickshell/Common/settings/Lists.qml
@@ -32,6 +32,8 @@ Singleton {
             showBatteryPercentOnlyOnBattery: false,
             showBatteryTime: false,
             showBatteryTimeOnlyOnBattery: false,
+            showBatteryPowerCharging: false,
+            showBatteryPowerDischarging: false,
             batteryPillStyle: false,
             showPrinterIcon: false,
             showScreenSharingIcon: true
@@ -96,6 +98,10 @@ Singleton {
                 item.showBatteryTime = order[i].showBatteryTime;
             if (isObj && order[i].showBatteryTimeOnlyOnBattery !== undefined)
                 item.showBatteryTimeOnlyOnBattery = order[i].showBatteryTimeOnlyOnBattery;
+            if (isObj && order[i].showBatteryPowerCharging !== undefined)
+                item.showBatteryPowerCharging = order[i].showBatteryPowerCharging;
+            if (isObj && order[i].showBatteryPowerDischarging !== undefined)
+                item.showBatteryPowerDischarging = order[i].showBatteryPowerDischarging;
             if (isObj && order[i].batteryPillStyle !== undefined)
                 item.batteryPillStyle = order[i].batteryPillStyle;
             if (isObj && order[i].showPrinterIcon !== undefined)

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -143,6 +143,8 @@ var SPEC = {
     showBatteryPercentOnlyOnBattery: { def: false },
     showBatteryTime: { def: false },
     showBatteryTimeOnlyOnBattery: { def: false },
+    showBatteryPowerCharging: { def: false },
+    showBatteryPowerDischarging: { def: false },
     batteryPillStyle: { def: false },
     showControlCenterButton: { def: true },
     showCapsLockIndicator: { def: true },

--- a/quickshell/Modules/DankBar/Widgets/Battery.qml
+++ b/quickshell/Modules/DankBar/Widgets/Battery.qml
@@ -19,6 +19,14 @@ BasePill {
     readonly property bool showTime: widgetData?.showBatteryTime !== undefined ? widgetData.showBatteryTime : SettingsData.showBatteryTime
     readonly property bool showTimeOnlyOnBattery: widgetData?.showBatteryTimeOnlyOnBattery !== undefined ? widgetData.showBatteryTimeOnlyOnBattery : SettingsData.showBatteryTimeOnlyOnBattery
     readonly property bool pillStyle: widgetData?.batteryPillStyle !== undefined ? widgetData.batteryPillStyle : SettingsData.batteryPillStyle
+    readonly property bool showPowerCharging: widgetData?.showBatteryPowerCharging !== undefined ? widgetData.showBatteryPowerCharging : SettingsData.showBatteryPowerCharging
+    readonly property bool showPowerDischarging: widgetData?.showBatteryPowerDischarging !== undefined ? widgetData.showBatteryPowerDischarging : SettingsData.showBatteryPowerDischarging
+    readonly property bool showPower: BatteryService.isCharging ? showPowerCharging : showPowerDischarging
+
+    // Signed charge/discharge rate, e.g. "+45W" while charging, "-8.4W" while
+    // draining. Empty (and therefore hidden) whenever the battery is idle.
+    readonly property string batteryPowerText: showPower ? BatteryService.formatPowerRate(false) : ""
+    readonly property string verticalBatteryPowerText: showPower ? BatteryService.formatPowerRate(true) : ""
 
     readonly property string batteryTimeText: {
         if (showTimeOnlyOnBattery && BatteryService.isPluggedIn) {
@@ -53,37 +61,46 @@ BasePill {
     }
 
     readonly property string horizontalDisplayText: {
-        if (showPercent && showTime && batteryTimeText) {
-            return `${BatteryService.batteryLevel}% (${batteryTimeText})`;
-        }
+        const parts = [];
         if (showPercent) {
-            return `${BatteryService.batteryLevel}%`;
+            parts.push(`${BatteryService.batteryLevel}%`);
         }
         if (showTime && batteryTimeText) {
-            return batteryTimeText;
+            parts.push(showPercent ? `(${batteryTimeText})` : batteryTimeText);
         }
-        return "";
+        if (batteryPowerText) {
+            parts.push(batteryPowerText);
+        }
+        return parts.join(" ");
     }
 
-    // Percent always stays inside the pill; only the time shows beside it.
+    // Percent always stays inside the pill; time and wattage show beside it.
     readonly property string horizontalSideText: {
         if (!pillStyle) {
             return horizontalDisplayText;
         }
-        return (showTime && batteryTimeText) ? batteryTimeText : "";
+        const parts = [];
+        if (showTime && batteryTimeText) {
+            parts.push(batteryTimeText);
+        }
+        if (batteryPowerText) {
+            parts.push(batteryPowerText);
+        }
+        return parts.join(" ");
     }
 
     readonly property string verticalDisplayText: {
-        if (showPercent && showTime && batteryTimeText) {
-            return `${BatteryService.batteryLevel}\n${verticalBatteryTimeText}`;
-        }
+        const lines = [];
         if (showPercent) {
-            return BatteryService.batteryLevel.toString();
+            lines.push(BatteryService.batteryLevel.toString());
         }
         if (showTime && batteryTimeText) {
-            return verticalBatteryTimeText;
+            lines.push(verticalBatteryTimeText);
         }
-        return "";
+        if (verticalBatteryPowerText) {
+            lines.push(verticalBatteryPowerText);
+        }
+        return lines.join("\n");
     }
 
     property real touchpadAccumulator: 0

--- a/quickshell/Modules/Settings/WidgetsTab.qml
+++ b/quickshell/Modules/Settings/WidgetsTab.qml
@@ -493,6 +493,8 @@ Item {
             widgetObj.showBatteryPercentOnlyOnBattery = SettingsData.showBatteryPercentOnlyOnBattery;
             widgetObj.showBatteryTime = SettingsData.showBatteryTime;
             widgetObj.showBatteryTimeOnlyOnBattery = SettingsData.showBatteryTimeOnlyOnBattery;
+            widgetObj.showBatteryPowerCharging = SettingsData.showBatteryPowerCharging;
+            widgetObj.showBatteryPowerDischarging = SettingsData.showBatteryPowerDischarging;
             widgetObj.batteryPillStyle = SettingsData.batteryPillStyle;
         }
         if (widgetId === "runningApps") {
@@ -1032,6 +1034,10 @@ Item {
                     item.showBatteryTime = widget.showBatteryTime;
                 if (widget.showBatteryTimeOnlyOnBattery !== undefined)
                     item.showBatteryTimeOnlyOnBattery = widget.showBatteryTimeOnlyOnBattery;
+                if (widget.showBatteryPowerCharging !== undefined)
+                    item.showBatteryPowerCharging = widget.showBatteryPowerCharging;
+                if (widget.showBatteryPowerDischarging !== undefined)
+                    item.showBatteryPowerDischarging = widget.showBatteryPowerDischarging;
                 if (widget.batteryPillStyle !== undefined)
                     item.batteryPillStyle = widget.batteryPillStyle;
                 if (widget.showPrinterIcon !== undefined)

--- a/quickshell/Modules/Settings/WidgetsTabSection.qml
+++ b/quickshell/Modules/Settings/WidgetsTabSection.qml
@@ -3345,6 +3345,124 @@ Column {
                     width: parent.width
                     height: Math.max(18, Theme.fontSizeSmall) + Theme.spacingM * 2
                     radius: Theme.cornerRadius
+                    color: batteryPowerChargingArea.containsMouse ? Theme.primaryHover : Theme.withAlpha(Theme.primaryHover, 0)
+
+                    Row {
+                        anchors.left: parent.left
+                        anchors.leftMargin: Theme.spacingS
+                        anchors.right: batteryPowerChargingToggle.left
+                        anchors.rightMargin: Theme.spacingS
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Theme.spacingS
+                        clip: true
+
+                        DankIcon {
+                            name: "bolt"
+                            size: 18
+                            color: Theme.outline
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+
+                        StyledText {
+                            text: I18n.tr("Show Charge Rate", "Battery bar widget setting: show how many watts are going into the battery while charging")
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            font.weight: Font.Normal
+                            anchors.verticalCenter: parent.verticalCenter
+                            elide: Text.ElideRight
+                            maximumLineCount: 1
+                            width: parent.width - 18 - Theme.spacingS
+                        }
+                    }
+
+                    DankToggle {
+                        id: batteryPowerChargingToggle
+                        anchors.right: parent.right
+                        anchors.rightMargin: Theme.spacingS
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 40
+                        height: 20
+                        checked: batteryContextMenu.currentWidgetData?.showBatteryPowerCharging ?? SettingsData.showBatteryPowerCharging
+                        onToggled: {
+                            root.overflowSettingChanged(batteryContextMenu.sectionId, batteryContextMenu.widgetIndex, "showBatteryPowerCharging", toggled);
+                        }
+                    }
+
+                    MouseArea {
+                        id: batteryPowerChargingArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onPressed: {
+                            batteryPowerChargingToggle.checked = !batteryPowerChargingToggle.checked;
+                            root.overflowSettingChanged(batteryContextMenu.sectionId, batteryContextMenu.widgetIndex, "showBatteryPowerCharging", batteryPowerChargingToggle.checked);
+                        }
+                    }
+                }
+
+                Rectangle {
+                    width: parent.width
+                    height: Math.max(18, Theme.fontSizeSmall) + Theme.spacingM * 2
+                    radius: Theme.cornerRadius
+                    color: batteryPowerDischargingArea.containsMouse ? Theme.primaryHover : Theme.withAlpha(Theme.primaryHover, 0)
+
+                    Row {
+                        anchors.left: parent.left
+                        anchors.leftMargin: Theme.spacingS
+                        anchors.right: batteryPowerDischargingToggle.left
+                        anchors.rightMargin: Theme.spacingS
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Theme.spacingS
+                        clip: true
+
+                        DankIcon {
+                            name: "battery_5_bar"
+                            size: 18
+                            color: Theme.outline
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+
+                        StyledText {
+                            text: I18n.tr("Show Discharge Rate", "Battery bar widget setting: show how many watts the system is drawing from the battery")
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            font.weight: Font.Normal
+                            anchors.verticalCenter: parent.verticalCenter
+                            elide: Text.ElideRight
+                            maximumLineCount: 1
+                            width: parent.width - 18 - Theme.spacingS
+                        }
+                    }
+
+                    DankToggle {
+                        id: batteryPowerDischargingToggle
+                        anchors.right: parent.right
+                        anchors.rightMargin: Theme.spacingS
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 40
+                        height: 20
+                        checked: batteryContextMenu.currentWidgetData?.showBatteryPowerDischarging ?? SettingsData.showBatteryPowerDischarging
+                        onToggled: {
+                            root.overflowSettingChanged(batteryContextMenu.sectionId, batteryContextMenu.widgetIndex, "showBatteryPowerDischarging", toggled);
+                        }
+                    }
+
+                    MouseArea {
+                        id: batteryPowerDischargingArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onPressed: {
+                            batteryPowerDischargingToggle.checked = !batteryPowerDischargingToggle.checked;
+                            root.overflowSettingChanged(batteryContextMenu.sectionId, batteryContextMenu.widgetIndex, "showBatteryPowerDischarging", batteryPowerDischargingToggle.checked);
+                        }
+                    }
+                }
+
+                Rectangle {
+                    width: parent.width
+                    height: Math.max(18, Theme.fontSizeSmall) + Theme.spacingM * 2
+                    radius: Theme.cornerRadius
                     color: batteryPillArea.containsMouse ? Theme.primaryHover : Theme.withAlpha(Theme.primaryHover, 0)
 
                     Row {

--- a/quickshell/Services/BatteryService.qml
+++ b/quickshell/Services/BatteryService.qml
@@ -273,6 +273,29 @@ Singleton {
         return val;
     }
 
+    // Aggregated charge/discharge rate, signed: positive while charging,
+    // negative while draining the battery, zero when idle/fully charged.
+    readonly property real signedChangeRate: {
+        if (!batteryAvailable)
+            return 0;
+        const rate = Math.abs(changeRate);
+        if (!isFinite(rate) || rate < 0.05)
+            return 0;
+        return isCharging ? rate : -rate;
+    }
+
+    // Compact signed wattage for bar widgets, e.g. "+45W" / "-8.4W".
+    // Returns an empty string when there is nothing meaningful to show.
+    // compact drops the decimal entirely (used by vertical bars).
+    function formatPowerRate(compact) {
+        const rate = signedChangeRate;
+        if (rate === 0)
+            return "";
+        const magnitude = Math.abs(rate);
+        const value = (compact || magnitude >= 10) ? Math.round(magnitude).toString() : magnitude.toFixed(1);
+        return `${rate > 0 ? "+" : "-"}${value}W`;
+    }
+
     // A time-weighted exponential moving average based on the aggregated charge/discharge rate
     property real _smoothedChangeRate: 0
     property real _lastRateSampleTime: 0


### PR DESCRIPTION
## Description

The battery popout already shows the UPower energy rate, but the bar widget could only show percentage and remaining time. Telling *how fast* the battery is charging or draining meant opening the popout, or running a third-party plugin that shells out to `/sys/class/power_supply/BAT*/power_now` on a timer.

This adds two independent, opt-in toggles to the battery widget — **Show Charge Rate** and **Show Discharge Rate** — which render the signed rate alongside the existing text.

| | |
|---|---|
| Charging | ![charging](https://raw.githubusercontent.com/SpyrosPsarras/DankMaterialShell/assets/battery-power-draw/pr-assets/pr-charging.png) |
| Discharging (with percentage + remaining time also enabled) | ![discharging](https://raw.githubusercontent.com/SpyrosPsarras/DankMaterialShell/assets/battery-power-draw/pr-assets/pr-discharging.png) |

### Design notes

- **No new process or polling.** The value is `BatteryService.changeRate`, the same aggregate the popout already renders.
- **Costs no bar space unless it has something to say.** Below `0.05W` — idle, fully charged, or parked at a charge limit — the text is empty and the widget collapses back to its previous width.
- **Stays narrow.** One decimal below `10W` (`-8.4W`), whole watts above (`+28W`); vertical bars get a whole-watt line so the value fits the bar thickness.
- **Two toggles instead of one + an "Only on Battery" sub-row.** Charging and discharging are genuinely separate interests (charger throughput vs. idle drain), and an "only on battery" modifier is meaningless for a discharge readout. This also keeps both labels inside the 270px menu without eliding.
- Follows the existing widget-setting pattern: a global default in `SettingsData`/`SettingsSpec.js` plus a per-widget-instance override plumbed through `Lists.qml` / `WidgetsTab.qml` / `WidgetsTabSection.qml`. Both default to `false`, so nothing changes for existing users until they opt in.

The string composition in `Battery.qml` was refactored from stacked early-returns to a parts array so a third element could be added without a combinatorial explosion; the output is byte-identical to `master` for every existing combination of percentage/time toggles.

`BatteryService` gains two small reusable pieces: `signedChangeRate` (positive charging, negative draining, zero idle) and `formatPowerRate(compact)`. Happy to follow up by pointing `BatteryPopout` at them too — it currently derives the sign from `isCharging || isPluggedIn`, which mislabels a plugged-in-but-draining machine as `+`. Left out here to keep the diff focused.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

None.

## Screenshots / video

Above. Both captured on a live session: charging at `28.3W` reported by `upower` renders `+28W`; discharging at `15.4W` renders `-15W`.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean — *n/a, no Go changes*
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors

Testing done: ran the branch against a live niri session and exercised charging, discharging, and the charge-limit/idle case (verified the readout disappears at `0W` rather than showing `+0W`); toggled both settings from the widget context menu and confirmed the per-widget override persists; `make lint-qml` passes; `check_term_variants.py` and `extract_settings_index.py` are clean (the new strings live in a widget context menu, so the settings search index is unchanged); catalogs left alone per CONTRIBUTING.

On the last checkbox — glad to open a dlx-docs PR for the two new toggles if you'd like them documented; just say where they belong.
