### PR TITLE
brightness: retry initial DDC read

### DIFF
--- a/core/internal/server/brightness/ddc.go
+++ b/core/internal/server/brightness/ddc.go
@@ -160,15 +160,20 @@ func (b *DDCBackend) getDDCName(bus int) string {
 }
 
 func (b *DDCBackend) readInitialBrightness(fd int, dev *ddcDevice) {
-	cap, err := b.getVCPFeature(fd, VCP_BRIGHTNESS)
-	if err != nil {
+	for attempt := 0; attempt < 3; attempt++ {
+		cap, err := b.getVCPFeature(fd, VCP_BRIGHTNESS)
+		if err == nil {
+			dev.max = cap.max
+			dev.lastBrightness = cap.current
+			log.Debugf("initialized %s with brightness %d/%d", dev.name, cap.current, cap.max)
+			return
+		}
+		if attempt < 2 {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
 		log.Debugf("failed to read initial brightness for %s: %v", dev.name, err)
-		return
 	}
-
-	dev.max = cap.max
-	dev.lastBrightness = cap.current
-	log.Debugf("initialized %s with brightness %d/%d", dev.name, cap.current, cap.max)
 }
 
 func (b *DDCBackend) GetDevices() ([]Device, error) {


### PR DESCRIPTION
Closes #3060

Retry the initial DDC brightness read when probing a monitor. Some monitors accept the probe but are not ready to answer the first VCP request, leaving the startup brightness at 0 until the user moves the slider.

Retrying only the initial read makes startup state recoverable without changing the successful path or brightness writes.

Validation: gofmt and git diff --check pass. The brightness package tests could not start because the repository's current lipgloss/cellbuf module graph does not provide github.com/charmbracelet/x/cellbuf.