### PR TITLE
niri: refresh bar visibility after fullscreen changes

### DIFF
--- a/quickshell/Modules/DankBar/DankBarBody.qml
+++ b/quickshell/Modules/DankBar/DankBarBody.qml
@@ -763,6 +763,11 @@ Item {
 
     Connections {
         target: NiriService
+        function onWindowsChanged() {
+            barWindow._updateHasMaximizedToplevel();
+            barWindow._updateShouldHideForWindows();
+        }
+
         function onAllWorkspacesChanged() {
             barWindow._updateHasMaximizedToplevel();
             barWindow._updateShouldHideForWindows();


### PR DESCRIPTION
Closes #2439

Refresh the bar's fullscreen and hide-on-window state directly when Niri reports a window change. This ensures the bar recalculates visibility immediately when a maximized fullscreen window is unfullscreened, without relying on a later unrelated compositor update.