### PR TITLE
notifications: auto-enable do not disturb while screen sharing

### DIFF
--- a/quickshell/Common/SessionData.qml
+++ b/quickshell/Common/SessionData.qml
@@ -36,6 +36,9 @@ Singleton {
     property bool isLightMode: false
     property bool doNotDisturb: false
     property real doNotDisturbUntil: 0
+    property bool doNotDisturbHeldByScreenShare: false
+    property bool screenShareDndDismissed: false
+    property var screenShareDismissedIds: []
     property bool idleInhibited: false
     property string terminalOverride: ""
     property bool isSwitchingMode: false
@@ -71,7 +74,15 @@ Singleton {
         id: dndExpireTimer
         repeat: false
         running: false
-        onTriggered: root.setDoNotDisturb(false)
+        onTriggered: root.setDoNotDisturb(false, 0, "timer")
+    }
+
+    Timer {
+        id: screenShareReleaseTimer
+        interval: 4000
+        repeat: false
+        running: false
+        onTriggered: root._endScreenShareDnd()
     }
 
     function _armDndExpireTimer() {
@@ -80,7 +91,7 @@ Singleton {
             return;
         const remaining = doNotDisturbUntil - Date.now();
         if (remaining <= 0) {
-            setDoNotDisturb(false);
+            setDoNotDisturb(false, 0, "timer");
             return;
         }
         dndExpireTimer.interval = remaining;
@@ -108,6 +119,21 @@ Singleton {
             root.suppressOSD = true;
             osdSuppressTimer.restart();
             root._applyDndExpirySanity();
+            Qt.callLater(root._syncScreenShareDnd);
+        }
+    }
+
+    Connections {
+        target: (!root.isGreeterMode && typeof SettingsData !== "undefined" && SettingsData.notificationDndWhileScreenSharing && typeof PrivacyService !== "undefined") ? PrivacyService : null
+        function onScreensharingActiveChanged() {
+            root._syncScreenShareDnd();
+        }
+    }
+
+    Connections {
+        target: typeof SettingsData !== "undefined" ? SettingsData : null
+        function onNotificationDndWhileScreenSharingChanged() {
+            root._syncScreenShareDnd();
         }
     }
 
@@ -309,6 +335,7 @@ Singleton {
                 Theme.generateSystemThemesFromCurrentTheme();
 
             loaded();
+            Qt.callLater(root._syncScreenShareDnd);
 
             _checkSessionWritable();
         } catch (e) {
@@ -390,6 +417,7 @@ Singleton {
                 Theme.generateSystemThemesFromCurrentTheme();
 
             loaded();
+            Qt.callLater(root._syncScreenShareDnd);
         } catch (e) {
             _parseError = true;
             const msg = e.message;
@@ -633,11 +661,24 @@ Singleton {
         });
     }
 
-    function setDoNotDisturb(enabled, durationMinutes) {
+    function setDoNotDisturb(enabled, durationMinutes, origin) {
+        const src = origin || "user";
+        if (src === "user") {
+            if (!enabled && _screenShareShouldHold()) {
+                screenShareDndDismissed = true;
+                screenShareDismissedIds = _screencastIds();
+            }
+            if (doNotDisturbHeldByScreenShare)
+                doNotDisturbHeldByScreenShare = false;
+        }
+
         const minutes = Number(durationMinutes) || 0;
         doNotDisturb = enabled;
         doNotDisturbUntil = (enabled && minutes > 0) ? Date.now() + minutes * 60 * 1000 : 0;
         saveSettings();
+
+        if (src !== "screenshare")
+            Qt.callLater(_syncScreenShareDnd);
     }
 
     function setIdleInhibited(enabled) {
@@ -654,9 +695,90 @@ Singleton {
             setDoNotDisturb(false);
             return;
         }
+        if (doNotDisturbHeldByScreenShare)
+            doNotDisturbHeldByScreenShare = false;
         doNotDisturb = true;
         doNotDisturbUntil = target;
         saveSettings();
+    }
+
+    function _screenShareShouldHold() {
+        if (isGreeterMode)
+            return false;
+        if (typeof SettingsData === "undefined" || !SettingsData.notificationDndWhileScreenSharing)
+            return false;
+        if (typeof PrivacyService === "undefined" || !PrivacyService.screensharingActive)
+            return false;
+        return true;
+    }
+
+    function _screencastIds() {
+        return (typeof PrivacyService !== "undefined") ? PrivacyService.screencastSourceIds() : [];
+    }
+
+    function _dismissalApplies() {
+        if (!screenShareDndDismissed)
+            return false;
+        const dismissed = screenShareDismissedIds || [];
+        if (!dismissed.length)
+            return true;
+        const current = _screencastIds();
+        if (!current.length)
+            return true;
+        return current.some(id => dismissed.indexOf(id) !== -1);
+    }
+
+    function _releaseScreenShareDndHold() {
+        if (!doNotDisturbHeldByScreenShare)
+            return;
+        doNotDisturbHeldByScreenShare = false;
+        if (!doNotDisturb || doNotDisturbUntil > 0) {
+            saveSettings();
+            return;
+        }
+        setDoNotDisturb(false, 0, "screenshare");
+    }
+
+    function _endScreenShareDnd() {
+        _clearScreenShareDismissal();
+        _releaseScreenShareDndHold();
+    }
+
+    function _clearScreenShareDismissal() {
+        if (!screenShareDndDismissed)
+            return;
+        screenShareDndDismissed = false;
+        screenShareDismissedIds = [];
+        saveSettings();
+    }
+
+    function _syncScreenShareDnd() {
+        if (isGreeterMode)
+            return;
+
+        if (!_screenShareShouldHold()) {
+            if (!doNotDisturbHeldByScreenShare && !screenShareDndDismissed)
+                return;
+            const settingOn = typeof SettingsData !== "undefined" && SettingsData.notificationDndWhileScreenSharing;
+            if (!settingOn) {
+                screenShareReleaseTimer.stop();
+                _endScreenShareDnd();
+                return;
+            }
+            screenShareReleaseTimer.restart();
+            return;
+        }
+
+        screenShareReleaseTimer.stop();
+
+        if (!_dismissalApplies())
+            _clearScreenShareDismissal();
+
+        if (screenShareDndDismissed || doNotDisturb)
+            return;
+
+        doNotDisturbHeldByScreenShare = true;
+        setDoNotDisturb(true, 0, "screenshare");
     }
 
     function setWallpaper(imagePath) {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -987,6 +987,7 @@ Singleton {
     property bool notificationHistorySaveCritical: true
     property var notificationRules: []
     property bool notificationDndAllowCritical: true
+    property bool notificationDndWhileScreenSharing: true
     property bool notificationFocusedMonitor: false
     // Island is a per-instance render mode: any bar config with island:true draws as an island
     // instead of a DankBar, and carries its own island* look settings.

--- a/quickshell/Common/settings/SessionSpec.js
+++ b/quickshell/Common/settings/SessionSpec.js
@@ -4,6 +4,9 @@ var SPEC = {
     isLightMode: { def: false },
     doNotDisturb: { def: false },
     doNotDisturbUntil: { def: 0 },
+    doNotDisturbHeldByScreenShare: { def: false },
+    screenShareDndDismissed: { def: false },
+    screenShareDismissedIds: { def: [] },
     idleInhibited: { def: false },
     terminalOverride: { def: "" },
 

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -532,6 +532,7 @@ var SPEC = {
     notificationHistorySaveCritical: { def: true },
     notificationRules: { def: [] },
     notificationDndAllowCritical: { def: true },
+    notificationDndWhileScreenSharing: { def: true },
     notificationFocusedMonitor: { def: false },
 
 

--- a/quickshell/Modules/Settings/NotificationsTab.qml
+++ b/quickshell/Modules/Settings/NotificationsTab.qml
@@ -430,6 +430,15 @@ Item {
                 }
 
                 SettingsToggleRow {
+                    settingKey: "notificationDndWhileScreenSharing"
+                    tags: ["notification", "dnd", "screenshare", "sharing", "privacy"]
+                    text: I18n.tr("Automatically enable while screen sharing", "do not disturb auto enable while screen sharing toggle")
+                    description: I18n.tr("Turn on Do Not Disturb while a screen share is active", "do not disturb auto enable while screen sharing description")
+                    checked: SettingsData.notificationDndWhileScreenSharing
+                    onToggled: checked => SettingsData.set("notificationDndWhileScreenSharing", checked)
+                }
+
+                SettingsToggleRow {
                     settingKey: "notificationDndAllowCritical"
                     tags: ["notification", "dnd", "critical", "priority", "urgent", "bypass"]
                     text: I18n.tr("Critical Priority")

--- a/quickshell/Services/PrivacyService.qml
+++ b/quickshell/Services/PrivacyService.qml
@@ -126,6 +126,37 @@ Singleton {
         return /xdg-desktop-portal|xdpw|screencast|screen-cast|screen|gnome shell|kwin|obs|niri/.test(combined)
     }
 
+    function screencastSourceIds() {
+        const ids = []
+
+        if (CompositorService.isNiri) {
+            for (const cast of NiriService.casts) {
+                if (cast && cast.is_active) {
+                    ids.push("niri:" + cast.stream_id)
+                }
+            }
+        }
+
+        if (!Pipewire.ready || !Pipewire.nodes?.values) {
+            return ids
+        }
+
+        for (let i = 0; i < Pipewire.nodes.values.length; i++) {
+            const node = Pipewire.nodes.values[i]
+            if (!node || !node.ready) {
+                continue
+            }
+
+            const isVideoSource = (node.type & PwNodeType.VideoSource) === PwNodeType.VideoSource
+            const isVideoStream = node.properties && node.properties["media.class"] === "Stream/Output/Video"
+            if ((isVideoSource || isVideoStream) && looksLikeScreencast(node)) {
+                ids.push("pw:" + node.id)
+            }
+        }
+
+        return ids.sort()
+    }
+
     function getMicrophoneStatus() {
         return microphoneActive ? "active" : "inactive"
     }

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -7097,6 +7097,32 @@
     "description": "Control animation duration for notification popups and history"
   },
   {
+    "section": "notificationDndWhileScreenSharing",
+    "label": "Automatically enable while screen sharing",
+    "tabIndex": 17,
+    "category": "Notifications",
+    "keywords": [
+      "active",
+      "alerts",
+      "automatically",
+      "disturb",
+      "dnd",
+      "enable",
+      "messages",
+      "notification",
+      "notifications",
+      "privacy",
+      "screen",
+      "screenshare",
+      "share",
+      "sharing",
+      "toast",
+      "turn",
+      "while"
+    ],
+    "description": "Turn on Do Not Disturb while a screen share is active"
+  },
+  {
     "section": "notificationPopupBodyInvokesAction",
     "label": "Body Click Runs Default Action",
     "tabIndex": 17,


### PR DESCRIPTION
## Description

Automatically enable Do Not Disturb while a screen share is active, so notification popups (and their contents) do not appear on the shared screen. The unread dot on the notification widget still appears. Existing DND bypasses (critical priority, per-app allow list) keep working.

The setting is under **Settings → Notifications → Do Not Disturb**: **Automatically enable while screen sharing**. It is on by default.

Detection is the same as the existing screen-sharing privacy indicator (Niri cast IPC, otherwise Pipewire / xdg-desktop-portal), so this applies on every compositor DMS already supports.

### Behavior

Auto-DND turns the normal DND switch on for the share, then turns it off shortly after the share ends — unless the user already owned DND. The release is deliberately delayed by about four seconds; the reasoning is below the table.

| Case | What happens |
| --- | --- |
| Share starts, DND was off | DND turns on for the share. Popups are suppressed. The unread dot still shows. |
| Share ends, we turned DND on | DND turns off about four seconds later. |
| DND already on (indefinite) before the share | Left alone. Stays on after the share ends. |
| Timed DND already on before the share | Left alone. The timer keeps running after the share ends. |
| User picks **Until I turn it off** during a share | User owns DND. It stays on after the share ends. |
| User sets a duration during a share | User owns DND. The timer survives the end of the share. |
| User turns DND off during a share | Treated as a dismiss. DND stays off for the rest of that share, and across a shell reload. A share started after that one has ended auto-enables again. |
| Timed DND expires while still sharing | Auto-DND takes over for the rest of the share, then releases about four seconds after it ends. |
| Setting is off, then a share starts | DND is not auto-enabled. |
| Setting turned off while auto-DND is holding | Hold is released and DND turns off immediately, with no delay. |
| Setting turned on while already sharing (DND off) | DND turns on for the rest of the share. |
| Restart mid-share | DND stays on if the share is still active. If the share ended while the shell was down, DND is released about four seconds after start. |
| Capture stopped and started again quickly | DND stays on. The short gap is ignored. |
| Critical / per-app DND allow list | Unchanged. Those popups still appear during a share. |

### Why the delay on release

Detection is asynchronous and neither source announces when it has finished reporting. Quickshell's Pipewire API exposes only `ready`, which means the connection is up, not that nodes have been enumerated; niri cast state cannot arrive until compositor detection has resolved. So a share reading as gone is only acted on once it stays gone for four seconds. Turning DND on stays immediate, and turning the setting off releases immediately, because that is a user action rather than a detection guess.

Measured here, the niri path (compositor detection, socket connect, first cast snapshot) takes about 150 ms. Four seconds also clears the 3 s timeout `detectCompositor` uses before it falls back to env probing.

A manual DND-off during a share is remembered against the sources that were sharing at the time (niri `stream_id`, Pipewire node id), so it holds for that share and survives a shell reload, while a newly started share gets a fresh decision.

### Cost

With the setting on, `SessionData` instantiates `PrivacyService` at startup, which opens a `PwObjectTracker` over every non-stream Pipewire node. Until now `PrivacyService` was only created when the privacy indicator bar widget was enabled. That is the cost of the feature being active, and it is only paid when the setting is on.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

**NOTE:** Default on might be considered breaking here, I don't know. I opted for on by default because of privacy reasons, I suspect most users would benefit from this, though we can change if maintainers feel like it. The idle cost above is the other side of that decision.

## Related issues

Closes #1482

## Screenshots / video

<img width="739" height="501" alt="image" src="https://github.com/user-attachments/assets/e31abf73-9cbf-483c-b793-0061b3fd90ae" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: n/a
- [x] QML changes: `make lint-qml`
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
