### PR TITLE
feat(screenshot): add --geometry flag to selection coordinates

### DIFF
--- a/core/cmd/dms/commands_screenshot.go
+++ b/core/cmd/dms/commands_screenshot.go
@@ -38,8 +38,8 @@ var (
 type screenshotMetadata struct {
 	Status string  `json:"status"`
 	Path   string  `json:"path,omitempty"`
-	X      int     `json:"x,omitempty"`
-	Y      int     `json:"y,omitempty"`
+	X      *int    `json:"x,omitempty"`
+	Y      *int    `json:"y,omitempty"`
 	Width  int     `json:"width,omitempty"`
 	Height int     `json:"height,omitempty"`
 	Scale  float64 `json:"scale,omitempty"`
@@ -325,10 +325,12 @@ func runScreenshot(config screenshot.Config) {
 
 	if config.Geometry {
 		if ssJSON {
+			x := int(result.Region.X)
+			y := int(result.Region.Y)
 			writeScreenshotJSON(screenshotMetadata{
 				Status: "success",
-				X:      int(result.Region.X),
-				Y:      int(result.Region.Y),
+				X:      &x,
+				Y:      &y,
 				Width:  int(result.Region.Width),
 				Height: int(result.Region.Height),
 			})

--- a/core/cmd/dms/commands_screenshot.go
+++ b/core/cmd/dms/commands_screenshot.go
@@ -32,11 +32,14 @@ var (
 	ssReset       bool
 	ssStdout      bool
 	ssJSON        bool
+	ssGeometry    bool
 )
 
 type screenshotMetadata struct {
 	Status string  `json:"status"`
 	Path   string  `json:"path,omitempty"`
+	X      int     `json:"x,omitempty"`
+	Y      int     `json:"y,omitempty"`
 	Width  int     `json:"width,omitempty"`
 	Height int     `json:"height,omitempty"`
 	Scale  float64 `json:"scale,omitempty"`
@@ -77,6 +80,7 @@ Examples:
   dms screenshot --cursor=on         # Include cursor
   dms screenshot -f jpg -q 85        # JPEG with quality 85
   dms screenshot --json              # Print capture metadata as JSON
+  dms screenshot -g                  # Print selected region geometry (X,Y WxH) to stdout
   dms screenshot scroll              # Scroll capture, Enter finishes / Esc cancels
   dms screenshot scroll --interval 250`,
 }
@@ -171,6 +175,7 @@ func init() {
 	screenshotCmd.PersistentFlags().BoolVar(&ssReset, "reset", false, "Reset saved last-region preselection before capturing")
 	screenshotCmd.PersistentFlags().BoolVar(&ssStdout, "stdout", false, "Output image to stdout (for piping to swappy, etc.)")
 	screenshotCmd.PersistentFlags().BoolVar(&ssJSON, "json", false, "Print capture metadata as JSON")
+	screenshotCmd.PersistentFlags().BoolVarP(&ssGeometry, "geometry", "g", false, "Print selected region geometry (X,Y WxH) to stdout without capturing an image")
 
 	ssScrollCmd.Flags().IntVar(&ssScrollInterval, "interval", 45, "Capture interval in milliseconds (30-1000)")
 
@@ -199,6 +204,13 @@ func getScreenshotConfig(mode screenshot.Mode) screenshot.Config {
 	config.NoConfirm = ssNoConfirm
 	config.Reset = ssReset
 	config.Stdout = ssStdout
+	config.Geometry = ssGeometry
+
+	if ssGeometry {
+		config.Clipboard = false
+		config.SaveFile = false
+		config.Notify = false
+	}
 
 	if ssOutputDir != "" {
 		config.OutputDir = ssOutputDir
@@ -279,6 +291,14 @@ func runScreenshot(config screenshot.Config) {
 		fmt.Fprintln(os.Stderr, "Error: --json cannot be combined with --stdout")
 		os.Exit(1)
 	}
+	if ssGeometry && config.Stdout {
+		fmt.Fprintln(os.Stderr, "Error: --geometry cannot be combined with --stdout")
+		os.Exit(1)
+	}
+	if ssGeometry && config.Mode == screenshot.ModeScroll {
+		fmt.Fprintln(os.Stderr, "Error: --geometry cannot be combined with scroll mode")
+		os.Exit(1)
+	}
 
 	// Short-lived process over a few tens of MB: let the heap grow instead of paying GC cycles mid-capture.
 	debug.SetGCPercent(-1)
@@ -295,13 +315,33 @@ func runScreenshot(config screenshot.Config) {
 		if ssJSON {
 			writeScreenshotJSON(screenshotMetadata{Status: "aborted", Error: "User cancelled selection"})
 		}
+		if config.Geometry {
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 
-	defer result.Buffer.Close()
+	if config.Geometry {
+		if ssJSON {
+			writeScreenshotJSON(screenshotMetadata{
+				Status: "success",
+				X:      int(result.Region.X),
+				Y:      int(result.Region.Y),
+				Width:  int(result.Region.Width),
+				Height: int(result.Region.Height),
+			})
+		} else {
+			fmt.Printf("%d,%d %dx%d\n", result.Region.X, result.Region.Y, result.Region.Width, result.Region.Height)
+		}
+		os.Exit(0)
+	}
 
-	if result.YInverted {
-		result.Buffer.FlipVertical()
+	if result.Buffer != nil {
+		defer result.Buffer.Close()
+
+		if result.YInverted {
+			result.Buffer.FlipVertical()
+		}
 	}
 
 	if config.Stdout {

--- a/core/cmd/dms/commands_screenshot.go
+++ b/core/cmd/dms/commands_screenshot.go
@@ -291,13 +291,15 @@ func runScreenshot(config screenshot.Config) {
 		fmt.Fprintln(os.Stderr, "Error: --json cannot be combined with --stdout")
 		os.Exit(1)
 	}
-	if ssGeometry && config.Stdout {
-		fmt.Fprintln(os.Stderr, "Error: --geometry cannot be combined with --stdout")
-		os.Exit(1)
-	}
-	if ssGeometry && config.Mode == screenshot.ModeScroll {
-		fmt.Fprintln(os.Stderr, "Error: --geometry cannot be combined with scroll mode")
-		os.Exit(1)
+	if config.Geometry {
+		if config.Stdout {
+			fmt.Fprintln(os.Stderr, "Error: --geometry cannot be combined with --stdout")
+			os.Exit(1)
+		}
+		if config.Mode == screenshot.ModeScroll {
+			fmt.Fprintln(os.Stderr, "Error: --geometry cannot be combined with scroll mode")
+			os.Exit(1)
+		}
 	}
 
 	// Short-lived process over a few tens of MB: let the heap grow instead of paying GC cycles mid-capture.
@@ -331,7 +333,7 @@ func runScreenshot(config screenshot.Config) {
 				Height: int(result.Region.Height),
 			})
 		} else {
-			fmt.Printf("%d,%d %dx%d\n", result.Region.X, result.Region.Y, result.Region.Width, result.Region.Height)
+			fmt.Println(result.Region.GeometryString())
 		}
 		os.Exit(0)
 	}

--- a/core/internal/screenshot/niri_window.go
+++ b/core/internal/screenshot/niri_window.go
@@ -156,7 +156,11 @@ func (s *Screenshoter) captureNiriWindow() (*CaptureResult, error) {
 	}
 
 	return &CaptureResult{
-		Buffer:    buf,
+		Buffer: buf,
+		Region: Region{
+			Width:  int32(img.Bounds().Dx()),
+			Height: int32(img.Bounds().Dy()),
+		},
 		YInverted: false,
 		Format:    uint32(FormatARGB8888),
 		Scale:     scale,

--- a/core/internal/screenshot/region.go
+++ b/core/internal/screenshot/region.go
@@ -2,6 +2,7 @@ package screenshot
 
 import (
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/AvengeMedia/DankMaterialShell/core/internal/log"
@@ -229,7 +230,31 @@ func (r *RegionSelector) Run() (*CaptureResult, bool, error) {
 		return nil, false, r.scroll.abortErr
 	}
 
-	if r.cancelled || r.capturedBuffer == nil {
+	if r.cancelled {
+		return nil, true, nil
+	}
+
+	if r.screenshoter != nil && r.screenshoter.config.Geometry {
+		gx, gy, gw, gh, ok := r.selectedLogicalGeometry()
+		if !ok {
+			return nil, true, nil
+		}
+		var outputName string
+		if r.selection.surface != nil && r.selection.surface.output != nil {
+			outputName = r.selection.surface.output.name
+		}
+		return &CaptureResult{
+			Region: Region{
+				X:      int32(gx),
+				Y:      int32(gy),
+				Width:  int32(gw),
+				Height: int32(gh),
+				Output: outputName,
+			},
+		}, false, nil
+	}
+
+	if r.capturedBuffer == nil {
 		return nil, r.cancelled, nil
 	}
 
@@ -255,6 +280,31 @@ func (r *RegionSelector) Run() (*CaptureResult, bool, error) {
 		Format:    format,
 		Scale:     scale,
 	}, false, nil
+}
+
+func (r *RegionSelector) selectedLogicalGeometry() (x, y, w, h int, ok bool) {
+	if !r.selection.hasSelection {
+		return 0, 0, 0, 0, false
+	}
+	minX := math.Min(r.selection.anchorX, r.selection.currentX)
+	minY := math.Min(r.selection.anchorY, r.selection.currentY)
+	maxX := math.Max(r.selection.anchorX, r.selection.currentX)
+	maxY := math.Max(r.selection.anchorY, r.selection.currentY)
+
+	x1 := int(math.Round(minX))
+	y1 := int(math.Round(minY))
+	x2 := int(math.Round(maxX))
+	y2 := int(math.Round(maxY))
+	lw := x2 - x1
+	lh := y2 - y1
+	if r.shiftHeld {
+		size := min(lw, lh)
+		lw, lh = size, size
+	}
+	if lw <= 0 || lh <= 0 {
+		return 0, 0, 0, 0, false
+	}
+	return x1, y1, lw, lh, true
 }
 
 func (r *RegionSelector) connect() error {

--- a/core/internal/screenshot/region.go
+++ b/core/internal/screenshot/region.go
@@ -235,23 +235,11 @@ func (r *RegionSelector) Run() (*CaptureResult, bool, error) {
 	}
 
 	if r.screenshoter != nil && r.screenshoter.config.Geometry {
-		gx, gy, gw, gh, ok := r.selectedLogicalGeometry()
+		reg, ok := r.selectedLogicalGeometry()
 		if !ok {
 			return nil, true, nil
 		}
-		var outputName string
-		if r.selection.surface != nil && r.selection.surface.output != nil {
-			outputName = r.selection.surface.output.name
-		}
-		return &CaptureResult{
-			Region: Region{
-				X:      int32(gx),
-				Y:      int32(gy),
-				Width:  int32(gw),
-				Height: int32(gh),
-				Output: outputName,
-			},
-		}, false, nil
+		return geometryResult(reg), false, nil
 	}
 
 	if r.capturedBuffer == nil {
@@ -282,9 +270,9 @@ func (r *RegionSelector) Run() (*CaptureResult, bool, error) {
 	}, false, nil
 }
 
-func (r *RegionSelector) selectedLogicalGeometry() (x, y, w, h int, ok bool) {
+func (r *RegionSelector) selectedLogicalGeometry() (Region, bool) {
 	if !r.selection.hasSelection {
-		return 0, 0, 0, 0, false
+		return Region{}, false
 	}
 	minX := math.Min(r.selection.anchorX, r.selection.currentX)
 	minY := math.Min(r.selection.anchorY, r.selection.currentY)
@@ -302,9 +290,19 @@ func (r *RegionSelector) selectedLogicalGeometry() (x, y, w, h int, ok bool) {
 		lw, lh = size, size
 	}
 	if lw <= 0 || lh <= 0 {
-		return 0, 0, 0, 0, false
+		return Region{}, false
 	}
-	return x1, y1, lw, lh, true
+	var outputName string
+	if r.selection.surface != nil && r.selection.surface.output != nil {
+		outputName = r.selection.surface.output.name
+	}
+	return Region{
+		X:      int32(x1),
+		Y:      int32(y1),
+		Width:  int32(lw),
+		Height: int32(lh),
+		Output: outputName,
+	}, true
 }
 
 func (r *RegionSelector) connect() error {

--- a/core/internal/screenshot/region.go
+++ b/core/internal/screenshot/region.go
@@ -271,34 +271,35 @@ func (r *RegionSelector) Run() (*CaptureResult, bool, error) {
 }
 
 func (r *RegionSelector) selectedLogicalGeometry() (Region, bool) {
-	if !r.selection.hasSelection {
+	ext, ok := r.selectionExtent()
+	if !ok || ext.width() <= 0 || ext.height() <= 0 {
 		return Region{}, false
 	}
-	minX := math.Min(r.selection.anchorX, r.selection.currentX)
-	minY := math.Min(r.selection.anchorY, r.selection.currentY)
-	maxX := math.Max(r.selection.anchorX, r.selection.currentX)
-	maxY := math.Max(r.selection.anchorY, r.selection.currentY)
 
-	x1 := int(math.Round(minX))
-	y1 := int(math.Round(minY))
-	x2 := int(math.Round(maxX))
-	y2 := int(math.Round(maxY))
-	lw := x2 - x1
-	lh := y2 - y1
-	if r.shiftHeld {
+	x1, y1, x2, y2 := ext.logical()
+	lx := int(math.Round(x1))
+	ly := int(math.Round(y1))
+	lw := int(math.Round(x2 - x1))
+	lh := int(math.Round(y2 - y1))
+
+	if r.shiftHeld && ext.within(ext.surface) {
 		size := min(lw, lh)
-		lw, lh = size, size
+		lw = size
+		lh = size
 	}
+
 	if lw <= 0 || lh <= 0 {
 		return Region{}, false
 	}
-	var outputName string
-	if r.selection.surface != nil && r.selection.surface.output != nil {
-		outputName = r.selection.surface.output.name
+
+	outputName := ""
+	if ext.within(ext.surface) && ext.surface.output != nil {
+		outputName = ext.surface.output.name
 	}
+
 	return Region{
-		X:      int32(x1),
-		Y:      int32(y1),
+		X:      int32(lx),
+		Y:      int32(ly),
 		Width:  int32(lw),
 		Height: int32(lh),
 		Output: outputName,

--- a/core/internal/screenshot/region_geometry_test.go
+++ b/core/internal/screenshot/region_geometry_test.go
@@ -5,6 +5,22 @@ import (
 )
 
 func TestSelectedLogicalGeometry(t *testing.T) {
+	mockSurface := &OutputSurface{
+		logicalW: 3840,
+		logicalH: 2160,
+		output: &WaylandOutput{
+			name:            "DP-1",
+			x:               0,
+			y:               0,
+			fractionalScale: 1.0,
+		},
+		screenBuf: &ShmBuffer{
+			Width:  3840,
+			Height: 2160,
+			Stride: 3840 * 4,
+		},
+	}
+
 	tests := []struct {
 		name          string
 		anchorX       float64
@@ -21,18 +37,18 @@ func TestSelectedLogicalGeometry(t *testing.T) {
 		wantFormatted string
 	}{
 		{
-			name:          "standard drag top-left to bottom-right",
+			name:          "standard drag inclusive edges",
 			anchorX:       2263,
 			anchorY:       118,
-			currentX:      2263 + 513,
-			currentY:      118 + 313,
+			currentX:      2776,
+			currentY:      431,
 			hasSelection:  true,
 			wantX:         2263,
 			wantY:         118,
-			wantW:         513,
-			wantH:         313,
+			wantW:         514,
+			wantH:         314,
 			wantOK:        true,
-			wantFormatted: "2263,118 513x313",
+			wantFormatted: "2263,118 514x314",
 		},
 		{
 			name:          "inverted drag bottom-right to top-left",
@@ -43,10 +59,10 @@ func TestSelectedLogicalGeometry(t *testing.T) {
 			hasSelection:  true,
 			wantX:         400,
 			wantY:         300,
-			wantW:         600,
-			wantH:         500,
+			wantW:         601,
+			wantH:         501,
 			wantOK:        true,
-			wantFormatted: "400,300 600x500",
+			wantFormatted: "400,300 601x501",
 		},
 		{
 			name:          "shift held square constraint",
@@ -58,23 +74,14 @@ func TestSelectedLogicalGeometry(t *testing.T) {
 			hasSelection:  true,
 			wantX:         100,
 			wantY:         100,
-			wantW:         200,
-			wantH:         200,
+			wantW:         201,
+			wantH:         201,
 			wantOK:        true,
-			wantFormatted: "100,100 200x200",
+			wantFormatted: "100,100 201x201",
 		},
 		{
 			name:         "no selection",
 			hasSelection: false,
-			wantOK:       false,
-		},
-		{
-			name:         "zero width",
-			anchorX:      100,
-			anchorY:      100,
-			currentX:     100,
-			currentY:     200,
-			hasSelection: true,
 			wantOK:       false,
 		},
 	}
@@ -85,6 +92,7 @@ func TestSelectedLogicalGeometry(t *testing.T) {
 				shiftHeld: tc.shiftHeld,
 				selection: SelectionState{
 					hasSelection: tc.hasSelection,
+					surface:      mockSurface,
 					anchorX:      tc.anchorX,
 					anchorY:      tc.anchorY,
 					currentX:     tc.currentX,
@@ -110,6 +118,66 @@ func TestSelectedLogicalGeometry(t *testing.T) {
 				t.Errorf("formatted = %q, want %q", formatted, tc.wantFormatted)
 			}
 		})
+	}
+}
+
+func TestSelectedLogicalGeometryPreSelection(t *testing.T) {
+	mockSurface := &OutputSurface{
+		logicalW: 1920,
+		logicalH: 1080,
+		output: &WaylandOutput{
+			name:            "eDP-1",
+			x:               0,
+			y:               0,
+			fractionalScale: 1.0,
+		},
+		screenBuf: &ShmBuffer{
+			Width:  1920,
+			Height: 1080,
+			Stride: 1920 * 4,
+		},
+	}
+
+	r := &RegionSelector{
+		preSelect: Region{
+			X:      2263,
+			Y:      118,
+			Width:  513,
+			Height: 313,
+			Output: "eDP-1",
+		},
+	}
+
+	r.applyPreSelection(mockSurface)
+	reg, ok := r.selectedLogicalGeometry()
+	if !ok {
+		t.Fatal("expected preselection to produce valid geometry")
+	}
+
+	if reg.X != 2263 || reg.Y != 118 || reg.Width != 513 || reg.Height != 313 {
+		t.Errorf("got (%d, %d, %d, %d), want (2263, 118, 513, 313)",
+			reg.X, reg.Y, reg.Width, reg.Height)
+	}
+	if got := reg.GeometryString(); got != "2263,118 513x313" {
+		t.Errorf("GeometryString() = %q, want %q", got, "2263,118 513x313")
+	}
+}
+
+func TestWaylandOutputBoundsScaled(t *testing.T) {
+	out := &WaylandOutput{
+		name:            "DP-2",
+		x:               1920,
+		y:               0,
+		width:           3840,
+		height:          2160,
+		scale:           2,
+		fractionalScale: 2.0,
+	}
+
+	b := out.bounds()
+	if b.X != 1920 || b.Y != 0 || b.Width != 1920 || b.Height != 1080 {
+		t.Errorf("bounds() = (%d, %d, %d, %d), want (1920, 0, 1920, 1080)",
+			b.X, b.Y, b.Width, b.Height)
 	}
 }
 

--- a/core/internal/screenshot/region_geometry_test.go
+++ b/core/internal/screenshot/region_geometry_test.go
@@ -1,0 +1,115 @@
+package screenshot
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSelectedLogicalGeometry(t *testing.T) {
+	tests := []struct {
+		name          string
+		anchorX       float64
+		anchorY       float64
+		currentX      float64
+		currentY      float64
+		shiftHeld     bool
+		hasSelection  bool
+		wantX         int
+		wantY         int
+		wantW         int
+		wantH         int
+		wantOK        bool
+		wantFormatted string
+	}{
+		{
+			name:          "standard drag top-left to bottom-right",
+			anchorX:       2263,
+			anchorY:       118,
+			currentX:      2263 + 513,
+			currentY:      118 + 313,
+			hasSelection:  true,
+			wantX:         2263,
+			wantY:         118,
+			wantW:         513,
+			wantH:         313,
+			wantOK:        true,
+			wantFormatted: "2263,118 513x313",
+		},
+		{
+			name:          "inverted drag bottom-right to top-left",
+			anchorX:       1000,
+			anchorY:       800,
+			currentX:      400,
+			currentY:      300,
+			hasSelection:  true,
+			wantX:         400,
+			wantY:         300,
+			wantW:         600,
+			wantH:         500,
+			wantOK:        true,
+			wantFormatted: "400,300 600x500",
+		},
+		{
+			name:          "shift held square constraint",
+			anchorX:       100,
+			anchorY:       100,
+			currentX:      500,
+			currentY:      300,
+			shiftHeld:     true,
+			hasSelection:  true,
+			wantX:         100,
+			wantY:         100,
+			wantW:         200,
+			wantH:         200,
+			wantOK:        true,
+			wantFormatted: "100,100 200x200",
+		},
+		{
+			name:         "no selection",
+			hasSelection: false,
+			wantOK:       false,
+		},
+		{
+			name:         "zero width",
+			anchorX:      100,
+			anchorY:      100,
+			currentX:     100,
+			currentY:     200,
+			hasSelection: true,
+			wantOK:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &RegionSelector{
+				shiftHeld: tc.shiftHeld,
+				selection: SelectionState{
+					hasSelection: tc.hasSelection,
+					anchorX:      tc.anchorX,
+					anchorY:      tc.anchorY,
+					currentX:     tc.currentX,
+					currentY:     tc.currentY,
+				},
+			}
+
+			x, y, w, h, ok := r.selectedLogicalGeometry()
+			if ok != tc.wantOK {
+				t.Fatalf("selectedLogicalGeometry() ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+
+			if x != tc.wantX || y != tc.wantY || w != tc.wantW || h != tc.wantH {
+				t.Errorf("got (%d, %d, %d, %d), want (%d, %d, %d, %d)",
+					x, y, w, h, tc.wantX, tc.wantY, tc.wantW, tc.wantH)
+			}
+
+			formatted := fmt.Sprintf("%d,%d %dx%d", x, y, w, h)
+			if formatted != tc.wantFormatted {
+				t.Errorf("formatted = %q, want %q", formatted, tc.wantFormatted)
+			}
+		})
+	}
+}

--- a/core/internal/screenshot/region_geometry_test.go
+++ b/core/internal/screenshot/region_geometry_test.go
@@ -1,7 +1,6 @@
 package screenshot
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -93,7 +92,7 @@ func TestSelectedLogicalGeometry(t *testing.T) {
 				},
 			}
 
-			x, y, w, h, ok := r.selectedLogicalGeometry()
+			reg, ok := r.selectedLogicalGeometry()
 			if ok != tc.wantOK {
 				t.Fatalf("selectedLogicalGeometry() ok = %v, want %v", ok, tc.wantOK)
 			}
@@ -101,15 +100,22 @@ func TestSelectedLogicalGeometry(t *testing.T) {
 				return
 			}
 
-			if x != tc.wantX || y != tc.wantY || w != tc.wantW || h != tc.wantH {
+			if int(reg.X) != tc.wantX || int(reg.Y) != tc.wantY || int(reg.Width) != tc.wantW || int(reg.Height) != tc.wantH {
 				t.Errorf("got (%d, %d, %d, %d), want (%d, %d, %d, %d)",
-					x, y, w, h, tc.wantX, tc.wantY, tc.wantW, tc.wantH)
+					reg.X, reg.Y, reg.Width, reg.Height, tc.wantX, tc.wantY, tc.wantW, tc.wantH)
 			}
 
-			formatted := fmt.Sprintf("%d,%d %dx%d", x, y, w, h)
+			formatted := reg.GeometryString()
 			if formatted != tc.wantFormatted {
 				t.Errorf("formatted = %q, want %q", formatted, tc.wantFormatted)
 			}
 		})
+	}
+}
+
+func TestRegionGeometryString(t *testing.T) {
+	r := Region{X: 1920, Y: 1080, Width: 800, Height: 600}
+	if got := r.GeometryString(); got != "1920,1080 800x600" {
+		t.Fatalf("GeometryString() = %q, want %q", got, "1920,1080 800x600")
 	}
 }

--- a/core/internal/screenshot/region_input.go
+++ b/core/internal/screenshot/region_input.go
@@ -495,6 +495,11 @@ func (r *RegionSelector) selectionDeviceRect() (*OutputSurface, int, int, int, i
 }
 
 func (r *RegionSelector) finishSelection() {
+	if r.screenshoter != nil && r.screenshoter.config.Geometry {
+		r.running = false
+		return
+	}
+
 	scrollMode := r.screenshoter != nil && r.screenshoter.config.Mode == ModeScroll
 	switch {
 	case scrollMode:

--- a/core/internal/screenshot/screenshot.go
+++ b/core/internal/screenshot/screenshot.go
@@ -116,6 +116,12 @@ func (s *Screenshoter) captureLastRegion() (*CaptureResult, error) {
 		return s.captureRegion()
 	}
 
+	if s.config.Geometry {
+		return &CaptureResult{
+			Region: lastRegion,
+		}, nil
+	}
+
 	output := s.findOutputForRegion(lastRegion)
 	if output == nil {
 		return s.captureRegion()
@@ -173,6 +179,12 @@ func (s *Screenshoter) captureWindow() (*CaptureResult, error) {
 		Y:      geom.Y,
 		Width:  geom.Width,
 		Height: geom.Height,
+	}
+
+	if s.config.Geometry {
+		return &CaptureResult{
+			Region: region,
+		}, nil
 	}
 
 	var output *WaylandOutput
@@ -308,6 +320,18 @@ func (s *Screenshoter) captureFullScreen() (*CaptureResult, error) {
 		return nil, fmt.Errorf("no output available")
 	}
 
+	if s.config.Geometry {
+		return &CaptureResult{
+			Region: Region{
+				X:      output.x,
+				Y:      output.y,
+				Width:  output.width,
+				Height: output.height,
+				Output: output.name,
+			},
+		}, nil
+	}
+
 	return s.captureWholeOutput(output)
 }
 
@@ -326,6 +350,18 @@ func (s *Screenshoter) captureOutput(name string) (*CaptureResult, error) {
 		return nil, fmt.Errorf("output %q not found", name)
 	}
 
+	if s.config.Geometry {
+		return &CaptureResult{
+			Region: Region{
+				X:      output.x,
+				Y:      output.y,
+				Width:  output.width,
+				Height: output.height,
+				Output: output.name,
+			},
+		}, nil
+	}
+
 	return s.captureWholeOutput(output)
 }
 
@@ -340,6 +376,34 @@ func (s *Screenshoter) captureAllScreens() (*CaptureResult, error) {
 	if len(outputs) == 0 {
 		return nil, fmt.Errorf("no outputs available")
 	}
+
+	if s.config.Geometry {
+		minX, minY := math.MaxInt32, math.MaxInt32
+		maxX, maxY := math.MinInt32, math.MinInt32
+		for _, o := range outputs {
+			if int(o.x) < minX {
+				minX = int(o.x)
+			}
+			if int(o.y) < minY {
+				minY = int(o.y)
+			}
+			if int(o.x+o.width) > maxX {
+				maxX = int(o.x + o.width)
+			}
+			if int(o.y+o.height) > maxY {
+				maxY = int(o.y + o.height)
+			}
+		}
+		return &CaptureResult{
+			Region: Region{
+				X:      int32(minX),
+				Y:      int32(minY),
+				Width:  int32(maxX - minX),
+				Height: int32(maxY - minY),
+			},
+		}, nil
+	}
+
 	if len(outputs) == 1 {
 		return s.captureWholeOutput(outputs[0])
 	}

--- a/core/internal/screenshot/screenshot.go
+++ b/core/internal/screenshot/screenshot.go
@@ -197,7 +197,7 @@ func (s *Screenshoter) captureRegion() (*CaptureResult, error) {
 		return nil, nil
 	}
 
-	if result.Region.Output != "" {
+	if !s.config.Geometry && result.Region.Output != "" {
 		if err := SaveLastRegion(result.Region); err != nil {
 			log.Debug("failed to save last region", "err", err)
 		}
@@ -212,6 +212,9 @@ func (s *Screenshoter) captureRegion() (*CaptureResult, error) {
 
 func (s *Screenshoter) captureWindow() (*CaptureResult, error) {
 	if DetectCompositor() == CompositorNiri {
+		if s.config.Geometry {
+			return nil, fmt.Errorf("window geometry mode is not supported on niri")
+		}
 		return s.captureNiriWindow()
 	}
 

--- a/core/internal/screenshot/screenshot.go
+++ b/core/internal/screenshot/screenshot.go
@@ -53,6 +53,14 @@ func (o *WaylandOutput) bounds() Region {
 		if hx, hy, hw, hh, ok := GetHyprlandMonitorGeometry(o.name); ok {
 			x, y, w, h = hx, hy, hw, hh
 		}
+	} else {
+		if o.transform == 1 || o.transform == 3 || o.transform == 5 || o.transform == 7 {
+			w, h = h, w
+		}
+		if scale := o.effectiveScale(); scale > 0 {
+			w = int32(math.Round(float64(w) / scale))
+			h = int32(math.Round(float64(h) / scale))
+		}
 	}
 	return Region{
 		X:      x,
@@ -136,13 +144,33 @@ func (s *Screenshoter) captureLastRegion() (*CaptureResult, error) {
 		return s.captureRegion()
 	}
 
-	if s.config.Geometry {
-		return geometryResult(lastRegion), nil
+	var output *WaylandOutput
+	if lastRegion.Output != "" {
+		output = s.findOutputByName(lastRegion.Output)
 	}
-
-	output := s.findOutputForRegion(lastRegion)
+	if output == nil {
+		output = s.findOutputForRegion(lastRegion)
+	}
 	if output == nil {
 		return s.captureRegion()
+	}
+
+	if s.config.Geometry {
+		scale := output.effectiveScale()
+		if scale <= 0 {
+			scale = 1.0
+		}
+		localX := float64(lastRegion.X-output.x) / scale
+		localY := float64(lastRegion.Y-output.y) / scale
+		logicalW := float64(lastRegion.Width) / scale
+		logicalH := float64(lastRegion.Height) / scale
+		return geometryResult(Region{
+			X:      int32(math.Round(float64(output.x) + localX)),
+			Y:      int32(math.Round(float64(output.y) + localY)),
+			Width:  int32(math.Round(logicalW)),
+			Height: int32(math.Round(logicalH)),
+			Output: output.name,
+		}), nil
 	}
 
 	return s.captureRegionOnOutput(output, lastRegion)

--- a/core/internal/screenshot/screenshot.go
+++ b/core/internal/screenshot/screenshot.go
@@ -47,6 +47,26 @@ func (o *WaylandOutput) effectiveScale() float64 {
 	return scale
 }
 
+func (o *WaylandOutput) bounds() Region {
+	x, y, w, h := o.x, o.y, o.width, o.height
+	if DetectCompositor() == CompositorHyprland {
+		if hx, hy, hw, hh, ok := GetHyprlandMonitorGeometry(o.name); ok {
+			x, y, w, h = hx, hy, hw, hh
+		}
+	}
+	return Region{
+		X:      x,
+		Y:      y,
+		Width:  w,
+		Height: h,
+		Output: o.name,
+	}
+}
+
+func geometryResult(region Region) *CaptureResult {
+	return &CaptureResult{Region: region}
+}
+
 type Screenshoter struct {
 	config Config
 
@@ -117,9 +137,7 @@ func (s *Screenshoter) captureLastRegion() (*CaptureResult, error) {
 	}
 
 	if s.config.Geometry {
-		return &CaptureResult{
-			Region: lastRegion,
-		}, nil
+		return geometryResult(lastRegion), nil
 	}
 
 	output := s.findOutputForRegion(lastRegion)
@@ -182,9 +200,7 @@ func (s *Screenshoter) captureWindow() (*CaptureResult, error) {
 	}
 
 	if s.config.Geometry {
-		return &CaptureResult{
-			Region: region,
-		}, nil
+		return geometryResult(region), nil
 	}
 
 	var output *WaylandOutput
@@ -321,15 +337,7 @@ func (s *Screenshoter) captureFullScreen() (*CaptureResult, error) {
 	}
 
 	if s.config.Geometry {
-		return &CaptureResult{
-			Region: Region{
-				X:      output.x,
-				Y:      output.y,
-				Width:  output.width,
-				Height: output.height,
-				Output: output.name,
-			},
-		}, nil
+		return geometryResult(output.bounds()), nil
 	}
 
 	return s.captureWholeOutput(output)
@@ -351,15 +359,7 @@ func (s *Screenshoter) captureOutput(name string) (*CaptureResult, error) {
 	}
 
 	if s.config.Geometry {
-		return &CaptureResult{
-			Region: Region{
-				X:      output.x,
-				Y:      output.y,
-				Width:  output.width,
-				Height: output.height,
-				Output: output.name,
-			},
-		}, nil
+		return geometryResult(output.bounds()), nil
 	}
 
 	return s.captureWholeOutput(output)
@@ -381,27 +381,26 @@ func (s *Screenshoter) captureAllScreens() (*CaptureResult, error) {
 		minX, minY := math.MaxInt32, math.MaxInt32
 		maxX, maxY := math.MinInt32, math.MinInt32
 		for _, o := range outputs {
-			if int(o.x) < minX {
-				minX = int(o.x)
+			b := o.bounds()
+			if int(b.X) < minX {
+				minX = int(b.X)
 			}
-			if int(o.y) < minY {
-				minY = int(o.y)
+			if int(b.Y) < minY {
+				minY = int(b.Y)
 			}
-			if int(o.x+o.width) > maxX {
-				maxX = int(o.x + o.width)
+			if int(b.X+b.Width) > maxX {
+				maxX = int(b.X + b.Width)
 			}
-			if int(o.y+o.height) > maxY {
-				maxY = int(o.y + o.height)
+			if int(b.Y+b.Height) > maxY {
+				maxY = int(b.Y + b.Height)
 			}
 		}
-		return &CaptureResult{
-			Region: Region{
-				X:      int32(minX),
-				Y:      int32(minY),
-				Width:  int32(maxX - minX),
-				Height: int32(maxY - minY),
-			},
-		}, nil
+		return geometryResult(Region{
+			X:      int32(minX),
+			Y:      int32(minY),
+			Width:  int32(maxX - minX),
+			Height: int32(maxY - minY),
+		}), nil
 	}
 
 	if len(outputs) == 1 {
@@ -969,26 +968,16 @@ func (s *Screenshoter) findOutputForRegion(region Region) *WaylandOutput {
 	cy := region.Y + region.Height/2
 
 	for _, o := range s.outputs {
-		x, y, w, h := o.x, o.y, o.width, o.height
-		if DetectCompositor() == CompositorHyprland {
-			if hx, hy, hw, hh, ok := GetHyprlandMonitorGeometry(o.name); ok {
-				x, y, w, h = hx, hy, hw, hh
-			}
-		}
-		if cx >= x && cx < x+w && cy >= y && cy < y+h {
+		b := o.bounds()
+		if cx >= b.X && cx < b.X+b.Width && cy >= b.Y && cy < b.Y+b.Height {
 			return o
 		}
 	}
 
 	for _, o := range s.outputs {
-		x, y, w, h := o.x, o.y, o.width, o.height
-		if DetectCompositor() == CompositorHyprland {
-			if hx, hy, hw, hh, ok := GetHyprlandMonitorGeometry(o.name); ok {
-				x, y, w, h = hx, hy, hw, hh
-			}
-		}
-		if region.X >= x && region.X < x+w &&
-			region.Y >= y && region.Y < y+h {
+		b := o.bounds()
+		if region.X >= b.X && region.X < b.X+b.Width &&
+			region.Y >= b.Y && region.Y < b.Y+b.Height {
 			return o
 		}
 	}

--- a/core/internal/screenshot/types.go
+++ b/core/internal/screenshot/types.go
@@ -63,6 +63,7 @@ type Config struct {
 	SaveFile   bool
 	Notify     bool
 	Stdout     bool
+	Geometry   bool
 	IntervalMs int
 	// SelectorHook runs as the interactive selector starts (true) and ends (false).
 	SelectorHook func(begin bool)

--- a/core/internal/screenshot/types.go
+++ b/core/internal/screenshot/types.go
@@ -1,5 +1,7 @@
 package screenshot
 
+import "fmt"
+
 type Mode int
 
 const (
@@ -37,6 +39,10 @@ type Region struct {
 
 func (r Region) IsEmpty() bool {
 	return r.Width <= 0 || r.Height <= 0
+}
+
+func (r Region) GeometryString() string {
+	return fmt.Sprintf("%d,%d %dx%d", r.X, r.Y, r.Width, r.Height)
 }
 
 type Output struct {


### PR DESCRIPTION
Adds a `-g, --geometry` flag to `dms screenshot` to output selected geometry (`X,Y WxH`) directly to `stdout` without capturing an image buffer, saving files, or copying to clipboard.

I am planning to add screen recording to Quick Capture, but currently I have to use `slurp` for geometry capture. So this PR should help make DMS more self-contained. It would also be nice since `dms screenshot` has better region selection than the alternatives.