### PR TITLE
fix(audio): show the muted icon when volume reaches 0%

### DIFF
--- a/quickshell/Modules/Greetd/GreeterContent.qml
+++ b/quickshell/Modules/Greetd/GreeterContent.qml
@@ -1579,17 +1579,15 @@ Item {
                         if (!AudioService.sink?.audio) {
                             return "volume_up";
                         }
-                        if (AudioService.sink.audio.muted)
+                        if (AudioService.isSilent(AudioService.sink))
                             return "volume_off";
-                        if (AudioService.sink.audio.volume === 0)
-                            return "volume_mute";
                         if (AudioService.sink.audio.volume * 100 < 33) {
                             return "volume_down";
                         }
                         return "volume_up";
                     }
                     size: Theme.iconSize - 2
-                    color: (AudioService.sink && AudioService.sink.audio && (AudioService.sink.audio.muted || AudioService.sink.audio.volume === 0)) ? Qt.rgba(255, 255, 255, 0.5) : "white"
+                    color: AudioService.sinkSilent ? Qt.rgba(255, 255, 255, 0.5) : "white"
                     anchors.verticalCenter: parent.verticalCenter
                     visible: AudioService.sink && AudioService.sink.audio
                 }

--- a/quickshell/Modules/OSD/VolumeOSD.qml
+++ b/quickshell/Modules/OSD/VolumeOSD.qml
@@ -65,7 +65,7 @@ DankOSD {
 
             OsdLevelRow {
                 anchors.fill: parent
-                iconName: AudioService.sink?.audio?.muted ? "volume_off" : "volume_up"
+                iconName: AudioService.sinkSilent ? "volume_off" : "volume_up"
                 iconInteractive: true
                 value: root._displayVolume
                 minimum: 0
@@ -108,7 +108,7 @@ DankOSD {
 
                 DankIcon {
                     anchors.centerIn: parent
-                    name: AudioService.sink?.audio?.muted ? "volume_off" : "volume_up"
+                    name: AudioService.sinkSilent ? "volume_off" : "volume_up"
                     size: Theme.iconSize
                     color: muteButtonVert.containsMouse ? Theme.primary : Theme.surfaceText
                 }

--- a/quickshell/Services/AudioService.qml
+++ b/quickshell/Services/AudioService.qml
@@ -796,15 +796,19 @@ EOFCONFIG
     }
 
     readonly property string sinkVolumeIconName: volumeIconName(sink)
+    readonly property bool sinkSilent: isSilent(sink)
+
+    function isSilent(node) {
+        const audio = node?.audio;
+        return !!audio && (audio.muted || audio.volume <= 0);
+    }
 
     function volumeIconName(node, noDeviceIcon = "volume_off") {
         const audio = node?.audio;
         if (!audio)
             return noDeviceIcon;
-        if (audio.muted)
+        if (isSilent(node))
             return "volume_off";
-        if (audio.volume === 0)
-            return "volume_mute";
         return audio.volume <= 0.33 ? "volume_down" : "volume_up";
     }
 


### PR DESCRIPTION
## Description

At zero volume `AudioService.volumeIconName()` returned `volume_mute` — the speaker glyph *without* sound waves. At bar size that reads as the ordinary speaker, which is why lowering the volume to 0% looks like nothing happened (the screenshots in #3050 show exactly this glyph). Zero is now treated like muted and returns `volume_off`, the crossed-out speaker.

Two other places never used the service helper at all:

- `Modules/OSD/VolumeOSD.qml` looked only at `audio.muted`, so the OSD showed `volume_up` while the level read 0 — that is the case in the issue's video. Both the horizontal and the vertical layout now go through the service.
- `Modules/Greetd/GreeterContent.qml` carried a third copy of the same branching, including a dimming condition that already treated "muted or zero" as one state.

To express that shared question once, the service gains `isSilent(node)` and a `sinkSilent` property; the icon helper is written in terms of it. The zero comparison is `<= 0` rather than `=== 0` so a slider drag that lands just under zero cannot slip through. `volume_mute` is no longer referenced anywhere in the tree.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Fixes #3050

## Screenshots / video

Bar, same session, before and after setting the sink to 0% (`dms ipc call audio setvolume 0`). At 100% the speaker keeps its waves; at 0% it is crossed out.

Volume 100%:

![volume at 100 percent](https://raw.githubusercontent.com/Mario-Mohar/DankMaterialShell/pr-screenshots/3050-vorher-100prozent.png)

Volume 0%:

![volume at 0 percent](https://raw.githubusercontent.com/Mario-Mohar/DankMaterialShell/pr-screenshots/3050-nachher-0prozent.png)

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible — no new strings in this PR
- [x] Go changes: none in this PR
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs — not applicable: this corrects an icon, it documents no new behavior

### How this was verified

Ran the built `dms` against this working tree inside a nested Hyprland session on its own `XDG_CONFIG_HOME`/`XDG_STATE_HOME`/`XDG_DATA_HOME`, drove the volume through `dms ipc call audio setvolume`, and compared the bar before and after.

`make lint-qml` needs the Quickshell tooling VFS (`.qmlls.ini`), which this machine does not generate outside a full DMS install, so the three touched files were checked with Qt 6 `qmllint` directly — no errors beyond the pre-existing unresolved-import warnings that every file in the tree produces without the VFS.
