### PR TITLE
niri: create screenshot directory lazily

### DIFF
--- a/quickshell/Services/NiriService.qml
+++ b/quickshell/Services/NiriService.qml
@@ -73,7 +73,6 @@ Singleton {
 
     Component.onCompleted: {
         fetchOutputs();
-        Paths.mkdir(screenshotsDir);
         generateNiriInputConfig();
     }
 


### PR DESCRIPTION
Closes #3281

Remove the eager creation of the Niri screenshots directory during service startup.

The screenshot, screenshotScreen, and screenshotWindow functions already create the directory immediately before saving, so screenshot behavior remains unchanged while unused directories are no longer recreated on every DMS start.