### PR TITLE
Fix Bluetooth sink volume controls

### DIFF
--- a/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
+++ b/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
@@ -69,7 +69,7 @@ Item {
             return;
         }
         if (AudioService.sink?.audio)
-            AudioService.sink.audio.volume = volume;
+            AudioService.setVolume(Math.round(volume * 100));
     }
 
     function selectPlayer(player) {

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -189,7 +189,7 @@ Item {
             return;
         }
         if (AudioService.sink?.audio)
-            AudioService.sink.audio.volume = clamped;
+            AudioService.setVolume(Math.round(clamped * 100));
     }
 
     function adjustVolume(step) {

--- a/quickshell/Services/AudioService.qml
+++ b/quickshell/Services/AudioService.qml
@@ -992,6 +992,21 @@ EOFCONFIG
         objects: Pipewire.nodes.values.filter(node => node.audio && (SettingsData.audioShowStreamDevices || !node.isStream))
     }
 
+    // Some BlueZ/PipeWire sinks do not reliably apply the QML volume property
+    // setter. Keep the fallback here so every DMS volume surface shares it.
+    Process {
+        id: sinkVolumeProcess
+        running: false
+    }
+
+    function setSinkVolume(volume) {
+        if (!root.sink?.name)
+            return false;
+        sinkVolumeProcess.command = ["pactl", "set-sink-volume", root.sink.name, Math.round(volume * 100) + "%"];
+        sinkVolumeProcess.running = true;
+        return true;
+    }
+
     function setVolume(percentage) {
         if (!root.sink?.audio)
             return "No audio sink available";
@@ -1000,7 +1015,8 @@ EOFCONFIG
 
         const maxVol = root.sinkMaxVolume;
         const clampedVolume = Math.max(0, Math.min(maxVol, percentage));
-        root.sink.audio.volume = clampedVolume / 100;
+        if (!setSinkVolume(clampedVolume / 100))
+            root.sink.audio.volume = clampedVolume / 100;
         return `Volume set to ${clampedVolume}%`;
     }
 
@@ -1019,7 +1035,8 @@ EOFCONFIG
         if (audio.muted)
             audio.muted = false;
 
-        audio.volume = newVolume / 100;
+        if (!setSinkVolume(newVolume / 100))
+            audio.volume = newVolume / 100;
         return newVolume;
     }
 


### PR DESCRIPTION
# DMS 上游 PR 草稿：蓝牙输出音量控制

## 类型

Draft / ready for maintainer review

## 上游

- 项目：DankMaterialShell
- 上游仓库：https://github.com/AvengeMedia/DankMaterialShell
- 本机来源：Arch AUR `dms-shell-bin`，版本 `1.0.3`；本机没有上游源码工作树，只有二进制包和本地补丁副本。

## 问题

在 PipeWire + BlueZ 环境中，DMS 音量滑块通过 `AudioService.sink.audio.volume = volume` 更新蓝牙输出时，界面状态可能变化，但实际蓝牙 sink 音量不变。相同目标通过 `pactl set-sink-volume <sink> <percent>` 可以正常控制。

## 最小修复方向

在 DMS 音量控件的蓝牙/系统 sink 分支中，通过受控的系统音频接口写入当前 sink，并保留对象属性写入作为回退。实现应优先使用 DMS/Quickshell 已有的音频服务抽象；若必须调用外部命令，应确认 Wayland、PulseAudio 兼容层和非 Linux 环境的行为。

## 本地验证

- 设备：`ROSE CAMBRIAN`，BlueZ/PipeWire sink；
- 直接使用 `wpctl set-volume`：成功；
- 直接使用 `pactl set-sink-volume`：成功；
- 原 DMS 属性赋值：未能改变实际耳机音量；
- 本地兼容补丁：DMS 可启动，音频服务正常，蓝牙保持连接。

## 不包含

- 不包含浏览器 MPRIS 识别扩展；
- 不包含个人 DMS 配置、设备地址、缓存或壁纸；
- 不包含凭据、浏览器状态或任何私人数据。

## 上游需要确认

- 是否有更适合的 DMS AudioService setter；
- 是否应将音量设置逻辑移入 AudioService，而不是 QML；
- 是否需要针对蓝牙绝对音量和软件音量分别建测试；
- 当前系统调用方案是否符合项目对跨平台和安全性的要求。

## 贡献说明

这是针对本地可复现问题的最小修复草稿。正式 PR 前应在 DMS 源码仓库中重建改动、补充测试，并遵守上游贡献指南。当前未向远端提交。

## 最苦难个体前置审核

- 离线：音量控制依赖本地 PulseAudio 兼容接口，不依赖账户或云端；
- 低资源：不引入常驻服务或后台同步；
- 权限：仅控制当前用户已选择的音频 sink，不读取凭据或私人数据；
- 失败与回退：系统接口失败时保留原有属性写入路径；
- 退出：可通过上游回退或禁用该路径恢复原行为；
- 待确认：跨平台可用性、非 Linux 行为和 DMS 维护者认可的 AudioService 抽象。

审核状态：`PARTIAL / 等待上游实现与跨平台测试`。在此状态下不得提交正式 PR。
