### PR TITLE
settings: backport dead window recovery to stable-1.5

### DIFF
--- a/assets/systemd/dms.service
+++ b/assets/systemd/dms.service
@@ -9,6 +9,7 @@ Type=dbus
 BusName=org.freedesktop.Notifications
 ExecStart=/usr/bin/dms run --session
 ExecReload=/usr/bin/pkill -USR1 -x dms
+LimitNOFILE=16384
 Restart=on-failure
 RestartSec=1.23
 TimeoutStartSec=90s

--- a/quickshell/Services/PopoutService.qml
+++ b/quickshell/Services/PopoutService.qml
@@ -388,8 +388,48 @@ Singleton {
     property string _settingsPendingTab: ""
     property int _settingsPendingTabIndex: -1
 
+    property double _settingsShownAt: 0
+
+    Connections {
+        target: root.settingsModal
+        function onVisibleChanged() {
+            if (root.settingsModal?.visible)
+                root._settingsShownAt = Date.now();
+        }
+    }
+
+    function _settingsWindowDead() {
+        if (!settingsModal?.visible)
+            return false;
+        // toplevel registration is async; a freshly shown window looks dead.
+        if (Date.now() - _settingsShownAt < 2000)
+            return false;
+        const settingsTitle = I18n.tr("Settings", "settings window title");
+        for (const toplevel of ToplevelManager.toplevels.values) {
+            if (toplevel.title === "Settings" || toplevel.title === settingsTitle)
+                return false;
+        }
+        return true;
+    }
+
+    function _rebuildDeadSettings() {
+        settingsModal.visible = false;
+        settingsModal = null;
+        settingsModalLoader.active = false;
+        _settingsWantsOpen = true;
+        _settingsWantsToggle = false;
+        Qt.callLater(() => {
+            if (settingsModalLoader)
+                settingsModalLoader.activeAsync = true;
+        });
+    }
+
     function openSettings() {
         if (settingsModal) {
+            if (_settingsWindowDead()) {
+                _rebuildDeadSettings();
+                return;
+            }
             settingsModal.show();
         } else if (settingsModalLoader) {
             _settingsWantsOpen = true;
@@ -400,6 +440,11 @@ Singleton {
 
     function openSettingsWithTab(tabName: string) {
         if (settingsModal) {
+            if (_settingsWindowDead()) {
+                _settingsPendingTab = tabName;
+                _rebuildDeadSettings();
+                return;
+            }
             settingsModal.showWithTabName(tabName);
             return;
         }
@@ -413,6 +458,11 @@ Singleton {
 
     function openSettingsWithTabIndex(tabIndex: int) {
         if (settingsModal) {
+            if (_settingsWindowDead()) {
+                _settingsPendingTabIndex = tabIndex;
+                _rebuildDeadSettings();
+                return;
+            }
             settingsModal.showWithTab(tabIndex);
             return;
         }


### PR DESCRIPTION
## Description

Backports the dead Settings window recovery from master commit [`17d535b7`](https://github.com/AvengeMedia/DankMaterialShell/commit/17d535b7a4b417a60e8ff7036c3d411819fd12bd) to `stable-1.5`.

On affected Wayland sessions, Qt may continue reporting `settingsModal.visible == true` after the compositor has lost or unmapped the underlying Settings toplevel. Subsequent `settings open` calls report success, but `show()` becomes a no-op and no Settings window appears.

This backport:

- records when the Settings modal becomes visible;
- allows two seconds for asynchronous toplevel registration;
- detects a stale modal when it is marked visible but absent from `ToplevelManager`;
- rebuilds the modal through its lazy loader while preserving the requested tab;
- sets `LimitNOFILE=16384`, matching the upstream mitigation for file descriptor exhaustion reported in the related issue.

The issue was reproduced with:

- DMS 1.5.3
- Quickshell 0.3.1
- Niri on Wayland
- NVIDIA GTX 1060
- NVIDIA proprietary driver 580.159.04

The recovery is not NVIDIA- or Niri-specific. It should apply to Wayland setups where Qt retains a visible `QQuickWindow` after its compositor toplevel has disappeared.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Refs #3140.

## Screenshots / video

Not applicable. This change has no intended visual differences.

## Testing

- `make build`
- `make lint-qml`
- Verified that Settings is recreated after its compositor window is closed
- Completed 100 rapid Settings open/close IPC cycles with zero failures
- Confirmed that Settings remained mapped after the stress test
- Quickshell file descriptor count did not increase (`161` → `153`)
- No EGL or QML errors were observed during the patched test

## Checklist

- [x] My code follows the conventions in `CONTRIBUTING.md`
- [x] I have tested my changes locally
- [x] No new user-facing strings were added
- [x] No Go changes were made
- [x] QML changes: ran `make lint-qml` with no new warnings
- [x] A documentation PR is not required because this is a bug-fix backport with no new user-facing behavior