### PR TITLE
fix(settings): label primary bar spacing sliders correctly

### DIFF
--- a/quickshell/Modules/Settings/DankBarTab.qml
+++ b/quickshell/Modules/Settings/DankBarTab.qml
@@ -980,6 +980,7 @@ Item {
                     value: selectedBarConfig?.spacing ?? 4
                     minimum: 0
                     maximum: 32
+                    unit: "px"
                     defaultValue: 4
                     onSliderDragFinished: finalValue => {
                         SettingsData.updateBarConfig(selectedBarId, {
@@ -1005,6 +1006,7 @@ Item {
                     value: selectedBarConfig?.bottomGap ?? 0
                     minimum: -50
                     maximum: 50
+                    unit: "px"
                     defaultValue: 0
                     onSliderDragFinished: finalValue => {
                         SettingsData.updateBarConfig(selectedBarId, {
@@ -1030,6 +1032,7 @@ Item {
                     value: selectedBarConfig?.innerPadding ?? 4
                     minimum: -8
                     maximum: 24
+                    unit: "px"
                     defaultValue: 4
                     onSliderDragFinished: finalValue => {
                         SettingsData.updateBarConfig(selectedBarId, {


### PR DESCRIPTION
## Description

<!-- What does this PR do and why? -->
Adds explicit 'unit' properties to the Edge Spacing, Exclusive Zone Offset, and Size sliders under Primary Bar > Appearance > Spacing.
They now properly display labelled as "px" and not the default "%".

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->
Closes #3226

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->
<img width="533" height="171" alt="image" src="https://github.com/user-attachments/assets/b6408ae4-61e7-41b2-8b6e-237fea9a3ac6" />
<img width="526" height="194" alt="image" src="https://github.com/user-attachments/assets/cc4e343b-ce43-40bd-a3e8-bb45de7692f3" />
<img width="503" height="190" alt="image" src="https://github.com/user-attachments/assets/05c889c8-239f-4d09-a21b-031736b9cffa" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [x] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
