### PR TITLE
fix(bar): centre widget content on whole pixels

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -2304,7 +2304,7 @@ Singleton {
                 continue;
             const otherSpacing = other.spacing !== undefined ? other.spacing : (defaultBar?.spacing ?? 4);
             const otherPadding = other.innerPadding !== undefined ? other.innerPadding : (defaultBar?.innerPadding ?? 4);
-            const otherThickness = Math.max(26 + otherPadding * 0.6, Theme.barHeight - 4 - (8 - otherPadding)) + otherSpacing;
+            const otherThickness = Theme.barThickness(otherPadding, CompositorService.getScreenScale(screen)) + otherSpacing;
 
             const useAutoGaps = other.popupGapsAuto !== undefined ? other.popupGapsAuto : (defaultBar?.popupGapsAuto ?? true);
             const manualGap = other.popupGapsManual !== undefined ? other.popupGapsManual : (defaultBar?.popupGapsManual ?? 4);
@@ -2380,7 +2380,7 @@ Singleton {
                     continue;
                 const otherSpacing = other.spacing !== undefined ? other.spacing : (defaultBar?.spacing ?? 4);
                 const otherPadding = other.innerPadding !== undefined ? other.innerPadding : (defaultBar?.innerPadding ?? 4);
-                const otherThickness = Math.max(26 + otherPadding * 0.6, Theme.barHeight - 4 - (8 - otherPadding)) + otherSpacing + wingSize;
+                const otherThickness = Theme.barThickness(otherPadding, CompositorService.getScreenScale(screen)) + otherSpacing + wingSize;
                 const otherBottomGap = isConnected ? 0 : (other.bottomGap !== undefined ? other.bottomGap : (defaultBar?.bottomGap ?? 0));
 
                 switch (other.position) {

--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -1517,7 +1517,7 @@ Singleton {
         const size = (maximizeIcon ?? false) ? iconSizeLarge : iconSize;
         const s = iconScale !== undefined ? iconScale : 1.0;
 
-        return Math.round((barThickness / 48) * (size + defaultOffset) * s);
+        return 2 * Math.round((barThickness / 48) * (size + defaultOffset) * s / 2);
     }
 
     function barTextSize(barThickness, fontScale, maximizeText) {
@@ -2078,6 +2078,13 @@ Singleton {
     function snap(value, dpr) {
         const s = dpr || 1;
         return Math.round(value * s) / s;
+    }
+
+    // Whole pairs of pixels. Qt rounds the offset of a centred anchor to whole
+    // pixels, so anything that content gets centred in has to keep its parity
+    // aligned with that content or the content lands on a half pixel.
+    function snapEven(value) {
+        return 2 * Math.round(value / 2);
     }
 
     function px(value, dpr) {

--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -1520,6 +1520,11 @@ Singleton {
         return 2 * Math.round((barThickness / 48) * (size + defaultOffset) * s / 2);
     }
 
+    // A widget that carries no icon, the clock above all, is centred as a whole
+    // line box, so the same parity rule as snapEven applies to it. At
+    // fontSizeSmall that box is 15 px tall and has no exact centre in an even
+    // pill, one step up it is 16 px and the widget lands on the grid. The 0.9
+    // branch already comes out at 14 px and stays where it is.
     function barTextSize(barThickness, fontScale, maximizeText) {
         const scale = barThickness / 48;
         const dankBarScale = fontScale !== undefined ? fontScale : 1.0;
@@ -1528,7 +1533,7 @@ Singleton {
             return Math.round(fontSizeSmall * 0.9 * dankBarScale * maxScale);
         if (scale >= 1.25)
             return Math.round(fontSizeMedium * dankBarScale * maxScale);
-        return Math.round(fontSizeSmall * dankBarScale * maxScale);
+        return Math.round((fontSizeSmall + 1) * dankBarScale * maxScale);
     }
 
     function getBatteryIcon(level, isCharging, batteryAvailable) {

--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -2111,6 +2111,14 @@ Singleton {
         return Math.round(value * s) / s;
     }
 
+    function barWidgetThickness(innerPadding, dpr) {
+        return snapEven(Math.max(20, 26 + innerPadding * 0.6), dpr);
+    }
+
+    function barThickness(innerPadding, dpr) {
+        return snapEven(Math.max(barWidgetThickness(innerPadding, dpr) + innerPadding + 4, barHeight - 4 - (8 - innerPadding)), dpr);
+    }
+
     function hairline(dpr) {
         return 1 / (dpr || 1);
     }

--- a/quickshell/Common/Theme.qml
+++ b/quickshell/Common/Theme.qml
@@ -1520,20 +1520,35 @@ Singleton {
         return 2 * Math.round((barThickness / 48) * (size + defaultOffset) * s / 2);
     }
 
-    // A widget that carries no icon, the clock above all, is centred as a whole
-    // line box, so the same parity rule as snapEven applies to it. At
-    // fontSizeSmall that box is 15 px tall and has no exact centre in an even
-    // pill, one step up it is 16 px and the widget lands on the grid. The 0.9
-    // branch already comes out at 14 px and stays where it is.
     function barTextSize(barThickness, fontScale, maximizeText) {
         const scale = barThickness / 48;
         const dankBarScale = fontScale !== undefined ? fontScale : 1.0;
         const maxScale = (maximizeText ?? false) ? 1.5 : 1.0;
         if (scale <= 0.75)
-            return Math.round(fontSizeSmall * 0.9 * dankBarScale * maxScale);
+            return evenLineBoxSize(Math.round(fontSizeSmall * 0.9 * dankBarScale * maxScale));
         if (scale >= 1.25)
-            return Math.round(fontSizeMedium * dankBarScale * maxScale);
-        return Math.round((fontSizeSmall + 1) * dankBarScale * maxScale);
+            return evenLineBoxSize(Math.round(fontSizeMedium * dankBarScale * maxScale));
+        return evenLineBoxSize(Math.round(fontSizeSmall * dankBarScale * maxScale));
+    }
+
+    FontMetrics {
+        id: lineBoxProbe
+    }
+
+    // Text.implicitHeight is ceil(FontMetrics.height); probe.font is written whole and read via boundingRect() so bindings capture no dependency on the probe
+    function lineBoxHeight(pixelSize) {
+        lineBoxProbe.font = Qt.font({
+            family: fontFamily,
+            weight: fontWeight,
+            pixelSize: pixelSize
+        });
+        return Math.ceil(lineBoxProbe.boundingRect("0").height);
+    }
+
+    function evenLineBoxSize(pixelSize) {
+        if (lineBoxHeight(pixelSize) % 2 === 0)
+            return pixelSize;
+        return lineBoxHeight(pixelSize + 1) % 2 === 0 ? pixelSize + 1 : pixelSize;
     }
 
     function getBatteryIcon(level, isCharging, batteryAvailable) {
@@ -2085,11 +2100,10 @@ Singleton {
         return Math.round(value * s) / s;
     }
 
-    // Whole pairs of pixels. Qt rounds the offset of a centred anchor to whole
-    // pixels, so anything that content gets centred in has to keep its parity
-    // aligned with that content or the content lands on a half pixel.
-    function snapEven(value) {
-        return 2 * Math.round(value / 2);
+    // Qt rounds a centred anchor offset to whole pixels, so a box must share its content's parity
+    function snapEven(value, dpr) {
+        const s = dpr || 1;
+        return 2 * Math.round(value * s / 2) / s;
     }
 
     function px(value, dpr) {

--- a/quickshell/Modals/PowerMenuModal.qml
+++ b/quickshell/Modals/PowerMenuModal.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import qs.Common
 import qs.Modals.Common
+import qs.Services
 import qs.Modules.PowerMenu
 
 DankModal {
@@ -38,8 +39,7 @@ DankModal {
     customPosition: {
         if (parentBounds.width > 0) {
             const bar = SettingsData.getPrimaryBarConfig();
-            const barPadding = bar?.innerPadding ?? 4;
-            const effectiveBarThickness = Math.max(26 + barPadding * 0.6 + barPadding + 4, Theme.barHeight - 4 - (8 - barPadding));
+            const effectiveBarThickness = Theme.barThickness(bar?.innerPadding ?? 4, CompositorService.getScreenScale(parentScreen));
             const barExclusionZone = effectiveBarThickness + (bar?.spacing ?? 4) + (bar?.bottomGap ?? 0);
             const barPosition = bar?.position ?? SettingsData.Position.Top;
             const screenW = parentScreen?.width ?? 1920;

--- a/quickshell/Modules/DankBar/DankBarBody.qml
+++ b/quickshell/Modules/DankBar/DankBarBody.qml
@@ -611,7 +611,7 @@ Item {
         return length > 0 ? Math.min(pad, Math.max(0, length / 2 - effectiveSpacing)) : pad;
     }
     readonly property bool effectiveOpenOnOverview: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? SettingsData.frameShowOnOverview : (barConfig?.openOnOverview ?? false)
-    readonly property real widgetThickness: Theme.snapEven(Math.max(20, 26 + (barConfig?.innerPadding ?? 4) * 0.6))
+    readonly property real widgetThickness: Theme.snapEven(Math.max(20, 26 + (barConfig?.innerPadding ?? 4) * 0.6), _dpr)
 
     readonly property bool hasAdjacentTopBar: {
         if (barConfig?.autoHide ?? false)

--- a/quickshell/Modules/DankBar/DankBarBody.qml
+++ b/quickshell/Modules/DankBar/DankBarBody.qml
@@ -611,7 +611,7 @@ Item {
         return length > 0 ? Math.min(pad, Math.max(0, length / 2 - effectiveSpacing)) : pad;
     }
     readonly property bool effectiveOpenOnOverview: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? SettingsData.frameShowOnOverview : (barConfig?.openOnOverview ?? false)
-    readonly property real widgetThickness: Theme.snap(Math.max(20, 26 + (barConfig?.innerPadding ?? 4) * 0.6), _dpr)
+    readonly property real widgetThickness: Theme.snapEven(Math.max(20, 26 + (barConfig?.innerPadding ?? 4) * 0.6))
 
     readonly property bool hasAdjacentTopBar: {
         if (barConfig?.autoHide ?? false)

--- a/quickshell/Modules/DankBar/DankBarBody.qml
+++ b/quickshell/Modules/DankBar/DankBarBody.qml
@@ -602,7 +602,7 @@ Item {
     }
 
     readonly property int notificationCount: NotificationService.notifications.length
-    readonly property real effectiveBarThickness: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? SettingsData.frameBarSize : Theme.snapEven(Math.max(barWindow.widgetThickness + (barConfig?.innerPadding ?? 4) + 4, Theme.barHeight - 4 - (8 - (barConfig?.innerPadding ?? 4))), _dpr)
+    readonly property real effectiveBarThickness: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? SettingsData.frameBarSize : Theme.barThickness(barConfig?.innerPadding ?? 4, _dpr)
     readonly property real effectiveBarLengthPadding: {
         if ((FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) || (flattenForMaximizedWindow && hasMaximizedToplevel))
             return 0;
@@ -611,7 +611,7 @@ Item {
         return length > 0 ? Math.min(pad, Math.max(0, length / 2 - effectiveSpacing)) : pad;
     }
     readonly property bool effectiveOpenOnOverview: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? SettingsData.frameShowOnOverview : (barConfig?.openOnOverview ?? false)
-    readonly property real widgetThickness: Theme.snapEven(Math.max(20, 26 + (barConfig?.innerPadding ?? 4) * 0.6), _dpr)
+    readonly property real widgetThickness: Theme.barWidgetThickness(barConfig?.innerPadding ?? 4, _dpr)
 
     readonly property bool hasAdjacentTopBar: {
         if (barConfig?.autoHide ?? false)

--- a/quickshell/Modules/DankBar/DankBarBody.qml
+++ b/quickshell/Modules/DankBar/DankBarBody.qml
@@ -602,7 +602,7 @@ Item {
     }
 
     readonly property int notificationCount: NotificationService.notifications.length
-    readonly property real effectiveBarThickness: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? SettingsData.frameBarSize : Theme.snap(Math.max(barWindow.widgetThickness + (barConfig?.innerPadding ?? 4) + 4, Theme.barHeight - 4 - (8 - (barConfig?.innerPadding ?? 4))), _dpr)
+    readonly property real effectiveBarThickness: (FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) ? SettingsData.frameBarSize : Theme.snapEven(Math.max(barWindow.widgetThickness + (barConfig?.innerPadding ?? 4) + 4, Theme.barHeight - 4 - (8 - (barConfig?.innerPadding ?? 4))), _dpr)
     readonly property real effectiveBarLengthPadding: {
         if ((FrameTransitionState.effectiveFrameEnabled && usesFrameBarChrome) || (flattenForMaximizedWindow && hasMaximizedToplevel))
             return 0;

--- a/quickshell/Modules/DankBar/Widgets/AppsDock.qml
+++ b/quickshell/Modules/DankBar/Widgets/AppsDock.qml
@@ -39,9 +39,7 @@ BasePill {
         if (barThickness > 0 && barSpacing > 0) {
             return barThickness + barSpacing;
         }
-        const innerPadding = barConfig?.innerPadding ?? 4;
-        const spacing = barConfig?.spacing ?? 4;
-        return Math.max(26 + innerPadding * 0.6, Theme.barHeight - 4 - (8 - innerPadding)) + spacing;
+        return Theme.barThickness(barConfig?.innerPadding ?? 4, CompositorService.getScreenScale(parentScreen)) + (barConfig?.spacing ?? 4);
     }
 
     readonly property var barBounds: {

--- a/quickshell/Modules/DankBar/Widgets/RunningApps.qml
+++ b/quickshell/Modules/DankBar/Widgets/RunningApps.qml
@@ -34,9 +34,7 @@ BasePill {
         if (barThickness > 0 && barSpacing > 0) {
             return barThickness + barSpacing;
         }
-        const innerPadding = barConfig?.innerPadding ?? 4;
-        const spacing = barConfig?.spacing ?? 4;
-        return Math.max(26 + innerPadding * 0.6, Theme.barHeight - 4 - (8 - innerPadding)) + spacing;
+        return Theme.barThickness(barConfig?.innerPadding ?? 4, CompositorService.getScreenScale(parentScreen)) + (barConfig?.spacing ?? 4);
     }
 
     readonly property var barBounds: {
@@ -784,7 +782,7 @@ BasePill {
                 if (triggerBarThickness > 0 && triggerBarSpacing > 0) {
                     return triggerBarThickness + triggerBarSpacing;
                 }
-                return Math.max(26 + (barConfig?.innerPadding ?? 4) * 0.6, Theme.barHeight - 4 - (8 - (barConfig?.innerPadding ?? 4))) + (barConfig?.spacing ?? 4);
+                return Theme.barThickness(barConfig?.innerPadding ?? 4, CompositorService.getScreenScale(contextMenuWindow.screen)) + (barConfig?.spacing ?? 4);
             }
 
             property var barBounds: {

--- a/quickshell/Modules/DankIsland/IslandSatelliteHost.qml
+++ b/quickshell/Modules/DankIsland/IslandSatelliteHost.qml
@@ -35,8 +35,8 @@ Item {
     readonly property string scrollYBehavior: satelliteConfig?.scrollYBehavior ?? "workspace"
     readonly property real screenScale: CompositorService.getScreenScale(root.targetScreen)
     readonly property real innerPadding: root.satelliteConfig?.innerPadding ?? 4
-    readonly property real widgetThickness: Theme.snapEven(Math.max(20, 26 + root.innerPadding * 0.6), root.screenScale)
-    readonly property real barThickness: Theme.snapEven(Math.max(root.widgetThickness + root.innerPadding + 4, Theme.barHeight - 4 - (8 - root.innerPadding)), root.screenScale)
+    readonly property real widgetThickness: Theme.barWidgetThickness(root.innerPadding, root.screenScale)
+    readonly property real barThickness: Theme.barThickness(root.innerPadding, root.screenScale)
     readonly property real satelliteSpacing: root.satelliteConfig?.spacing ?? 4
     readonly property bool edgeAligned: SettingsData.dankIslandSatellitePosition === "edges"
     readonly property real edgeBaseMargin: Math.max(Theme.spacingXS, root.innerPadding * 0.8)

--- a/quickshell/Modules/DankIsland/IslandSatelliteHost.qml
+++ b/quickshell/Modules/DankIsland/IslandSatelliteHost.qml
@@ -36,7 +36,7 @@ Item {
     readonly property real screenScale: CompositorService.getScreenScale(root.targetScreen)
     readonly property real innerPadding: root.satelliteConfig?.innerPadding ?? 4
     readonly property real widgetThickness: Theme.snapEven(Math.max(20, 26 + root.innerPadding * 0.6), root.screenScale)
-    readonly property real barThickness: Theme.snap(Math.max(root.widgetThickness + root.innerPadding + 4, Theme.barHeight - 4 - (8 - root.innerPadding)), root.screenScale)
+    readonly property real barThickness: Theme.snapEven(Math.max(root.widgetThickness + root.innerPadding + 4, Theme.barHeight - 4 - (8 - root.innerPadding)), root.screenScale)
     readonly property real satelliteSpacing: root.satelliteConfig?.spacing ?? 4
     readonly property bool edgeAligned: SettingsData.dankIslandSatellitePosition === "edges"
     readonly property real edgeBaseMargin: Math.max(Theme.spacingXS, root.innerPadding * 0.8)

--- a/quickshell/Modules/DankIsland/IslandSatelliteHost.qml
+++ b/quickshell/Modules/DankIsland/IslandSatelliteHost.qml
@@ -35,7 +35,7 @@ Item {
     readonly property string scrollYBehavior: satelliteConfig?.scrollYBehavior ?? "workspace"
     readonly property real screenScale: CompositorService.getScreenScale(root.targetScreen)
     readonly property real innerPadding: root.satelliteConfig?.innerPadding ?? 4
-    readonly property real widgetThickness: Theme.snap(Math.max(20, 26 + root.innerPadding * 0.6), root.screenScale)
+    readonly property real widgetThickness: Theme.snapEven(Math.max(20, 26 + root.innerPadding * 0.6), root.screenScale)
     readonly property real barThickness: Theme.snap(Math.max(root.widgetThickness + root.innerPadding + 4, Theme.barHeight - 4 - (8 - root.innerPadding)), root.screenScale)
     readonly property real satelliteSpacing: root.satelliteConfig?.spacing ?? 4
     readonly property bool edgeAligned: SettingsData.dankIslandSatellitePosition === "edges"

--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -44,7 +44,7 @@ Item {
     function getBarHeight(barConfig) {
         if (!barConfig)
             return 0;
-        const barThickness = Theme.barThickness(barConfig.innerPadding ?? 4, dock._dpr);
+        const barThickness = Theme.barThickness(barConfig.innerPadding ?? 4, CompositorService.getScreenScale(dock.screen));
         const spacing = barConfig.spacing ?? 4;
         const bottomGap = barConfig.bottomGap ?? 0;
         return barThickness + spacing + bottomGap;

--- a/quickshell/Modules/Dock/DockBody.qml
+++ b/quickshell/Modules/Dock/DockBody.qml
@@ -44,9 +44,7 @@ Item {
     function getBarHeight(barConfig) {
         if (!barConfig)
             return 0;
-        const innerPadding = barConfig.innerPadding ?? 4;
-        const widgetThickness = Math.max(20, 26 + innerPadding * 0.6);
-        const barThickness = Math.max(widgetThickness + innerPadding + 4, Theme.barHeight - 4 - (8 - innerPadding));
+        const barThickness = Theme.barThickness(barConfig.innerPadding ?? 4, dock._dpr);
         const spacing = barConfig.spacing ?? 4;
         const bottomGap = barConfig.bottomGap ?? 0;
         return barThickness + spacing + bottomGap;

--- a/quickshell/Widgets/DankOSD.qml
+++ b/quickshell/Widgets/DankOSD.qml
@@ -140,8 +140,7 @@ PanelWindow {
             if (!SettingsData.barConfigCoversScreen(bc, screen))
                 continue;
             const innerPadding = bc.innerPadding ?? (defaultBar?.innerPadding ?? 4);
-            const widgetThickness = Math.max(20, 26 + innerPadding * 0.6);
-            const thickness = Math.max(widgetThickness + innerPadding + 4, Theme.barHeight - 4 - (8 - innerPadding));
+            const thickness = Theme.barThickness(innerPadding, dpr);
             const spacing = bc.spacing ?? (defaultBar?.spacing ?? 4);
             const bottomGap = bc.bottomGap ?? (defaultBar?.bottomGap ?? 0);
             const offset = thickness + spacing + bottomGap;

--- a/quickshell/Widgets/DankPopoutConnected.qml
+++ b/quickshell/Widgets/DankPopoutConnected.qml
@@ -72,8 +72,7 @@ Item {
     readonly property real effectiveBarThickness: {
         if (root.usesConnectedSurfaceChrome)
             return Math.max(0, storedBarThickness);
-        const padding = storedBarConfig ? (storedBarConfig.innerPadding !== undefined ? storedBarConfig.innerPadding : 4) : 4;
-        return Math.max(26 + padding * 0.6, Theme.barHeight - 4 - (8 - padding)) + storedBarSpacing;
+        return Theme.barThickness(storedBarConfig?.innerPadding ?? 4, dpr) + storedBarSpacing;
     }
 
     readonly property var barBounds: {

--- a/quickshell/Widgets/DankPopoutStandalone.qml
+++ b/quickshell/Widgets/DankPopoutStandalone.qml
@@ -104,8 +104,7 @@ Item {
     }
 
     readonly property real effectiveBarThickness: {
-        const padding = storedBarConfig ? (storedBarConfig.innerPadding !== undefined ? storedBarConfig.innerPadding : 4) : 4;
-        return Math.max(26 + padding * 0.6, Theme.barHeight - 4 - (8 - padding)) + storedBarSpacing;
+        return Theme.barThickness(storedBarConfig?.innerPadding ?? 4, dpr) + storedBarSpacing;
     }
 
     readonly property var barBounds: {


### PR DESCRIPTION
## Description

Bar widgets centre their content inside a box of `widgetThickness - horizontalPadding * 2`, and Qt rounds the offset of a centred anchor to whole pixels. When the content and that box have different parity the exact offset falls on a half pixel, Qt rounds it away from zero, and the content renders half a pixel above the centre. Widgets drawn from rectangles, the workspace switcher above all, compute their own snapped height and stay exactly centred, which is why they look right next to everything else in the issue.

With the stock configuration this is the normal case, not an edge case. The bar is 40 px, the content box is 14 px, and `barIconSize` returns `round((40 / 48) * 18) = 15`.

Two commits, and they are independent of each other.

**1. `fix(bar): keep widget content on whole pixels`.** The icon size and `widgetThickness` now round to whole pairs of pixels. The box inherits its parity from `widgetThickness` because the padding is doubled and can never change it, so this makes the two agree. Going through every `innerPadding` from 0 to 16, nine of the seventeen configurations currently put the icon on a half pixel and none of them do afterwards. The 48 px default bar is untouched, the sizes that do change move by one pixel.

**2. `fix(bar): give bar text a line box that can be centred`.** A widget without an icon is centred as one line box, and the same rule applies to it. At `fontSizeSmall` that box is 15 px tall, so on a 28 px pill it has no exact centre no matter how the offset is rounded. One step up it is 16 px and the clock lands on the grid. Only the branch the standard bar uses changes, the 0.9 branch already comes out at 14 px and the `fontSizeMedium` branch is left alone because there the next even box is two steps away. This is the visible half of the PR, the bar font goes from 12 px to 13 px, which is why it is separate and can be dropped on its own.

## Measurements

Nested Hyprland at scale 1, same session for both runs, ink centroid of the widget content relative to the centre of its pill:

| widget | before | after |
|---|---|---|
| app launcher | -0.50 | +0.00 |
| clock and date | -0.58 | +0.05 |
| weather | -0.82 | -0.28 |
| battery | -0.63 | -0.05 |
| bluetooth and volume | -0.52 | -0.03 |
| clipboard | -1.49 | -0.93 |
| notifications | +0.03 | +0.46 |

The last two do not land on zero and are not meant to. I rendered the same glyphs separately at an exact position and `content_paste` measures -0.87 and `notifications` +0.42 there, so what is left is the ink asymmetry of those two glyphs, the paste icon carries its tab at the top and the bell its clapper at the bottom. That part is in the font, not in the placement.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Closes #3074

## Screenshots / video

The bar with both commits, 1:1:

![bar with both changes](https://raw.githubusercontent.com/Mario-Mohar/DankMaterialShell/pr-screenshots/3074-balken-1zu1.png)

Before and after at eight times magnification, the red line is the exact centre of the pill:

![before and after](https://raw.githubusercontent.com/Mario-Mohar/DankMaterialShell/pr-screenshots/3074-vorher-nachher.png)

## Not covered

Two things I left out on purpose rather than guess at them. On a fractional or HiDPI scale `horizontalPadding` can itself land on a half pixel, which puts the box back between the grid lines, and `IslandSatelliteHost` carries the same `widgetThickness` expression but I have not tested that surface, so I did not touch it.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors

No new strings and no Go changes in this one. `make lint-qml` needs a `.qmlls.ini` that only a full installation produces, so I ran `qmllint` directly on both files instead and the only warnings are the unresolved `qs.*` imports that every file in the tree produces without it. Nothing new to document either, the behaviour is unchanged, only the pixel it lands on.
