### PR TITLE
keyboard layout widget: refresh once compositor detection lands

### DIFF
--- a/quickshell/Modules/DankBar/Widgets/KeyboardLayoutName.qml
+++ b/quickshell/Modules/DankBar/Widgets/KeyboardLayoutName.qml
@@ -171,6 +171,14 @@ BasePill {
         }
     }
 
+    Connections {
+        target: CompositorService
+
+        function onCompositorChanged() {
+            root.updateLayout();
+        }
+    }
+
     Component.onCompleted: {
         if (CompositorService.isHyprland || CompositorService.isSway) {
             updateLayout();


### PR DESCRIPTION
## Description

On Hyprland (and Sway) the Keyboard Layout Name bar widget renders with an empty label after every DMS start — the pill has no text and no reserved width, so it is effectively invisible in the bar. It only appears once the layout is switched by hand, and then works correctly for the rest of the session.

**Cause:** compositor detection is asynchronous, but the widget's initial refresh is gated on its result synchronously.

`Services/CompositorService.qml` never sets `isHyprland` during creation: `compositorInitTimer` waits 100 ms before calling `detectCompositor()`, which shells out (`Proc.runCommand`, 3000 ms timeout) to identify the Wayland socket owner and only assigns the compositor flags later, in `_applyCompositor()`.

`Modules/DankBar/Widgets/KeyboardLayoutName.qml` populates itself from Hyprland in exactly two places — the `activelayout` raw event handler, and `Component.onCompleted`:

```qml
Component.onCompleted: {
    if (CompositorService.isHyprland || CompositorService.isSway) {
        updateLayout();
    }
}
```

Bar widgets complete long before the 100 ms timer even fires, so `isHyprland` is still `false`, `updateLayout()` is never called, and `currentLayout` / `hyprlandLayoutLabels` stay `""` / `[]` — which empties both the label and `reserveLabel`. The first `activelayout` event, i.e. the user's first manual layout switch, is what finally calls `updateLayout()`.

Niri is unaffected because its `currentLayout` is a live binding on `NiriService`, so it re-evaluates on its own once detection lands; the Hyprland/Sway path is a one-shot imperative call gated on a value that isn't ready yet.

**Fix:** re-run `updateLayout()` when the detected compositor changes. `updateLayout()` already branches on the compositor internally, so a single `onCompositorChanged` handler covers every backend.

Note that gating on `compositorDetected` instead does *not* work: it is set to `true` in `compositorInitTimer.onTriggered` immediately after kicking off the async `detectCompositor()`, so it flips before the compositor is known, and the later assignment in `_applyCompositor()` is a no-op that emits no second change signal. I verified that variant fails (below).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Closes #3222

## Testing

Hyprland 0.56.0, NixOS, `kb_layout = us,il`, `kb_options = grp:alt_shift_toggle`, compact mode on. Instrumented the widget with `console.warn` at `Component.onCompleted` and at t+6s, and ran the shell three times from a clean start with no layout switch:

| Build | at `Component.onCompleted` | at t+6s |
|---|---|---|
| unpatched | `isHyprland=false compositor=unknown` | `currentLayout='' labels=[]` — blank widget |
| this PR (`onCompositorChanged`) | `isHyprland=false compositor=unknown` | `currentLayout='us' labels=["us","il"]` — correct |
| `onIsHyprlandChanged` (earlier revision) | `isHyprland=false` | `currentLayout='us' labels=["us","il"]` — also correct, but needs one handler per backend |
| `onCompositorDetectedChanged` variant | `isHyprland=false detected=false` | `currentLayout='' labels=[]` — still blank |

The third run logged `detectedChanged fired, isHyprland=false` exactly once, confirming why that gate cannot work.

`qmlformat` is a no-op on the changed file, and `make lint-qml` passes (3 entrypoints, no warnings).

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible — n/a, no new strings
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean — n/a, QML only
- [x] QML changes: ran `make lint-qml` with no new warnings — `lint-qml: PASS (3 entrypoints)`, no output; `qmlformat` is also a no-op on the touched file
- [x] I have opened a corresponding pull request in dlx-docs to document any new behaviors — n/a, no behavior to document beyond the fix



