### PR TITLE
fix(lock): do not spend a PAM attempt on an empty password submit

### DIFF
--- a/quickshell/Modules/Lock/LockScreenContent.qml
+++ b/quickshell/Modules/Lock/LockScreenContent.qml
@@ -106,6 +106,15 @@ Item {
         pam.u2f.startForAlternativeAuth();
     }
 
+    function canSubmitPassword() {
+        // Submitting an empty buffer spends a PAM attempt that cannot succeed,
+        // pushing the session towards a faillock lockout for nothing. The
+        // exception is a PAM stack DMS does not own: there the conversation
+        // itself may prompt (inline u2f/fprint), so an empty response is
+        // meaningful and Enter is how the user starts it.
+        return passwordBuffer.length > 0 || SettingsData.lockPamExternallyManaged || (pam && pam.customPamActive);
+    }
+
     function securityKeyShortcutMatches(event) {
         return SettingsData.lockScreenSecurityKeyShortcutEnabled && KeyUtils.eventMatchesCombo(event, SettingsData.lockScreenSecurityKeyShortcut);
     }
@@ -994,7 +1003,7 @@ Item {
                         activeFocusOnTab: !demoMode
                         onTextChanged: cursorPosition = text.length
                         onAccepted: {
-                            if (!demoMode && !root.unlocking && !pam.passwd.active && !pam.u2fPending) {
+                            if (!demoMode && !root.unlocking && !pam.passwd.active && !pam.u2fPending && root.canSubmitPassword()) {
                                 pam.passwd.start();
                             }
                         }
@@ -1468,7 +1477,7 @@ Item {
                         visible: (demoMode || (!pam.passwd.active && !root.unlocking && !pam.u2fPending))
                         enabled: !demoMode
                         onClicked: {
-                            if (!demoMode && !root.unlocking && !pam.u2fPending) {
+                            if (!demoMode && !root.unlocking && !pam.u2fPending && root.canSubmitPassword()) {
                                 pam.passwd.start();
                             }
                         }


### PR DESCRIPTION
## Description

`Enter` button, on an empty password field calls `pam.passwd.start()`. The attempt cannot succeed, but it still consumes a `pam_faillock` attempt, so a stray `Enter` on the lock screen moves the session towards a real lockout for nothing.

Guard both submit paths with `canSubmitPassword()`. The guard is not unconditional: an empty submit is still allowed when the PAM stack is not DMS's own (`lockPamExternallyManaged`, or a custom `lockPamPath`), because there the conversation itself may prompt for an inline u2f or fingerprint touch and Enter is how the user starts it. The DMS-managed u2f path is unaffected, since #2982 was resolved with a dedicated `lockScreenSecurityKeyShortcut` rather than bare `Enter`.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

I'm not sure yet, whether this is a breaking change or not.

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally (I've made them and use them for myself)
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [x] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
