### PR TITLE
fix(popouts): close hover surface on click

### DIFF
--- a/quickshell/Common/PopoutManager.qml
+++ b/quickshell/Common/PopoutManager.qml
@@ -254,7 +254,7 @@ Singleton {
         if (!popout || !popout.screen)
             return;
 
-        // Clicking a transient popout pins it instead of toggling it closed.
+        // Clicking a transient popout closes it instead of leaving it hover-owned.
         const wasTransient = popout.hoverDismissEnabled === true;
         if (!hoverRequest && popout.hoverDismissEnabled !== undefined)
             popout.hoverDismissEnabled = false;
@@ -309,15 +309,8 @@ Singleton {
             if (hoverRequest && sameDefinedTrigger)
                 return;
 
-            if (!hoverRequest && (triggerId === undefined || sameDefinedTrigger)) {
-                if (!wasTransient) {
-                    _closePopout(popout);
-                    return;
-                }
-                if (popout.updateSurfacePosition)
-                    popout.updateSurfacePosition();
-                if (triggerId !== undefined)
-                    currentPopoutTriggers[screenName] = triggerId;
+            if (!hoverRequest && (wasTransient || triggerId === undefined || sameDefinedTrigger)) {
+                _closePopout(popout);
                 return;
             }
 

--- a/quickshell/Common/PopoutManager.qml
+++ b/quickshell/Common/PopoutManager.qml
@@ -254,8 +254,7 @@ Singleton {
         if (!popout || !popout.screen)
             return;
 
-        // Clicking a transient popout closes it instead of leaving it hover-owned.
-        const wasTransient = popout.hoverDismissEnabled === true;
+        // Clicks pin a popout, while clicking its active trigger toggles it closed below.
         if (!hoverRequest && popout.hoverDismissEnabled !== undefined)
             popout.hoverDismissEnabled = false;
 
@@ -309,7 +308,7 @@ Singleton {
             if (hoverRequest && sameDefinedTrigger)
                 return;
 
-            if (!hoverRequest && (wasTransient || triggerId === undefined || sameDefinedTrigger)) {
+            if (!hoverRequest && (triggerId === undefined || sameDefinedTrigger)) {
                 _closePopout(popout);
                 return;
             }

--- a/quickshell/Modules/DankBar/DankBarHoverController.qml
+++ b/quickshell/Modules/DankBar/DankBarHoverController.qml
@@ -137,6 +137,7 @@ Item {
 
         cancelQueuedHitTest();
         _cancelPendingHover();
+        _hoverReopenSuppressedTrigger = "";
         if (!hoverPopoutsEnabled || isActiveHoverSurfacePinned())
             return;
         _barExitPending = true;

--- a/quickshell/Modules/DankBar/DankBarHoverController.qml
+++ b/quickshell/Modules/DankBar/DankBarHoverController.qml
@@ -32,6 +32,7 @@ Item {
     property bool _barExitPending: false
     property var _pendingHoverHit: null
     property string _pendingHoverTrigger: ""
+    property string _hoverReopenSuppressedTrigger: ""
 
     property bool _candidateCacheValid: false
     property var _candidateCache: []
@@ -54,6 +55,7 @@ Item {
         if (hasOpenHoverSurface() && !isActiveHoverSurfacePinned())
             closeHoverSurfaces();
         activeHoverTrigger = "";
+        _hoverReopenSuppressedTrigger = "";
     }
 
     Component.onDestruction: _disconnectCandidateWatchers()
@@ -154,6 +156,7 @@ Item {
         cancelQueuedHitTest();
         _cancelPendingHover();
         _hoverCloseTimer.stop();
+        _hoverReopenSuppressedTrigger = "";
         barContent._pendingPopoutOpenSpec = null;
 
         const activePopout = PopoutManager.getActivePopout(barWindow?.screen);
@@ -631,12 +634,16 @@ Item {
     function _syncHoverTriggerState() {
         if (activeHoverTrigger === "notepadButton") {
             const instance = _notepadWidgetForScreen()?.notepadInstance;
-            if (!instance?.isVisible)
+            if (!instance?.isVisible) {
+                _hoverReopenSuppressedTrigger = activeHoverTrigger;
                 activeHoverTrigger = "";
+            }
             return;
         }
-        if (activeHoverTrigger !== "" && !hasOpenHoverSurface())
+        if (activeHoverTrigger !== "" && !hasOpenHoverSurface()) {
+            _hoverReopenSuppressedTrigger = activeHoverTrigger;
             activeHoverTrigger = "";
+        }
     }
 
     function hasOpenHoverSurface() {
@@ -819,6 +826,7 @@ Item {
 
         const hit = findWidgetAtGlobalPoint(gx, gy);
         if (!hit) {
+            _hoverReopenSuppressedTrigger = "";
             _cancelPendingHover();
             scheduleHoverClose(gx, gy);
             return;
@@ -842,6 +850,14 @@ Item {
             scheduleHoverClose(gx, gy);
             return;
         }
+
+        if (_hoverReopenSuppressedTrigger === triggerKey) {
+            _cancelPendingHover();
+            _hoverCloseTimer.stop();
+            return;
+        }
+        if (_hoverReopenSuppressedTrigger !== "")
+            _hoverReopenSuppressedTrigger = "";
 
         _hoverCloseTimer.stop();
 


### PR DESCRIPTION
Fixes hover popouts reopening after the user clicks a widget to close them. Transient hover-owned popouts now close immediately on the first click, and the hover controller suppresses reopening the same trigger until the cursor leaves the widget.

This covers both native widgets routed through `PopoutManager` and plugin widgets that toggle their popout directly.

Fixes #3217

https://github.com/user-attachments/assets/99b244ac-b0e6-431c-bc72-f4c0e4de9a5d

