### PR TITLE
system-update: make popout reopen after terminal upgrade optional

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1177,6 +1177,7 @@ Singleton {
     property int updaterIntervalSeconds: 1800
     property bool updaterIncludeFlatpak: true
     property bool updaterAllowAUR: true
+    property bool updaterReopenAfterUpgrade: true
     property var updaterIgnoredPackages: []
 
     property string displayNameMode: "system"

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -568,6 +568,7 @@ var SPEC = {
     updaterIntervalSeconds: { def: 1800 },
     updaterIncludeFlatpak: { def: true },
     updaterAllowAUR: { def: true },
+    updaterReopenAfterUpgrade: { def: true },
     updaterIgnoredPackages: { def: [] },
 
     displayNameMode: { def: "system" },

--- a/quickshell/Modules/DankBar/Popouts/SystemUpdatePopout.qml
+++ b/quickshell/Modules/DankBar/Popouts/SystemUpdatePopout.qml
@@ -260,7 +260,7 @@ DankPopout {
                                 terminal: SessionData.terminalOverride
                             };
                             if (updaterPanel.upgradeRunsInTerminal) {
-                                systemUpdatePopout._reopenAfterUpgrade = true;
+                                systemUpdatePopout._reopenAfterUpgrade = SettingsData.updaterReopenAfterUpgrade;
                                 SystemUpdateService.runUpdates(opts);
                                 systemUpdatePopout.close();
                                 return;

--- a/quickshell/Modules/Settings/SystemUpdaterTab.qml
+++ b/quickshell/Modules/Settings/SystemUpdaterTab.qml
@@ -187,6 +187,16 @@ Item {
                     onToggled: checked => SettingsData.set("updaterAllowAUR", checked)
                 }
 
+                SettingsToggleRow {
+                    settingKey: "systemUpdaterReopenAfterUpgrade"
+                    tags: ["reopen", "popout", "terminal", "upgrade"]
+                    text: I18n.tr("Reopen panel after update")
+                    description: I18n.tr("Reopen the update panel once the terminal window closes after running updates.")
+                    visible: SystemUpdateService.useCustomCommand || (SystemUpdateService.backends || []).some(b => b.runsInTerminal === true)
+                    checked: SettingsData.updaterReopenAfterUpgrade
+                    onToggled: checked => SettingsData.set("updaterReopenAfterUpgrade", checked)
+                }
+
                 TerminalPickerRow {}
             }
 

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -8226,6 +8226,30 @@
     "description": "Apply Flatpak updates alongside system updates when running "
   },
   {
+    "section": "systemUpdaterReopenAfterUpgrade",
+    "label": "Reopen panel after update",
+    "tabIndex": 20,
+    "category": "System Updater",
+    "keywords": [
+      "after",
+      "closes",
+      "once",
+      "packages",
+      "panel",
+      "popout",
+      "reopen",
+      "running",
+      "system",
+      "terminal",
+      "update",
+      "updater",
+      "updates",
+      "upgrade",
+      "window"
+    ],
+    "description": "Reopen the update panel once the terminal window closes after running updates."
+  },
+  {
     "section": "systemUpdater",
     "label": "System Updater",
     "tabIndex": 20,


### PR DESCRIPTION
## Description

When the upgrade runs in a terminal (paru/yay backends, or a custom update command), the update popout closes, launches the terminal, and then unconditionally reopens itself once the terminal exits:

1. Clicking "Update" sets `_reopenAfterUpgrade = true` and closes the popout (`quickshell/Modules/DankBar/Popouts/SystemUpdatePopout.qml`)
2. When the terminal exits, the daemon settles the phase back to idle, so `isUpgrading` flips to `false`
3. The `Connections` handler sees the flag and calls `open()`, bringing the popout back up

There is currently no way to opt out, and the popout popping back up on its own can feel intrusive — it interrupts whatever you switched to while the update was running. It also reopens showing a spurious error when the terminal window is closed directly instead of pressing Enter at the "Press Enter to close" prompt (the wrapper shell dies with a non-zero exit even though the update itself succeeded).

This PR adds an `updaterReopenAfterUpgrade` setting (Settings → System Updater), **default `true`** so current behavior is preserved. With the toggle off, the popout stays closed after the terminal exits. The bar widget already reflects the outcome (error icon/color on failure), so nothing fails silently.

The toggle row is only visible when the reopen path can actually trigger (a `runsInTerminal` backend or a custom command), mirroring how the Flatpak/AUR rows gate their visibility.

`settings_search_index.json` regenerated with `quickshell/translations/extract_settings_index.py`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

## Screenshots / video

The new row is a standard `SettingsToggleRow` under Settings → System Updater, right below "Include AUR updates". Happy to attach a screenshot if useful.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [ ] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean (no Go changes)
- [ ] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
