### PR TITLE
fix(keybinds): show hl.unbind + hl.bind overrides from user Lua modules

### DIFF
--- a/core/internal/keybinds/providers/hyprland_parser.go
+++ b/core/internal/keybinds/providers/hyprland_parser.go
@@ -53,10 +53,14 @@ type HyprlandParser struct {
 	bindOrder          []string
 	processedFiles     map[string]bool
 	dmsProcessed       bool
-	removedKeys        map[string]bool // bare hl.unbind targets (negative overrides)
-	defaultDMSKeys     map[string]bool // keys present in dms/binds.{lua,conf}
-	configFormat       string
-	readOnly           bool
+	removedKeys        map[string]bool // hl.unbind targets
+	// rebindSources maps a removed key to the files that unbind and then rebind
+	// it. Their own bind survives the removal; binds from anywhere else do not.
+	rebindSources  map[string]map[string]bool
+	fileUnbinds    map[string]bool // hl.unbind targets seen so far in the file being parsed
+	defaultDMSKeys map[string]bool // keys present in dms/binds.{lua,conf}
+	configFormat   string
+	readOnly       bool
 }
 
 func NewHyprlandParser(configDir string) *HyprlandParser {
@@ -72,6 +76,7 @@ func NewHyprlandParser(configDir string) *HyprlandParser {
 		bindOrder:          []string{},
 		processedFiles:     make(map[string]bool),
 		removedKeys:        make(map[string]bool),
+		rebindSources:      make(map[string]map[string]bool),
 		defaultDMSKeys:     make(map[string]bool),
 	}
 }
@@ -372,7 +377,10 @@ func (p *HyprlandParser) addBind(kb *HyprlandKeyBinding) bool {
 	}
 	if isDMSBind {
 		p.dmsBindKeys[normalizedKey] = true
-	} else if p.dmsBindKeys[normalizedKey] {
+	} else if p.dmsBindKeys[normalizedKey] && !p.fileUnbinds[normalizedKey] {
+		// Without a preceding hl.unbind both binds stay live in Hyprland, which
+		// is the conflict this counts. With one, the DMS bind is gone and this
+		// is the effective bind, so it belongs in the list (#3145).
 		p.bindsAfterDMS++
 		p.conflictingConfigs[normalizedKey] = kb
 		p.configBindKeys[normalizedKey] = true
@@ -437,7 +445,8 @@ func (p *HyprlandParser) removeUnboundDMSBinds(section *HyprlandSection) {
 	filtered := section.Keybinds[:0]
 	for i := range section.Keybinds {
 		kb := section.Keybinds[i]
-		if isDMSBindsSourcePath(kb.Source) && p.removedKeys[p.normalizeKey(p.formatBindKey(&kb))] {
+		key := p.normalizeKey(p.formatBindKey(&kb))
+		if isDMSBindsSourcePath(kb.Source) && p.removedKeys[key] && !p.rebindSources[key][kb.Source] {
 			continue
 		}
 		filtered = append(filtered, kb)
@@ -622,7 +631,9 @@ func (p *HyprlandParser) parseLuaLinesFromPath(absPath string) (*HyprlandSection
 func (p *HyprlandParser) parseLuaLines(content string, baseDir, absPath, sectionName string) (*HyprlandSection, error) {
 	section := &HyprlandSection{Name: sectionName}
 	prevSource := p.currentSource
+	prevUnbinds := p.fileUnbinds
 	p.currentSource = absPath
+	p.fileUnbinds = make(map[string]bool)
 
 	lines := expandLuaConfigLines(strings.Split(content, "\n"))
 	boundInFile := make(map[string]bool)
@@ -675,8 +686,12 @@ func (p *HyprlandParser) parseLuaLines(content string, baseDir, absPath, section
 		if strings.HasPrefix(trimmed, "hl.unbind") {
 			if key, ok := parseLuaUnbindLine(trimmed); ok {
 				normalized := strings.ToLower(key)
-				if !boundInFile[normalized] {
-					p.removedKeys[normalized] = true
+				p.removedKeys[normalized] = true
+				p.fileUnbinds[normalized] = true
+				if boundInFile[normalized] {
+					// unbind plus rebind in one file is an override, not a
+					// removal: this file's own bind has to survive
+					p.noteRebindSource(normalized, absPath)
 				}
 			}
 			continue
@@ -703,7 +718,15 @@ func (p *HyprlandParser) parseLuaLines(content string, baseDir, absPath, section
 	}
 
 	p.currentSource = prevSource
+	p.fileUnbinds = prevUnbinds
 	return section, nil
+}
+
+func (p *HyprlandParser) noteRebindSource(key, source string) {
+	if p.rebindSources[key] == nil {
+		p.rebindSources[key] = make(map[string]bool)
+	}
+	p.rebindSources[key][source] = true
 }
 
 func luaBindOptFlags(optSuffix string) string {

--- a/core/internal/keybinds/providers/hyprland_parser_override_test.go
+++ b/core/internal/keybinds/providers/hyprland_parser_override_test.go
@@ -1,0 +1,186 @@
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// hyprlandBindIndex flattens a parsed section into "SUPER+V" -> binding.
+func hyprlandBindIndex(section HyprlandSection) map[string]HyprlandKeyBinding {
+	index := make(map[string]HyprlandKeyBinding)
+	var walk func(HyprlandSection)
+	walk = func(s HyprlandSection) {
+		for _, kb := range s.Keybinds {
+			parts := append(append([]string{}, kb.Mods...), kb.Key)
+			index[strings.ToUpper(strings.Join(parts, "+"))] = kb
+		}
+		for _, child := range s.Children {
+			walk(child)
+		}
+	}
+	walk(section)
+	return index
+}
+
+func writeHyprlandConfig(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// A user module that unbinds a DMS key and binds it again is an override: in
+// Hyprland the DMS bind is gone and only the new one fires, so the modal has to
+// show the new one. It used to show the DMS bind instead, because the unbind was
+// discarded whenever the same file rebound the key and the rebind was then
+// dropped as a conflicting config bind (#3145).
+func TestParserShowsUnbindRebindOverrideFromUserModule(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeHyprlandConfig(t, tmpDir, map[string]string{
+		"hyprland.lua": `
+require("dms.binds")
+require("mybinds")
+`,
+		"dms/binds.lua": `hl.bind("SUPER + V", hl.dsp.exec_cmd("dms ipc call clipboard toggle"), { description = "Clipboard history" })
+hl.bind("SUPER + T", hl.dsp.exec_cmd("kitty"), { description = "Terminal" })`,
+		"mybinds.lua": `hl.unbind("SUPER + V")
+hl.bind("SUPER + V", hl.dsp.togglefloating(), { description = "float toggle" })`,
+	})
+
+	result, err := ParseHyprlandKeysWithDMS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	binds := hyprlandBindIndex(*result.Section)
+	got, ok := binds["SUPER+V"]
+	if !ok {
+		t.Fatalf("SUPER+V missing entirely, got keys: %v", bindKeys(binds))
+	}
+	if got.Comment != "float toggle" {
+		t.Errorf("SUPER+V shows %q from %s, want the override %q",
+			got.Comment, filepath.Base(got.Source), "float toggle")
+	}
+	if filepath.Base(got.Source) != "mybinds.lua" {
+		t.Errorf("SUPER+V sourced from %s, want mybinds.lua", filepath.Base(got.Source))
+	}
+	if _, ok := binds["SUPER+T"]; !ok {
+		t.Errorf("SUPER+T should be untouched, got keys: %v", bindKeys(binds))
+	}
+	// An unbind makes this an override rather than two live binds on one key.
+	if result.DMSStatus.BindsAfterDMS != 0 {
+		t.Errorf("BindsAfterDMS = %d, want 0 for an unbind+rebind override",
+			result.DMSStatus.BindsAfterDMS)
+	}
+}
+
+// Without an unbind both binds stay live in Hyprland. That is the ambiguous case
+// the conflict counter is for, and it must keep behaving as before.
+func TestParserStillReportsConflictWithoutUnbind(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeHyprlandConfig(t, tmpDir, map[string]string{
+		"hyprland.lua": `
+require("dms.binds")
+require("mybinds")
+`,
+		"dms/binds.lua": `hl.bind("SUPER + V", hl.dsp.exec_cmd("dms ipc call clipboard toggle"), { description = "Clipboard history" })`,
+		"mybinds.lua":   `hl.bind("SUPER + V", hl.dsp.togglefloating(), { description = "float toggle" })`,
+	})
+
+	result, err := ParseHyprlandKeysWithDMS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	binds := hyprlandBindIndex(*result.Section)
+	got, ok := binds["SUPER+V"]
+	if !ok {
+		t.Fatalf("SUPER+V missing entirely, got keys: %v", bindKeys(binds))
+	}
+	if got.Comment != "Clipboard history" {
+		t.Errorf("SUPER+V shows %q, want the DMS bind to be kept as before", got.Comment)
+	}
+	if result.DMSStatus.BindsAfterDMS != 1 {
+		t.Errorf("BindsAfterDMS = %d, want 1 for a config bind without unbind",
+			result.DMSStatus.BindsAfterDMS)
+	}
+}
+
+// An unbind without a rebind stays a plain removal, from a user module as well
+// as from dms/binds-user.lua.
+func TestParserUnbindWithoutRebindStillRemoves(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeHyprlandConfig(t, tmpDir, map[string]string{
+		"hyprland.lua": `
+require("dms.binds")
+require("mybinds")
+`,
+		"dms/binds.lua": `hl.bind("SUPER + V", hl.dsp.exec_cmd("dms ipc call clipboard toggle"))
+hl.bind("SUPER + T", hl.dsp.exec_cmd("kitty"))`,
+		"mybinds.lua": `hl.unbind("SUPER + V")`,
+	})
+
+	result, err := ParseHyprlandKeysWithDMS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	binds := hyprlandBindIndex(*result.Section)
+	if _, ok := binds["SUPER+V"]; ok {
+		t.Errorf("SUPER+V should be removed by the bare unbind, got keys: %v", bindKeys(binds))
+	}
+	if _, ok := binds["SUPER+T"]; !ok {
+		t.Errorf("SUPER+T should remain, got keys: %v", bindKeys(binds))
+	}
+}
+
+// dms/binds-user.lua is what the settings modal writes, and it writes an unbind
+// followed by a bind. Recording that unbind must not delete the rebind that
+// comes with it.
+func TestParserKeepsBindsUserRebindAfterItsOwnUnbind(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeHyprlandConfig(t, tmpDir, map[string]string{
+		"hyprland.lua": `
+require("dms.binds")
+require("dms.binds-user")
+`,
+		"dms/binds.lua": `hl.bind("SUPER + V", hl.dsp.exec_cmd("dms ipc call clipboard toggle"), { description = "Clipboard history" })
+hl.bind("SUPER + T", hl.dsp.exec_cmd("kitty"), { description = "Terminal" })`,
+		"dms/binds-user.lua": `hl.unbind("SUPER + V")
+hl.bind("SUPER + V", hl.dsp.togglefloating(), { description = "float toggle" })`,
+	})
+
+	result, err := ParseHyprlandKeysWithDMS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	binds := hyprlandBindIndex(*result.Section)
+	got, ok := binds["SUPER+V"]
+	if !ok {
+		t.Fatalf("SUPER+V missing entirely, got keys: %v", bindKeys(binds))
+	}
+	if got.Comment != "float toggle" {
+		t.Errorf("SUPER+V shows %q from %s, want the binds-user.lua override",
+			got.Comment, filepath.Base(got.Source))
+	}
+	if _, ok := binds["SUPER+T"]; !ok {
+		t.Errorf("SUPER+T should be untouched, got keys: %v", bindKeys(binds))
+	}
+}
+
+func bindKeys(binds map[string]HyprlandKeyBinding) []string {
+	keys := make([]string, 0, len(binds))
+	for k := range binds {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
## Description

In Hyprland a second bind on an already bound key does not replace the first — both stay live. That is why an override is written as `hl.unbind` followed by `hl.bind`, and it is what DMS itself emits into `dms/binds-user.lua` (`writeLuaBindLine`). The parser dropped that pair on the floor when it came from a user's own Lua module:

- `parseLuaLines` discarded the unbind whenever the same file rebound the key (`if !boundInFile[normalized]`), so the DMS default was never removed
- `addBind` then saw a non-DMS bind on a key DMS had already bound, counted it in `bindsAfterDMS`, put it in `conflictingConfigs` and returned `false`, so it never reached the section

Net effect for the reporter's config: the keybinds modal shows the DMS default for that key and the user's actual action is nowhere — "observe nothing searchable for float".

The discard was not arbitrary. It protects `dms/binds-user.lua`, the file the settings modal writes, which uses the very same unbind+bind pair: recording its unbind would delete its own rebind too, because that file is itself a DMS bind source and `removeUnboundDMSBinds` filters on `isDMSBindsSourcePath`. The guard was simply too coarse — it suppressed the unbind entirely instead of exempting the one bind it belongs to.

**Fix**, in three connected places:

1. The unbind is always recorded in `removedKeys`.
2. New `rebindSources` remembers which file unbound *and* rebound a key, and `removeUnboundDMSBinds` spares that file's own bind. This keeps `dms/binds-user.lua` working exactly as before.
3. `addBind` treats a bind as an override rather than a conflict when the same file unbound the key earlier. That is tracked per file in `fileUnbinds`, saved and restored around each parsed file alongside `currentSource`, so an include cannot leak into its parent.

A config bind **without** a preceding unbind is deliberately unchanged: both binds really are live in Hyprland, so it stays a conflict and keeps counting towards "Some DMS binds may be overridden by config binds".

Before / after for the reported config (`dms/binds.lua` binds `SUPER+V`, `mybinds.lua` unbinds and rebinds it):

| | `SUPER+V` shown | source | `BindsAfterDMS` |
|---|---|---|---|
| before | `exec dms ipc call clipboard toggle` ("Clipboard history") | `binds.lua` | 1 |
| after | `hl.dsp.togglefloating()` ("float toggle") | `mybinds.lua` | 0 |

No other provider has an unbind concept — `mangowc`, `niri` and `sway` parse formats without one — so this is Hyprland-only.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Fixes #3145

## Screenshots / video

Not applicable — no visual change; the fix is in what the keybinds modal is given to display. The before/after is in the table above and asserted in the tests.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible — no new strings in this PR
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings — no QML touched
- [x] I have opened a corresponding pull request in dlx-docs to document any new behaviors — not applicable, this makes the documented override pattern work rather than adding one

## Tests

`core/internal/keybinds/providers/hyprland_parser_override_test.go` (new):

- `TestParserShowsUnbindRebindOverrideFromUserModule` — the reported case: the override is shown, sourced from the user module, and is not counted as a conflict
- `TestParserStillReportsConflictWithoutUnbind` — a config bind with no unbind is still a conflict, `BindsAfterDMS` stays 1
- `TestParserUnbindWithoutRebindStillRemoves` — a bare unbind is still a plain removal
- `TestParserKeepsBindsUserRebindAfterItsOwnUnbind` — the `dms/binds-user.lua` round trip survives the now-always-recorded unbind

Counter-check: with the fix reverted only the first fails, on all three of its assertions. The other three pass in both states, which is the point — they guard against over-correcting. `go test ./...` across `core` is green, `go vet` clean, `go mod tidy` a no-op.
