### PR TITLE
bluetooth: route headset controls to the active player

### DIFF
--- a/core/internal/server/bluez/handlers.go
+++ b/core/internal/server/bluez/handlers.go
@@ -1,7 +1,9 @@
 package bluez
 
 import (
+	"encoding/json"
 	"fmt"
+	"math"
 
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/models"
 	"github.com/AvengeMedia/dankgo/ipc/params"
@@ -43,6 +45,8 @@ func HandleRequest(conn *models.Conn, req models.Request, manager *Manager) {
 		handleUntrustDevice(conn, req, manager)
 	case "bluetooth.subscribe":
 		handleSubscribe(conn, req, manager)
+	case "bluetooth.mpris.publish":
+		handleMPRISPublish(conn, req, manager)
 	case "bluetooth.pairing.submit":
 		handlePairingSubmit(conn, req, manager)
 	case "bluetooth.pairing.cancel":
@@ -54,6 +58,100 @@ func HandleRequest(conn *models.Conn, req models.Request, manager *Manager) {
 
 func handleGetState(conn *models.Conn, req models.Request, manager *Manager) {
 	models.Respond(conn, req.ID, manager.GetState())
+}
+
+func handleMPRISPublish(conn *models.Conn, req models.Request, manager *Manager) {
+	lease, err := params.String(req.Params, "lease")
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+	snapshot, err := playerSnapshotFromParams(req.Params)
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+	if err := manager.PublishMPRIS(lease, snapshot); err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+	models.Respond(conn, req.ID, models.SuccessResult{Success: true, Message: "MPRIS state published"})
+}
+
+func playerSnapshotFromParams(values map[string]any) (PlayerSnapshot, error) {
+	var snapshot PlayerSnapshot
+	var err error
+	if snapshot.Enabled, err = params.Bool(values, "enabled"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if snapshot.Identity, err = params.String(values, "identity"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if snapshot.PlaybackStatus, err = params.String(values, "playbackStatus"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if snapshot.Title, err = params.String(values, "title"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if snapshot.Artist, err = params.String(values, "artist"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if snapshot.Album, err = params.String(values, "album"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if snapshot.Length, err = int64Param(values, "length"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if snapshot.Position, err = int64Param(values, "position"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if snapshot.CanControl, err = params.Bool(values, "canControl"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if snapshot.CanPlay, err = params.Bool(values, "canPlay"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if snapshot.CanPause, err = params.Bool(values, "canPause"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if snapshot.CanGoNext, err = params.Bool(values, "canGoNext"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if snapshot.CanGoPrevious, err = params.Bool(values, "canGoPrevious"); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	if err := validatePlayerSnapshot(snapshot); err != nil {
+		return PlayerSnapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func int64Param(values map[string]any, key string) (int64, error) {
+	value, ok := values[key]
+	if !ok {
+		return 0, fmt.Errorf("missing or invalid '%s' parameter", key)
+	}
+	var number float64
+	switch typed := value.(type) {
+	case float64:
+		number = typed
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil {
+			return 0, fmt.Errorf("missing or invalid '%s' parameter", key)
+		}
+		return parsed, nil
+	case int64:
+		return typed, nil
+	case int:
+		return int64(typed), nil
+	default:
+		return 0, fmt.Errorf("missing or invalid '%s' parameter", key)
+	}
+	if math.IsNaN(number) || math.IsInf(number, 0) || math.Trunc(number) != number || number < math.MinInt64 || number >= 9223372036854775808 {
+		return 0, fmt.Errorf("missing or invalid '%s' parameter", key)
+	}
+	return int64(number), nil
 }
 
 func handleStartDiscovery(conn *models.Conn, req models.Request, manager *Manager) {

--- a/core/internal/server/bluez/manager.go
+++ b/core/internal/server/bluez/manager.go
@@ -1,6 +1,8 @@
 package bluez
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"slices"
 	"strings"
@@ -16,12 +18,14 @@ const (
 	adapter1Iface   = "org.bluez.Adapter1"
 	objectMgrIface  = "org.freedesktop.DBus.ObjectManager"
 	propertiesIface = "org.freedesktop.DBus.Properties"
+	dbusIface       = "org.freedesktop.DBus"
 )
 
 var bluezMatchRules = [][]dbus.MatchOption{
 	{dbus.WithMatchInterface(propertiesIface), dbus.WithMatchMember("PropertiesChanged")},
 	{dbus.WithMatchInterface(objectMgrIface), dbus.WithMatchMember("InterfacesAdded")},
 	{dbus.WithMatchInterface(objectMgrIface), dbus.WithMatchMember("InterfacesRemoved")},
+	{dbus.WithMatchSender(dbusIface), dbus.WithMatchInterface(dbusIface), dbus.WithMatchMember("NameOwnerChanged"), dbus.WithMatchArg(0, bluezService)},
 }
 
 func NewManager() (*Manager, error) {
@@ -41,11 +45,12 @@ func NewManager() (*Manager, error) {
 		},
 		stateMutex: sync.RWMutex{},
 
-		stopChan:   make(chan struct{}),
-		dbusConn:   conn,
-		signals:    make(chan *dbus.Signal, 256),
-		dirty:      make(chan struct{}, 1),
-		eventQueue: make(chan func(), 32),
+		stopChan:       make(chan struct{}),
+		dbusConn:       conn,
+		signals:        make(chan *dbus.Signal, 256),
+		dirty:          make(chan struct{}, 1),
+		eventQueue:     make(chan func(), 32),
+		adapterRefresh: make(chan struct{}, 1),
 	}
 
 	broker := NewSubscriptionBroker(m.broadcastPairingPrompt)
@@ -67,6 +72,12 @@ func NewManager() (*Manager, error) {
 
 	if err := m.startAgent(); err != nil {
 		return nil, fmt.Errorf("agent start failed: %w", err)
+	}
+
+	m.mprisPlayer = newMPRISPlayer(conn, m.dispatchPlayerCommand)
+	if err := m.mprisPlayer.export(); err != nil {
+		m.agent.Close()
+		return nil, err
 	}
 
 	if err := m.startSignalPump(); err != nil {
@@ -135,6 +146,11 @@ func (m *Manager) refreshAdapters() {
 	m.adapterPaths = paths
 	m.stateMutex.Unlock()
 
+	if m.mprisPlayer != nil {
+		if err := m.mprisPlayer.reconcile(paths); err != nil {
+			log.Warnf("[BluezManager] MPRIS registration reconcile failed: %v", err)
+		}
+	}
 	if !changed {
 		return
 	}
@@ -336,6 +352,27 @@ func (m *Manager) handleSignal(sig *dbus.Signal) {
 	case objectMgrIface + ".InterfacesRemoved":
 		m.maybeRefreshAdapters(sig)
 		m.notifySubscribers()
+
+	case dbusIface + ".NameOwnerChanged":
+		m.handleBluezOwnerChanged(sig)
+	}
+}
+
+func (m *Manager) handleBluezOwnerChanged(sig *dbus.Signal) {
+	if len(sig.Body) < 3 {
+		return
+	}
+	name, nameOK := sig.Body[0].(string)
+	oldOwner, oldOK := sig.Body[1].(string)
+	newOwner, newOK := sig.Body[2].(string)
+	if !nameOK || !oldOK || !newOK || name != bluezService {
+		return
+	}
+	if oldOwner != "" && m.mprisPlayer != nil {
+		m.mprisPlayer.clearRegistrations()
+	}
+	if newOwner != "" {
+		m.enqueueAdapterRefresh()
 	}
 }
 
@@ -343,8 +380,12 @@ func (m *Manager) maybeRefreshAdapters(sig *dbus.Signal) {
 	if !signalTouchesAdapter(sig) {
 		return
 	}
+	m.enqueueAdapterRefresh()
+}
+
+func (m *Manager) enqueueAdapterRefresh() {
 	select {
-	case m.eventQueue <- m.refreshAdapters:
+	case m.adapterRefresh <- struct{}{}:
 	default:
 	}
 }
@@ -452,6 +493,8 @@ func (m *Manager) eventWorker() {
 			return
 		case event := <-m.eventQueue:
 			event()
+		case <-m.adapterRefresh:
+			m.refreshAdapters()
 		}
 	}
 }
@@ -546,6 +589,132 @@ func (m *Manager) UnsubscribePairing(id string) {
 	if ch, ok := m.pairingSubscribers.LoadAndDelete(id); ok {
 		close(ch)
 	}
+}
+
+func newPlayerCommandLease() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate MPRIS command lease: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
+}
+
+func (m *Manager) hasPlayerCommandWaiterLocked() bool {
+	for _, id := range m.commandWaiters {
+		if _, ok := m.commandSubscribers.Load(id); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) promotePlayerCommandSubscriberLocked() error {
+	for len(m.commandWaiters) > 0 {
+		id := m.commandWaiters[0]
+		ch, ok := m.commandSubscribers.Load(id)
+		if !ok {
+			m.commandWaiters = m.commandWaiters[1:]
+			continue
+		}
+		lease, err := newPlayerCommandLease()
+		if err != nil {
+			return err
+		}
+		m.commandWaiters = m.commandWaiters[1:]
+		m.commandLease = lease
+		m.commandSubscription = id
+		ch <- PlayerCommand{Lease: lease}
+		return nil
+	}
+	return nil
+}
+
+func (m *Manager) SubscribePlayerCommands(id string) (chan PlayerCommand, error) {
+	ch := make(chan PlayerCommand, 16)
+	m.commandMutex.Lock()
+	defer m.commandMutex.Unlock()
+	if _, exists := m.commandSubscribers.Load(id); exists {
+		return nil, fmt.Errorf("mpris command subscriber %q already exists", id)
+	}
+	m.commandSubscribers.Store(id, ch)
+	m.commandWaiters = append(m.commandWaiters, id)
+	if m.commandSubscription == "" {
+		if err := m.promotePlayerCommandSubscriberLocked(); err != nil {
+			m.commandSubscribers.Delete(id)
+			close(ch)
+			return nil, err
+		}
+	}
+	return ch, nil
+}
+
+func (m *Manager) UnsubscribePlayerCommands(id string) {
+	m.commandMutex.Lock()
+	defer m.commandMutex.Unlock()
+
+	ch, removed := m.commandSubscribers.LoadAndDelete(id)
+	if removed {
+		close(ch)
+	}
+	m.commandWaiters = slices.DeleteFunc(m.commandWaiters, func(waiter string) bool {
+		return waiter == id
+	})
+	if m.commandSubscription != id {
+		return
+	}
+	m.commandLease = ""
+	m.commandSubscription = ""
+	if m.mprisPlayer != nil {
+		transition := disabledPlayerSnapshot()
+		if m.hasPlayerCommandWaiterLocked() {
+			transition = stalePlayerSnapshot(m.mprisPlayer.currentSnapshot())
+		}
+		if err := m.mprisPlayer.publish(transition, m.adapterPathsSnapshot()); err != nil {
+			log.Warnf("[BluezManager] MPRIS owner loss publish failed: %v", err)
+		}
+	}
+	if err := m.promotePlayerCommandSubscriberLocked(); err != nil {
+		if m.mprisPlayer != nil {
+			if disableErr := m.mprisPlayer.publish(disabledPlayerSnapshot(), m.adapterPathsSnapshot()); disableErr != nil {
+				log.Warnf("[BluezManager] MPRIS disable after promotion failure failed: %v", disableErr)
+			}
+		}
+		log.Warnf("[BluezManager] MPRIS command subscriber promotion failed: %v", err)
+	}
+}
+
+func (m *Manager) dispatchPlayerCommand(command PlayerCommand) *dbus.Error {
+	m.commandMutex.RLock()
+	defer m.commandMutex.RUnlock()
+
+	if m.commandSubscription == "" || m.commandLease == "" {
+		return commandDeliveryError("no active MPRIS command owner")
+	}
+	if m.mprisPlayer == nil || !supportsPlayerCommand(m.mprisPlayer.currentSnapshot(), command.Command) {
+		return notSupportedError(command.Command)
+	}
+	ch, ok := m.commandSubscribers.Load(m.commandSubscription)
+	if !ok {
+		return commandDeliveryError("active MPRIS command owner is unavailable")
+	}
+	select {
+	case ch <- command:
+		return nil
+	default:
+		return commandDeliveryError("active MPRIS command owner is not accepting commands")
+	}
+}
+
+func (m *Manager) PublishMPRIS(lease string, snapshot PlayerSnapshot) error {
+	if m.mprisPlayer == nil {
+		return fmt.Errorf("MPRIS player not initialized")
+	}
+	m.commandMutex.RLock()
+	defer m.commandMutex.RUnlock()
+	if lease == "" || lease != m.commandLease || m.commandSubscription == "" {
+		return fmt.Errorf("MPRIS publisher does not hold the active command lease")
+	}
+	return m.mprisPlayer.publish(snapshot, m.adapterPathsSnapshot())
 }
 
 func (m *Manager) broadcastPairingPrompt(prompt PairingPrompt) {
@@ -686,6 +855,12 @@ func (m *Manager) Close() {
 		_ = m.dbusConn.RemoveMatchSignal(rule...)
 	}
 
+	if m.mprisPlayer != nil {
+		if err := m.mprisPlayer.close(); err != nil {
+			log.Debugf("[BluezManager] MPRIS player close failed: %v", err)
+		}
+	}
+
 	if m.agent != nil {
 		m.agent.Close()
 	}
@@ -701,6 +876,17 @@ func (m *Manager) Close() {
 		m.pairingSubscribers.Delete(key)
 		return true
 	})
+
+	m.commandMutex.Lock()
+	m.commandSubscribers.Range(func(key string, ch chan PlayerCommand) bool {
+		close(ch)
+		m.commandSubscribers.Delete(key)
+		return true
+	})
+	m.commandLease = ""
+	m.commandSubscription = ""
+	m.commandWaiters = nil
+	m.commandMutex.Unlock()
 }
 
 func stateChanged(old, new *BluetoothState) bool {

--- a/core/internal/server/bluez/player.go
+++ b/core/internal/server/bluez/player.go
@@ -1,0 +1,449 @@
+package bluez
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"sync"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
+)
+
+const (
+	media1Iface         = "org.bluez.Media1"
+	mprisPlayerIface    = "org.mpris.MediaPlayer2.Player"
+	introspectableIface = "org.freedesktop.DBus.Introspectable"
+	mprisPlayerPath     = dbus.ObjectPath("/com/danklinux/bluez/player")
+)
+
+const mprisPlayerIntrospection = `
+<node>
+	<interface name="org.mpris.MediaPlayer2.Player">
+		<method name="Next"/>
+		<method name="Previous"/>
+		<method name="Pause"/>
+		<method name="PlayPause"/>
+		<method name="Stop"/>
+		<method name="Play"/>
+		<method name="Seek"><arg direction="in" type="x" name="Offset"/></method>
+		<method name="SetPosition"><arg direction="in" type="o" name="TrackId"/><arg direction="in" type="x" name="Position"/></method>
+		<method name="OpenUri"><arg direction="in" type="s" name="Uri"/></method>
+		<signal name="Seeked"><arg type="x" name="Position"/></signal>
+		<property name="PlaybackStatus" type="s" access="read"/>
+		<property name="LoopStatus" type="s" access="readwrite"/>
+		<property name="Rate" type="d" access="readwrite"/>
+		<property name="Shuffle" type="b" access="readwrite"/>
+		<property name="Metadata" type="a{sv}" access="read"/>
+		<property name="Volume" type="d" access="readwrite"/>
+		<property name="Position" type="x" access="read"/>
+		<property name="MinimumRate" type="d" access="read"/>
+		<property name="MaximumRate" type="d" access="read"/>
+		<property name="Identity" type="s" access="read"/>
+		<property name="CanGoNext" type="b" access="read"/>
+		<property name="CanGoPrevious" type="b" access="read"/>
+		<property name="CanPlay" type="b" access="read"/>
+		<property name="CanPause" type="b" access="read"/>
+		<property name="CanSeek" type="b" access="read"/>
+		<property name="CanControl" type="b" access="read"/>
+	</interface>
+	<interface name="org.freedesktop.DBus.Properties">
+		<method name="Get"><arg direction="in" type="s" name="interface_name"/><arg direction="in" type="s" name="property_name"/><arg direction="out" type="v" name="value"/></method>
+		<method name="GetAll"><arg direction="in" type="s" name="interface_name"/><arg direction="out" type="a{sv}" name="properties"/></method>
+		<method name="Set"><arg direction="in" type="s" name="interface_name"/><arg direction="in" type="s" name="property_name"/><arg direction="in" type="v" name="value"/></method>
+		<signal name="PropertiesChanged"><arg type="s" name="interface_name"/><arg type="a{sv}" name="changed_properties"/><arg type="as" name="invalidated_properties"/></signal>
+	</interface>
+	<interface name="org.freedesktop.DBus.Introspectable">
+		<method name="Introspect"><arg direction="out" type="s" name="data"/></method>
+	</interface>
+</node>`
+
+type PlayerSnapshot struct {
+	Enabled        bool   `json:"enabled"`
+	Identity       string `json:"identity"`
+	PlaybackStatus string `json:"playbackStatus"`
+	Title          string `json:"title"`
+	Artist         string `json:"artist"`
+	Album          string `json:"album"`
+	Length         int64  `json:"length"`
+	Position       int64  `json:"position"`
+	CanControl     bool   `json:"canControl"`
+	CanPlay        bool   `json:"canPlay"`
+	CanPause       bool   `json:"canPause"`
+	CanGoNext      bool   `json:"canGoNext"`
+	CanGoPrevious  bool   `json:"canGoPrevious"`
+}
+
+type PlayerCommand struct {
+	Command string `json:"command,omitempty"`
+	Lease   string `json:"lease,omitempty"`
+}
+
+type mprisPlayer struct {
+	conn       *dbus.Conn
+	dispatch   func(PlayerCommand) *dbus.Error
+	stateMu    sync.RWMutex
+	snapshot   PlayerSnapshot
+	closed     bool
+	publishMu  sync.Mutex
+	registerMu sync.Mutex
+	registered map[dbus.ObjectPath]struct{}
+}
+
+type mprisPlayerMethods struct{ player *mprisPlayer }
+type mprisProperties struct{ player *mprisPlayer }
+
+func newMPRISPlayer(conn *dbus.Conn, dispatch func(PlayerCommand) *dbus.Error) *mprisPlayer {
+	return &mprisPlayer{
+		conn:       conn,
+		dispatch:   dispatch,
+		snapshot:   disabledPlayerSnapshot(),
+		registered: make(map[dbus.ObjectPath]struct{}),
+	}
+}
+
+func disabledPlayerSnapshot() PlayerSnapshot {
+	return PlayerSnapshot{PlaybackStatus: "Stopped"}
+}
+
+func stalePlayerSnapshot(snapshot PlayerSnapshot) PlayerSnapshot {
+	return PlayerSnapshot{
+		Enabled:        snapshot.Enabled,
+		Identity:       snapshot.Identity,
+		PlaybackStatus: "Stopped",
+	}
+}
+
+func normalizePlayerSnapshot(snapshot PlayerSnapshot) PlayerSnapshot {
+	if !snapshot.CanControl {
+		snapshot.CanPlay = false
+		snapshot.CanPause = false
+		snapshot.CanGoNext = false
+		snapshot.CanGoPrevious = false
+	}
+	return snapshot
+}
+
+func validatePlayerSnapshot(snapshot PlayerSnapshot) error {
+	switch snapshot.PlaybackStatus {
+	case "Playing", "Paused", "Stopped":
+	default:
+		return fmt.Errorf("invalid playbackStatus: %q", snapshot.PlaybackStatus)
+	}
+	if snapshot.Length < 0 {
+		return fmt.Errorf("length must be nonnegative")
+	}
+	if snapshot.Position < 0 {
+		return fmt.Errorf("position must be nonnegative")
+	}
+	return nil
+}
+
+func playerProperties(snapshot PlayerSnapshot) map[string]dbus.Variant {
+	if !snapshot.Enabled {
+		snapshot = disabledPlayerSnapshot()
+	}
+
+	metadata := map[string]dbus.Variant{
+		"mpris:trackid": dbus.MakeVariant(playerTrackID(snapshot)),
+	}
+	if hasPlayerTrack(snapshot) {
+		metadata["xesam:title"] = dbus.MakeVariant(snapshot.Title)
+		metadata["xesam:artist"] = dbus.MakeVariant([]string{snapshot.Artist})
+		metadata["xesam:album"] = dbus.MakeVariant(snapshot.Album)
+		metadata["mpris:length"] = dbus.MakeVariant(snapshot.Length)
+	}
+
+	return map[string]dbus.Variant{
+		"PlaybackStatus": dbus.MakeVariant(snapshot.PlaybackStatus),
+		"LoopStatus":     dbus.MakeVariant("None"),
+		"Rate":           dbus.MakeVariant(1.0),
+		"Shuffle":        dbus.MakeVariant(false),
+		"Metadata":       dbus.MakeVariant(metadata),
+		"Volume":         dbus.MakeVariant(1.0),
+		"Position":       dbus.MakeVariant(snapshot.Position),
+		"MinimumRate":    dbus.MakeVariant(1.0),
+		"MaximumRate":    dbus.MakeVariant(1.0),
+		"Identity":       dbus.MakeVariant(snapshot.Identity),
+		"CanGoNext":      dbus.MakeVariant(snapshot.CanGoNext),
+		"CanGoPrevious":  dbus.MakeVariant(snapshot.CanGoPrevious),
+		"CanPlay":        dbus.MakeVariant(snapshot.CanPlay),
+		"CanPause":       dbus.MakeVariant(snapshot.CanPause),
+		"CanSeek":        dbus.MakeVariant(false),
+		"CanControl":     dbus.MakeVariant(snapshot.CanControl),
+	}
+}
+
+func hasPlayerTrack(snapshot PlayerSnapshot) bool {
+	return snapshot.Enabled && (snapshot.Title != "" || snapshot.Artist != "" || snapshot.Album != "" || snapshot.Length > 0)
+}
+
+func playerTrackID(snapshot PlayerSnapshot) dbus.ObjectPath {
+	if !hasPlayerTrack(snapshot) {
+		return dbus.ObjectPath("/org/mpris/MediaPlayer2/TrackList/NoTrack")
+	}
+	metadata := fmt.Sprintf("%q\x00%q\x00%q\x00%d", snapshot.Title, snapshot.Artist, snapshot.Album, snapshot.Length)
+	hash := sha256.Sum256([]byte(metadata))
+	return dbus.ObjectPath(fmt.Sprintf("/com/danklinux/bluez/player/track/%x", hash[:12]))
+}
+
+func changedPlayerProperties(old, current PlayerSnapshot) map[string]dbus.Variant {
+	oldProperties := playerProperties(old)
+	currentProperties := playerProperties(current)
+	changed := make(map[string]dbus.Variant)
+	for name, value := range currentProperties {
+		if name == "Position" || reflect.DeepEqual(oldProperties[name], value) {
+			continue
+		}
+		changed[name] = value
+	}
+	return changed
+}
+
+func (p *mprisPlayer) export() error {
+	if p.conn == nil {
+		return fmt.Errorf("system bus connection not initialized")
+	}
+	if err := p.conn.ExportWithMap(&mprisPlayerMethods{player: p}, map[string]string{"SeekCommand": "Seek"}, mprisPlayerPath, mprisPlayerIface); err != nil {
+		return fmt.Errorf("MPRIS player export failed: %w", err)
+	}
+	if err := p.conn.Export(&mprisProperties{player: p}, mprisPlayerPath, propertiesIface); err != nil {
+		p.unexport()
+		return fmt.Errorf("MPRIS properties export failed: %w", err)
+	}
+	if err := p.conn.Export(introspect.Introspectable(mprisPlayerIntrospection), mprisPlayerPath, introspectableIface); err != nil {
+		p.unexport()
+		return fmt.Errorf("MPRIS introspection export failed: %w", err)
+	}
+	return nil
+}
+
+func (p *mprisPlayer) unexport() {
+	if p.conn == nil {
+		return
+	}
+	_ = p.conn.Export(nil, mprisPlayerPath, mprisPlayerIface)
+	_ = p.conn.Export(nil, mprisPlayerPath, propertiesIface)
+	_ = p.conn.Export(nil, mprisPlayerPath, introspectableIface)
+}
+
+func (p *mprisPlayer) publish(snapshot PlayerSnapshot, adapters []dbus.ObjectPath) error {
+	snapshot = normalizePlayerSnapshot(snapshot)
+	p.publishMu.Lock()
+	defer p.publishMu.Unlock()
+
+	old, err := p.updateSnapshot(snapshot)
+	if err != nil {
+		return err
+	}
+	return p.publishSnapshotChange(old, snapshot, adapters)
+}
+
+func (p *mprisPlayer) updateSnapshot(snapshot PlayerSnapshot) (PlayerSnapshot, error) {
+	snapshot = normalizePlayerSnapshot(snapshot)
+	if err := validatePlayerSnapshot(snapshot); err != nil {
+		return PlayerSnapshot{}, err
+	}
+
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+	if p.closed {
+		return PlayerSnapshot{}, fmt.Errorf("MPRIS player is closed")
+	}
+	old := p.snapshot
+	p.snapshot = snapshot
+	return old, nil
+}
+
+func (p *mprisPlayer) publishSnapshotChange(old, snapshot PlayerSnapshot, adapters []dbus.ObjectPath) error {
+	var propertiesErr error
+	if changed := changedPlayerProperties(old, snapshot); len(changed) > 0 && p.conn != nil {
+		propertiesErr = p.conn.Emit(mprisPlayerPath, propertiesIface+".PropertiesChanged", mprisPlayerIface, changed, []string{})
+	}
+	return errors.Join(propertiesErr, p.reconcile(adapters))
+}
+
+func (p *mprisPlayer) currentSnapshot() PlayerSnapshot {
+	p.stateMu.RLock()
+	defer p.stateMu.RUnlock()
+	return p.snapshot
+}
+
+func registrationChanges(registered map[dbus.ObjectPath]struct{}, adapters []dbus.ObjectPath, enabled bool) (add, remove []dbus.ObjectPath) {
+	desired := make(map[dbus.ObjectPath]struct{}, len(adapters))
+	if enabled {
+		for _, path := range adapters {
+			desired[path] = struct{}{}
+		}
+	}
+	for path := range registered {
+		if _, ok := desired[path]; !ok {
+			remove = append(remove, path)
+		}
+	}
+	for path := range desired {
+		if _, ok := registered[path]; !ok {
+			add = append(add, path)
+		}
+	}
+	slices.Sort(add)
+	slices.Sort(remove)
+	return add, remove
+}
+
+func (p *mprisPlayer) reconcile(adapters []dbus.ObjectPath) error {
+	if p.conn == nil {
+		return nil
+	}
+
+	p.registerMu.Lock()
+	defer p.registerMu.Unlock()
+
+	snapshot := p.currentSnapshot()
+	add, remove := registrationChanges(p.registered, adapters, snapshot.Enabled)
+	var errs []error
+	for _, adapter := range remove {
+		obj := p.conn.Object(bluezService, adapter)
+		err := obj.Call(media1Iface+".UnregisterPlayer", 0, mprisPlayerPath).Err
+		if err != nil {
+			errs = append(errs, fmt.Errorf("unregister MPRIS player from %s: %w", adapter, err))
+		}
+		if err == nil || !slices.Contains(adapters, adapter) {
+			delete(p.registered, adapter)
+		}
+	}
+	for _, adapter := range add {
+		obj := p.conn.Object(bluezService, adapter)
+		if err := obj.Call(media1Iface+".RegisterPlayer", 0, mprisPlayerPath, playerProperties(snapshot)).Err; err != nil {
+			errs = append(errs, fmt.Errorf("register MPRIS player on %s: %w", adapter, err))
+			continue
+		}
+		p.registered[adapter] = struct{}{}
+	}
+	return errors.Join(errs...)
+}
+
+func (p *mprisPlayer) clearRegistrations() {
+	p.registerMu.Lock()
+	clear(p.registered)
+	p.registerMu.Unlock()
+}
+
+func (p *mprisPlayer) close() error {
+	p.stateMu.Lock()
+	if p.closed {
+		p.stateMu.Unlock()
+		return nil
+	}
+	p.closed = true
+	p.snapshot = disabledPlayerSnapshot()
+	p.stateMu.Unlock()
+
+	p.registerMu.Lock()
+	registered := maps.Clone(p.registered)
+	var errs []error
+	if p.conn != nil {
+		for adapter := range registered {
+			obj := p.conn.Object(bluezService, adapter)
+			if err := obj.Call(media1Iface+".UnregisterPlayer", 0, mprisPlayerPath).Err; err != nil {
+				errs = append(errs, fmt.Errorf("unregister MPRIS player from %s: %w", adapter, err))
+			}
+		}
+	}
+	clear(p.registered)
+	p.registerMu.Unlock()
+	p.unexport()
+	return errors.Join(errs...)
+}
+
+func (p *mprisPlayer) dispatchCommand(command string) *dbus.Error {
+	if p.dispatch == nil {
+		return commandDeliveryError("no active MPRIS command owner")
+	}
+	return p.dispatch(PlayerCommand{Command: command})
+}
+
+func supportsPlayerCommand(snapshot PlayerSnapshot, command string) bool {
+	allowed := snapshot.Enabled && snapshot.CanControl
+	switch command {
+	case "play":
+		return allowed && snapshot.CanPlay
+	case "pause":
+		return allowed && snapshot.CanPause
+	case "playPause":
+		if snapshot.PlaybackStatus == "Playing" {
+			return allowed && snapshot.CanPause
+		}
+		return allowed && snapshot.CanPlay
+	case "next":
+		return allowed && snapshot.CanGoNext
+	case "previous":
+		return allowed && snapshot.CanGoPrevious
+	case "stop":
+		return allowed
+	default:
+		return false
+	}
+}
+
+func notSupportedError(method string) *dbus.Error {
+	return dbus.NewError("org.freedesktop.DBus.Error.NotSupported", []any{fmt.Sprintf("MPRIS command %s is not supported", method)})
+}
+
+func commandDeliveryError(message string) *dbus.Error {
+	return dbus.NewError("org.freedesktop.DBus.Error.Failed", []any{message})
+}
+
+func (m *mprisPlayerMethods) Next() *dbus.Error     { return m.player.dispatchCommand("next") }
+func (m *mprisPlayerMethods) Previous() *dbus.Error { return m.player.dispatchCommand("previous") }
+func (m *mprisPlayerMethods) Pause() *dbus.Error    { return m.player.dispatchCommand("pause") }
+func (m *mprisPlayerMethods) PlayPause() *dbus.Error {
+	return m.player.dispatchCommand("playPause")
+}
+func (m *mprisPlayerMethods) Stop() *dbus.Error { return m.player.dispatchCommand("stop") }
+func (m *mprisPlayerMethods) Play() *dbus.Error { return m.player.dispatchCommand("play") }
+func (m *mprisPlayerMethods) SeekCommand(_ int64) *dbus.Error {
+	return notSupportedError("seek")
+}
+func (m *mprisPlayerMethods) SetPosition(_ dbus.ObjectPath, _ int64) *dbus.Error {
+	return notSupportedError("setPosition")
+}
+func (m *mprisPlayerMethods) OpenUri(_ string) *dbus.Error {
+	return notSupportedError("openUri")
+}
+
+func (p *mprisProperties) Get(iface, property string) (dbus.Variant, *dbus.Error) {
+	if iface != mprisPlayerIface {
+		return dbus.Variant{}, dbus.NewError("org.freedesktop.DBus.Error.UnknownInterface", []any{iface})
+	}
+	value, ok := playerProperties(p.player.currentSnapshot())[property]
+	if !ok {
+		return dbus.Variant{}, dbus.NewError("org.freedesktop.DBus.Error.UnknownProperty", []any{property})
+	}
+	return value, nil
+}
+
+func (p *mprisProperties) GetAll(iface string) (map[string]dbus.Variant, *dbus.Error) {
+	if iface != mprisPlayerIface {
+		return nil, dbus.NewError("org.freedesktop.DBus.Error.UnknownInterface", []any{iface})
+	}
+	return playerProperties(p.player.currentSnapshot()), nil
+}
+
+func (p *mprisProperties) Set(iface, property string, _ dbus.Variant) *dbus.Error {
+	if iface != mprisPlayerIface {
+		return dbus.NewError("org.freedesktop.DBus.Error.UnknownInterface", []any{iface})
+	}
+	if _, ok := playerProperties(p.player.currentSnapshot())[property]; !ok {
+		return dbus.NewError("org.freedesktop.DBus.Error.UnknownProperty", []any{property})
+	}
+	switch property {
+	case "LoopStatus", "Rate", "Shuffle", "Volume":
+		return dbus.NewError("org.freedesktop.DBus.Error.NotSupported", []any{fmt.Sprintf("setting MPRIS property %s is not supported", property)})
+	default:
+		return dbus.NewError("org.freedesktop.DBus.Error.PropertyReadOnly", []any{property})
+	}
+}

--- a/core/internal/server/bluez/player_test.go
+++ b/core/internal/server/bluez/player_test.go
@@ -1,0 +1,616 @@
+package bluez
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePlayerSnapshot(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot PlayerSnapshot
+		wantErr  string
+	}{
+		{name: "playing", snapshot: PlayerSnapshot{PlaybackStatus: "Playing"}},
+		{name: "paused", snapshot: PlayerSnapshot{PlaybackStatus: "Paused"}},
+		{name: "stopped", snapshot: PlayerSnapshot{PlaybackStatus: "Stopped"}},
+		{name: "invalid status", snapshot: PlayerSnapshot{PlaybackStatus: "Buffering"}, wantErr: "invalid playbackStatus"},
+		{name: "negative length", snapshot: PlayerSnapshot{PlaybackStatus: "Stopped", Length: -1}, wantErr: "length must be nonnegative"},
+		{name: "negative position", snapshot: PlayerSnapshot{PlaybackStatus: "Stopped", Position: -1}, wantErr: "position must be nonnegative"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePlayerSnapshot(tt.snapshot)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestPlayerProperties(t *testing.T) {
+	snapshot := PlayerSnapshot{
+		Enabled:        true,
+		Identity:       "DMS Music",
+		PlaybackStatus: "Playing",
+		Title:          "Title",
+		Artist:         "Artist",
+		Album:          "Album",
+		Length:         12_000_000,
+		Position:       3_000_000,
+		CanControl:     true,
+		CanPlay:        true,
+		CanPause:       true,
+		CanGoNext:      true,
+		CanGoPrevious:  false,
+	}
+
+	properties := playerProperties(snapshot)
+	expectedSignatures := map[string]string{
+		"PlaybackStatus": "s",
+		"LoopStatus":     "s",
+		"Rate":           "d",
+		"Shuffle":        "b",
+		"Metadata":       "a{sv}",
+		"Volume":         "d",
+		"Position":       "x",
+		"MinimumRate":    "d",
+		"MaximumRate":    "d",
+		"Identity":       "s",
+		"CanGoNext":      "b",
+		"CanGoPrevious":  "b",
+		"CanPlay":        "b",
+		"CanPause":       "b",
+		"CanSeek":        "b",
+		"CanControl":     "b",
+	}
+	require.Len(t, properties, len(expectedSignatures))
+	for name, signature := range expectedSignatures {
+		assert.Equal(t, signature, properties[name].Signature().String(), name)
+	}
+
+	assert.Equal(t, "Playing", properties["PlaybackStatus"].Value())
+	assert.Equal(t, "None", properties["LoopStatus"].Value())
+	assert.Equal(t, 1.0, properties["Rate"].Value())
+	assert.Equal(t, false, properties["Shuffle"].Value())
+	assert.Equal(t, 1.0, properties["Volume"].Value())
+	assert.Equal(t, int64(3_000_000), properties["Position"].Value())
+	assert.Equal(t, 1.0, properties["MinimumRate"].Value())
+	assert.Equal(t, 1.0, properties["MaximumRate"].Value())
+	assert.Equal(t, "DMS Music", properties["Identity"].Value())
+	assert.Equal(t, false, properties["CanSeek"].Value())
+	assert.Equal(t, true, properties["CanControl"].Value())
+	assert.Equal(t, false, properties["CanGoPrevious"].Value())
+
+	metadata, ok := properties["Metadata"].Value().(map[string]dbus.Variant)
+	require.True(t, ok)
+	trackID, ok := metadata["mpris:trackid"].Value().(dbus.ObjectPath)
+	require.True(t, ok)
+	assert.True(t, trackID.IsValid())
+	assert.NotEqual(t, dbus.ObjectPath("/org/mpris/MediaPlayer2/TrackList/NoTrack"), trackID)
+	assert.Equal(t, "Title", metadata["xesam:title"].Value())
+	assert.Equal(t, []string{"Artist"}, metadata["xesam:artist"].Value())
+	assert.Equal(t, "Album", metadata["xesam:album"].Value())
+	assert.Equal(t, int64(12_000_000), metadata["mpris:length"].Value())
+}
+
+func TestChangedPlayerPropertiesExcludesPosition(t *testing.T) {
+	old := PlayerSnapshot{Enabled: true, PlaybackStatus: "Paused", Position: 1_000_000}
+	current := old
+	current.Position = 2_000_000
+
+	assert.Empty(t, changedPlayerProperties(old, current))
+
+	current.PlaybackStatus = "Playing"
+	changed := changedPlayerProperties(old, current)
+	assert.NotContains(t, changed, "Position")
+	assert.Equal(t, "Playing", changed["PlaybackStatus"].Value())
+}
+
+func TestPlayerTrackIDIsStableAndMetadataDependent(t *testing.T) {
+	snapshot := PlayerSnapshot{Enabled: true, Title: "Title", Artist: "Artist", Album: "Album", Length: 42}
+	trackID := playerTrackID(snapshot)
+	assert.Equal(t, trackID, playerTrackID(snapshot))
+
+	snapshot.Title = "Other Title"
+	assert.NotEqual(t, trackID, playerTrackID(snapshot))
+	assert.True(t, playerTrackID(snapshot).IsValid())
+}
+
+func TestMPRISPlayerIntrospectionSurface(t *testing.T) {
+	var node introspect.Node
+	require.NoError(t, xml.Unmarshal([]byte(mprisPlayerIntrospection), &node))
+
+	var playerInterface introspect.Interface
+	for _, iface := range node.Interfaces {
+		if iface.Name == mprisPlayerIface {
+			playerInterface = iface
+			break
+		}
+	}
+	require.Equal(t, mprisPlayerIface, playerInterface.Name)
+
+	expectedPropertyCount := 16
+	require.Len(t, playerInterface.Properties, expectedPropertyCount)
+	properties := make(map[string]introspect.Property, len(playerInterface.Properties))
+	for _, property := range playerInterface.Properties {
+		properties[property.Name] = property
+	}
+	expected := map[string]introspect.Property{
+		"PlaybackStatus": {Type: "s", Access: "read"},
+		"LoopStatus":     {Type: "s", Access: "readwrite"},
+		"Rate":           {Type: "d", Access: "readwrite"},
+		"Shuffle":        {Type: "b", Access: "readwrite"},
+		"Metadata":       {Type: "a{sv}", Access: "read"},
+		"Volume":         {Type: "d", Access: "readwrite"},
+		"Position":       {Type: "x", Access: "read"},
+		"MinimumRate":    {Type: "d", Access: "read"},
+		"MaximumRate":    {Type: "d", Access: "read"},
+		"Identity":       {Type: "s", Access: "read"},
+		"CanGoNext":      {Type: "b", Access: "read"},
+		"CanGoPrevious":  {Type: "b", Access: "read"},
+		"CanPlay":        {Type: "b", Access: "read"},
+		"CanPause":       {Type: "b", Access: "read"},
+		"CanSeek":        {Type: "b", Access: "read"},
+		"CanControl":     {Type: "b", Access: "read"},
+	}
+	require.Len(t, expected, expectedPropertyCount)
+	require.Len(t, properties, len(expected))
+	for name, want := range expected {
+		property, ok := properties[name]
+		require.True(t, ok, name)
+		assert.Equal(t, want.Type, property.Type, name)
+		assert.Equal(t, want.Access, property.Access, name)
+	}
+
+	expectedMethods := map[string][]introspect.Arg{
+		"Next":        nil,
+		"Previous":    nil,
+		"Pause":       nil,
+		"PlayPause":   nil,
+		"Stop":        nil,
+		"Play":        nil,
+		"Seek":        {{Name: "Offset", Type: "x", Direction: "in"}},
+		"SetPosition": {{Name: "TrackId", Type: "o", Direction: "in"}, {Name: "Position", Type: "x", Direction: "in"}},
+		"OpenUri":     {{Name: "Uri", Type: "s", Direction: "in"}},
+	}
+	require.Len(t, playerInterface.Methods, len(expectedMethods))
+	methods := make(map[string][]introspect.Arg, len(playerInterface.Methods))
+	for _, method := range playerInterface.Methods {
+		methods[method.Name] = method.Args
+	}
+	require.Len(t, methods, len(expectedMethods))
+	for name, want := range expectedMethods {
+		args, ok := methods[name]
+		require.True(t, ok, name)
+		assert.Equal(t, want, args, name)
+	}
+
+	require.Len(t, playerInterface.Signals, 1)
+	assert.Equal(t, "Seeked", playerInterface.Signals[0].Name)
+	require.Len(t, playerInterface.Signals[0].Args, 1)
+	assert.Equal(t, introspect.Arg{Name: "Position", Type: "x"}, playerInterface.Signals[0].Args[0])
+}
+
+func TestStalePlayerPropertiesClearMetadataAndCapabilities(t *testing.T) {
+	old := PlayerSnapshot{
+		Enabled:        true,
+		Identity:       "DankMaterialShell",
+		PlaybackStatus: "Playing",
+		Title:          "Title",
+		Artist:         "Artist",
+		Album:          "Album",
+		Length:         10_000_000,
+		Position:       2_000_000,
+		CanControl:     true,
+		CanPlay:        true,
+		CanPause:       true,
+		CanGoNext:      true,
+		CanGoPrevious:  true,
+	}
+
+	changed := changedPlayerProperties(old, stalePlayerSnapshot(old))
+
+	assert.Equal(t, "Stopped", changed["PlaybackStatus"].Value())
+	assert.Equal(t, false, changed["CanControl"].Value())
+	assert.Equal(t, false, changed["CanPlay"].Value())
+	assert.Equal(t, false, changed["CanPause"].Value())
+	assert.Equal(t, false, changed["CanGoNext"].Value())
+	assert.Equal(t, false, changed["CanGoPrevious"].Value())
+	assert.NotContains(t, changed, "Position")
+	metadata, ok := changed["Metadata"].Value().(map[string]dbus.Variant)
+	require.True(t, ok)
+	require.Len(t, metadata, 1)
+	assert.Equal(t, dbus.ObjectPath("/org/mpris/MediaPlayer2/TrackList/NoTrack"), metadata["mpris:trackid"].Value())
+}
+
+func TestPlayerPropertiesDisabled(t *testing.T) {
+	properties := playerProperties(PlayerSnapshot{
+		PlaybackStatus: "Playing",
+		Identity:       "ignored",
+		Title:          "ignored",
+		Position:       42,
+		CanControl:     true,
+		CanPlay:        true,
+	})
+
+	assert.Equal(t, "Stopped", properties["PlaybackStatus"].Value())
+	assert.Equal(t, int64(0), properties["Position"].Value())
+	assert.Equal(t, "", properties["Identity"].Value())
+	assert.Equal(t, false, properties["CanControl"].Value())
+	metadata, ok := properties["Metadata"].Value().(map[string]dbus.Variant)
+	require.True(t, ok)
+	require.Len(t, metadata, 1)
+	assert.Equal(t, dbus.ObjectPath("/org/mpris/MediaPlayer2/TrackList/NoTrack"), metadata["mpris:trackid"].Value())
+}
+
+func TestPlayerWritablePropertiesReportNotSupported(t *testing.T) {
+	properties := &mprisProperties{player: newMPRISPlayer(nil, nil)}
+	for _, name := range []string{"LoopStatus", "Rate", "Shuffle", "Volume"} {
+		dbusErr := properties.Set(mprisPlayerIface, name, dbus.MakeVariant(false))
+		require.NotNil(t, dbusErr, name)
+		assert.Equal(t, "org.freedesktop.DBus.Error.NotSupported", dbusErr.Name, name)
+	}
+
+	dbusErr := properties.Set(mprisPlayerIface, "Position", dbus.MakeVariant(int64(0)))
+	require.NotNil(t, dbusErr)
+	assert.Equal(t, "org.freedesktop.DBus.Error.PropertyReadOnly", dbusErr.Name)
+}
+
+func TestPlayerPublishNormalizesCapabilitiesWithoutControl(t *testing.T) {
+	player := newMPRISPlayer(nil, nil)
+	require.NoError(t, player.publish(PlayerSnapshot{
+		Enabled:        true,
+		PlaybackStatus: "Paused",
+		CanPlay:        true,
+		CanPause:       true,
+		CanGoNext:      true,
+		CanGoPrevious:  true,
+	}, nil))
+
+	snapshot := player.currentSnapshot()
+	assert.False(t, snapshot.CanPlay)
+	assert.False(t, snapshot.CanPause)
+	assert.False(t, snapshot.CanGoNext)
+	assert.False(t, snapshot.CanGoPrevious)
+}
+
+func TestPlayerCommandCapabilityGatingAndDispatch(t *testing.T) {
+	manager := &Manager{}
+	player := newMPRISPlayer(nil, manager.dispatchPlayerCommand)
+	manager.mprisPlayer = player
+	commands, err := manager.SubscribePlayerCommands("test")
+	require.NoError(t, err)
+	assert.NotEmpty(t, (<-commands).Lease)
+	player.snapshot = PlayerSnapshot{
+		Enabled:        true,
+		PlaybackStatus: "Playing",
+		CanControl:     true,
+		CanPlay:        true,
+		CanPause:       false,
+		CanGoNext:      true,
+	}
+
+	require.Nil(t, player.dispatchCommand("play"))
+	assert.Equal(t, PlayerCommand{Command: "play"}, <-commands)
+	require.Nil(t, player.dispatchCommand("next"))
+	assert.Equal(t, PlayerCommand{Command: "next"}, <-commands)
+
+	dbusErr := player.dispatchCommand("pause")
+	require.NotNil(t, dbusErr)
+	assert.Equal(t, "org.freedesktop.DBus.Error.NotSupported", dbusErr.Name)
+
+	dbusErr = player.dispatchCommand("playPause")
+	require.NotNil(t, dbusErr)
+	assert.Empty(t, commands)
+	manager.UnsubscribePlayerCommands("test")
+}
+
+func TestManagerPlayerCommandSubscription(t *testing.T) {
+	manager := &Manager{}
+	player := newMPRISPlayer(nil, manager.dispatchPlayerCommand)
+	manager.mprisPlayer = player
+	commands, err := manager.SubscribePlayerCommands("test")
+	require.NoError(t, err)
+	assert.NotEmpty(t, (<-commands).Lease)
+	player.snapshot = PlayerSnapshot{
+		Enabled:        true,
+		PlaybackStatus: "Stopped",
+		CanControl:     true,
+		CanPlay:        true,
+	}
+
+	require.Nil(t, player.dispatchCommand("play"))
+	assert.Equal(t, PlayerCommand{Command: "play"}, <-commands)
+	manager.UnsubscribePlayerCommands("test")
+	_, open := <-commands
+	assert.False(t, open)
+}
+
+func TestPlayerCommandFailsWithoutActiveOwner(t *testing.T) {
+	manager := &Manager{}
+	player := newMPRISPlayer(nil, manager.dispatchPlayerCommand)
+	manager.mprisPlayer = player
+	player.snapshot = PlayerSnapshot{
+		Enabled:        true,
+		PlaybackStatus: "Stopped",
+		CanControl:     true,
+		CanPlay:        true,
+	}
+
+	dbusErr := player.dispatchCommand("play")
+	require.NotNil(t, dbusErr)
+	assert.Equal(t, "org.freedesktop.DBus.Error.Failed", dbusErr.Name)
+}
+
+func TestPlayerCommandFailsWhenOwnerQueueIsFull(t *testing.T) {
+	manager := &Manager{}
+	player := newMPRISPlayer(nil, manager.dispatchPlayerCommand)
+	manager.mprisPlayer = player
+	commands, err := manager.SubscribePlayerCommands("test")
+	require.NoError(t, err)
+	assert.NotEmpty(t, (<-commands).Lease)
+	player.snapshot = PlayerSnapshot{
+		Enabled:        true,
+		PlaybackStatus: "Stopped",
+		CanControl:     true,
+		CanPlay:        true,
+	}
+
+	for range cap(commands) {
+		require.Nil(t, player.dispatchCommand("play"))
+	}
+	dbusErr := player.dispatchCommand("play")
+	require.NotNil(t, dbusErr)
+	assert.Equal(t, "org.freedesktop.DBus.Error.Failed", dbusErr.Name)
+	manager.UnsubscribePlayerCommands("test")
+}
+
+func TestDuplicatePlayerCommandSubscriberIsRejected(t *testing.T) {
+	manager := &Manager{}
+	commands, err := manager.SubscribePlayerCommands("duplicate")
+	require.NoError(t, err)
+	assert.NotEmpty(t, (<-commands).Lease)
+
+	duplicate, err := manager.SubscribePlayerCommands("duplicate")
+	require.ErrorContains(t, err, "already exists")
+	assert.Nil(t, duplicate)
+
+	manager.UnsubscribePlayerCommands("duplicate")
+}
+
+func TestManagerPlayerCommandLeaseControlsPublication(t *testing.T) {
+	player := newMPRISPlayer(nil, nil)
+	manager := &Manager{mprisPlayer: player}
+	commands, err := manager.SubscribePlayerCommands("first")
+	require.NoError(t, err)
+	lease := (<-commands).Lease
+	assert.NotEmpty(t, lease)
+	second, err := manager.SubscribePlayerCommands("second")
+	require.NoError(t, err)
+	select {
+	case event := <-second:
+		t.Fatalf("waiting subscriber received unexpected event: %#v", event)
+	default:
+	}
+
+	snapshot := PlayerSnapshot{
+		Enabled:        true,
+		PlaybackStatus: "Stopped",
+		CanControl:     true,
+		CanPlay:        true,
+	}
+	require.Error(t, manager.PublishMPRIS("wrong-lease", snapshot))
+	require.NoError(t, manager.PublishMPRIS(lease, snapshot))
+	require.Nil(t, manager.dispatchPlayerCommand(PlayerCommand{Command: "play"}))
+	assert.Equal(t, PlayerCommand{Command: "play"}, <-commands)
+
+	manager.UnsubscribePlayerCommands("first")
+	require.Error(t, manager.PublishMPRIS(lease, snapshot))
+	replacementLease := (<-second).Lease
+	assert.NotEmpty(t, replacementLease)
+	require.NoError(t, manager.PublishMPRIS(replacementLease, snapshot))
+	manager.UnsubscribePlayerCommands("second")
+}
+
+func TestDisconnectedPlayerCommandWaiterIsRemoved(t *testing.T) {
+	manager := &Manager{}
+	first, err := manager.SubscribePlayerCommands("first")
+	require.NoError(t, err)
+	assert.NotEmpty(t, (<-first).Lease)
+	waiting, err := manager.SubscribePlayerCommands("waiting")
+	require.NoError(t, err)
+
+	manager.UnsubscribePlayerCommands("waiting")
+	_, open := <-waiting
+	assert.False(t, open)
+	assert.Empty(t, manager.commandWaiters)
+
+	third, err := manager.SubscribePlayerCommands("third")
+	require.NoError(t, err)
+	manager.UnsubscribePlayerCommands("first")
+	assert.NotEmpty(t, (<-third).Lease)
+	manager.UnsubscribePlayerCommands("third")
+}
+
+func TestPlayerCommandOwnerLossWithoutWaiterDisablesPlayer(t *testing.T) {
+	player := newMPRISPlayer(nil, nil)
+	player.snapshot = PlayerSnapshot{
+		Enabled:        true,
+		Identity:       "DankMaterialShell",
+		PlaybackStatus: "Playing",
+		Title:          "Title",
+		CanControl:     true,
+		CanPlay:        true,
+	}
+	manager := &Manager{mprisPlayer: player}
+	owner, err := manager.SubscribePlayerCommands("owner")
+	require.NoError(t, err)
+	ownerLease := (<-owner).Lease
+	require.NotEmpty(t, ownerLease)
+
+	manager.UnsubscribePlayerCommands("owner")
+
+	assert.Equal(t, disabledPlayerSnapshot(), player.currentSnapshot())
+	require.Error(t, manager.PublishMPRIS(ownerLease, PlayerSnapshot{Enabled: true}))
+}
+
+func TestPlayerCommandOwnerLossClearsStaleStateAndPromotesWaiter(t *testing.T) {
+	player := newMPRISPlayer(nil, nil)
+	player.snapshot = PlayerSnapshot{
+		Enabled:        true,
+		Identity:       "DankMaterialShell",
+		PlaybackStatus: "Playing",
+		Title:          "Title",
+		Artist:         "Artist",
+		Album:          "Album",
+		Length:         10_000_000,
+		Position:       2_000_000,
+		CanControl:     true,
+		CanPlay:        true,
+		CanPause:       true,
+		CanGoNext:      true,
+		CanGoPrevious:  true,
+	}
+	manager := &Manager{mprisPlayer: player}
+	owner, err := manager.SubscribePlayerCommands("owner")
+	require.NoError(t, err)
+	ownerLease := (<-owner).Lease
+	require.NotEmpty(t, ownerLease)
+	waiter, err := manager.SubscribePlayerCommands("waiter")
+	require.NoError(t, err)
+
+	manager.UnsubscribePlayerCommands("owner")
+	assert.Equal(t, PlayerSnapshot{
+		Enabled:        true,
+		Identity:       "DankMaterialShell",
+		PlaybackStatus: "Stopped",
+	}, player.currentSnapshot())
+	waiterLease := (<-waiter).Lease
+	require.NotEmpty(t, waiterLease)
+	assert.NotEqual(t, ownerLease, waiterLease)
+	require.Error(t, manager.PublishMPRIS(ownerLease, PlayerSnapshot{Enabled: true}))
+	require.NoError(t, manager.PublishMPRIS(waiterLease, PlayerSnapshot{Enabled: true, PlaybackStatus: "Stopped"}))
+
+	manager.UnsubscribePlayerCommands("waiter")
+}
+
+func TestPlayerPlayPauseDispatchesWhenPaused(t *testing.T) {
+	manager := &Manager{}
+	player := newMPRISPlayer(nil, manager.dispatchPlayerCommand)
+	manager.mprisPlayer = player
+	commands, err := manager.SubscribePlayerCommands("test")
+	require.NoError(t, err)
+	assert.NotEmpty(t, (<-commands).Lease)
+	player.snapshot = PlayerSnapshot{
+		Enabled:        true,
+		PlaybackStatus: "Paused",
+		CanControl:     true,
+		CanPlay:        true,
+	}
+
+	require.Nil(t, player.dispatchCommand("playPause"))
+	assert.Equal(t, PlayerCommand{Command: "playPause"}, <-commands)
+	manager.UnsubscribePlayerCommands("test")
+}
+
+func TestBluezOwnerChangedClearsAndRefreshesOnReplacement(t *testing.T) {
+	player := newMPRISPlayer(nil, nil)
+	player.registered["/org/bluez/hci0"] = struct{}{}
+	manager := &Manager{
+		mprisPlayer:    player,
+		adapterRefresh: make(chan struct{}, 1),
+	}
+
+	manager.handleBluezOwnerChanged(&dbus.Signal{
+		Name: dbusIface + ".NameOwnerChanged",
+		Body: []any{bluezService, ":1.10", ":1.11"},
+	})
+
+	assert.Empty(t, player.registered)
+	assert.Len(t, manager.adapterRefresh, 1)
+}
+
+func TestBluezOwnerChangedRefreshCoalescesWithoutDropping(t *testing.T) {
+	manager := &Manager{adapterRefresh: make(chan struct{}, 1)}
+	signal := &dbus.Signal{
+		Name: dbusIface + ".NameOwnerChanged",
+		Body: []any{bluezService, "", ":1.11"},
+	}
+
+	manager.handleBluezOwnerChanged(signal)
+	manager.handleBluezOwnerChanged(signal)
+
+	assert.Len(t, manager.adapterRefresh, 1)
+}
+
+func TestBluezOwnerChangedClearsOnLossWithoutRefresh(t *testing.T) {
+	player := newMPRISPlayer(nil, nil)
+	player.registered["/org/bluez/hci0"] = struct{}{}
+	manager := &Manager{
+		mprisPlayer:    player,
+		adapterRefresh: make(chan struct{}, 1),
+	}
+
+	manager.handleBluezOwnerChanged(&dbus.Signal{
+		Name: dbusIface + ".NameOwnerChanged",
+		Body: []any{bluezService, ":1.10", ""},
+	})
+
+	assert.Empty(t, player.registered)
+	assert.Empty(t, manager.adapterRefresh)
+}
+
+func TestRegistrationChanges(t *testing.T) {
+	registered := map[dbus.ObjectPath]struct{}{
+		"/org/bluez/hci0": {},
+		"/org/bluez/hci2": {},
+	}
+
+	add, remove := registrationChanges(registered, []dbus.ObjectPath{"/org/bluez/hci0", "/org/bluez/hci1"}, true)
+	assert.Equal(t, []dbus.ObjectPath{"/org/bluez/hci1"}, add)
+	assert.Equal(t, []dbus.ObjectPath{"/org/bluez/hci2"}, remove)
+
+	add, remove = registrationChanges(registered, []dbus.ObjectPath{"/org/bluez/hci0"}, false)
+	assert.Empty(t, add)
+	assert.Equal(t, []dbus.ObjectPath{"/org/bluez/hci0", "/org/bluez/hci2"}, remove)
+}
+
+func TestPlayerSnapshotFromParamsRequiresCompleteIntegralSnapshot(t *testing.T) {
+	params := map[string]any{
+		"enabled":        true,
+		"identity":       "DMS",
+		"playbackStatus": "Paused",
+		"title":          "Title",
+		"artist":         "Artist",
+		"album":          "Album",
+		"length":         float64(10_000_000),
+		"position":       float64(1_000_000),
+		"canControl":     true,
+		"canPlay":        true,
+		"canPause":       true,
+		"canGoNext":      false,
+		"canGoPrevious":  false,
+	}
+
+	snapshot, err := playerSnapshotFromParams(params)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10_000_000), snapshot.Length)
+	assert.Equal(t, int64(1_000_000), snapshot.Position)
+
+	delete(params, "album")
+	_, err = playerSnapshotFromParams(params)
+	require.ErrorContains(t, err, "album")
+	params["album"] = "Album"
+	params["position"] = 1.5
+	_, err = playerSnapshotFromParams(params)
+	require.ErrorContains(t, err, "position")
+}

--- a/core/internal/server/bluez/types.go
+++ b/core/internal/server/bluez/types.go
@@ -67,21 +67,28 @@ type PairingPrompt struct {
 }
 
 type Manager struct {
-	state              *BluetoothState
-	stateMutex         sync.RWMutex
-	subscribers        syncmap.Map[string, chan BluetoothState]
-	stopChan           chan struct{}
-	dbusConn           *dbus.Conn
-	signals            chan *dbus.Signal
-	sigWG              sync.WaitGroup
-	agent              *BluezAgent
-	promptBroker       PromptBroker
-	pairingSubscribers syncmap.Map[string, chan PairingPrompt]
-	dirty              chan struct{}
-	notifierWg         sync.WaitGroup
-	lastNotifiedState  *BluetoothState
-	adapterPaths       []dbus.ObjectPath
-	pendingPairings    syncmap.Map[string, bool]
-	eventQueue         chan func()
-	eventWg            sync.WaitGroup
+	state               *BluetoothState
+	stateMutex          sync.RWMutex
+	subscribers         syncmap.Map[string, chan BluetoothState]
+	stopChan            chan struct{}
+	dbusConn            *dbus.Conn
+	signals             chan *dbus.Signal
+	sigWG               sync.WaitGroup
+	agent               *BluezAgent
+	promptBroker        PromptBroker
+	pairingSubscribers  syncmap.Map[string, chan PairingPrompt]
+	commandSubscribers  syncmap.Map[string, chan PlayerCommand]
+	commandMutex        sync.RWMutex
+	commandLease        string
+	commandSubscription string
+	commandWaiters      []string
+	mprisPlayer         *mprisPlayer
+	dirty               chan struct{}
+	notifierWg          sync.WaitGroup
+	lastNotifiedState   *BluetoothState
+	adapterPaths        []dbus.ObjectPath
+	pendingPairings     syncmap.Map[string, bool]
+	eventQueue          chan func()
+	adapterRefresh      chan struct{}
+	eventWg             sync.WaitGroup
 }

--- a/core/internal/server/router.go
+++ b/core/internal/server/router.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -30,7 +31,7 @@ import (
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/wlroutput"
 )
 
-func RouteRequest(conn *models.Conn, req models.Request) {
+func RouteRequest(ctx context.Context, conn *models.Conn, req models.Request) {
 	if strings.HasPrefix(req.Method, "network.") {
 		if networkManager == nil {
 			models.RespondError(conn, req.ID, "network manager not initialized")
@@ -235,7 +236,7 @@ func RouteRequest(conn *models.Conn, req models.Request) {
 		info := getServerInfo()
 		models.Respond(conn, req.ID, info)
 	case "subscribe":
-		handleSubscribe(conn, req)
+		handleSubscribe(ctx, conn, req)
 	case "matugen.queue":
 		handleMatugenQueue(conn, req)
 	case "matugen.status":

--- a/core/internal/server/server.go
+++ b/core/internal/server/server.go
@@ -385,28 +385,28 @@ func InitializeSysUpdateManager() error {
 	return nil
 }
 
-func routeHandler(_ context.Context, conn *models.Conn, req ipc.Request, _ *ipc.Subscriber) {
-	routeRequestRecovered(conn, models.Request(req))
+func routeHandler(ctx context.Context, conn *models.Conn, req ipc.Request, _ *ipc.Subscriber) {
+	routeRequestRecovered(ctx, conn, models.Request(req))
 }
 
-func subscribeHandler(_ context.Context, conn *models.Conn, req ipc.Request, _ *ipc.Subscriber) {
+func subscribeHandler(ctx context.Context, conn *models.Conn, req ipc.Request, _ *ipc.Subscriber) {
 	switch req.Method {
 	case "subscribe":
-		routeRequestRecovered(conn, models.Request(req))
+		routeRequestRecovered(ctx, conn, models.Request(req))
 	default:
 		models.RespondError(conn, req.ID, fmt.Sprintf("unknown method: %s", req.Method))
 	}
 }
 
 // routeRequestRecovered keeps a panicking handler from taking down the whole daemon
-func routeRequestRecovered(conn *models.Conn, req models.Request) {
+func routeRequestRecovered(ctx context.Context, conn *models.Conn, req models.Request) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Errorf("RouteRequest panic recovered: method=%s panic=%v\n%s", req.Method, r, debug.Stack())
 			models.RespondError(conn, req.ID, "internal server error")
 		}
 	}()
-	RouteRequest(conn, req)
+	RouteRequest(ctx, conn, req)
 }
 
 func getCapabilities() Capabilities {
@@ -502,7 +502,11 @@ func notifyCapabilityChange() {
 	})
 }
 
-func handleSubscribe(conn *models.Conn, req models.Request) {
+func serviceSubscribed(services []string, service string, includeAll bool) bool {
+	return slices.Contains(services, service) || includeAll && slices.Contains(services, "all")
+}
+
+func handleSubscribe(ctx context.Context, conn *models.Conn, req models.Request) {
 	clientID := fmt.Sprintf("meta-client-%p", conn)
 
 	dbusClient := dbusClientID
@@ -528,6 +532,13 @@ func handleSubscribe(conn *models.Conn, req models.Request) {
 	var wg sync.WaitGroup
 	eventChan := make(chan ServiceEvent, 256)
 	stopChan := make(chan struct{})
+	stop := sync.OnceFunc(func() { close(stopChan) })
+	stopContext := context.AfterFunc(ctx, stop)
+	defer func() {
+		stopContext()
+		stop()
+		wg.Wait()
+	}()
 
 	capChan := make(chan ServerInfo, 64)
 	capabilitySubscribers.Store(clientID+"-capabilities", capChan)
@@ -553,10 +564,7 @@ func handleSubscribe(conn *models.Conn, req models.Request) {
 	})
 
 	shouldSubscribe := func(service string) bool {
-		if subscribeAll {
-			return true
-		}
-		return slices.Contains(services, service)
+		return serviceSubscribed(services, service, subscribeAll)
 	}
 
 	if shouldSubscribe("network") && networkManager != nil {
@@ -838,6 +846,36 @@ func handleSubscribe(conn *models.Conn, req models.Request) {
 				}
 			}
 		}()
+	}
+
+	if serviceSubscribed(services, "mpris.command", false) && bluezManager != nil {
+		commandID := clientID + "-mpris-command"
+		commandChan, err := bluezManager.SubscribePlayerCommands(commandID)
+		if err != nil {
+			log.Warnf("MPRIS command subscription rejected: %v", err)
+		} else {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer bluezManager.UnsubscribePlayerCommands(commandID)
+
+				for {
+					select {
+					case command, ok := <-commandChan:
+						if !ok {
+							return
+						}
+						select {
+						case eventChan <- ServiceEvent{Service: "mpris.command", Data: command}:
+						case <-stopChan:
+							return
+						}
+					case <-stopChan:
+						return
+					}
+				}
+			}()
+		}
 	}
 
 	if shouldSubscribe("bluetooth.pairing") && bluezManager != nil {
@@ -1223,17 +1261,23 @@ func handleSubscribe(conn *models.Conn, req models.Request) {
 		ID:     req.ID,
 		Result: &ServiceEvent{Service: "server", Data: info},
 	}); err != nil {
-		close(stopChan)
 		return
 	}
 
-	for event := range eventChan {
-		if err := conn.WriteResponse(models.Response[ServiceEvent]{
-			ID:     req.ID,
-			Result: &event,
-		}); err != nil {
-			close(stopChan)
+	for {
+		select {
+		case <-ctx.Done():
 			return
+		case event, ok := <-eventChan:
+			if !ok {
+				return
+			}
+			if err := conn.WriteResponse(models.Response[ServiceEvent]{
+				ID:     req.ID,
+				Result: &event,
+			}); err != nil {
+				return
+			}
 		}
 	}
 }

--- a/core/internal/server/server_test.go
+++ b/core/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -8,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/bluez"
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/models"
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/server/network"
 	"github.com/stretchr/testify/assert"
@@ -155,4 +157,90 @@ func TestResponse_JSON(t *testing.T) {
 		assert.Equal(t, "test error", decoded.Error)
 		assert.Nil(t, decoded.Result)
 	})
+}
+
+func TestExclusiveServiceRequiresExplicitSubscription(t *testing.T) {
+	tests := []struct {
+		name       string
+		services   []string
+		includeAll bool
+		want       bool
+	}{
+		{name: "explicit", services: []string{"mpris.command"}, want: true},
+		{name: "all excluded", services: []string{"all"}, want: false},
+		{name: "omitted excluded", services: nil, want: false},
+		{name: "regular service via all", services: []string{"all"}, includeAll: true, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := "mpris.command"
+			if tt.includeAll {
+				service = "bluetooth"
+			}
+			assert.Equal(t, tt.want, serviceSubscribed(tt.services, service, tt.includeAll))
+		})
+	}
+}
+
+func TestSubscriptionCancellationPromotesMPRISWaiter(t *testing.T) {
+	originalBluezManager := bluezManager
+	manager := &bluez.Manager{}
+	bluezManager = manager
+	defer func() { bluezManager = originalBluezManager }()
+
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleSubscribe(ctx, models.NewConn(serverConn), models.Request{
+			ID:     42,
+			Method: "subscribe",
+			Params: map[string]any{"services": []any{"mpris.command"}},
+		})
+	}()
+
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	decoder := json.NewDecoder(clientConn)
+	var ownerLease string
+	for ownerLease == "" {
+		var response models.Response[ServiceEvent]
+		require.NoError(t, decoder.Decode(&response))
+		if response.Result == nil || response.Result.Service != "mpris.command" {
+			continue
+		}
+		data, ok := response.Result.Data.(map[string]any)
+		require.True(t, ok)
+		ownerLease, _ = data["lease"].(string)
+	}
+	require.NotEmpty(t, ownerLease)
+
+	waiter, err := manager.SubscribePlayerCommands("waiter")
+	require.NoError(t, err)
+	select {
+	case event := <-waiter:
+		t.Fatalf("waiting subscriber received unexpected event: %#v", event)
+	default:
+	}
+
+	cancel()
+
+	select {
+	case event := <-waiter:
+		require.NotEmpty(t, event.Lease)
+		assert.NotEqual(t, ownerLease, event.Lease)
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiting MPRIS subscriber was not promoted after connection cancellation")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("subscription handler did not stop after connection cancellation")
+	}
+
+	manager.UnsubscribePlayerCommands("waiter")
 }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -514,6 +514,7 @@ Singleton {
     property string audioScrollMode: "volume"
     property int audioWheelScrollAmount: 5
     property bool audioDeviceScrollVolumeEnabled: false
+    property bool bluetoothMprisEnabled: false
     property var mediaExcludePlayers: []
     property bool clockCompactMode: false
     property int focusedWindowSize: 1

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -233,6 +233,7 @@ var SPEC = {
     audioScrollMode: { def: "volume" },
     audioWheelScrollAmount: { def: 5 },
     audioDeviceScrollVolumeEnabled: { def: false },
+    bluetoothMprisEnabled: { def: false },
     mediaExcludePlayers: { def: [] },
     clockCompactMode: { def: false },
     focusedWindowCompactMode: { def: false },

--- a/quickshell/DMSShellIPC.qml
+++ b/quickshell/DMSShellIPC.qml
@@ -570,21 +570,15 @@ Item {
         }
 
         function play(): void {
-            if (MprisController.activePlayer && MprisController.activePlayer.canPlay) {
-                MprisController.activePlayer.play();
-            }
+            MprisController.play();
         }
 
         function pause(): void {
-            if (MprisController.activePlayer && MprisController.activePlayer.canPause) {
-                MprisController.activePlayer.pause();
-            }
+            MprisController.pause();
         }
 
         function playPause(): void {
-            if (MprisController.activePlayer && MprisController.activePlayer.canTogglePlaying) {
-                MprisController.activePlayer.togglePlaying();
-            }
+            MprisController.playPause();
         }
 
         function previous(): void {
@@ -596,9 +590,7 @@ Item {
         }
 
         function stop(): void {
-            if (MprisController.activePlayer) {
-                MprisController.activePlayer.stop();
-            }
+            MprisController.stop();
         }
 
         function increment(step: string): string {

--- a/quickshell/Modules/Settings/MediaPlayerTab.qml
+++ b/quickshell/Modules/Settings/MediaPlayerTab.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import Quickshell.Io
 import qs.Common
 import qs.Widgets
 import qs.Modules.Settings.Widgets
@@ -9,9 +10,36 @@ Item {
 
     property var desktopApps: []
     property var parentModal: null
+    property bool mprisProxyRunning: false
 
     Component.onCompleted: {
         desktopApps = AppSearchService.getVisibleApplications() || [];
+        if (visible)
+            checkMprisProxy();
+    }
+    onVisibleChanged: checkMprisProxy()
+
+    function checkMprisProxy(): void {
+        if (!root.visible || !SettingsData.bluetoothMprisEnabled) {
+            mprisProxyRunning = false;
+            return;
+        }
+        if (!mprisProxyCheck.running)
+            mprisProxyCheck.running = true;
+    }
+
+    Connections {
+        target: SettingsData
+        function onBluetoothMprisEnabledChanged() {
+            root.checkMprisProxy();
+        }
+    }
+
+    Process {
+        id: mprisProxyCheck
+        command: ["sh", "-c", "systemctl --user --quiet is-active mpris-proxy.service 2>/dev/null || pgrep -U \"$(id -u)\" -x mpris-proxy >/dev/null"]
+        running: false
+        onExited: exitCode => root.mprisProxyRunning = root.visible && SettingsData.bluetoothMprisEnabled && exitCode === 0
     }
 
     Component.onDestruction: {
@@ -170,6 +198,24 @@ Item {
                     description: I18n.tr("Allow adjusting device volume by scrolling on the right half of items in the device list")
                     checked: SettingsData.audioDeviceScrollVolumeEnabled
                     onToggled: checked => SettingsData.set("audioDeviceScrollVolumeEnabled", checked)
+                }
+
+                SettingsToggleRow {
+                    settingKey: "bluetoothMpris"
+                    tags: ["bluetooth", "headphones", "media", "mpris", "avrcp"]
+                    text: I18n.tr("Bluetooth media controls", "Title for the setting that routes Bluetooth headset media buttons through DMS")
+                    description: I18n.tr("Route Bluetooth headset controls to the active DMS media player", "Description of how Bluetooth headset media buttons select a player")
+                    checked: SettingsData.bluetoothMprisEnabled
+                    onToggled: checked => SettingsData.set("bluetoothMprisEnabled", checked)
+                }
+
+                StyledText {
+                    visible: SettingsData.bluetoothMprisEnabled && root.mprisProxyRunning
+                    width: parent.width
+                    text: I18n.tr("mpris-proxy is running and will create duplicate Bluetooth players. Disable it with: systemctl --user disable --now mpris-proxy.service", "Warning shown when the legacy BlueZ MPRIS proxy conflicts with DMS Bluetooth media controls")
+                    color: Theme.error
+                    font.pixelSize: Theme.fontSizeSmall
+                    wrapMode: Text.WordWrap
                 }
             }
 

--- a/quickshell/Services/DMSService.qml
+++ b/quickshell/Services/DMSService.qml
@@ -24,6 +24,7 @@ Singleton {
     property bool isConnected: false
     readonly property bool isConnecting: requestSocket.connected && !requestSocket.linkUp
     property bool subscribeConnected: false
+    property string mprisCommandLease: ""
     property bool matugenSmartSupported: false
 
     readonly property string socketPath: Quickshell.env("DMS_SOCKET")
@@ -51,6 +52,7 @@ Singleton {
     signal capabilitiesReceived
     signal credentialsRequest(var data)
     signal bluetoothPairingRequest(var data)
+    signal mprisCommandReceived(string command)
     signal brightnessStateUpdate(var data)
     signal brightnessDeviceUpdate(var device)
     signal wlrOutputStateUpdate(var data)
@@ -191,6 +193,7 @@ Singleton {
 
         onConnectionStateChanged: {
             root.subscribeConnected = linkUp;
+            root.mprisCommandLease = "";
             if (!linkUp) {
                 root.connectionCapabilities = null;
                 return;
@@ -281,16 +284,15 @@ Singleton {
     }
 
     function addSubscription(service) {
-        if (activeSubscriptions.includes("all"))
+        if (activeSubscriptions.includes(service))
             return;
-        if (!activeSubscriptions.includes(service)) {
-            const newSubs = [...activeSubscriptions, service];
-            subscribe(newSubs);
-        }
+        if (activeSubscriptions.includes("all") && service !== "mpris.command")
+            return;
+        subscribe([...activeSubscriptions, service]);
     }
 
     function removeSubscription(service) {
-        if (activeSubscriptions.includes("all")) {
+        if (activeSubscriptions.includes("all") && service !== "mpris.command") {
             const allServices = ["network", "loginctl", "freedesktop", "gamma", "bluetooth", "brightness", "browser", "location"];
             const filtered = allServices.filter(s => s !== service);
             subscribe(filtered);
@@ -352,6 +354,11 @@ Singleton {
             loginctlStateUpdate(data);
         } else if (service === "bluetooth.pairing") {
             bluetoothPairingRequest(data);
+        } else if (service === "mpris.command") {
+            if (data && typeof data.lease === "string")
+                mprisCommandLease = data.lease;
+            else if (data && typeof data.command === "string")
+                mprisCommandReceived(data.command);
         } else if (service === "cups") {
             cupsStateUpdate(data);
         } else if (service === "brightness") {

--- a/quickshell/Services/MprisController.qml
+++ b/quickshell/Services/MprisController.qml
@@ -49,6 +49,9 @@ Singleton {
     property string stableTitle: ""
     property string stableArtist: ""
     property string stableAlbum: ""
+    property bool _mprisRequestInFlight: false
+    property bool _mprisPublishDirty: false
+    property int _mprisConnectionEpoch: 0
 
     Connections {
         target: root.activePlayer
@@ -68,10 +71,66 @@ Singleton {
             if (root.activePlayer && root.activePlayer.lengthSupported && root.activePlayer.length > 1) {
                 root.activePlayerStableLength = root.activePlayer.length;
             }
+            root._scheduleMPRISPublish();
+        }
+        function onMetadataChanged() {
+            root._scheduleMPRISPublish();
+        }
+        function onPositionChanged() {
+            root._scheduleMPRISPublish();
         }
         function onPlaybackStateChanged() {
             root._syncStableMeta();
             root._checkIdle();
+            root._scheduleMPRISPublish();
+        }
+        function onCanControlChanged() {
+            root._scheduleMPRISPublish();
+        }
+        function onCanPlayChanged() {
+            root._scheduleMPRISPublish();
+        }
+        function onCanPauseChanged() {
+            root._scheduleMPRISPublish();
+        }
+        function onCanGoNextChanged() {
+            root._scheduleMPRISPublish();
+        }
+        function onCanGoPreviousChanged() {
+            root._scheduleMPRISPublish();
+        }
+    }
+
+    Connections {
+        target: SettingsData
+        function onBluetoothMprisEnabledChanged() {
+            if (SettingsData.bluetoothMprisEnabled)
+                DMSService.addSubscription("mpris.command");
+            root._scheduleMPRISPublish();
+        }
+    }
+
+    Connections {
+        target: DMSService
+        function onConnectionStateChanged() {
+            root._invalidateMPRISPublishRequests();
+            root._scheduleMPRISPublish();
+        }
+        function onCapabilitiesReceived() {
+            if (!DMSService.capabilities.includes("bluetooth"))
+                root._invalidateMPRISPublishRequests();
+            root._scheduleMPRISPublish();
+        }
+        function onSubscribeConnectedChanged() {
+            root._invalidateMPRISPublishRequests();
+            root._scheduleMPRISPublish();
+        }
+        function onMprisCommandLeaseChanged() {
+            root._invalidateMPRISPublishRequests();
+            root._scheduleMPRISPublish();
+        }
+        function onMprisCommandReceived(command) {
+            root._dispatchMPRISCommand(command);
         }
     }
 
@@ -82,7 +141,12 @@ Singleton {
         stableAlbum = "";
         _syncStableMeta();
         _checkIdle();
+        _scheduleMPRISPublish();
     }
+    onActivePlayerStableLengthChanged: _scheduleMPRISPublish()
+    onStableTitleChanged: _scheduleMPRISPublish()
+    onStableArtistChanged: _scheduleMPRISPublish()
+    onStableAlbumChanged: _scheduleMPRISPublish()
 
     function _syncStableMeta(): void {
         const p = activePlayer;
@@ -133,7 +197,12 @@ Singleton {
     }
 
     onAvailablePlayersChanged: _resolveActivePlayer()
-    Component.onCompleted: _resolveActivePlayer()
+    Component.onCompleted: {
+        _resolveActivePlayer();
+        if (SettingsData.bluetoothMprisEnabled)
+            DMSService.addSubscription("mpris.command");
+        _scheduleMPRISPublish();
+    }
 
     Instantiator {
         model: root.availablePlayers
@@ -330,10 +399,178 @@ Singleton {
     }
 
     Timer {
+        id: _mprisPublishTimer
+        interval: 25
+        repeat: false
+        onTriggered: root._publishMPRISSnapshot()
+    }
+
+    Timer {
+        id: _mprisRetryTimer
+        interval: 2000
+        repeat: false
+        onTriggered: root._scheduleMPRISPublish()
+    }
+
+    Timer {
         interval: 1000
         running: root.activePlayer?.playbackState === MprisPlaybackState.Playing
         repeat: true
         onTriggered: root.activePlayer?.positionChanged()
+    }
+
+    function _hasMPRISSubscription(): bool {
+        return DMSService.activeSubscriptions.includes("mpris.command");
+    }
+
+    function _canPublishMPRIS(): bool {
+        return DMSService.isConnected && DMSService.subscribeConnected && DMSService.mprisCommandLease && DMSService.capabilities.includes("bluetooth");
+    }
+
+    function _scheduleMPRISPublish(): void {
+        const enabled = SettingsData.bluetoothMprisEnabled;
+        const subscribed = _hasMPRISSubscription();
+
+        if (!enabled && !subscribed && !_mprisRequestInFlight) {
+            _mprisPublishDirty = false;
+            return;
+        }
+        if (!enabled && subscribed && !DMSService.mprisCommandLease && !_mprisRequestInFlight) {
+            _mprisPublishDirty = false;
+            DMSService.removeSubscription("mpris.command");
+            return;
+        }
+
+        _mprisPublishDirty = true;
+        if (enabled && !subscribed) {
+            DMSService.addSubscription("mpris.command");
+            return;
+        }
+        if (_mprisRequestInFlight || !_canPublishMPRIS())
+            return;
+        if (!_mprisPublishTimer.running)
+            _mprisPublishTimer.start();
+    }
+
+    function _scheduleMPRISRetry(): void {
+        if (!SettingsData.bluetoothMprisEnabled && !_hasMPRISSubscription())
+            return;
+        if (!_mprisRetryTimer.running)
+            _mprisRetryTimer.start();
+    }
+
+    function _invalidateMPRISPublishRequests(): void {
+        _mprisConnectionEpoch++;
+    }
+
+    function _publishMPRISSnapshot(): void {
+        if (_mprisRequestInFlight || !_mprisPublishDirty)
+            return;
+        if (!SettingsData.bluetoothMprisEnabled && !_hasMPRISSubscription()) {
+            _mprisPublishDirty = false;
+            return;
+        }
+        if (!_canPublishMPRIS())
+            return;
+
+        const enabled = SettingsData.bluetoothMprisEnabled;
+        const requestLease = DMSService.mprisCommandLease;
+        const requestEpoch = _mprisConnectionEpoch;
+        const snapshot = _mprisSnapshot(enabled, requestLease);
+        _mprisPublishDirty = false;
+        _mprisRequestInFlight = true;
+        _mprisRetryTimer.stop();
+
+        DMSService.sendRequest("bluetooth.mpris.publish", snapshot, response => {
+            const changedWhileInFlight = root._mprisPublishDirty;
+            const currentConnection = requestEpoch === root._mprisConnectionEpoch
+                && requestLease === DMSService.mprisCommandLease
+                && DMSService.isConnected
+                && DMSService.subscribeConnected;
+            root._mprisRequestInFlight = false;
+
+            if (!currentConnection) {
+                root._mprisPublishDirty = true;
+                root._scheduleMPRISPublish();
+                return;
+            }
+            if (response?.error) {
+                root._mprisPublishDirty = true;
+                root._scheduleMPRISRetry();
+                return;
+            }
+
+            _mprisRetryTimer.stop();
+
+            if (!enabled && !SettingsData.bluetoothMprisEnabled) {
+                root._mprisPublishDirty = false;
+                DMSService.removeSubscription("mpris.command");
+                return;
+            }
+            if (changedWhileInFlight || enabled !== SettingsData.bluetoothMprisEnabled)
+                root._scheduleMPRISPublish();
+        });
+    }
+
+    function _mprisSnapshot(enabled: bool, lease: string): var {
+        const player = enabled ? activePlayer : null;
+        return {
+            "lease": lease,
+            "enabled": enabled,
+            "identity": "DankMaterialShell",
+            "playbackStatus": _mprisPlaybackStatus(player),
+            "title": player ? stableTitle : "",
+            "artist": player ? stableArtist : "",
+            "album": player ? stableAlbum : "",
+            "length": player ? _secondsToMicroseconds(activePlayerStableLength) : 0,
+            "position": player && player.positionSupported ? _secondsToMicroseconds(player.position) : 0,
+            "canControl": player ? player.canControl : false,
+            "canPlay": player ? player.canPlay : false,
+            "canPause": player ? player.canPause : false,
+            "canGoNext": player ? player.canGoNext : false,
+            "canGoPrevious": player ? player.canGoPrevious : false
+        };
+    }
+
+    function _mprisPlaybackStatus(player: MprisPlayer): string {
+        if (!player)
+            return "Stopped";
+        if (player.playbackState === MprisPlaybackState.Playing)
+            return "Playing";
+        if (player.playbackState === MprisPlaybackState.Paused)
+            return "Paused";
+        return "Stopped";
+    }
+
+    function _secondsToMicroseconds(seconds: real): real {
+        if (!Number.isFinite(seconds) || seconds <= 0)
+            return 0;
+        return Math.round(seconds * 1000000);
+    }
+
+    function _dispatchMPRISCommand(command: string): void {
+        if (!SettingsData.bluetoothMprisEnabled || !DMSService.mprisCommandLease)
+            return;
+        switch (command) {
+        case "play":
+            play();
+            break;
+        case "pause":
+            pause();
+            break;
+        case "playPause":
+            playPause();
+            break;
+        case "stop":
+            stop();
+            break;
+        case "next":
+            next();
+            break;
+        case "previous":
+            previous();
+            break;
+        }
     }
 
     function isFirefoxYoutubeHoverPreview(player: MprisPlayer): bool {
@@ -346,6 +583,33 @@ Singleton {
         return /^https?:\/\/(www\.)?youtube\.com\/?($|\?|#)/i.test(url);
     }
 
+    function play(): void {
+        const player = activePlayer;
+        if (!player?.canPlay)
+            return;
+        player.play();
+    }
+
+    function pause(): void {
+        const player = activePlayer;
+        if (!player?.canPause)
+            return;
+        player.pause();
+    }
+
+    function playPause(): void {
+        const player = activePlayer;
+        if (!player?.canTogglePlaying)
+            return;
+        player.togglePlaying();
+    }
+
+    function stop(): void {
+        const player = activePlayer;
+        if (player)
+            player.stop();
+    }
+
     function previousOrRewind(): void {
         if (!activePlayer)
             return;
@@ -353,6 +617,12 @@ Singleton {
             activePlayer.position = 0.1;
         else if (activePlayer.canGoPrevious)
             activePlayer.previous();
+    }
+
+    function previous(): void {
+        const player = activePlayer;
+        if (player?.canGoPrevious)
+            player.previous();
     }
 
     function next(): void {

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -6836,6 +6836,30 @@
     "description": "Show cava audio visualizer in media widget"
   },
   {
+    "section": "bluetoothMpris",
+    "label": "Bluetooth media controls",
+    "tabIndex": 16,
+    "category": "Media Player",
+    "keywords": [
+      "active",
+      "audio",
+      "avrcp",
+      "bluetooth",
+      "bt",
+      "controls",
+      "headphones",
+      "headset",
+      "media",
+      "mpris",
+      "music",
+      "playback",
+      "player",
+      "route",
+      "spotify"
+    ],
+    "description": "Route Bluetooth headset controls to the active DMS media player"
+  },
+  {
     "section": "mediaDeviceScrollVolume",
     "label": "Device list scroll volume",
     "tabIndex": 16,


### PR DESCRIPTION
## Description

Bluetooth headset controls can target a different application from DMS when several MPRIS players are available. BlueZ's `mpris-proxy` exports every player independently and cannot follow DMS's active or pinned player selection.

This adds an opt-in BlueZ MPRIS bridge to DMS. The backend registers one stable player with BlueZ, while `MprisController.activePlayer` remains the sole selection authority. Incoming media commands are forwarded to that player, and its playback status, metadata, position, and capabilities are published to BlueZ.

The bridge remains registered with a stopped state while enabled without an active player. It supports multiple Bluetooth adapters and recovers from BlueZ restarts, shell reconnects, and ownership changes.

Bridge ownership follows the active shell connection, preventing stale or secondary shell instances from publishing player state or receiving Bluetooth commands.

The setting warns when `mpris-proxy` is running but does not alter the service. Standard MPRIS command semantics, including discrete and idempotent `Play` and `Pause`, are preserved.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

none found

## Screenshots / video

<img width="883" height="929" alt="image" src="https://github.com/user-attachments/assets/938d4b38-1e69-41ac-92cd-bba657016220" />
<img width="595" height="929" alt="image" src="https://github.com/user-attachments/assets/f9eebf45-4051-4a9f-9668-77bc29c6aebb" />

## Testing

Focused Go coverage verifies the exported MPRIS contract, property and capability changes, adapter and BlueZ restart handling, lease ownership, waiter promotion, disconnect cleanup, stale-owner rejection, explicit subscription policy, command queue failures, and concurrent lifecycle behavior.

The affected server packages also pass under the Go race detector.

Hardware validation passed with Bose QC Ultra 2 headphones, Spotify, and Zen/Chromium, including:

- dynamic and pinned-player routing
- discrete Play and Pause, including repeated Pause
- Next and Previous
- wear removal and replacement
- stopped and no-player states
- bridge disable and re-enable
- headset reconnect
- DMS restart recovery
- BlueZ restart recovery
- the `mpris-proxy` conflict warning

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
