### PR TITLE
fix(dock): hide overlay dock over fullscreen

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -870,6 +870,7 @@ Singleton {
     property bool dockAutoHide: false
     property bool dockSmartAutoHide: false
     property bool dockUseOverlayLayer: false
+    property bool dockShowOnFullscreen: false
     property bool dockGroupByApp: false
     property bool dockSeparatePinnedAndRunningApps: false
     property bool dockRestoreSpecialWorkspaceOnClick: false

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -436,6 +436,7 @@ var SPEC = {
     dockAutoHide: { def: false },
     dockSmartAutoHide: { def: false },
     dockUseOverlayLayer: { def: false },
+    dockShowOnFullscreen: { def: false },
     dockGroupByApp: { def: false },
     dockSeparatePinnedAndRunningApps: { def: false },
     dockRestoreSpecialWorkspaceOnClick: { def: false },

--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -154,7 +154,7 @@ Item {
     readonly property bool usesConnectedFrameChrome: CompositorService.usesConnectedFrameChromeForScreen(dock._dockScreenName)
     readonly property bool usesOverlayLayer: CompositorService.framePeerSurfacesUseOverlayForScreen(dock._dockScreenName) || SettingsData.dockUseOverlayLayer
     readonly property bool fullscreenOnScreen: CompositorService.fullscreenToplevelOnScreen(dock._dockScreenName)
-    readonly property bool hiddenForFullscreen: usesOverlayLayer && fullscreenOnScreen
+    readonly property bool hiddenForFullscreen: usesOverlayLayer && fullscreenOnScreen && !SettingsData.dockShowOnFullscreen
     readonly property bool geometryReady: dock.width > 0 && dock.height > 0 && dockBackground.width > 0 && dockBackground.height > 0
 
     function _syncDockChromeState() {
@@ -366,8 +366,11 @@ Item {
             return true;
         }
 
-        if (usesOverlayLayer && fullscreenOnScreen)
+        if (hiddenForFullscreen)
             return false;
+
+        if (usesOverlayLayer && fullscreenOnScreen && SettingsData.dockShowOnFullscreen)
+            return true;
 
         // Smart auto-hide: show dock when no windows overlap, hide when they do
         if (SettingsData.dockSmartAutoHide) {

--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -369,9 +369,6 @@ Item {
         if (hiddenForFullscreen)
             return false;
 
-        if (usesOverlayLayer && fullscreenOnScreen && SettingsData.dockShowOnFullscreen)
-            return true;
-
         // Smart auto-hide: show dock when no windows overlap, hide when they do
         if (SettingsData.dockSmartAutoHide) {
             if (shouldHideForWindows)

--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -154,6 +154,7 @@ Item {
     readonly property bool usesConnectedFrameChrome: CompositorService.usesConnectedFrameChromeForScreen(dock._dockScreenName)
     readonly property bool usesOverlayLayer: CompositorService.framePeerSurfacesUseOverlayForScreen(dock._dockScreenName) || SettingsData.dockUseOverlayLayer
     readonly property bool fullscreenOnScreen: CompositorService.fullscreenToplevelOnScreen(dock._dockScreenName)
+    readonly property bool hiddenForFullscreen: usesOverlayLayer && fullscreenOnScreen
     readonly property bool geometryReady: dock.width > 0 && dock.height > 0 && dockBackground.width > 0 && dockBackground.height > 0
 
     function _syncDockChromeState() {
@@ -474,6 +475,8 @@ Item {
             return expanded ? Math.min(bodyY - innerReach, dock.height - 1) : dock.height - 1;
         }
         width: {
+            if (dock.hiddenForFullscreen)
+                return 0;
             if (chrome)
                 return dockMouseArea.width + (isVertical && expanded ? animationHeadroom : 0) + (expanded ? borderThickness * 2 + dock.horizontalConnectorExtent * 2 : 0);
             if (!isVertical)
@@ -483,6 +486,8 @@ Item {
             return atEndEdge ? dock.width - x : Math.max(bodyX + dockBackground.width + innerReach, 1);
         }
         height: {
+            if (dock.hiddenForFullscreen)
+                return 0;
             if (chrome)
                 return dockMouseArea.height + (!isVertical && expanded ? animationHeadroom : 0) + (expanded ? borderThickness * 2 + dock.verticalConnectorExtent * 2 : 0);
             if (isVertical)

--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -153,12 +153,8 @@ Item {
     readonly property string _dockScreenName: dock.modelData ? dock.modelData.name : (dock.screen ? dock.screen.name : "")
     readonly property bool usesConnectedFrameChrome: CompositorService.usesConnectedFrameChromeForScreen(dock._dockScreenName)
     readonly property bool usesOverlayLayer: CompositorService.framePeerSurfacesUseOverlayForScreen(dock._dockScreenName) || SettingsData.dockUseOverlayLayer
-    property bool fullscreenOnScreen: false
+    readonly property bool fullscreenOnScreen: CompositorService.fullscreenToplevelOnScreen(dock._dockScreenName)
     readonly property bool geometryReady: dock.width > 0 && dock.height > 0 && dockBackground.width > 0 && dockBackground.height > 0
-
-    function _updateFullscreenOnScreen() {
-        fullscreenOnScreen = CompositorService.fullscreenToplevelOnScreen(dock._dockScreenName);
-    }
 
     function _syncDockChromeState() {
         if (!dock._dockScreenName)
@@ -390,10 +386,7 @@ Item {
         }
     }
 
-    Component.onCompleted: {
-        _updateFullscreenOnScreen();
-        dockChromeSync.schedule();
-    }
+    Component.onCompleted: dockChromeSync.schedule()
     Component.onDestruction: {
         dockChromeSync.cancel();
         dockSlideSync.cancel();
@@ -407,13 +400,6 @@ Item {
     onHasAppsChanged: dock._syncDockChromeState()
     onConnectedBarSideChanged: dock._syncDockChromeState()
     onUsesConnectedFrameChromeChanged: dock._syncDockChromeState()
-
-    Connections {
-        target: CompositorService
-        function onToplevelsChanged() {
-            dock._updateFullscreenOnScreen();
-        }
-    }
 
     Connections {
         target: SettingsData

--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -153,7 +153,12 @@ Item {
     readonly property string _dockScreenName: dock.modelData ? dock.modelData.name : (dock.screen ? dock.screen.name : "")
     readonly property bool usesConnectedFrameChrome: CompositorService.usesConnectedFrameChromeForScreen(dock._dockScreenName)
     readonly property bool usesOverlayLayer: CompositorService.framePeerSurfacesUseOverlayForScreen(dock._dockScreenName) || SettingsData.dockUseOverlayLayer
+    property bool fullscreenOnScreen: false
     readonly property bool geometryReady: dock.width > 0 && dock.height > 0 && dockBackground.width > 0 && dockBackground.height > 0
+
+    function _updateFullscreenOnScreen() {
+        fullscreenOnScreen = CompositorService.fullscreenToplevelOnScreen(dock._dockScreenName);
+    }
 
     function _syncDockChromeState() {
         if (!dock._dockScreenName)
@@ -364,6 +369,9 @@ Item {
             return true;
         }
 
+        if (usesOverlayLayer && fullscreenOnScreen)
+            return false;
+
         // Smart auto-hide: show dock when no windows overlap, hide when they do
         if (SettingsData.dockSmartAutoHide) {
             if (shouldHideForWindows)
@@ -382,7 +390,10 @@ Item {
         }
     }
 
-    Component.onCompleted: dockChromeSync.schedule()
+    Component.onCompleted: {
+        _updateFullscreenOnScreen();
+        dockChromeSync.schedule();
+    }
     Component.onDestruction: {
         dockChromeSync.cancel();
         dockSlideSync.cancel();
@@ -396,6 +407,13 @@ Item {
     onHasAppsChanged: dock._syncDockChromeState()
     onConnectedBarSideChanged: dock._syncDockChromeState()
     onUsesConnectedFrameChromeChanged: dock._syncDockChromeState()
+
+    Connections {
+        target: CompositorService
+        function onToplevelsChanged() {
+            dock._updateFullscreenOnScreen();
+        }
+    }
 
     Connections {
         target: SettingsData

--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -475,7 +475,7 @@ Item {
             return expanded ? Math.min(bodyY - innerReach, dock.height - 1) : dock.height - 1;
         }
         width: {
-            if (dock.hiddenForFullscreen)
+            if (dock.hiddenForFullscreen && !expanded)
                 return 0;
             if (chrome)
                 return dockMouseArea.width + (isVertical && expanded ? animationHeadroom : 0) + (expanded ? borderThickness * 2 + dock.horizontalConnectorExtent * 2 : 0);
@@ -486,7 +486,7 @@ Item {
             return atEndEdge ? dock.width - x : Math.max(bodyX + dockBackground.width + innerReach, 1);
         }
         height: {
-            if (dock.hiddenForFullscreen)
+            if (dock.hiddenForFullscreen && !expanded)
                 return 0;
             if (chrome)
                 return dockMouseArea.height + (!isVertical && expanded ? animationHeadroom : 0) + (expanded ? borderThickness * 2 + dock.verticalConnectorExtent * 2 : 0);

--- a/quickshell/Modules/Frame/FrameWindow.qml
+++ b/quickshell/Modules/Frame/FrameWindow.qml
@@ -87,7 +87,8 @@ PanelWindow {
 
     readonly property bool _connectedActive: CompositorService.usesConnectedFrameChromeForScreen(win.targetScreen)
     readonly property bool _dockHostedHere: {
-        if (!win._connectedActive || !SettingsData.showDock || SettingsData.dockUseOverlayLayer)
+        const dockVisible = SettingsData.showDock || (CompositorService.isNiri && NiriService.inOverview && SettingsData.dockOpenOnOverview);
+        if (!win._connectedActive || !dockVisible || SettingsData.dockUseOverlayLayer)
             return false;
         const screens = SettingsData.getFilteredScreens("dock");
         for (let i = 0; i < screens.length; i++) {

--- a/quickshell/Modules/Settings/DockTab.qml
+++ b/quickshell/Modules/Settings/DockTab.qml
@@ -98,6 +98,16 @@ Item {
                     visible: SettingsData.showDock
                     onToggled: checked => SettingsData.set("dockUseOverlayLayer", checked)
                 }
+
+                SettingsToggleRow {
+                    settingKey: "dockShowOnFullscreen"
+                    tags: ["dock", "fullscreen", "overlay", "show", "visibility"]
+                    text: I18n.tr("Show Dock Over Fullscreen")
+                    description: I18n.tr("Keep the dock visible above fullscreen applications")
+                    checked: SettingsData.dockShowOnFullscreen
+                    visible: SettingsData.showDock && SettingsData.dockUseOverlayLayer
+                    onToggled: checked => SettingsData.set("dockShowOnFullscreen", checked)
+                }
             }
 
             SettingsCard {

--- a/quickshell/Modules/Settings/DockTab.qml
+++ b/quickshell/Modules/Settings/DockTab.qml
@@ -105,7 +105,7 @@ Item {
                     text: I18n.tr("Show Dock Over Fullscreen", "dock visibility toggle")
                     description: I18n.tr("Keep the dock visible above fullscreen applications", "dock visibility toggle description")
                     checked: SettingsData.dockShowOnFullscreen
-                    visible: SettingsData.showDock && SettingsData.dockUseOverlayLayer
+                    visible: SettingsData.showDock
                     onToggled: checked => SettingsData.set("dockShowOnFullscreen", checked)
                 }
             }

--- a/quickshell/Modules/Settings/DockTab.qml
+++ b/quickshell/Modules/Settings/DockTab.qml
@@ -102,8 +102,8 @@ Item {
                 SettingsToggleRow {
                     settingKey: "dockShowOnFullscreen"
                     tags: ["dock", "fullscreen", "overlay", "show", "visibility"]
-                    text: I18n.tr("Show Dock Over Fullscreen")
-                    description: I18n.tr("Keep the dock visible above fullscreen applications")
+                    text: I18n.tr("Show Dock Over Fullscreen", "dock visibility toggle")
+                    description: I18n.tr("Keep the dock visible above fullscreen applications", "dock visibility toggle description")
                     checked: SettingsData.dockShowOnFullscreen
                     visible: SettingsData.showDock && SettingsData.dockUseOverlayLayer
                     onToggled: checked => SettingsData.set("dockShowOnFullscreen", checked)

--- a/quickshell/Services/CompositorService.qml
+++ b/quickshell/Services/CompositorService.qml
@@ -526,6 +526,20 @@ Singleton {
         return toplevels;
     }
 
+    function fullscreenToplevelOnScreen(screenOrName) {
+        const screenName = _screenName(screenOrName);
+        if (!screenName || !ToplevelManager.toplevels?.values)
+            return false;
+
+        const toplevels = ToplevelManager.toplevels.values;
+        for (let i = 0; i < toplevels.length; i++) {
+            const toplevel = toplevels[i];
+            if (toplevel?.fullscreen && toplevel.activated && _toplevelOnScreen(toplevel, screenName))
+                return true;
+        }
+        return false;
+    }
+
     function filterCurrentDisplay(toplevels, screenName) {
         if (!toplevels || toplevels.length === 0 || !screenName)
             return toplevels;

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -2253,6 +2253,32 @@
     "description": "Display a dock with pinned and running applications"
   },
   {
+    "section": "dockShowOnFullscreen",
+    "label": "Show Dock Over Fullscreen",
+    "tabIndex": 5,
+    "category": "Dock",
+    "keywords": [
+      "above",
+      "app",
+      "applications",
+      "apps",
+      "dock",
+      "fullscreen",
+      "keep",
+      "launcher bar",
+      "over",
+      "overlay",
+      "panel",
+      "program",
+      "programs",
+      "show",
+      "taskbar",
+      "visibility",
+      "visible"
+    ],
+    "description": "Keep the dock visible above fullscreen applications"
+  },
+  {
     "section": "dockLauncherEnabled",
     "label": "Show Launcher Button",
     "tabIndex": 5,


### PR DESCRIPTION
Hide the Dock over fullscreen applications when it uses the Wayland overlay layer, while allowing users to opt in to keeping it visible.

The Dock now tracks fullscreen toplevels per screen. Overlay Dock content and its input mask retract during fullscreen by default, preventing visual overlap and edge pointer interception. A new `Show Dock Over Fullscreen` setting explicitly overrides this behavior and takes precedence over smart/regular auto-hide while fullscreen is active.