### PR TITLE
feat(lock): add vertical clock style

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -914,6 +914,7 @@ Singleton {
     property bool lockScreenShowPowerActions: true
     property bool lockScreenShowSystemIcons: true
     property bool lockScreenShowTime: true
+    property string lockScreenClockStyle: "horizontal"
     property bool lockScreenShowDate: true
     property bool lockScreenShowProfileImage: true
     property bool lockScreenShowPasswordField: true

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -480,6 +480,7 @@ var SPEC = {
     lockScreenShowPowerActions: { def: true },
     lockScreenShowSystemIcons: { def: true },
     lockScreenShowTime: { def: true },
+    lockScreenClockStyle: { def: "horizontal" },
     lockScreenShowDate: { def: true },
     lockScreenShowProfileImage: { def: true },
     lockScreenShowPasswordField: { def: true },

--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -459,7 +459,7 @@ Item {
                     spacing: 0
 
                     ClockDigitText {
-                        width: 75
+                        width: clockText.hours.length > 1 ? 75 : 0
                         text: clockText.hours.length > 1 ? clockText.hours[0] : ""
                     }
                     ClockDigitText {

--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -369,7 +369,7 @@ Item {
             anchors.bottom: parent.verticalCenter
             anchors.bottomMargin: 60
             width: parent.width
-            height: clockText.implicitHeight
+            height: verticalClock.visible ? verticalClock.implicitHeight : clockText.implicitHeight
             visible: SettingsData.lockScreenShowTime
 
             Row {
@@ -377,6 +377,7 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.top: parent.top
                 spacing: 0
+                visible: SettingsData.lockScreenClockStyle !== "vertical"
 
                 property string fullTimeStr: {
                     const format = SettingsData.getEffectiveTimeFormat();
@@ -443,6 +444,52 @@ Item {
                 ClockDigitText {
                     text: clockText.ampm
                     visible: clockText.ampm !== ""
+                }
+            }
+
+            Column {
+                id: verticalClock
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.top: parent.top
+                spacing: -8
+                visible: SettingsData.lockScreenClockStyle === "vertical"
+
+                Row {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    spacing: 0
+
+                    ClockDigitText {
+                        width: 75
+                        text: clockText.hours.length > 1 ? clockText.hours[0] : ""
+                    }
+                    ClockDigitText {
+                        width: 75
+                        text: clockText.hours.length > 1 ? clockText.hours[1] : clockText.hours.length > 0 ? clockText.hours[0] : ""
+                    }
+                }
+
+                Row {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    spacing: 0
+
+                    ClockDigitText {
+                        width: 75
+                        text: clockText.minutes.length > 0 ? clockText.minutes[0] : ""
+                    }
+                    ClockDigitText {
+                        width: 75
+                        text: clockText.minutes.length > 1 ? clockText.minutes[1] : ""
+                    }
+                }
+
+                StyledText {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: clockText.hasSeconds ? clockText.seconds + (clockText.ampm !== "" ? " " + clockText.ampm : "") : clockText.ampm
+                    font.pixelSize: 42
+                    font.weight: Font.Light
+                    font.family: root.lockFontFamily !== "" ? root.lockFontFamily : resolvedFontFamily
+                    color: "white"
+                    visible: clockText.hasSeconds || clockText.ampm !== ""
                 }
             }
         }

--- a/quickshell/Modules/Settings/LockScreenTab.qml
+++ b/quickshell/Modules/Settings/LockScreenTab.qml
@@ -294,6 +294,20 @@ Item {
                     onToggled: checked => SettingsData.set("lockScreenShowTime", checked)
                 }
 
+                SettingsButtonGroupRow {
+                    settingKey: "lockScreenClockStyle"
+                    tags: ["lock", "screen", "time", "clock", "style", "vertical"]
+                    text: I18n.tr("Clock Style", "lock screen clock layout setting")
+                    visible: SettingsData.lockScreenShowTime
+                    model: [I18n.tr("Horizontal", "lock screen clock style option"), I18n.tr("Vertical", "lock screen clock style option")]
+                    currentIndex: SettingsData.lockScreenClockStyle === "vertical" ? 1 : 0
+                    onSelectionChanged: (index, selected) => {
+                        if (!selected)
+                            return;
+                        SettingsData.set("lockScreenClockStyle", index === 1 ? "vertical" : "horizontal");
+                    }
+                }
+
                 SettingsToggleRow {
                     settingKey: "lockScreenShowDate"
                     tags: ["lock", "screen", "date", "calendar", "display"]

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -5519,6 +5519,24 @@
     "description": "Bind lock screen to dbus signals from loginctl. Disable if using an external lock screen"
   },
   {
+    "section": "lockScreenClockStyle",
+    "label": "Clock Style",
+    "tabIndex": 11,
+    "category": "Lock Screen",
+    "keywords": [
+      "clock",
+      "lock",
+      "login",
+      "password",
+      "screen",
+      "security",
+      "style",
+      "time",
+      "vertical",
+      "watch"
+    ]
+  },
+  {
     "section": "lockDisplay",
     "label": "Display Assignment",
     "tabIndex": 11,


### PR DESCRIPTION
Adds a vertical clock layout option to the DMS lock screen. Users can switch between horizontal and vertical layouts from Settings > Lock Screen; the style selector is hidden when system time display is disabled.

The vertical layout keeps the existing time-format state, displays hour and minute digits in stacked rows, and preserves seconds/AM-PM information below when enabled.

Closes #2200 