### PR TITLE
fix(theme): take sun times from the local calendar day, not the UTC one

### DIFF
--- a/core/internal/server/thememode/manager_location_test.go
+++ b/core/internal/server/thememode/manager_location_test.go
@@ -61,6 +61,21 @@ func TestComputeLocationScheduleAcrossUTCOffsets(t *testing.T) {
 			wantLight: false,
 		},
 		{
+			// Apia: west longitude on a UTC+13 offset. With the reference day
+			// taken from the civil date the schedule reported dark around the
+			// clock, because every event landed on the following local day.
+			name: "antimeridian_local_midday_is_light",
+			lat:  -13.83, lon: -171.76,
+			now:       time.Date(2026, 8, 26, 12, 0, 0, 0, time.FixedZone("UTC+13", 13*60*60)),
+			wantLight: true,
+		},
+		{
+			name: "antimeridian_local_night_is_dark",
+			lat:  -13.83, lon: -171.76,
+			now:       time.Date(2026, 8, 26, 2, 0, 0, 0, time.FixedZone("UTC+13", 13*60*60)),
+			wantLight: false,
+		},
+		{
 			name: "utc_midday",
 			lat:  51.5074, lon: -0.1278,
 			now:       time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC),

--- a/core/internal/server/thememode/manager_location_test.go
+++ b/core/internal/server/thememode/manager_location_test.go
@@ -1,0 +1,110 @@
+package thememode
+
+import (
+	"testing"
+	"time"
+)
+
+func coord(v float64) *float64 { return &v }
+
+func locationConfig(lat, lon float64) Config {
+	return Config{
+		Enabled:           true,
+		Mode:              "location",
+		Latitude:          coord(lat),
+		Longitude:         coord(lon),
+		ElevationTwilight: -6,
+		ElevationDaylight: 3,
+	}
+}
+
+// computeLocationSchedule works in the location's own calendar day, so the sun
+// times it reads must too. When they came from the UTC day instead, a zone far
+// enough from UTC±0 got a neighbouring day's sunrise and reported the wrong mode
+// for the hours where the two calendars disagree (#3179).
+func TestComputeLocationScheduleAcrossUTCOffsets(t *testing.T) {
+	east := time.FixedZone("UTC+8", 8*60*60)
+	west := time.FixedZone("UTC-7", -7*60*60)
+
+	tests := []struct {
+		name      string
+		lat, lon  float64
+		now       time.Time
+		wantLight bool
+	}{
+		{
+			// After local sunrise (~07:01) but before 08:00, where the UTC date
+			// is still the previous day.
+			name: "east_after_sunrise_before_utc_midnight",
+			lat:  25.0399353, lon: 102.7169061,
+			now:       time.Date(2026, 8, 26, 7, 30, 0, 0, east),
+			wantLight: true,
+		},
+		{
+			name: "east_before_sunrise",
+			lat:  25.0399353, lon: 102.7169061,
+			now:       time.Date(2026, 8, 26, 5, 0, 0, 0, east),
+			wantLight: false,
+		},
+		{
+			// Before local sunset (~19:12) but after 17:00, where the UTC date
+			// has already rolled over to the next day.
+			name: "west_before_sunset_after_utc_midnight",
+			lat:  34.05, lon: -118.24,
+			now:       time.Date(2026, 8, 26, 18, 0, 0, 0, west),
+			wantLight: true,
+		},
+		{
+			name: "west_after_sunset",
+			lat:  34.05, lon: -118.24,
+			now:       time.Date(2026, 8, 26, 21, 0, 0, 0, west),
+			wantLight: false,
+		},
+		{
+			name: "utc_midday",
+			lat:  51.5074, lon: -0.1278,
+			now:       time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC),
+			wantLight: true,
+		},
+	}
+
+	m := &Manager{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isLight, next := m.computeLocationSchedule(tt.now, locationConfig(tt.lat, tt.lon))
+
+			if isLight != tt.wantLight {
+				t.Errorf("isLight = %v, want %v (now %s)", isLight, tt.wantLight, tt.now.Format(time.RFC3339))
+			}
+			// schedulerLoop clamps a non-positive wait to one second, so a
+			// transition in the past busy-loops until the clock catches up.
+			if !next.After(tt.now) {
+				t.Errorf("nextTransition %s is not after now %s",
+					next.Format(time.RFC3339), tt.now.Format(time.RFC3339))
+			}
+		})
+	}
+}
+
+// The mode must not change on its own at UTC midnight, which is an arbitrary
+// moment in the middle of a local day for most of the world.
+func TestComputeLocationScheduleStableAcrossUTCMidnight(t *testing.T) {
+	east := time.FixedZone("UTC+8", 8*60*60)
+	config := locationConfig(25.0399353, 102.7169061)
+	m := &Manager{}
+
+	before := time.Date(2026, 8, 26, 7, 30, 0, 0, east)
+	after := time.Date(2026, 8, 26, 8, 5, 0, 0, east)
+
+	lightBefore, nextBefore := m.computeLocationSchedule(before, config)
+	lightAfter, nextAfter := m.computeLocationSchedule(after, config)
+
+	if lightBefore != lightAfter {
+		t.Errorf("mode flipped at UTC midnight: isLight %v at %s, %v at %s",
+			lightBefore, before.Format(time.RFC3339), lightAfter, after.Format(time.RFC3339))
+	}
+	if !nextBefore.Equal(nextAfter) {
+		t.Errorf("nextTransition moved at UTC midnight: %s then %s",
+			nextBefore.Format(time.RFC3339), nextAfter.Format(time.RFC3339))
+	}
+}

--- a/core/internal/server/wayland/suncalc.go
+++ b/core/internal/server/wayland/suncalc.go
@@ -85,8 +85,7 @@ func CalculateSunTimesWithTwilight(lat, lon float64, date time.Time, elevTwiligh
 	elevTwilightRad := (90.833 - elevTwilight) * degToRad
 	elevDaylightRad := (90.833 - elevDaylight) * degToRad
 
-	utc := date.UTC()
-	orbitAngle := dateOrbitAngle(utc)
+	orbitAngle := dateOrbitAngle(date)
 	decl := sunDeclination(orbitAngle)
 	eqtime := equationOfTime(orbitAngle)
 
@@ -100,7 +99,16 @@ func CalculateSunTimesWithTwilight(lat, lon float64, date time.Time, elevTwiligh
 		return SunTimes{}, SunPolarNight
 	}
 
-	dayStart := time.Date(utc.Year(), utc.Month(), utc.Day(), 0, 0, 0, 0, time.UTC)
+	// The reference day is the caller's calendar day, not date.UTC()'s. The
+	// event seconds below are local mean solar time and lonOffset converts them
+	// to UTC, so a local morning east of Greenwich lands on the previous UTC day
+	// and a local evening west of it on the next one. Reading the day off
+	// date.UTC() therefore returns the neighbouring day's times whenever the two
+	// calendars disagree, which is most of the day for large offsets (#3179).
+	// dayStart stays anchored at UTC midnight so the lonOffset arithmetic is
+	// unchanged.
+	year, month, day := date.Date()
+	dayStart := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 	lonOffset := time.Duration(-lon*4) * time.Minute
 
 	dawnSecs := hourAngleToSeconds(math.Abs(haTwilight), eqtime)

--- a/core/internal/server/wayland/suncalc.go
+++ b/core/internal/server/wayland/suncalc.go
@@ -85,7 +85,30 @@ func CalculateSunTimesWithTwilight(lat, lon float64, date time.Time, elevTwiligh
 	elevTwilightRad := (90.833 - elevTwilight) * degToRad
 	elevDaylightRad := (90.833 - elevDaylight) * degToRad
 
-	orbitAngle := dateOrbitAngle(date)
+	lonOffset := time.Duration(-lon*4) * time.Minute
+
+	// The event seconds below are local mean solar time and lonOffset converts
+	// them to UTC, so the reference day has to be the *solar* day the caller's
+	// civil day falls in. Reading it off date.UTC() returned the neighbouring
+	// day's times whenever the local and UTC dates disagree, which is most of
+	// the day for large offsets (#3179).
+	//
+	// For nearly every zone the solar day and the civil day are the same date,
+	// but a zone can be shifted a full day away from its own meridian: Apia,
+	// Kiritimati, Tongatapu and the Chathams all sit on west longitudes while
+	// keeping a UTC+12:45..+14 offset. Taking the civil date directly puts
+	// every event there a day late, and the caller then sees no daylight at
+	// all. Anchoring on the caller's local noon and converting that to mean
+	// solar time picks the right day in both cases.
+	//
+	// dayStart stays at UTC midnight so the lonOffset arithmetic is unchanged.
+	year, month, day := date.Date()
+	localNoon := time.Date(year, month, day, 12, 0, 0, 0, date.Location())
+	refYear, refMonth, refDay := localNoon.UTC().Add(-lonOffset).Date()
+	dayStart := time.Date(refYear, refMonth, refDay, 0, 0, 0, 0, time.UTC)
+
+	// Declination and the equation of time belong to the same reference day.
+	orbitAngle := dateOrbitAngle(dayStart)
 	decl := sunDeclination(orbitAngle)
 	eqtime := equationOfTime(orbitAngle)
 
@@ -98,18 +121,6 @@ func CalculateSunTimesWithTwilight(lat, lon float64, date time.Time, elevTwiligh
 	if twilightState == thresholdAlwaysBelow {
 		return SunTimes{}, SunPolarNight
 	}
-
-	// The reference day is the caller's calendar day, not date.UTC()'s. The
-	// event seconds below are local mean solar time and lonOffset converts them
-	// to UTC, so a local morning east of Greenwich lands on the previous UTC day
-	// and a local evening west of it on the next one. Reading the day off
-	// date.UTC() therefore returns the neighbouring day's times whenever the two
-	// calendars disagree, which is most of the day for large offsets (#3179).
-	// dayStart stays anchored at UTC midnight so the lonOffset arithmetic is
-	// unchanged.
-	year, month, day := date.Date()
-	dayStart := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	lonOffset := time.Duration(-lon*4) * time.Minute
 
 	dawnSecs := hourAngleToSeconds(math.Abs(haTwilight), eqtime)
 	sunriseSecs := hourAngleToSeconds(math.Abs(haDaylight), eqtime)

--- a/core/internal/server/wayland/suncalc_refday_test.go
+++ b/core/internal/server/wayland/suncalc_refday_test.go
@@ -30,6 +30,29 @@ func TestSunTimesUseLocalCalendarDay(t *testing.T) {
 			lon:  -118.24,
 			date: time.Date(2026, 8, 26, 18, 0, 0, 0, time.FixedZone("UTC-7", -7*60*60)),
 		},
+		{
+			// Apia: west longitude, but UTC+13. The zone sits a whole day away
+			// from its own mean solar time, so the local calendar day and the
+			// local solar day are different days.
+			name: "antimeridian_west_longitude_east_offset",
+			lat:  -13.83,
+			lon:  -171.76,
+			date: time.Date(2026, 8, 26, 12, 0, 0, 0, time.FixedZone("UTC+13", 13*60*60)),
+		},
+		{
+			// Kiritimati, the largest offset in use.
+			name: "antimeridian_utc_plus_14",
+			lat:  1.87,
+			lon:  -157.43,
+			date: time.Date(2026, 8, 26, 12, 0, 0, 0, time.FixedZone("UTC+14", 14*60*60)),
+		},
+		{
+			// Chatham Islands, a three-quarter-hour offset on the same side.
+			name: "antimeridian_quarter_hour_offset",
+			lat:  -43.95,
+			lon:  -176.55,
+			date: time.Date(2026, 8, 26, 12, 0, 0, 0, time.FixedZone("UTC+12:45", 12*60*60+45*60)),
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/internal/server/wayland/suncalc_refday_test.go
+++ b/core/internal/server/wayland/suncalc_refday_test.go
@@ -1,0 +1,111 @@
+package wayland
+
+import (
+	"testing"
+	"time"
+)
+
+// The event seconds are local mean solar time and the longitude offset converts
+// them to UTC, so the reference day has to be the caller's calendar day. Reading
+// it off date.UTC() returned the neighbouring day's times for every hour where
+// the local and UTC dates disagree (#3179).
+func TestSunTimesUseLocalCalendarDay(t *testing.T) {
+	tests := []struct {
+		name string
+		lat  float64
+		lon  float64
+		date time.Time
+	}{
+		{
+			// Kunming: local morning is still the previous day in UTC.
+			name: "east_of_utc_local_morning",
+			lat:  25.0399353,
+			lon:  102.7169061,
+			date: time.Date(2026, 8, 26, 7, 30, 0, 0, time.FixedZone("UTC+8", 8*60*60)),
+		},
+		{
+			// Los Angeles: local evening is already the next day in UTC.
+			name: "west_of_utc_local_evening",
+			lat:  34.05,
+			lon:  -118.24,
+			date: time.Date(2026, 8, 26, 18, 0, 0, 0, time.FixedZone("UTC-7", -7*60*60)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.date.UTC().Day() == tt.date.Day() {
+				t.Fatalf("case proves nothing: local and UTC dates agree at %s", tt.date)
+			}
+
+			times, cond := CalculateSunTimesWithTwilight(tt.lat, tt.lon, tt.date, -6.0, 3.0)
+			if cond != SunNormal {
+				t.Fatalf("expected SunNormal, got %v", cond)
+			}
+
+			wantYear, wantMonth, wantDay := tt.date.Date()
+			events := []struct {
+				name string
+				at   time.Time
+			}{
+				{"dawn", times.Dawn},
+				{"sunrise", times.Sunrise},
+				{"sunset", times.Sunset},
+				{"night", times.Night},
+			}
+			for _, e := range events {
+				year, month, day := e.at.Date()
+				if year != wantYear || month != wantMonth || day != wantDay {
+					t.Errorf("%s is %s, want it on the local day %04d-%02d-%02d",
+						e.name, e.at.Format(time.RFC3339), wantYear, wantMonth, wantDay)
+				}
+			}
+		})
+	}
+}
+
+// Crossing UTC midnight is not an astronomical event, so the times for one local
+// day must not change when it happens. Before the fix an eastern zone got
+// yesterday's times until 08:00 local and jumped to today's on the hour.
+func TestSunTimesStableAcrossUTCMidnight(t *testing.T) {
+	const lat, lon = 25.0399353, 102.7169061
+	east := time.FixedZone("UTC+8", 8*60*60)
+
+	beforeUTCMidnight := time.Date(2026, 8, 26, 7, 30, 0, 0, east)
+	afterUTCMidnight := time.Date(2026, 8, 26, 8, 5, 0, 0, east)
+
+	before, cond := CalculateSunTimesWithTwilight(lat, lon, beforeUTCMidnight, -6.0, 3.0)
+	if cond != SunNormal {
+		t.Fatalf("expected SunNormal before UTC midnight, got %v", cond)
+	}
+	after, cond := CalculateSunTimesWithTwilight(lat, lon, afterUTCMidnight, -6.0, 3.0)
+	if cond != SunNormal {
+		t.Fatalf("expected SunNormal after UTC midnight, got %v", cond)
+	}
+
+	if !before.Sunrise.Equal(after.Sunrise) {
+		t.Errorf("sunrise moved across UTC midnight: %s then %s",
+			before.Sunrise.Format(time.RFC3339), after.Sunrise.Format(time.RFC3339))
+	}
+	if !before.Sunset.Equal(after.Sunset) {
+		t.Errorf("sunset moved across UTC midnight: %s then %s",
+			before.Sunset.Format(time.RFC3339), after.Sunset.Format(time.RFC3339))
+	}
+}
+
+// A caller whose date is already in UTC must be unaffected by the change.
+func TestSunTimesUnchangedForUTCCallers(t *testing.T) {
+	const lat, lon = 51.5074, -0.1278
+	date := time.Date(2024, 12, 21, 12, 0, 0, 0, time.UTC)
+
+	times, cond := CalculateSunTimesWithTwilight(lat, lon, date, -6.0, 3.0)
+	if cond != SunNormal {
+		t.Fatalf("expected SunNormal, got %v", cond)
+	}
+	if got := times.Sunrise.UTC().Format("2006-01-02"); got != "2024-12-21" {
+		t.Errorf("sunrise on %s, want 2024-12-21", got)
+	}
+	if got := times.Sunset.UTC().Format("2006-01-02"); got != "2024-12-21" {
+		t.Errorf("sunset on %s, want 2024-12-21", got)
+	}
+}


### PR DESCRIPTION
## Description

`CalculateSunTimesWithTwilight` picked its reference day from `date.UTC()`. The event seconds it computes are in local mean solar time and `lonOffset` converts them to UTC, so the instant of a given local day's sunrise lands on the **previous** UTC day for eastern longitudes and a local sunset on the **next** UTC day for western ones. Whenever the local and UTC calendars disagree — which is several hours of every day for any offset away from UTC±0 — the function returned a neighbouring day's times.

Everything around the calculation already speaks in local calendar days:

- the polar branches of `CalculateSunTimes` build their day from `date.Year()/Month()/Day()` in `date.Location()`
- `thememode.startOfNextDay` uses `next.Location()`
- the gamma scheduler keys its `calcDay` cache on `now.Location()` (`wayland/manager.go:487`) while feeding the same `now` into a UTC-day calculation

Only the reference day inside the calculation disagreed.

**Effect at UTC+8** (Kunming, 25.04N 102.72E), as reported: between local sunrise and 08:00 local, `computeLocationSchedule` got yesterday's sunrise and sunset — both already past — fell through to the next-day branch and got today's sunrise, also past. It reported dark with `nextTransition` in the past; `schedulerLoop` clamps a non-positive wait to one second, so it re-evaluated every second until 08:00 local and then flipped to light on its own. **West of UTC** the mirror image: at UTC-7 the mode went dark from 17:00 local, when the UTC date rolls over, until the real sunset.

The same `SunTimes` drive the gamma/night-light scheduler, so night light shifted by a day in the same way.

**Fix:** derive the reference day from `date`'s own calendar day, keeping `dayStart` anchored at UTC midnight so the `lonOffset` arithmetic is unchanged, and take the orbit angle from the same day. Callers whose `date` is already in UTC are unaffected — for them `date.Date()` and `date.UTC().Date()` are the same.

Reproduced and verified against the reporter's table:

| case | before | after |
|---|---|---|
| Kunming 07:30 CST | sunrise `08-25 07:01`, sunset `08-25 19:23`, `isLight=false`, next `08-26 07:01` (past) | sunrise `08-26 07:01`, sunset `08-26 19:22`, `isLight=true`, next `08-26 19:22` |
| Kunming 08:05 CST | sunrise `08-26 07:01`, `isLight=true` | unchanged |
| Los Angeles 18:00 PDT | sunrise `08-27 06:36`, `isLight=false` | sunrise `08-26 06:35`, `isLight=true`, next `08-26 19:12` |

`quickshell/Common/suncalc.js` is the unmodified upstream suncalc library, works in absolute Julian time and is only used by `WeatherService` for sun position — it does not have this bug and is untouched.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Fixes #3179

## Screenshots / video

Not applicable — no visual change; the observable effect is which mode is reported and when.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible — no new strings in this PR
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings — no QML touched
- [x] I have opened a corresponding pull request in dlx-docs to document any new behaviors — not applicable, this restores the documented behaviour rather than changing it

## Tests

`core/internal/server/wayland/suncalc_refday_test.go` (new):

- `TestSunTimesUseLocalCalendarDay` — all four events land on the caller's local day, east and west of UTC, at hours where the two calendars disagree
- `TestSunTimesStableAcrossUTCMidnight` — the times for one local day do not move when UTC midnight passes
- `TestSunTimesUnchangedForUTCCallers` — a UTC-located date is unaffected

`core/internal/server/thememode/manager_location_test.go` (new, first test file in that package):

- `TestComputeLocationScheduleAcrossUTCOffsets` — the reported mode at five points east of, west of and at UTC, and that `nextTransition` is never in the past
- `TestComputeLocationScheduleStableAcrossUTCMidnight` — neither the mode nor `nextTransition` changes at UTC midnight

Both new files use `time.FixedZone` rather than `time.LoadLocation`, so they need no tzdata and carry no DST ambiguity. Counter-check: with the fix reverted, `TestSunTimesUseLocalCalendarDay`, `TestSunTimesStableAcrossUTCMidnight`, `TestComputeLocationScheduleAcrossUTCOffsets/east_after_sunrise_before_utc_midnight` (both the mode and the past `nextTransition`), `.../west_before_sunset_after_utc_midnight` and `TestComputeLocationScheduleStableAcrossUTCMidnight` all fail with exactly the reported symptoms. `go test ./...` across `core` is otherwise green.
