### PR TITLE
feat(dock): sync background and icons in frame overview

### DIFF
--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -369,14 +369,14 @@ Item {
         if ((!startupRevealDone && !overviewReveal) || !dock.geometryReady || !(hostWindow?.visible ?? true))
             return false;
 
-        if (_modalRetractActive || hiddenForFullscreen)
+        if (_modalRetractActive)
             return false;
 
         if (overviewReveal)
             return true;
 
-        if (!SettingsData.showDock)
-            return autoHide && hoverOrActive;
+        if (hiddenForFullscreen || !SettingsData.showDock)
+            return false;
 
         if (SettingsData.dockSmartAutoHide)
             return !shouldHideForWindows || hoverOrActive;

--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -354,30 +354,34 @@ Item {
         onTriggered: dock.startupRevealDone = true
     }
 
+    readonly property bool overviewReveal: CompositorService.isNiri && NiriService.inOverview && SettingsData.dockOpenOnOverview
+    readonly property bool hoverOrActive: dockMouseArea.containsMouse || dockApps.requestDockShow || contextMenuOpen || revealSticky
+
+    onOverviewRevealChanged: {
+        if (overviewReveal && usesConnectedFrameChrome) {
+            slideXSpring.snapTo(dockSlide.targetX);
+            slideYSpring.snapTo(dockSlide.targetY);
+            dock._syncDockChromeState();
+        }
+    }
+
     property bool reveal: {
-        const overviewReveal = CompositorService.isNiri && NiriService.inOverview && SettingsData.dockOpenOnOverview;
         if ((!startupRevealDone && !overviewReveal) || !dock.geometryReady || !(hostWindow?.visible ?? true))
             return false;
 
-        if (_modalRetractActive)
+        if (_modalRetractActive || hiddenForFullscreen)
             return false;
 
-        if (overviewReveal) {
+        if (overviewReveal)
             return true;
-        }
 
-        if (hiddenForFullscreen)
-            return false;
+        if (!SettingsData.showDock)
+            return autoHide && hoverOrActive;
 
-        // Smart auto-hide: show dock when no windows overlap, hide when they do
-        if (SettingsData.dockSmartAutoHide) {
-            if (shouldHideForWindows)
-                return dockMouseArea.containsMouse || dockApps.requestDockShow || contextMenuOpen || revealSticky;
-            return true;  // No overlapping windows - show dock
-        }
+        if (SettingsData.dockSmartAutoHide)
+            return !shouldHideForWindows || hoverOrActive;
 
-        // Regular auto-hide: always hide unless hovering
-        return !autoHide || dockMouseArea.containsMouse || dockApps.requestDockShow || contextMenuOpen || revealSticky;
+        return !autoHide || hoverOrActive;
     }
 
     onContextMenuOpenChanged: {

--- a/quickshell/Modules/Frame/FrameWindow.qml
+++ b/quickshell/Modules/Frame/FrameWindow.qml
@@ -87,7 +87,7 @@ PanelWindow {
 
     readonly property bool _connectedActive: CompositorService.usesConnectedFrameChromeForScreen(win.targetScreen)
     readonly property bool _dockHostedHere: {
-        const dockVisible = SettingsData.showDock || (CompositorService.isNiri && NiriService.inOverview && SettingsData.dockOpenOnOverview);
+        const dockVisible = SettingsData.showDock || (CompositorService.isNiri && SettingsData.dockOpenOnOverview);
         if (!win._connectedActive || !dockVisible || SettingsData.dockUseOverlayLayer)
             return false;
         const screens = SettingsData.getFilteredScreens("dock");


### PR DESCRIPTION
- Keep FrameDockHost pre-instantiated in FrameWindow when dockOpenOnOverview is enabled to eliminate QML Loader instantiation lag on overview toggle.
- Add overviewReveal property to DockBody and snap slide spring positions instantly on overview enter.
- Enforce showDock check in DockBody reveal property so dock stays hidden outside overview when showDock is disabled.

https://github.com/user-attachments/assets/08aec148-d6ff-4f40-b000-84cc82e9502c

