### PR TITLE
fix(lint-qml): explain how to actually create the tooling VFS config

### DIFF
--- a/quickshell/scripts/qmllint-entrypoints.sh
+++ b/quickshell/scripts/qmllint-entrypoints.sh
@@ -66,9 +66,18 @@ read_ini_value() {
 }
 
 print_vfs_recovery() {
-    printf 'Generate it by starting the local shell config once, for example:\n' >&2
-    printf '  dms -c %q run\n' "${quickshell_dir}" >&2
+    printf 'Quickshell fills the VFS config in itself, but only into a file that already\n' >&2
+    printf 'exists; it never creates one. The nix develop shell touches it for you, so\n' >&2
+    printf 'outside that shell you have to create it yourself. The VFS also lives under\n' >&2
+    printf 'the XDG runtime directory, so a reboot removes it and leaves the file\n' >&2
+    printf 'dangling, which makes a plain touch fail. Recreate both with:\n' >&2
+    printf '  rm -f %q\n' "${qmlls_config}" >&2
+    printf '  touch %q\n' "${qmlls_config}" >&2
     printf '  qs -p %q\n' "${quickshell_dir}" >&2
+    printf '  # or: dms -c %q run\n' "${quickshell_dir}" >&2
+    printf 'The shell only has to run long enough to write the config, then:\n' >&2
+    printf '  qs kill -p %q\n' "${quickshell_dir}" >&2
+    printf 'Linting itself does not need a running shell.\n' >&2
 }
 
 if [[ -L "${qmlls_config}" && ! -e "${qmlls_config}" ]]; then


### PR DESCRIPTION
## Description

Explains how to actually create the tooling VFS config in `print_vfs_recovery`.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [x] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
