### PR TITLE
feat(clipboard): clear only the filtered entries

### DIFF
--- a/core/internal/server/clipboard/handlers.go
+++ b/core/internal/server/clipboard/handlers.go
@@ -1,8 +1,10 @@
 package clipboard
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 
 	clipboardstore "github.com/AvengeMedia/DankMaterialShell/core/internal/clipboard"
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/models"
@@ -19,6 +21,8 @@ func HandleRequest(conn *models.Conn, req models.Request, m *Manager) {
 		handleGetEntry(conn, req, m)
 	case "clipboard.deleteEntry":
 		handleDeleteEntry(conn, req, m)
+	case "clipboard.deleteEntries":
+		handleDeleteEntries(conn, req, m)
 	case "clipboard.clearHistory":
 		handleClearHistory(conn, req, m)
 	case "clipboard.copy":
@@ -101,6 +105,71 @@ func handleDeleteEntry(conn *models.Conn, req models.Request, m *Manager) {
 	}
 
 	models.Respond(conn, req.ID, models.SuccessResult{Success: true, Message: "entry deleted"})
+}
+
+func handleDeleteEntries(conn *models.Conn, req models.Request, m *Manager) {
+	raw, ok := params.Any(req.Params, "ids")
+	if !ok {
+		models.RespondError(conn, req.ID, "missing 'ids' parameter")
+		return
+	}
+
+	list, ok := raw.([]any)
+	if !ok {
+		models.RespondError(conn, req.ID, "'ids' must be an array")
+		return
+	}
+
+	ids := make([]uint64, 0, len(list))
+	for _, item := range list {
+		id, err := toEntryID(item)
+		if err != nil {
+			models.RespondError(conn, req.ID, err.Error())
+			return
+		}
+		ids = append(ids, id)
+	}
+
+	deleted, err := m.DeleteEntries(ids)
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+
+	models.Respond(conn, req.ID, map[string]int{"deleted": deleted})
+}
+
+// toEntryID accepts the shapes a clipboard entry id can arrive in: JSON decodes
+// numbers as float64, while Go callers and tests pass the integer types
+// directly.
+func toEntryID(value any) (uint64, error) {
+	switch v := value.(type) {
+	case float64:
+		if v < 0 || v != math.Trunc(v) {
+			return 0, fmt.Errorf("invalid entry id: %v", v)
+		}
+		return uint64(v), nil
+	case json.Number:
+		id, err := v.Int64()
+		if err != nil || id < 0 {
+			return 0, fmt.Errorf("invalid entry id: %v", v)
+		}
+		return uint64(id), nil
+	case int:
+		if v < 0 {
+			return 0, fmt.Errorf("invalid entry id: %v", v)
+		}
+		return uint64(v), nil
+	case int64:
+		if v < 0 {
+			return 0, fmt.Errorf("invalid entry id: %v", v)
+		}
+		return uint64(v), nil
+	case uint64:
+		return v, nil
+	default:
+		return 0, fmt.Errorf("invalid entry id: %v", value)
+	}
 }
 
 func handleClearHistory(conn *models.Conn, req models.Request, m *Manager) {

--- a/core/internal/server/clipboard/manager.go
+++ b/core/internal/server/clipboard/manager.go
@@ -155,6 +155,12 @@ func recoverDBPanic(err *error) {
 	*err = fmt.Errorf("clipboard db panic: %v", r)
 }
 
+// a pgid past the mmap end faults instead of panicking; only recoverable while armed
+func armDBFaultPanics() func() {
+	prev := debug.SetPanicOnFault(true)
+	return func() { debug.SetPanicOnFault(prev) }
+}
+
 func tryOpenDB(path string) (db *bolt.DB, err error) {
 	defer func() {
 		r := recover()
@@ -166,6 +172,7 @@ func tryOpenDB(path string) (db *bolt.DB, err error) {
 		}
 		db, err = nil, fmt.Errorf("clipboard db panic: %v", r)
 	}()
+	defer armDBFaultPanics()()
 
 	db, err = bolt.Open(path, 0o644, &bolt.Options{
 		Timeout: 1 * time.Second,
@@ -200,11 +207,13 @@ func tryOpenDB(path string) (db *bolt.DB, err error) {
 
 func (m *Manager) dbUpdate(fn func(tx *bolt.Tx) error) (err error) {
 	defer recoverDBPanic(&err)
+	defer armDBFaultPanics()()
 	return m.db.Update(fn)
 }
 
 func (m *Manager) dbView(fn func(tx *bolt.Tx) error) (err error) {
 	defer recoverDBPanic(&err)
+	defer armDBFaultPanics()()
 	return m.db.View(fn)
 }
 
@@ -1277,6 +1286,7 @@ func (m *Manager) compactDB() error {
 
 func compactInto(srcPath, dstPath string, txMaxSize int64) (err error) {
 	defer recoverDBPanic(&err)
+	defer armDBFaultPanics()()
 
 	srcDB, err := bolt.Open(srcPath, 0o644, &bolt.Options{ReadOnly: true, Timeout: time.Second})
 	if err != nil {

--- a/core/internal/server/clipboard/manager.go
+++ b/core/internal/server/clipboard/manager.go
@@ -1096,6 +1096,52 @@ func (m *Manager) DeleteEntry(id uint64) error {
 	return err
 }
 
+// DeleteEntries removes several entries in one transaction and reports how many
+// were actually deleted. Pinned entries are skipped: a bulk delete must never be
+// able to take out saved items.
+func (m *Manager) DeleteEntries(ids []uint64) (int, error) {
+	if m.db == nil {
+		return 0, fmt.Errorf("database not available")
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	deleted := 0
+	err := m.dbUpdate(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("clipboard"))
+		if b == nil {
+			return nil
+		}
+		for _, id := range ids {
+			key := itob(id)
+			v := b.Get(key)
+			if v == nil {
+				continue
+			}
+			if entry, err := decodeEntryMeta(v); err == nil && entry.Pinned {
+				continue
+			}
+			if err := b.Delete(key); err != nil {
+				return err
+			}
+			deleted++
+		}
+		return nil
+	})
+
+	if err != nil {
+		return 0, err
+	}
+
+	if deleted > 0 {
+		m.updateState()
+		m.notifySubscribers()
+	}
+
+	return deleted, nil
+}
+
 func (m *Manager) TouchEntry(id uint64) error {
 	if m.db == nil {
 		return fmt.Errorf("database not available")

--- a/core/internal/server/clipboard/manager_test.go
+++ b/core/internal/server/clipboard/manager_test.go
@@ -923,34 +923,67 @@ func TestManager_ConcurrentPostWithMock(t *testing.T) {
 	assert.Equal(t, int32(100), postCount.Load())
 }
 
-func corruptInlineBucketRoot(t *testing.T, path string) {
+// zero padding in a fresh db, never a valid page
+const corruptRootPgid = 7
+
+func corruptInlineBucketRoot(t *testing.T, path string, rootPgid byte) {
 	t.Helper()
 
 	f, err := os.OpenFile(path, os.O_RDWR, 0o644)
 	require.NoError(t, err)
 	defer f.Close()
 
-	// flips the inline bucket root pgid to an out-of-range page, per issue #3232
-	_, err = f.WriteAt([]byte{16}, int64(4*os.Getpagesize()+32+9))
+	// flips the inline bucket root pgid to an unwritten page, per issue #3232
+	_, err = f.WriteAt([]byte{rootPgid}, int64(4*os.Getpagesize()+32+9))
 	require.NoError(t, err)
 }
 
-func TestOpenDB_HealsCorruptedBucketPage(t *testing.T) {
+// bbolt maps to the next power of two, so the root stays mapped but past EOF: fault, not panic
+func dropPage(t *testing.T, path string, pgid byte) {
+	t.Helper()
+
+	require.NoError(t, os.Truncate(path, int64(pgid)*int64(os.Getpagesize())))
+}
+
+func newCorruptDB(t *testing.T, pastEOF bool) string {
+	t.Helper()
+
 	path := filepath.Join(t.TempDir(), "db")
 
 	db, err := openDB(path)
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
 
-	corruptInlineBucketRoot(t, path)
+	corruptInlineBucketRoot(t, path, corruptRootPgid)
+	if pastEOF {
+		dropPage(t, path, corruptRootPgid)
+	}
 
-	db, err = openDB(path)
-	require.NoError(t, err)
-	defer db.Close()
+	return path
+}
 
-	m := &Manager{config: DefaultConfig(), db: db, dbPath: path}
-	require.NoError(t, m.storeEntry(Entry{Data: []byte("x"), MimeType: "text/plain"}))
-	assert.Len(t, m.GetHistory(), 1)
+var corruptDBCases = []struct {
+	name    string
+	pastEOF bool
+}{
+	{"root page unwritten", false},
+	{"root page past end of file", true},
+}
+
+func TestOpenDB_HealsCorruptedBucketPage(t *testing.T) {
+	for _, tt := range corruptDBCases {
+		t.Run(tt.name, func(t *testing.T) {
+			path := newCorruptDB(t, tt.pastEOF)
+
+			db, err := openDB(path)
+			require.NoError(t, err)
+			defer db.Close()
+
+			m := &Manager{config: DefaultConfig(), db: db, dbPath: path}
+			require.NoError(t, m.storeEntry(Entry{Data: []byte("x"), MimeType: "text/plain"}))
+			assert.Len(t, m.GetHistory(), 1)
+		})
+	}
 }
 
 func TestOpenDB_HealsGarbageFile(t *testing.T) {
@@ -966,19 +999,17 @@ func TestOpenDB_HealsGarbageFile(t *testing.T) {
 }
 
 func TestStoreEntry_CorruptDBReturnsErrorNotPanic(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "db")
+	for _, tt := range corruptDBCases {
+		t.Run(tt.name, func(t *testing.T) {
+			path := newCorruptDB(t, tt.pastEOF)
 
-	db, err := openDB(path)
-	require.NoError(t, err)
-	require.NoError(t, db.Close())
+			db, err := bolt.Open(path, 0o644, &bolt.Options{Timeout: time.Second})
+			require.NoError(t, err)
+			defer db.Close()
 
-	corruptInlineBucketRoot(t, path)
-
-	db, err = bolt.Open(path, 0o644, &bolt.Options{Timeout: time.Second})
-	require.NoError(t, err)
-	defer db.Close()
-
-	m := &Manager{config: DefaultConfig(), db: db, dbPath: path}
-	_ = m.storeEntry(Entry{Data: []byte("x"), MimeType: "text/plain"})
-	_ = m.GetHistory()
+			m := &Manager{config: DefaultConfig(), db: db, dbPath: path}
+			assert.Error(t, m.storeEntry(Entry{Data: []byte("x"), MimeType: "text/plain"}))
+			assert.Empty(t, m.GetHistory())
+		})
+	}
 }

--- a/core/internal/server/clipboard/manager_test.go
+++ b/core/internal/server/clipboard/manager_test.go
@@ -345,6 +345,135 @@ func TestHandleGetEntry_MissingIDReturnsNullResult(t *testing.T) {
 	assert.Nil(t, resp.Result)
 }
 
+func storeTestEntry(t *testing.T, m *Manager, text string) uint64 {
+	t.Helper()
+
+	require.NoError(t, m.storeEntry(Entry{
+		Data:      []byte(text),
+		MimeType:  "text/plain;charset=utf-8",
+		Preview:   text,
+		Size:      len(text),
+		Timestamp: time.Now().Truncate(time.Second),
+		IsImage:   false,
+	}))
+
+	for _, entry := range m.GetHistory() {
+		if entry.Preview == text {
+			return entry.ID
+		}
+	}
+
+	t.Fatalf("stored entry %q not found in history", text)
+	return 0
+}
+
+func TestDeleteEntries_DeletesRequestedKeepsRest(t *testing.T) {
+	m := newTestManagerWithDB(t)
+
+	first := storeTestEntry(t, m, "first")
+	second := storeTestEntry(t, m, "second")
+	third := storeTestEntry(t, m, "third")
+
+	deleted, err := m.DeleteEntries([]uint64{first, third})
+	require.NoError(t, err)
+	assert.Equal(t, 2, deleted)
+
+	history := m.GetHistory()
+	require.Len(t, history, 1)
+	assert.Equal(t, second, history[0].ID)
+}
+
+func TestDeleteEntries_SkipsPinnedEntries(t *testing.T) {
+	m := newTestManagerWithDB(t)
+
+	unpinned := storeTestEntry(t, m, "unpinned")
+	pinned := storeTestEntry(t, m, "pinned")
+	require.NoError(t, m.PinEntry(pinned))
+
+	deleted, err := m.DeleteEntries([]uint64{unpinned, pinned})
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+
+	history := m.GetHistory()
+	require.Len(t, history, 1)
+	assert.True(t, history[0].Pinned)
+}
+
+func TestDeleteEntries_IgnoresUnknownIDs(t *testing.T) {
+	m := newTestManagerWithDB(t)
+
+	only := storeTestEntry(t, m, "only")
+
+	deleted, err := m.DeleteEntries([]uint64{only, only + 1000})
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+	assert.Empty(t, m.GetHistory())
+}
+
+func TestDeleteEntries_EmptyListIsNoOp(t *testing.T) {
+	m := newTestManagerWithDB(t)
+
+	storeTestEntry(t, m, "keep me")
+
+	deleted, err := m.DeleteEntries(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleted)
+	assert.Len(t, m.GetHistory(), 1)
+}
+
+func TestHandleDeleteEntries_ReportsDeletedCount(t *testing.T) {
+	m := newTestManagerWithDB(t)
+
+	first := storeTestEntry(t, m, "first")
+	second := storeTestEntry(t, m, "second")
+
+	mc := newClipboardTestConn()
+	conn := models.NewConn(mc)
+	handleDeleteEntries(conn, models.Request{
+		ID:     1,
+		Params: map[string]any{"ids": []any{float64(first), float64(second)}},
+	}, m)
+
+	var resp models.Response[map[string]int]
+	require.NoError(t, json.NewDecoder(mc.writeBuf).Decode(&resp))
+	assert.Empty(t, resp.Error)
+	require.NotNil(t, resp.Result)
+	assert.Equal(t, 2, (*resp.Result)["deleted"])
+	assert.Empty(t, m.GetHistory())
+}
+
+func TestHandleDeleteEntries_RejectsBadParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]any
+	}{
+		{"missing ids", map[string]any{}},
+		{"ids not an array", map[string]any{"ids": float64(1)}},
+		{"negative id", map[string]any{"ids": []any{float64(-1)}}},
+		{"fractional id", map[string]any{"ids": []any{float64(1.5)}}},
+		{"id of the wrong type", map[string]any{"ids": []any{"1"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestManagerWithDB(t)
+			kept := storeTestEntry(t, m, "kept")
+
+			mc := newClipboardTestConn()
+			conn := models.NewConn(mc)
+			handleDeleteEntries(conn, models.Request{ID: 1, Params: tt.params}, m)
+
+			var resp models.Response[any]
+			require.NoError(t, json.NewDecoder(mc.writeBuf).Decode(&resp))
+			assert.NotEmpty(t, resp.Error)
+
+			history := m.GetHistory()
+			require.Len(t, history, 1)
+			assert.Equal(t, kept, history[0].ID)
+		})
+	}
+}
+
 func TestUnpinEntry_KeepsTopUnpinnedDuplicate(t *testing.T) {
 	m := newTestManagerWithDB(t)
 

--- a/core/internal/server/server.go
+++ b/core/internal/server/server.go
@@ -1497,6 +1497,7 @@ func (s *Server) Serve(printDocs bool) error {
 		log.Info(" clipboard.getHistory                  - Get clipboard history with previews")
 		log.Info(" clipboard.getEntry                    - Get full entry by ID (params: id)")
 		log.Info(" clipboard.deleteEntry                 - Delete entry by ID (params: id)")
+		log.Info(" clipboard.deleteEntries               - Delete entries by ID, skipping pinned ones (params: ids)")
 		log.Info(" clipboard.clearHistory                - Clear all clipboard history")
 		log.Info(" clipboard.copy                        - Copy text to clipboard (params: text)")
 		log.Info(" clipboard.paste                       - Get current clipboard text")

--- a/quickshell/Modals/Clipboard/ClipboardContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContent.qml
@@ -95,6 +95,7 @@ Item {
             showKeyboardHints: modal.showKeyboardHints
             activeTab: modal.activeTab
             pinnedCount: modal.pinnedCount
+            clearsFilteredOnly: modal.clearsFilteredOnly
             onKeyboardHintsToggled: modal.showKeyboardHints = !modal.showKeyboardHints
             onTabChanged: tabName => modal.activeTab = tabName
             onClearAllClicked: modal.confirmClearAll()

--- a/quickshell/Modals/Clipboard/ClipboardHeader.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHeader.qml
@@ -68,7 +68,7 @@ Item {
             iconName: "delete_sweep"
             iconSize: Theme.iconSize
             iconColor: Theme.surfaceText
-            tooltipText: header.clearsFilteredOnly ? I18n.tr("Clear Filtered") : I18n.tr("Clear All")
+            tooltipText: header.clearsFilteredOnly ? I18n.tr("Clear Filtered", "clipboard modal: clear button tooltip while a search filter is active") : I18n.tr("Clear All")
             onClicked: clearAllClicked()
         }
 

--- a/quickshell/Modals/Clipboard/ClipboardHeader.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHeader.qml
@@ -11,6 +11,7 @@ Item {
     property bool showKeyboardHints: false
     property string activeTab: "recents"
     property int pinnedCount: 0
+    property bool clearsFilteredOnly: false
 
     signal keyboardHintsToggled
     signal clearAllClicked
@@ -67,7 +68,7 @@ Item {
             iconName: "delete_sweep"
             iconSize: Theme.iconSize
             iconColor: Theme.surfaceText
-            tooltipText: I18n.tr("Clear All")
+            tooltipText: header.clearsFilteredOnly ? I18n.tr("Clear Filtered") : I18n.tr("Clear All")
             onClicked: clearAllClicked()
         }
 

--- a/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
@@ -29,6 +29,7 @@ FocusScope {
     readonly property var unpinnedEntries: ClipboardService.unpinnedEntries
     readonly property int selectedIndex: ClipboardService.selectedIndex
     readonly property bool keyboardNavigationActive: ClipboardService.keyboardNavigationActive
+    readonly property bool clearsFilteredOnly: activeTab === "recents" && ClipboardService.filterActive
 
     readonly property var modalFocusScope: root
     property alias searchField: historyContent.searchField
@@ -134,7 +135,23 @@ FocusScope {
         ClipboardService.clearAll();
     }
 
+    function clearFiltered() {
+        ClipboardService.clearFiltered();
+    }
+
     function confirmClearAll() {
+        if (clearsFilteredOnly) {
+            // The list is filtered, so clear what it shows and leave the modal
+            // open on the filter the user is working through. A filter that
+            // matches nothing must never fall back to clearing everything.
+            if (unpinnedEntries.length === 0) {
+                return;
+            }
+            clearConfirmDialog.show(I18n.tr("Clear History?"), I18n.tr("This will delete the %1 entries matching the current filter. Pinned entries are kept.").arg(unpinnedEntries.length), function () {
+                clearFiltered();
+            }, function () {});
+            return;
+        }
         const hasPinned = pinnedCount > 0;
         const message = hasPinned ? I18n.tr("This will delete all unpinned entries. %1 pinned entries will be kept.").arg(pinnedCount) : I18n.tr("This will permanently delete all clipboard history.");
         clearConfirmDialog.show(I18n.tr("Clear History?"), message, function () {

--- a/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
@@ -147,7 +147,7 @@ FocusScope {
             if (unpinnedEntries.length === 0) {
                 return;
             }
-            clearConfirmDialog.show(I18n.tr("Clear History?"), I18n.tr("This will delete the %1 entries matching the current filter. Pinned entries are kept.").arg(unpinnedEntries.length), function () {
+            clearConfirmDialog.show(I18n.tr("Clear History?"), I18n.tr("This will delete the %1 entries matching the current filter. Pinned entries are kept.", "clipboard modal: clear confirmation while a search filter is active, %1 is the number of matching entries").arg(unpinnedEntries.length), function () {
                 clearFiltered();
             }, function () {});
             return;

--- a/quickshell/Services/ClipboardService.qml
+++ b/quickshell/Services/ClipboardService.qml
@@ -27,6 +27,7 @@ Singleton {
     property int totalCount: 0
     property string searchText: ""
     property string activeFilter: "all"
+    readonly property bool filterActive: searchText.trim().length > 0 || activeFilter !== "all"
     property int selectedIndex: 0
     property bool keyboardNavigationActive: false
     property int refCount: 0
@@ -344,6 +345,23 @@ Singleton {
             if (hasPinned) {
                 ToastService.showInfo(I18n.tr("History cleared. %1 pinned entries kept.").arg(savedCount));
             }
+        });
+    }
+
+    function clearFiltered() {
+        const ids = unpinnedEntries.map(entry => entry.id);
+        if (ids.length === 0) {
+            return;
+        }
+        DMSService.sendRequest("clipboard.deleteEntries", {
+            "ids": ids
+        }, function (response) {
+            if (response.error) {
+                log.warn("Failed to clear filtered entries:", response.error);
+                return;
+            }
+            refresh();
+            historyCleared();
         });
     }
 


### PR DESCRIPTION
## Description

The clear button in the clipboard modal deleted every unpinned entry regardless of the active search query or type filter, so pruning a subset meant deleting entries one at a time from the context menu (#3198).

**Behaviour**

- When the recents list is filtered — search text, or a type filter other than `all` — the button clears exactly the entries the list is showing, and the modal stays open on that filter so the next one can be worked through. `Shift+Del` takes the same path.
- With no filter, nothing changes: all unpinned entries, pinned kept, modal closes.
- A filter that matches nothing does **nothing**. Without that guard, filtering to zero results and hitting clear would have fallen back to wiping the whole history — the sharpest edge in this change.
- The tooltip reads "Clear Filtered" while a filter is active, and the confirmation names the count.
- The saved tab and the bar widget's context-menu entry are untouched; both still clear everything, since neither is showing a filtered list.

**Why a new IPC method.** Deleting the filtered ids one at a time would cost a round trip *and* a full clipboard state broadcast per entry. `clipboard.deleteEntries` does it in one bolt transaction with a single `updateState`/`notifySubscribers`, and returns how many rows it removed. It skips pinned entries server-side: the UI never sends a pinned id, but a bulk delete should not be *able* to take out saved items.

New strings: `Clear Filtered` and the confirmation sentence. The term freeze is currently inactive (`term_freeze.json` absent) and `check_term_variants.py` reports no case or punctuation duplicates against the existing catalog. Catalogs are left alone per CONTRIBUTING.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Fixes #3198

## Screenshots / video

Six entries, one pinned.

Filtered to `TREFFER` — two of six match:

![filtered list](https://raw.githubusercontent.com/Mario-Mohar/DankMaterialShell/pr-screenshots/3198-1-gefiltert.png)

The confirmation names the count:

![confirmation dialog](https://raw.githubusercontent.com/Mario-Mohar/DankMaterialShell/pr-screenshots/3198-2-dialog.png)

After confirming, the modal stays open on the filter and the other four entries survive:

![after clearing](https://raw.githubusercontent.com/Mario-Mohar/DankMaterialShell/pr-screenshots/3198-3-danach.png)

With no filter the dialog is unchanged:

![unfiltered dialog](https://raw.githubusercontent.com/Mario-Mohar/DankMaterialShell/pr-screenshots/3198-4-ungefiltert-unveraendert.png)

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()`, reusing existing terms where possible (the dialog title reuses `Clear History?`)
- [x] Go changes: ran `make fmt`, added tests, `make test` passes, `go mod tidy` is clean
- [x] QML changes: linted, no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs — happy to, if you want it: the clipboard page in dlx-docs documents the `dms cl` CLI, which this PR does not change, and the modal's clear button is not described there today. Say the word and I will add a section.

### How this was verified

Six new Go tests in `internal/server/clipboard`: deletes the requested ids and keeps the rest, skips pinned, ignores unknown ids, empty list is a no-op, the handler reports the deleted count, and five malformed `ids` shapes are rejected without touching the store. `go test ./...` passes for the whole core.

End to end: the built `dms` running against this working tree in a nested Hyprland session on its own XDG dirs. Populated six entries, pinned one, filtered, cleared, and checked the result with `dms cl history` — the two matching entries gone, the other four including the pinned one intact. Then filtered to a term that only the pinned entry matches and pressed `Shift+Del`: no dialog, nothing deleted. Then cleared with no filter: only the pinned entry left, modal closed, as before.

`make lint-qml` needs the Quickshell tooling VFS (`.qmlls.ini`), which this machine does not generate outside a full DMS install, so the touched QML was checked with Qt 6 `qmllint` directly — no errors beyond the pre-existing unresolved-import warnings.
