### PR TITLE
dankbar: animate fullscreen transitions on niri

### DIFF
--- a/quickshell/Modules/DankBar/DankBarBody.qml
+++ b/quickshell/Modules/DankBar/DankBarBody.qml
@@ -19,6 +19,7 @@ Item {
     property var rightWidgetsModel
 
     readonly property bool barRevealed: inputMask.showing
+    readonly property bool hiddenForFullscreen: CompositorService.isNiri && !NiriService.inOverview && CompositorService.fullscreenToplevelOnScreen(barWindow.screen)
 
     property var controlCenterButtonRef: null
     property var clockButtonRef: null
@@ -986,6 +987,9 @@ Item {
         }
 
         property bool reveal: {
+            if (barWindow.hiddenForFullscreen)
+                return false;
+
             const inOverviewWithShow = CompositorService.isNiri && NiriService.inOverview && barWindow.effectiveOpenOnOverview;
             if (inOverviewWithShow)
                 return true;

--- a/quickshell/Modules/DankBar/DankBarWindow.qml
+++ b/quickshell/Modules/DankBar/DankBarWindow.qml
@@ -49,7 +49,8 @@ PanelWindow {
         return body.containsGlobalPoint(gx, gy, padding);
     }
 
-    readonly property bool usesOverlayLayer: CompositorService.framePeerSurfacesUseOverlayForScreen(barWindow.screen) || (barConfig?.useOverlayLayer ?? false)
+    // Niri covers the top layer immediately when a client enters fullscreen.
+    readonly property bool usesOverlayLayer: CompositorService.isNiri || CompositorService.framePeerSurfacesUseOverlayForScreen(barWindow.screen) || (barConfig?.useOverlayLayer ?? false)
     readonly property var dBarLayer: LayerShell.fromEnv("DMS_DANKBAR_LAYER", barWindow.usesOverlayLayer ? WlrLayer.Overlay : WlrLayer.Top)
 
     screen: modelData


### PR DESCRIPTION
## Description

On niri, entering fullscreen immediately covers a bar on the Top layer, so its slide animation cannot run visibly. Selecting Overlay keeps the bar above the fullscreen client instead, because DankBar does not use fullscreen state in its reveal policy.

Use Overlay for niri bar windows and drive the existing reveal animation from `CompositorService.fullscreenToplevelOnScreen()`, the same Wayland fullscreen detector used by the dock. Leaving fullscreen restores the normal reveal policy. Overview bypasses fullscreen hiding. Animation timing and disabled-animation behavior continue to follow `Theme.shortDuration`.

This changes the default bar layer on niri to Overlay; the explicit `DMS_DANKBAR_LAYER` override still takes precedence. Other compositor paths are unchanged. The existing detector tracks the activated fullscreen toplevel on its screen, including its current multi-monitor limitations. No polling, additional processes, or timers are introduced.

## Type of change

- [x] Bug fix

## Validation

- Tested the same fullscreen detection and layer change on DMS 1.6.0 with niri 26.04. Captured intermediate slide positions on fullscreen entry and exit, the fully hidden state, and the restored bar. That local version used a 200 ms minimum; this PR retains upstream theme timing.
- Loaded this branch as the live DMS UI successfully, then restored the installed UI.
- Ran `make lint-qml` on the base commit and this branch. Both report identical existing warnings in the unchanged `DMSShell.qml` (block-scoped `var` and IDs shadowing members); no new diagnostics.
- `git diff --check` and the translation term-variant check pass. Term freeze is inactive in this checkout.
- Browser F11/video requests, multiple monitors, and other compositors have not been separately tested.

## Screenshots / video

Local screen captures verified both slide directions; no desktop screenshots are attached.

## Checklist

- [x] Code follows CONTRIBUTING.md conventions.
- [x] Tested the change locally as described above.
- [x] No new user-facing strings or Go changes.
- [x] Ran `make lint-qml` with no new warnings compared with the base commit.
- [ ] Corresponding documentation PR (none opened).
