### PR TITLE
feat(controlcenter): add wifi refresh button

### DIFF
--- a/quickshell/Modules/ControlCenter/Details/NetworkDetail.qml
+++ b/quickshell/Modules/ControlCenter/Details/NetworkDetail.qml
@@ -165,6 +165,16 @@ Rectangle {
                 }
             }
 
+            DankActionButton {
+                anchors.verticalCenter: parent.verticalCenter
+                iconName: "refresh"
+                buttonSize: 28
+                iconSize: 16
+                iconColor: Theme.surfaceVariantText
+                visible: currentConnectionType === "wifi" && NetworkService.wifiEnabled && !NetworkService.wifiToggling && !NetworkService.isScanning
+                onClicked: NetworkService.scanWifi()
+            }
+
             DankButtonGroup {
                 id: preferenceControls
                 anchors.verticalCenter: parent.verticalCenter


### PR DESCRIPTION
Add a refresh action to the Network detail header that calls NetworkService.scanWifi(), mirroring the existing button in the Settings WiFi tab. The button is hidden while WiFi is toggling or a scan is in progress, and sits left of the connection-type tabs so the tab group does not shift when switching between Ethernet, WiFi and Cellular.

## Description

Add WiFi refresh/scan button to the Control Center network detail

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Closes #3244 

## Screenshots / video

<img width="920" height="655" alt="Screenshot from 2026-09-01 02-06-01" src="https://github.com/user-attachments/assets/a5a632e9-2827-4edf-9059-c954d5f3afa0" />


## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible (N/A)
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean (N/A)
- [x] QML changes: ran `make lint-qml` with no new warnings
- [x] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs (N/A — no new config, CLI, IPC, or plugin surface; the refresh button reuses the existing `NetworkService.scanWifi()` call)
