### PR TITLE
plugins: use plugin ids for management actions

### DIFF
--- a/quickshell/Modals/Greeter/GreeterPluginsPage.qml
+++ b/quickshell/Modals/Greeter/GreeterPluginsPage.qml
@@ -193,7 +193,7 @@ Item {
                             if (modelData.repo)
                                 Qt.openUrlExternally(modelData.repo);
                         }
-                        onInstallRequested: PluginService.installFromRegistry(modelData.name, modelData.type === "desktop")
+                        onInstallRequested: PluginService.installFromRegistry(modelData.id, modelData.name, modelData.type === "desktop")
                     }
                 }
             }

--- a/quickshell/Modules/Settings/PluginBrowser.qml
+++ b/quickshell/Modules/Settings/PluginBrowser.qml
@@ -434,8 +434,8 @@ DankFloatingWindow {
         ensureSelectedVisible();
     }
 
-    function installPlugin(pluginName, enableAfterInstall) {
-        PluginService.installFromRegistry(pluginName, enableAfterInstall, success => {
+    function installPlugin(pluginId, pluginName, enableAfterInstall) {
+        PluginService.installFromRegistry(pluginId, pluginName, enableAfterInstall, success => {
             if (!success)
                 return;
             refreshPlugins();
@@ -471,7 +471,7 @@ DankFloatingWindow {
             "message": I18n.tr("Install plugin '%1' from the DMS registry?", "plugin installation confirmation").arg(pluginId),
             "confirmText": I18n.tr("Install", "install action button"),
             "cancelText": I18n.tr("Cancel"),
-            "onConfirm": () => installPlugin(pluginId, true),
+            "onConfirm": () => installPlugin(pluginId, pluginId, true),
             "onCancel": () => hide()
         });
     }
@@ -952,7 +952,7 @@ DankFloatingWindow {
                             installed: cardCell.modelData.installed || false
                             selected: root.keyboardNavigationActive && cardCell.index === root.selectedIndex
                             onClicked: root.openPluginDetail(cardCell.modelData)
-                            onInstallRequested: root.installPlugin(cardCell.modelData.name, cardCell.modelData.type === "desktop")
+                            onInstallRequested: root.installPlugin(cardCell.modelData.id, cardCell.modelData.name, cardCell.modelData.type === "desktop")
                         }
                     }
                 }
@@ -1236,7 +1236,7 @@ DankFloatingWindow {
                             hoverEnabled: true
                             cursorShape: detailInstallButton.buttonState === "available" ? Qt.PointingHandCursor : Qt.ArrowCursor
                             enabled: detailInstallButton.buttonState === "available"
-                            onClicked: root.installPlugin(detailPane.plugin.name, detailPane.plugin.type === "desktop")
+                            onClicked: root.installPlugin(detailPane.plugin.id, detailPane.plugin.name, detailPane.plugin.type === "desktop")
                         }
                     }
                 }

--- a/quickshell/Modules/Settings/PluginListItem.qml
+++ b/quickshell/Modules/Settings/PluginListItem.qml
@@ -202,7 +202,7 @@ StyledRect {
                         onClicked: {
                             const currentPluginName = root.pluginName;
                             const currentPluginId = root.pluginId;
-                            DMSService.update(currentPluginName, response => {
+                            DMSService.update(currentPluginId, response => {
                                 if (response.error) {
                                     ToastService.showError(I18n.tr("Update failed: %1").arg(response.error));
                                     return;
@@ -244,8 +244,9 @@ StyledRect {
                         hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor
                         onClicked: {
+                            const currentPluginId = root.pluginId;
                             const currentPluginName = root.pluginName;
-                            DMSService.uninstall(currentPluginName, response => {
+                            DMSService.uninstall(currentPluginId, response => {
                                 if (response.error) {
                                     ToastService.showError(I18n.tr("Uninstall failed: %1").arg(response.error));
                                     return;

--- a/quickshell/Modules/Settings/PluginUpdatesDialog.qml
+++ b/quickshell/Modules/Settings/PluginUpdatesDialog.qml
@@ -52,7 +52,7 @@ StyledRect {
         isUpdating = true;
         currentUpdatingPlugin = plugin.name;
 
-        DMSService.update(plugin.name, response => {
+        DMSService.update(plugin.id, response => {
             isUpdating = false;
             currentUpdatingPlugin = "";
             if (response.error) {
@@ -89,7 +89,7 @@ StyledRect {
             var plugin = list[idx];
             currentUpdatingPlugin = plugin.name;
 
-            DMSService.update(plugin.name, response => {
+            DMSService.update(plugin.id, response => {
                 if (response.error) {
                     ToastService.showError(I18n.tr("Failed to update %1: %2").arg(plugin.name).arg(response.error));
                 } else {

--- a/quickshell/Services/PluginService.qml
+++ b/quickshell/Services/PluginService.qml
@@ -1281,16 +1281,17 @@ Singleton {
         return badges;
     }
 
-    function installFromRegistry(pluginName, enableAfterInstall, onDone) {
-        ToastService.showInfo(I18n.tr("Installing: %1", "installation progress").arg(pluginName));
-        DMSService.install(pluginName, response => {
+    function installFromRegistry(pluginId, pluginName, enableAfterInstall, onDone) {
+        const displayName = pluginName || pluginId;
+        ToastService.showInfo(I18n.tr("Installing: %1", "installation progress").arg(displayName));
+        DMSService.install(pluginId, response => {
             if (response.error) {
                 ToastService.showError(I18n.tr("Install failed: %1", "installation error").arg(response.error));
                 if (onDone)
                     onDone(false);
                 return;
             }
-            ToastService.showInfo(I18n.tr("Installed: %1", "installation success").arg(pluginName));
+            ToastService.showInfo(I18n.tr("Installed: %1", "installation success").arg(displayName));
             scanPlugins();
             if (!enableAfterInstall) {
                 if (onDone)
@@ -1298,11 +1299,11 @@ Singleton {
                 return;
             }
             Qt.callLater(() => {
-                enablePlugin(pluginName);
-                const plugin = availablePlugins[pluginName];
+                enablePlugin(pluginId);
+                const plugin = availablePlugins[pluginId];
                 if (plugin?.type === "desktop") {
-                    const defaultConfig = DesktopWidgetRegistry.getDefaultConfig(pluginName);
-                    SettingsData.createDesktopWidgetInstance(pluginName, plugin.name || pluginName, defaultConfig);
+                    const defaultConfig = DesktopWidgetRegistry.getDefaultConfig(pluginId);
+                    SettingsData.createDesktopWidgetInstance(pluginId, plugin.name || displayName, defaultConfig);
                 }
                 if (onDone)
                     onDone(true);


### PR DESCRIPTION
## Description

Plugin registry entries expose a stable ID and a human-readable name. The UI was passing the display name to management operations and then using it to index ID-keyed plugin state, which fails when the name and ID differ.

This change uses the ID for install, update, uninstall, enablement, registry lookup, desktop defaults, and widget instance creation, while retaining the display name for user-facing notifications. The existing DMS RPC method and payload shape remain unchanged.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

N/A

## Screenshots / video

N/A — no visual change.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible (not applicable: no new strings)
- [x] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean (not applicable: no Go changes)
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [x] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs (not applicable: no new behavior)

### Local verification

- `uvx prek run --files ...`: all configured hooks passed for the five changed files
- `qmldom --dump-ast`: all five changed QML files parse successfully
- `git diff --check`: passed
- Full `make lint-qml` could not be completed locally because the packaged Quickshell 0.3.1 installation does not provide the QML module type metadata required by `qmllint`; CI is left to perform the repository-native lint check
