### PR TITLE
frame: keep connected surfaces on the frame's layer

### DIFF
--- a/quickshell/Modals/Common/DankModalConnected.qml
+++ b/quickshell/Modals/Common/DankModalConnected.qml
@@ -55,6 +55,12 @@ Item {
         return false;
     }
 
+    // Layer shell cannot restack: set_layer re-inserts a surface at the top of the
+    // destination layer, so a frame that follows us to the overlay layer ends up
+    // above the content it should sit behind. Stay on the frame's layer while it
+    // owns our chrome; creation order then keeps the content on top.
+    readonly property bool effectiveOverlayLayer: useOverlayLayer && !frameOwnsConnectedChrome
+
     readonly property bool _dockBlocksEmergence: frameOwnsConnectedChrome && _dockOccupiesSide(resolvedConnectedBarSide)
 
     readonly property bool connectedMotionParity: frameOwnsConnectedChrome
@@ -140,7 +146,7 @@ Item {
             "phase": phase,
             "visible": presented,
             "presented": presented,
-            "layer": root.useOverlayLayer ? "overlay" : "top",
+            "layer": root.effectiveOverlayLayer ? "overlay" : "top",
             "barSide": resolvedConnectedBarSide,
             "bodyRect": bodyRect,
             "animationOffset": animationOffset,
@@ -397,7 +403,7 @@ Item {
         }
 
         WlrLayershell.namespace: root.layerNamespace
-        WlrLayershell.layer: root.useOverlayLayer ? WlrLayer.Overlay : LayerShell.fromEnv("DMS_MODAL_LAYER", WlrLayer.Top, {
+        WlrLayershell.layer: root.effectiveOverlayLayer ? WlrLayer.Overlay : LayerShell.fromEnv("DMS_MODAL_LAYER", WlrLayer.Top, {
             "allow": ["top", "overlay"],
             "invalidLayer": WlrLayer.Top,
             "label": "modals",

--- a/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalConnected.qml
+++ b/quickshell/Modals/DankLauncherV2/DankLauncherV2ModalConnected.qml
@@ -44,7 +44,11 @@ Item {
     readonly property real screenWidth: effectiveScreen?.width ?? 1920
     readonly property real screenHeight: effectiveScreen?.height ?? 1080
     readonly property real dpr: effectiveScreen ? CompositorService.getScreenScale(effectiveScreen) : 1
-    readonly property bool usesOverlayLayer: SettingsData.launcherUseOverlayLayer || triggerUsesOverlayLayer
+    // Layer shell cannot restack: set_layer re-inserts a surface at the top of the
+    // destination layer, so a frame that follows us to the overlay layer ends up
+    // above the content it should sit behind. Stay on the frame's layer while it
+    // owns our chrome; creation order then keeps the content on top.
+    readonly property bool usesOverlayLayer: !frameOwnsConnectedChrome && (SettingsData.launcherUseOverlayLayer || triggerUsesOverlayLayer)
     readonly property var effectiveLauncherLayer: LayerShell.fromEnv("DMS_MODAL_LAYER", root.usesOverlayLayer ? WlrLayer.Overlay : WlrLayer.Top, {
         "allow": ["top", "overlay"],
         "invalidLayer": WlrLayer.Top,

--- a/quickshell/Widgets/DankPopoutConnected.qml
+++ b/quickshell/Widgets/DankPopoutConnected.qml
@@ -63,7 +63,12 @@ Item {
         })
     property var screen: null
     readonly property bool useBackgroundWindow: false
-    readonly property var effectivePopoutLayer: LayerShell.fromEnv("DMS_POPOUT_LAYER", root.triggerUsesOverlayLayer ? WlrLayer.Overlay : WlrLayer.Top, {
+    // Layer shell cannot restack: set_layer re-inserts a surface at the top of the
+    // destination layer, so a frame that follows us to the overlay layer ends up
+    // above the content it should sit behind. Stay on the frame's layer while it
+    // owns our chrome; creation order then keeps the content on top.
+    readonly property bool effectiveOverlayLayer: triggerUsesOverlayLayer && !frameOwnsConnectedChrome
+    readonly property var effectivePopoutLayer: LayerShell.fromEnv("DMS_POPOUT_LAYER", root.effectiveOverlayLayer ? WlrLayer.Overlay : WlrLayer.Top, {
         "allow": ["top", "overlay"],
         "invalidLayer": WlrLayer.Top,
         "label": "popouts"
@@ -266,7 +271,7 @@ Item {
             "phase": phase,
             "visible": visible,
             "presented": presented,
-            "layer": root.triggerUsesOverlayLayer ? "overlay" : "top",
+            "layer": root.effectiveOverlayLayer ? "overlay" : "top",
             "barSide": contentContainer.connectedBarSide,
             "bodyRect": bodyRect,
             "animationOffset": animationOffset,


### PR DESCRIPTION
Fixes #3163

## Problem

With frame mode set to `connected`, modals open as an empty panel: the chrome slides in, the content is visible for a frame or two, then disappears.

| before | after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/bernardopg/DankMaterialShell/assets-issue-3163/img/before-power-menu.png" width="420"> | <img src="https://raw.githubusercontent.com/bernardopg/DankMaterialShell/assets-issue-3163/img/after-power-menu.png" width="420"> |
| <img src="https://raw.githubusercontent.com/bernardopg/DankMaterialShell/assets-issue-3163/img/before-launcher.png" width="420"> | <img src="https://raw.githubusercontent.com/bernardopg/DankMaterialShell/assets-issue-3163/img/after-launcher.png" width="420"> |

## Root cause

In connected frame mode the frame window paints the chrome for the surface, so it follows that surface onto the overlay layer when the surface asks for it:

```qml
// Modules/Frame/FrameWindow.qml
readonly property bool _usesOverlayLayer: (win._modalDescriptor.presented && win._modalDescriptor.layer === "overlay")
    || (win._popoutDescriptor.presented && win._popoutDescriptor.layer === "overlay")
```

`wlr-layer-shell` has no restack request. `zwlr_layer_surface_v1.set_layer` re-inserts the surface at the **top** of the destination layer, so the frame always lands above the surface it just followed. `hyprctl layers` on master, opening the power menu (level 2 = top, level 3 = overlay):

```
closed:  level 2 ['dms:frame', 'dms:frame-exclusion' x4]     level 3 []
open:    level 2 ['dms:frame-exclusion' x4]                  level 3 ['dms:power-menu', 'dms:frame']
```

`dms:frame` is now the last entry in the overlay list, i.e. drawn on top, and its opaque connected chrome covers the content it is supposed to sit behind. The content is only visible until the frame window re-stacks, which is why it reads as a one-frame flash rather than as nothing happening.

Deferring the surface, publishing the descriptor earlier, or re-asserting the layer from the surface side does not help: the frame's `set_layer` is always applied a frame later than the surface's own commit, so it always wins the stack.

### Who is affected

- **Every modal built on `DankModalConnected` that sets `useOverlayLayer: true`** — power menu, keybinds overlay, notepad, file browser, display confirmation, clipboard popout. These are unconditional, so in connected frame mode they are broken for everyone.
- **The launcher** (`DankLauncherV2ModalConnected`) when `launcherUseOverlayLayer` is set, or when it is opened from a bar that is itself on the overlay layer (`triggerUsesOverlayLayer`). Note `launcherUseOverlayLayer` now defaults to `false`, so users who never touched it are fine — but a value saved back when the default was `true` keeps the launcher permanently blank.
- **Connected popouts** (`DankPopoutConnected`) through `triggerUsesOverlayLayer`, same mechanism.

## Fix

Keep the decorated surface co-planar with the frame while the frame owns its chrome — for both the published descriptor and the surface's own `WlrLayershell.layer`. The frame then never changes layer, and creation order (frame first, surface later) puts the content above the chrome, which is exactly what already happens in the working `useOverlayLayer: false` path.

Both halves are required: changing only the window layer would leave the descriptor saying `"overlay"` and the frame would still promote itself.

Outside frame-owned chrome nothing changes — standalone modals, popouts and the launcher keep honouring the overlay preference and the `DMS_MODAL_LAYER` / `DMS_POPOUT_LAYER` env overrides.

`FrameWindow._usesOverlayLayer` is intentionally left alone: it stays as the guard for any surface that publishes an overlay descriptor without the frame drawing for it.

## Testing

Hyprland 0.53, Quickshell 0.3.1, single output, `frameMode = connected`, `frameEnabled = true`, `launcherUseOverlayLayer = true` (to reproduce the launcher case).

| case | before | after |
| --- | --- | --- |
| `dms ipc call powermenu open` | empty panel | renders, `level 2 ['dms:frame', ..., 'dms:power-menu']` |
| `dms ipc call spotlight open` | empty panel | renders, `level 2 ['dms:frame', ..., 'dms:spotlight']` |
| `dms ipc call clipboard open` | empty panel | renders, `level 2 ['dms:frame', ..., 'dms:clipboard']` |
| `dms ipc call control-center open` | ok | ok, no change |
| frame mode disabled | ok | ok, no change |

In every fixed case the frame stays on the top layer and the surface is created after it, so the content is stacked above the chrome.

`qmllint` is clean on the three touched files (import resolution warnings only, no tooling VFS available outside `nix develop`).
