### PR TITLE
Island: Added middle-click to play/pause media and mute audio

### DIFF
--- a/quickshell/Modules/DankIsland/Activities/HomeCompact.qml
+++ b/quickshell/Modules/DankIsland/Activities/HomeCompact.qml
@@ -374,7 +374,19 @@ Item {
             height: root.height
             enabled: !item.isClock
             controller: root.controller
-            onClicked: root.activateGroup(item.groupId)
+            acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+            onClicked: (event) => {
+                if (event.button === Qt.MiddleButton) {
+                    if (item.isMedia && root.controller.mediaAvailable && MprisController.activePlayer?.canTogglePlaying)
+                        MprisController.activePlayer.togglePlaying();
+                    if (item.isVolume && AudioService.sink?.audio) {
+                        SessionData.suppressOSDTemporarily();
+                        AudioService.toggleMute();
+                    }
+                    return;
+                }
+                root.activateGroup(item.groupId)
+            }
             onWheel: wheel => {
                 if (!item.isVolume && !item.isBrightness)
                     return;
@@ -568,7 +580,19 @@ Item {
             height: parent.height + item.leadPad + item.trailPad
             enabled: !item.isClock
             controller: root.controller
-            onClicked: root.activateGroup(item.groupId)
+            acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+            onClicked: (event) => {
+                if (event.button === Qt.MiddleButton) {
+                    if (item.isMedia && root.controller.mediaAvailable && MprisController.activePlayer?.canTogglePlaying)
+                        MprisController.activePlayer.togglePlaying();
+                    if (item.isVolume && AudioService.sink?.audio) {
+                        SessionData.suppressOSDTemporarily();
+                        AudioService.toggleMute();
+                    }
+                    return;
+                }
+                root.activateGroup(item.groupId)
+            }
             onWheel: wheel => {
                 if (!item.isVolume && !item.isBrightness)
                     return;


### PR DESCRIPTION
## Description
I found that the ability pause currently playing media from the central media widget now became a 2 or more click task given the conciseness of the island interface. I have therefore implemented a way to handle this via middle-clicking the media icon.

I have implemented the same for the audio widget in the island.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues


## Screenshots / video
This is a input UX change. Screenshot is not applicable.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible. (No new user-facing strings)
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean. (No Go changes)
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs (docs do not document island click behaviour, could only find mentions of it in the Updates and Keybinds & IPC sections)
