### PR TITLE
fix(dock): layout & indicator misalignment on orientation switch

### DIFF
--- a/quickshell/Modules/Dock/DockAppButton.qml
+++ b/quickshell/Modules/Dock/DockAppButton.qml
@@ -586,8 +586,8 @@ Item {
         Loader {
             readonly property real indicatorOffset: SettingsData.dockSpacing / 2 + 1.4
 
-            width: item ? item.width : 0
-            height: item ? item.height : 0
+            width: item ? item.implicitWidth : 0
+            height: item ? item.implicitHeight : 0
 
             x: !root.isVertical ? Math.round((parent.width - width) / 2) : (SettingsData.dockPosition === SettingsData.Position.Right ? parent.width - width + indicatorOffset : -indicatorOffset)
             y: root.isVertical ? Math.round((parent.height - height) / 2) : (SettingsData.dockPosition === SettingsData.Position.Bottom ? parent.height - height + indicatorOffset : -indicatorOffset)
@@ -602,6 +602,8 @@ Item {
 
         Row {
             spacing: Theme.spacingXXS
+            width: implicitWidth
+            height: implicitHeight
 
             Repeater {
                 model: {
@@ -660,6 +662,8 @@ Item {
 
         Column {
             spacing: Theme.spacingXXS
+            width: implicitWidth
+            height: implicitHeight
 
             Repeater {
                 model: {

--- a/quickshell/Modules/Dock/DockAppButton.qml
+++ b/quickshell/Modules/Dock/DockAppButton.qml
@@ -584,19 +584,15 @@ Item {
         }
 
         Loader {
-            anchors.horizontalCenter: SettingsData.dockPosition === SettingsData.Position.Left || SettingsData.dockPosition === SettingsData.Position.Right ? undefined : parent.horizontalCenter
-            anchors.verticalCenter: SettingsData.dockPosition === SettingsData.Position.Left || SettingsData.dockPosition === SettingsData.Position.Right ? parent.verticalCenter : undefined
-            anchors.bottom: SettingsData.dockPosition === SettingsData.Position.Bottom ? parent.bottom : undefined
-            anchors.top: SettingsData.dockPosition === SettingsData.Position.Top ? parent.top : undefined
-            anchors.left: SettingsData.dockPosition === SettingsData.Position.Left ? parent.left : undefined
-            anchors.right: SettingsData.dockPosition === SettingsData.Position.Right ? parent.right : undefined
-            anchors.bottomMargin: SettingsData.dockPosition === SettingsData.Position.Bottom ? -(SettingsData.dockSpacing / 2 + 1.4) : 0
-            anchors.topMargin: SettingsData.dockPosition === SettingsData.Position.Top ? -(SettingsData.dockSpacing / 2 + 1.4) : 0
-            anchors.leftMargin: SettingsData.dockPosition === SettingsData.Position.Left ? -(SettingsData.dockSpacing / 2 + 1.4) : 0
-            anchors.rightMargin: SettingsData.dockPosition === SettingsData.Position.Right ? -(SettingsData.dockSpacing / 2 + 1.4) : 0
+            readonly property real indicatorOffset: SettingsData.dockSpacing / 2 + 1.4
 
-            sourceComponent: SettingsData.dockPosition === SettingsData.Position.Left || SettingsData.dockPosition === SettingsData.Position.Right ? columnIndicator : rowIndicator
+            width: item ? item.width : 0
+            height: item ? item.height : 0
 
+            x: !root.isVertical ? Math.round((parent.width - width) / 2) : (SettingsData.dockPosition === SettingsData.Position.Right ? parent.width - width + indicatorOffset : -indicatorOffset)
+            y: root.isVertical ? Math.round((parent.height - height) / 2) : (SettingsData.dockPosition === SettingsData.Position.Bottom ? parent.height - height + indicatorOffset : -indicatorOffset)
+
+            sourceComponent: root.isVertical ? columnIndicator : rowIndicator
             visible: root.shouldShowIndicator
         }
     }

--- a/quickshell/Modules/Dock/DockApps.qml
+++ b/quickshell/Modules/Dock/DockApps.qml
@@ -44,6 +44,7 @@ Item {
     readonly property real baseAppHeight: iconSize
 
     clip: false
+    property bool _switchingPosition: false
     implicitWidth: isVertical ? appLayout.height : appLayout.width
     implicitHeight: isVertical ? appLayout.width : appLayout.height
 
@@ -77,6 +78,7 @@ Item {
         height: layoutFlow.height
 
         Behavior on width {
+            enabled: !root._switchingPosition
             NumberAnimation {
                 duration: Theme.shortDuration
                 easing.type: Easing.OutCubic
@@ -84,16 +86,13 @@ Item {
         }
 
         Behavior on height {
+            enabled: !root._switchingPosition
             NumberAnimation {
                 duration: Theme.shortDuration
                 easing.type: Easing.OutCubic
             }
         }
-        anchors.horizontalCenter: root.isVertical ? undefined : parent.horizontalCenter
-        anchors.verticalCenter: root.isVertical ? parent.verticalCenter : undefined
-        anchors.left: root.isVertical && SettingsData.dockPosition === SettingsData.Position.Left ? parent.left : undefined
-        anchors.right: root.isVertical && SettingsData.dockPosition === SettingsData.Position.Right ? parent.right : undefined
-        anchors.top: root.isVertical ? undefined : parent.top
+        anchors.centerIn: parent
 
         Flow {
             id: layoutFlow
@@ -722,6 +721,12 @@ Item {
 
     Connections {
         target: SettingsData
+        function onDockPositionChanged() {
+            root._switchingPosition = true;
+            Qt.callLater(() => {
+                root._switchingPosition = false;
+            });
+        }
         function onDockIsolateDisplaysChanged() {
             repeater.updateModel();
         }

--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -403,10 +403,16 @@ Item {
     onHeightChanged: dock._syncDockChromeState()
     onVisibleChanged: dock._syncDockChromeState()
     onHasAppsChanged: dock._syncDockChromeState()
+    property bool _switchingPosition: false
+
     onConnectedBarSideChanged: {
+        dock._switchingPosition = true;
         slideXSpring.snapTo(dock.isVertical ? dockSlide.targetX : 0);
         slideYSpring.snapTo(!dock.isVertical ? dockSlide.targetY : 0);
         dockChromeSync.schedule();
+        Qt.callLater(() => {
+            dock._switchingPosition = false;
+        });
     }
     onUsesConnectedFrameChromeChanged: dock._syncDockChromeState()
 
@@ -627,7 +633,7 @@ Item {
 
             height: {
                 if (dock.isVertical) {
-                    const h = dockApps.implicitHeight + SettingsData.dockSpacing * 2;
+                    const h = dockApps.implicitWidth + SettingsData.dockSpacing * 2;
                     return Math.min(Math.max(h + 64, 200), maxDockHeight);
                 }
                 return dock.reveal ? Theme.px(dockGeometry.motionThickness, _dpr) : 1;
@@ -645,6 +651,7 @@ Item {
             acceptedButtons: Qt.NoButton
 
             Behavior on height {
+                enabled: !dock._switchingPosition
                 NumberAnimation {
                     duration: Theme.shortDuration
                     easing.type: Easing.OutCubic
@@ -652,6 +659,7 @@ Item {
             }
 
             Behavior on width {
+                enabled: !dock._switchingPosition
                 NumberAnimation {
                     duration: Theme.shortDuration
                     easing.type: Easing.OutCubic
@@ -753,10 +761,10 @@ Item {
                     }
 
                     // Sync dockBackground geometry to ConnectedModeState
-                    onXChanged: dock._syncDockChromeState()
-                    onYChanged: dock._syncDockChromeState()
-                    onWidthChanged: dock._syncDockChromeState()
-                    onHeightChanged: dock._syncDockChromeState()
+                    onXChanged: dockChromeSync.schedule()
+                    onYChanged: dockChromeSync.schedule()
+                    onWidthChanged: dockChromeSync.schedule()
+                    onHeightChanged: dockChromeSync.schedule()
                 }
 
                 Item {

--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -403,7 +403,11 @@ Item {
     onHeightChanged: dock._syncDockChromeState()
     onVisibleChanged: dock._syncDockChromeState()
     onHasAppsChanged: dock._syncDockChromeState()
-    onConnectedBarSideChanged: dock._syncDockChromeState()
+    onConnectedBarSideChanged: {
+        slideXSpring.snapTo(dock.isVertical ? dockSlide.targetX : 0);
+        slideYSpring.snapTo(!dock.isVertical ? dockSlide.targetY : 0);
+        dockChromeSync.schedule();
+    }
     onUsesConnectedFrameChromeChanged: dock._syncDockChromeState()
 
     Connections {
@@ -623,8 +627,8 @@ Item {
 
             height: {
                 if (dock.isVertical) {
-                    // Keep the taller hit area regardless of the reveal state to prevent shrinking loop
-                    return Math.min(Math.max(dockBackground.height + 64, 200), maxDockHeight);
+                    const h = dockApps.implicitHeight + SettingsData.dockSpacing * 2;
+                    return Math.min(Math.max(h + 64, 200), maxDockHeight);
                 }
                 return dock.reveal ? Theme.px(dockGeometry.motionThickness, _dpr) : 1;
             }
@@ -632,17 +636,11 @@ Item {
                 if (dock.isVertical) {
                     return dock.reveal ? Theme.px(dockGeometry.motionThickness, _dpr) : 1;
                 }
-                // Keep the wider hit area regardless of the reveal state to prevent shrinking loop
-                return Math.min(dockBackground.width + 8 + dock.borderThickness, maxDockWidth);
+                const w = dockApps.implicitWidth + SettingsData.dockSpacing * 2;
+                return Math.min(w + 8 + dock.borderThickness, maxDockWidth);
             }
-            anchors {
-                top: !dock.isVertical ? (SettingsData.dockPosition === SettingsData.Position.Bottom ? undefined : parent.top) : undefined
-                bottom: !dock.isVertical ? (SettingsData.dockPosition === SettingsData.Position.Bottom ? parent.bottom : undefined) : undefined
-                horizontalCenter: !dock.isVertical ? parent.horizontalCenter : undefined
-                left: dock.isVertical ? (SettingsData.dockPosition === SettingsData.Position.Right ? undefined : parent.left) : undefined
-                right: dock.isVertical ? (SettingsData.dockPosition === SettingsData.Position.Right ? parent.right : undefined) : undefined
-                verticalCenter: dock.isVertical ? parent.verticalCenter : undefined
-            }
+            x: !dock.isVertical ? Math.round((parent.width - width) / 2) : (SettingsData.dockPosition === SettingsData.Position.Right ? parent.width - width : 0)
+            y: dock.isVertical ? Math.round((parent.height - height) / 2) : (SettingsData.dockPosition === SettingsData.Position.Bottom ? parent.height - height : 0)
             hoverEnabled: true
             acceptedButtons: Qt.NoButton
 
@@ -659,6 +657,9 @@ Item {
                     easing.type: Easing.OutCubic
                 }
             }
+
+            onXChanged: dockChromeSync.schedule()
+            onYChanged: dockChromeSync.schedule()
 
             Item {
                 id: dockContainer
@@ -702,8 +703,8 @@ Item {
                         }
                     }
 
-                    x: slideXSpring.value
-                    y: slideYSpring.value
+                    x: dock.isVertical ? slideXSpring.value : 0
+                    y: !dock.isVertical ? slideYSpring.value : 0
 
                     onTargetXChanged: slideXSpring.retarget(targetX)
                     onTargetYChanged: slideYSpring.retarget(targetY)
@@ -716,18 +717,8 @@ Item {
                     id: dockBackground
                     objectName: "dockBackground"
                     visible: dock.hasApps
-                    anchors {
-                        top: !dock.isVertical ? (SettingsData.dockPosition === SettingsData.Position.Top ? parent.top : undefined) : undefined
-                        bottom: !dock.isVertical ? (SettingsData.dockPosition === SettingsData.Position.Bottom ? parent.bottom : undefined) : undefined
-                        horizontalCenter: !dock.isVertical ? parent.horizontalCenter : undefined
-                        left: dock.isVertical ? (SettingsData.dockPosition === SettingsData.Position.Left ? parent.left : undefined) : undefined
-                        right: dock.isVertical ? (SettingsData.dockPosition === SettingsData.Position.Right ? parent.right : undefined) : undefined
-                        verticalCenter: dock.isVertical ? parent.verticalCenter : undefined
-                    }
-                    anchors.topMargin: !dock.isVertical && SettingsData.dockPosition === SettingsData.Position.Top ? dockGeometry.bodyEdgeMargin : 0
-                    anchors.bottomMargin: !dock.isVertical && SettingsData.dockPosition === SettingsData.Position.Bottom ? dockGeometry.bodyEdgeMargin : 0
-                    anchors.leftMargin: dock.isVertical && SettingsData.dockPosition === SettingsData.Position.Left ? dockGeometry.bodyEdgeMargin : 0
-                    anchors.rightMargin: dock.isVertical && SettingsData.dockPosition === SettingsData.Position.Right ? dockGeometry.bodyEdgeMargin : 0
+                    x: !dock.isVertical ? Math.round((parent.width - width) / 2) : (SettingsData.dockPosition === SettingsData.Position.Right ? parent.width - width - dockGeometry.bodyEdgeMargin : dockGeometry.bodyEdgeMargin)
+                    y: dock.isVertical ? Math.round((parent.height - height) / 2) : (SettingsData.dockPosition === SettingsData.Position.Bottom ? parent.height - height - dockGeometry.bodyEdgeMargin : dockGeometry.bodyEdgeMargin)
 
                     implicitWidth: dock.isVertical ? (dockApps.implicitHeight + SettingsData.dockSpacing * 2) : (dockApps.implicitWidth + SettingsData.dockSpacing * 2)
                     implicitHeight: dock.isVertical ? (dockApps.implicitWidth + SettingsData.dockSpacing * 2) : (dockApps.implicitHeight + SettingsData.dockSpacing * 2)
@@ -865,16 +856,9 @@ Item {
                 DockApps {
                     id: dockApps
 
-                    anchors.top: !dock.isVertical ? (SettingsData.dockPosition === SettingsData.Position.Top ? dockBackground.top : undefined) : undefined
-                    anchors.bottom: !dock.isVertical ? (SettingsData.dockPosition === SettingsData.Position.Bottom ? dockBackground.bottom : undefined) : undefined
-                    anchors.horizontalCenter: !dock.isVertical ? dockBackground.horizontalCenter : undefined
-                    anchors.left: dock.isVertical ? (SettingsData.dockPosition === SettingsData.Position.Left ? dockBackground.left : undefined) : undefined
-                    anchors.right: dock.isVertical ? (SettingsData.dockPosition === SettingsData.Position.Right ? dockBackground.right : undefined) : undefined
-                    anchors.verticalCenter: dock.isVertical ? dockBackground.verticalCenter : undefined
-                    anchors.topMargin: !dock.isVertical ? SettingsData.dockSpacing : 0
-                    anchors.bottomMargin: !dock.isVertical ? SettingsData.dockSpacing : 0
-                    anchors.leftMargin: dock.isVertical ? SettingsData.dockSpacing : 0
-                    anchors.rightMargin: dock.isVertical ? SettingsData.dockSpacing : 0
+                    width: dock.isVertical ? implicitHeight : implicitWidth
+                    height: dock.isVertical ? implicitWidth : implicitHeight
+                    anchors.centerIn: dockBackground
 
                     contextMenu: dock.contextMenu
                     trashContextMenu: dock.trashContextMenu


### PR DESCRIPTION
Fixes a regression where switching dock orientation between vertical (Left/Right) and horizontal (Bottom) in connected frame mode caused the dock background to stretch across the entire screen, render a solid surface color mask over the workspace cutout in overview, or misalign the running app indicator dots.