### PR TITLE
idle inhibitor: add duration presets and timed expiry

### DIFF
--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -295,17 +295,27 @@ Idle inhibitor control to prevent automatic sleep/lock.
 - Returns: Current inhibit state message
 
 **`enable`**
-- Enable idle inhibit (prevent sleep/lock)
-- Returns: Confirmation message
+- Enable idle inhibit indefinitely (prevent sleep/lock)
+- Returns: Current inhibit state message
+
+**`enableFor <minutes>`**
+- Enable idle inhibit for a number of minutes
+- Returns: Current inhibit state message
 
 **`disable`**
 - Disable idle inhibit (allow sleep/lock)
 - Returns: Confirmation message
 
+**`status`**
+- Report whether idle inhibit is on, and remaining time when a timer is set
+- Returns: Current inhibit state message
+
 ### Examples
 ```bash
 dms ipc call inhibit toggle
 dms ipc call inhibit enable
+dms ipc call inhibit enableFor 60
+dms ipc call inhibit status
 ```
 
 ## Target: `powerprofile`

--- a/quickshell/Common/SessionData.qml
+++ b/quickshell/Common/SessionData.qml
@@ -37,6 +37,7 @@ Singleton {
     property bool doNotDisturb: false
     property real doNotDisturbUntil: 0
     property bool idleInhibited: false
+    property real idleInhibitedUntil: 0
     property string terminalOverride: ""
     property bool isSwitchingMode: false
     property bool suppressOSD: true
@@ -301,6 +302,7 @@ Singleton {
 
             Store.parse(root, obj);
             _applyDndExpirySanity();
+            _applyIdleInhibitExpirySanity();
 
             _loadedSessionSnapshot = getCurrentSessionJson();
             _hasLoaded = true;
@@ -382,6 +384,7 @@ Singleton {
 
             Store.parse(root, obj);
             _applyDndExpirySanity();
+            _applyIdleInhibitExpirySanity();
 
             _loadedSessionSnapshot = getCurrentSessionJson();
             _hasLoaded = true;
@@ -406,6 +409,15 @@ Singleton {
             doNotDisturbUntil = 0;
         }
         _armDndExpireTimer();
+    }
+
+    function _applyIdleInhibitExpirySanity() {
+        if (idleInhibited && idleInhibitedUntil > 0 && Date.now() >= idleInhibitedUntil) {
+            idleInhibited = false;
+            idleInhibitedUntil = 0;
+        } else if (!idleInhibited && idleInhibitedUntil !== 0) {
+            idleInhibitedUntil = 0;
+        }
     }
 
     function saveSettings() {
@@ -640,11 +652,14 @@ Singleton {
         saveSettings();
     }
 
-    function setIdleInhibited(enabled) {
+    function setIdleInhibited(enabled, durationMinutes) {
         const next = !!enabled;
-        if (idleInhibited === next)
+        const minutes = Number(durationMinutes) || 0;
+        const nextUntil = (next && minutes > 0) ? Date.now() + minutes * 60 * 1000 : 0;
+        if (idleInhibited === next && idleInhibitedUntil === nextUntil)
             return;
         idleInhibited = next;
+        idleInhibitedUntil = nextUntil;
         saveSettings();
     }
 

--- a/quickshell/Common/settings/SessionSpec.js
+++ b/quickshell/Common/settings/SessionSpec.js
@@ -5,6 +5,7 @@ var SPEC = {
     doNotDisturb: { def: false },
     doNotDisturbUntil: { def: 0 },
     idleInhibited: { def: false },
+    idleInhibitedUntil: { def: 0 },
     terminalOverride: { def: "" },
 
     wallpaperPath: { def: "" },

--- a/quickshell/DMSShellIPC.qml
+++ b/quickshell/DMSShellIPC.qml
@@ -101,6 +101,28 @@ Item {
         return `DEFAULTAPP_LAUNCH_REQUESTED: ${appName}`;
     }
 
+    function parseIdleInhibitMinutes(duration) {
+        if (duration === undefined || duration === null)
+            return -1;
+        const trimmed = String(duration).trim();
+        if (!trimmed)
+            return -1;
+        const minutes = parseInt(trimmed, 10);
+        if (isNaN(minutes) || minutes <= 0 || String(minutes) !== trimmed)
+            return -1;
+        return minutes;
+    }
+
+    function idleInhibitStatusMessage() {
+        if (!SessionService.idleInhibited)
+            return "Idle inhibit is disabled";
+        if (SessionData.idleInhibitedUntil <= 0)
+            return "Idle inhibit is enabled indefinitely";
+        const remainingMs = Math.max(0, SessionData.idleInhibitedUntil - Date.now());
+        const remainingMin = Math.ceil(remainingMs / 60000);
+        return `Idle inhibit is enabled for ${remainingMin} more minute${remainingMin === 1 ? "" : "s"}`;
+    }
+
     IpcHandler {
         function browser(): string {
             return root.launchDefaultMimeApp("browser", root.defaultAppMimeTypes.browser);
@@ -535,21 +557,29 @@ Item {
     IpcHandler {
         function toggle(): string {
             SessionService.toggleIdleInhibit();
-            return SessionService.idleInhibited ? "Idle inhibit enabled" : "Idle inhibit disabled";
+            return root.idleInhibitStatusMessage();
         }
 
         function enable(): string {
             SessionService.enableIdleInhibit();
-            return "Idle inhibit enabled";
+            return root.idleInhibitStatusMessage();
+        }
+
+        function enableFor(minutes: string): string {
+            const parsed = root.parseIdleInhibitMinutes(minutes);
+            if (parsed < 0)
+                return "Invalid duration. Use minutes, e.g. 60.";
+            SessionService.enableIdleInhibit(parsed);
+            return root.idleInhibitStatusMessage();
         }
 
         function disable(): string {
             SessionService.disableIdleInhibit();
-            return "Idle inhibit disabled";
+            return "Idle inhibit is disabled";
         }
 
         function status(): string {
-            return SessionService.idleInhibited ? "Idle inhibit is enabled" : "Idle inhibit is disabled";
+            return root.idleInhibitStatusMessage();
         }
 
         function reason(newReason: string): string {

--- a/quickshell/Modules/ControlCenter/Components/DetailHost.qml
+++ b/quickshell/Modules/ControlCenter/Components/DetailHost.qml
@@ -210,6 +210,9 @@ Item {
         case "doNotDisturb":
             coreDetailLoader.sourceComponent = doNotDisturbDetailComponent;
             break;
+        case "idleInhibitor":
+            coreDetailLoader.sourceComponent = idleInhibitorDetailComponent;
+            break;
         default:
             return;
         }
@@ -260,6 +263,11 @@ Item {
     Component {
         id: doNotDisturbDetailComponent
         DoNotDisturbDetail {}
+    }
+
+    Component {
+        id: idleInhibitorDetailComponent
+        IdleInhibitorDetail {}
     }
 
     Component {

--- a/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
+++ b/quickshell/Modules/ControlCenter/Components/DragDropGrid.qml
@@ -260,6 +260,8 @@ Column {
             return widgetWidth <= 25 ? smallColorPickerComponent : colorPickerPillComponent;
         case "doNotDisturb":
             return widgetWidth <= 25 ? smallToggleComponent : dndPillComponent;
+        case "idleInhibitor":
+            return widgetWidth <= 25 ? smallToggleComponent : idleInhibitorPillComponent;
         default:
             return widgetWidth <= 25 ? smallToggleComponent : toggleButtonComponent;
         }
@@ -715,6 +717,22 @@ Column {
     }
 
     Component {
+        id: idleInhibitorPillComponent
+        IdleInhibitorPill {
+            property var widgetData: parent.widgetData || {}
+            property int widgetIndex: parent.widgetIndex || 0
+            width: parent.width
+            height: 60
+
+            onExpandClicked: {
+                if (!root.editMode) {
+                    root.expandClicked(widgetData, widgetIndex);
+                }
+            }
+        }
+    }
+
+    Component {
         id: smallBatteryComponent
         SmallBatteryButton {
             property var widgetData: parent.widgetData || {}
@@ -744,8 +762,6 @@ Column {
                     return DisplayService.nightModeEnabled ? "nightlight" : "dark_mode";
                 case "darkMode":
                     return "contrast";
-                case "idleInhibitor":
-                    return "motion_sensor_active";
                 default:
                     return "help";
                 }
@@ -761,8 +777,6 @@ Column {
                             return SessionData.isLightMode ? I18n.tr("Auto (Light Mode)", "dark mode toggle label when matugen smart mode resolved light") : I18n.tr("Auto (Dark Mode)", "dark mode toggle label when matugen smart mode resolved dark");
                         return I18n.tr("Dark Mode");
                     }
-                case "idleInhibitor":
-                    return SessionService.idleInhibited ? I18n.tr("Keeping Awake") : I18n.tr("Keep Awake");
                 default:
                     return I18n.tr("Unknown", "widget status");
                 }
@@ -783,8 +797,6 @@ Column {
                     return DisplayService.nightModeEnabled || false;
                 case "darkMode":
                     return !SessionData.isLightMode;
-                case "idleInhibitor":
-                    return SessionService.idleInhibited || false;
                 default:
                     return false;
                 }
@@ -807,11 +819,6 @@ Column {
                         const newMode = !SessionData.isLightMode;
                         Theme.screenTransition();
                         Theme.setLightMode(newMode);
-                        break;
-                    }
-                case "idleInhibitor":
-                    {
-                        SessionService.toggleIdleInhibit();
                         break;
                     }
                 }

--- a/quickshell/Modules/ControlCenter/Details/IdleInhibitorDetail.qml
+++ b/quickshell/Modules/ControlCenter/Details/IdleInhibitorDetail.qml
@@ -1,0 +1,244 @@
+import QtQuick
+import qs.Common
+import qs.Services
+import qs.Widgets
+import "../../../Common/Format.js" as Format
+
+Rectangle {
+    id: root
+
+    LayoutMirroring.enabled: I18n.isRtl
+    LayoutMirroring.childrenInherit: true
+
+    implicitHeight: contentColumn.implicitHeight + Theme.spacingL * 2
+    radius: Theme.cornerRadius
+    color: Theme.nestedSurface
+    border.color: Theme.outlineMedium
+    border.width: Theme.layerOutlineWidth
+
+    property real nowMs: Date.now()
+
+    function _syncNow() {
+        nowMs = Date.now();
+    }
+
+    onVisibleChanged: {
+        if (visible)
+            _syncNow();
+    }
+
+    Connections {
+        target: SessionData
+        function onIdleInhibitedUntilChanged() {
+            if (root.visible)
+                root._syncNow();
+        }
+    }
+
+    Timer {
+        interval: 1000
+        repeat: true
+        running: root.visible && SessionService.idleInhibited && SessionData.idleInhibitedUntil > 0
+        triggeredOnStart: true
+        onTriggered: root._syncNow()
+    }
+
+    function formatRemaining(ms) {
+        return Format.formatRemaining(ms, "", I18n.tr("%1 min left"), I18n.tr("%1 h left"), I18n.tr("%1 h %2 m left"));
+    }
+
+    readonly property var presets: [
+        {
+            "label": I18n.tr("15 min"),
+            "minutes": 15
+        },
+        {
+            "label": I18n.tr("30 min"),
+            "minutes": 30
+        },
+        {
+            "label": I18n.tr("1 hour"),
+            "minutes": 60
+        },
+        {
+            "label": I18n.tr("2 hours"),
+            "minutes": 120
+        },
+        {
+            "label": I18n.tr("4 hours"),
+            "minutes": 240
+        },
+        {
+            "label": I18n.tr("8 hours"),
+            "minutes": 480
+        }
+    ]
+
+    Column {
+        id: contentColumn
+        width: parent.width - Theme.spacingL * 2
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.margins: Theme.spacingL
+        spacing: Theme.spacingM
+
+        Row {
+            width: parent.width
+            spacing: Theme.spacingM
+
+            DankIcon {
+                name: SessionService.idleInhibited ? "motion_sensor_active" : "motion_sensor_idle"
+                size: Theme.iconSizeLarge
+                color: SessionService.idleInhibited ? Theme.primary : Theme.surfaceText
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            Column {
+                anchors.verticalCenter: parent.verticalCenter
+                width: parent.width - Theme.iconSizeLarge - Theme.spacingM
+                spacing: Theme.spacingXXS
+
+                StyledText {
+                    text: I18n.tr("Prevent screen timeout")
+                    font.pixelSize: Theme.fontSizeLarge
+                    font.weight: Font.Medium
+                    color: Theme.surfaceText
+                    width: parent.width
+                    elide: Text.ElideRight
+                }
+
+                StyledText {
+                    text: {
+                        if (!SessionService.idleInhibited)
+                            return I18n.tr("Pick how long to stay awake");
+                        if (SessionData.idleInhibitedUntil <= 0)
+                            return I18n.tr("On indefinitely");
+                        const remaining = Math.max(0, SessionData.idleInhibitedUntil - root.nowMs);
+                        return root.formatRemaining(remaining) + " · " + I18n.tr("until %1").arg(Format.formatUntil(SessionData.idleInhibitedUntil, SettingsData.use24HourClock));
+                    }
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceVariantText
+                    width: parent.width
+                    elide: Text.ElideRight
+                }
+            }
+        }
+
+        Grid {
+            width: parent.width
+            columns: 3
+            columnSpacing: Theme.spacingS
+            rowSpacing: Theme.spacingS
+
+            Repeater {
+                model: root.presets
+
+                Rectangle {
+                    required property var modelData
+                    width: (contentColumn.width - Theme.spacingS * 2) / 3
+                    height: 36
+                    radius: Theme.cornerRadius
+                    color: presetArea.containsMouse ? Theme.primaryPressed : Theme.floatingSurface
+                    border.color: Theme.outlineStrong
+                    border.width: 1
+
+                    StyledText {
+                        anchors.centerIn: parent
+                        text: modelData.label
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.weight: Font.Medium
+                        color: Theme.surfaceText
+                    }
+
+                    MouseArea {
+                        id: presetArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: SessionService.enableIdleInhibit(modelData.minutes)
+                    }
+                }
+            }
+        }
+
+        Row {
+            width: parent.width
+            spacing: Theme.spacingS
+
+            Rectangle {
+                width: (contentColumn.width - Theme.spacingS) / 2
+                height: 36
+                radius: Theme.cornerRadius
+                color: foreverArea.containsMouse ? Theme.primaryPressed : Theme.floatingSurface
+                border.color: Theme.outlineStrong
+                border.width: 1
+
+                Row {
+                    anchors.centerIn: parent
+                    spacing: Theme.spacingXS
+
+                    DankIcon {
+                        anchors.verticalCenter: parent.verticalCenter
+                        name: "block"
+                        size: Theme.iconSizeSmall
+                        color: Theme.surfaceText
+                    }
+
+                    StyledText {
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: I18n.tr("Until I turn it off")
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.weight: Font.Medium
+                        color: Theme.surfaceText
+                    }
+                }
+
+                MouseArea {
+                    id: foreverArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: SessionService.enableIdleInhibit(0)
+                }
+            }
+
+            Rectangle {
+                width: (contentColumn.width - Theme.spacingS) / 2
+                height: 36
+                radius: Theme.cornerRadius
+                visible: SessionService.idleInhibited
+                color: offArea.containsMouse ? Theme.errorPressed : Theme.floatingSurface
+                border.color: Theme.outlineStrong
+                border.width: 1
+
+                Row {
+                    anchors.centerIn: parent
+                    spacing: Theme.spacingXS
+
+                    DankIcon {
+                        anchors.verticalCenter: parent.verticalCenter
+                        name: "motion_sensor_idle"
+                        size: Theme.iconSizeSmall
+                        color: offArea.containsMouse ? Theme.error : Theme.surfaceText
+                    }
+
+                    StyledText {
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: I18n.tr("Turn off")
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.weight: Font.Medium
+                        color: offArea.containsMouse ? Theme.error : Theme.surfaceText
+                    }
+                }
+
+                MouseArea {
+                    id: offArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: SessionService.disableIdleInhibit()
+                }
+            }
+        }
+    }
+}

--- a/quickshell/Modules/ControlCenter/Details/IdleInhibitorDetail.qml
+++ b/quickshell/Modules/ControlCenter/Details/IdleInhibitorDetail.qml
@@ -110,7 +110,7 @@ Rectangle {
                 StyledText {
                     text: {
                         if (!SessionService.idleInhibited)
-                            return I18n.tr("Pick how long to stay awake");
+                            return I18n.tr("Pick how long to stay awake", "idle inhibitor detail subtitle shown while keep awake is off");
                         if (SessionData.idleInhibitedUntil <= 0)
                             return I18n.tr("On indefinitely");
                         const remaining = Math.max(0, SessionData.idleInhibitedUntil - root.nowMs);

--- a/quickshell/Modules/ControlCenter/Widgets/IdleInhibitorPill.qml
+++ b/quickshell/Modules/ControlCenter/Widgets/IdleInhibitorPill.qml
@@ -1,0 +1,24 @@
+import QtQuick
+import qs.Common
+import qs.Modules.ControlCenter.Widgets
+import qs.Services
+import "../../../Common/Format.js" as Format
+
+CompoundPill {
+    id: root
+
+    iconName: SessionService.idleInhibited ? "motion_sensor_active" : "motion_sensor_idle"
+    iconColor: SessionService.idleInhibited ? Theme.primary : Theme.surfaceText
+    primaryText: I18n.tr("Keep Awake")
+    isActive: SessionService.idleInhibited
+
+    secondaryText: {
+        if (!SessionService.idleInhibited)
+            return I18n.tr("Off");
+        if (SessionData.idleInhibitedUntil <= 0)
+            return I18n.tr("On");
+        return I18n.tr("Until %1").arg(Format.formatUntil(SessionData.idleInhibitedUntil, SettingsData.use24HourClock));
+    }
+
+    onToggled: SessionService.toggleIdleInhibit()
+}

--- a/quickshell/Modules/DankBar/DankBarContent.qml
+++ b/quickshell/Modules/DankBar/DankBarContent.qml
@@ -1486,6 +1486,8 @@ Item {
 
         IdleInhibitor {
             widgetThickness: barWindow.widgetThickness
+            barThickness: barWindow.effectiveBarThickness
+            axis: barWindow.axis
             section: topBarContent.getWidgetSection(parent) || "right"
             parentScreen: barWindow.screen
         }

--- a/quickshell/Modules/DankBar/Widgets/IdleInhibitDurationMenu.qml
+++ b/quickshell/Modules/DankBar/Widgets/IdleInhibitDurationMenu.qml
@@ -1,0 +1,223 @@
+import QtQuick
+import qs.Common
+import qs.Services
+import qs.Widgets
+import "../../../Common/Format.js" as Format
+
+Rectangle {
+    id: root
+
+    LayoutMirroring.enabled: I18n.isRtl
+    LayoutMirroring.childrenInherit: true
+
+    signal dismissed
+
+    readonly property bool currentlyActive: SessionService.idleInhibited
+    readonly property real currentRemainingMs: SessionData.idleInhibitedUntil > 0 ? Math.max(0, SessionData.idleInhibitedUntil - nowMs) : 0
+    property real nowMs: Date.now()
+
+    function _syncNow() {
+        nowMs = Date.now();
+    }
+
+    onVisibleChanged: {
+        if (visible)
+            _syncNow();
+    }
+
+    Timer {
+        interval: 1000
+        repeat: true
+        running: root.visible && root.currentlyActive && SessionData.idleInhibitedUntil > 0
+        triggeredOnStart: true
+        onTriggered: root._syncNow()
+    }
+
+    function formatRemaining(ms) {
+        return Format.formatRemaining(ms, I18n.tr("Off"), I18n.tr("%1 min left"), I18n.tr("%1 h left"), I18n.tr("%1 h %2 m left"));
+    }
+
+    readonly property var presetOptions: [
+        {
+            "label": I18n.tr("For 15 minutes"),
+            "minutes": 15
+        },
+        {
+            "label": I18n.tr("For 30 minutes"),
+            "minutes": 30
+        },
+        {
+            "label": I18n.tr("For 1 hour"),
+            "minutes": 60
+        },
+        {
+            "label": I18n.tr("For 2 hours"),
+            "minutes": 120
+        },
+        {
+            "label": I18n.tr("For 4 hours"),
+            "minutes": 240
+        },
+        {
+            "label": I18n.tr("For 8 hours"),
+            "minutes": 480
+        },
+        {
+            "label": I18n.tr("Until I turn it off"),
+            "minutes": 0
+        }
+    ]
+
+    function selectPreset(option) {
+        SessionService.enableIdleInhibit(option.minutes);
+        root.dismissed();
+    }
+
+    function turnOff() {
+        SessionService.disableIdleInhibit();
+        root.dismissed();
+    }
+
+    implicitWidth: Math.max(220, menuColumn.implicitWidth + Theme.spacingM * 2)
+    implicitHeight: menuColumn.implicitHeight + Theme.spacingM * 2
+    color: Theme.floatingSurface
+    radius: Theme.cornerRadius
+    border.color: BlurService.borderColor
+    border.width: BlurService.borderWidth
+
+    Column {
+        id: menuColumn
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.margins: Theme.spacingM
+        spacing: Theme.spacingXS
+
+        Row {
+            width: parent.width
+            spacing: Theme.spacingS
+
+            DankIcon {
+                name: SessionService.idleInhibited ? "motion_sensor_active" : "motion_sensor_idle"
+                size: Theme.iconSize - 2
+                color: SessionService.idleInhibited ? Theme.primary : Theme.surfaceText
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            Column {
+                width: parent.width - Theme.iconSize - parent.spacing
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: 0
+
+                StyledText {
+                    text: I18n.tr("Keep Awake")
+                    font.pixelSize: Theme.fontSizeMedium
+                    font.weight: Font.Medium
+                    color: Theme.surfaceText
+                    elide: Text.ElideRight
+                    width: parent.width
+                }
+
+                StyledText {
+                    visible: root.currentlyActive
+                    text: {
+                        if (SessionData.idleInhibitedUntil > 0) {
+                            return root.formatRemaining(root.currentRemainingMs) + " · " + I18n.tr("until %1").arg(Format.formatUntil(SessionData.idleInhibitedUntil, SettingsData.use24HourClock));
+                        }
+                        return I18n.tr("On indefinitely");
+                    }
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceVariantText
+                    elide: Text.ElideRight
+                    width: parent.width
+                }
+            }
+        }
+
+        Rectangle {
+            width: parent.width
+            height: 1
+            color: Theme.outlineStrong
+        }
+
+        Repeater {
+            model: root.presetOptions
+
+            Rectangle {
+                id: optionRect
+                required property var modelData
+                width: menuColumn.width
+                height: 32
+                radius: Theme.cornerRadius
+                color: optionArea.containsMouse ? BlurService.hoverColor(Theme.widgetBaseHoverColor) : Theme.withAlpha(BlurService.hoverColor(Theme.widgetBaseHoverColor), 0)
+
+                StyledText {
+                    anchors.left: parent.left
+                    anchors.leftMargin: Theme.spacingS
+                    anchors.right: parent.right
+                    anchors.rightMargin: Theme.spacingS
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: optionRect.modelData.label
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceText
+                    elide: Text.ElideRight
+                }
+
+                MouseArea {
+                    id: optionArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root.selectPreset(optionRect.modelData)
+                }
+            }
+        }
+
+        Rectangle {
+            visible: root.currentlyActive
+            width: parent.width
+            height: 1
+            color: Theme.outlineStrong
+        }
+
+        Rectangle {
+            visible: root.currentlyActive
+            width: menuColumn.width
+            height: 32
+            radius: Theme.cornerRadius
+            color: offArea.containsMouse ? Theme.errorPressed : Theme.withAlpha(Theme.errorPressed, 0)
+
+            Row {
+                anchors.left: parent.left
+                anchors.leftMargin: Theme.spacingS
+                anchors.right: parent.right
+                anchors.rightMargin: Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Theme.spacingS
+
+                DankIcon {
+                    anchors.verticalCenter: parent.verticalCenter
+                    name: "motion_sensor_idle"
+                    size: Theme.iconSizeSmall
+                    color: offArea.containsMouse ? Theme.error : Theme.surfaceText
+                }
+
+                StyledText {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: I18n.tr("Turn off now")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: offArea.containsMouse ? Theme.error : Theme.surfaceText
+                    font.weight: Font.Medium
+                }
+            }
+
+            MouseArea {
+                id: offArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: root.turnOff()
+            }
+        }
+    }
+}

--- a/quickshell/Modules/DankBar/Widgets/IdleInhibitDurationMenu.qml
+++ b/quickshell/Modules/DankBar/Widgets/IdleInhibitDurationMenu.qml
@@ -51,11 +51,11 @@ Rectangle {
             "minutes": 60
         },
         {
-            "label": I18n.tr("For 2 hours"),
+            "label": I18n.tr("For 2 hours", "idle inhibit duration menu option"),
             "minutes": 120
         },
         {
-            "label": I18n.tr("For 4 hours"),
+            "label": I18n.tr("For 4 hours", "idle inhibit duration menu option"),
             "minutes": 240
         },
         {

--- a/quickshell/Modules/DankBar/Widgets/IdleInhibitDurationPopup.qml
+++ b/quickshell/Modules/DankBar/Widgets/IdleInhibitDurationPopup.qml
@@ -1,0 +1,102 @@
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import qs.Common
+import qs.Services
+import qs.Widgets
+
+PanelWindow {
+    id: root
+
+    WindowBlur {
+        targetWindow: root
+        blurX: menu.x
+        blurY: menu.y
+        blurWidth: root.visible ? menu.width : 0
+        blurHeight: root.visible ? menu.height : 0
+        blurRadius: Theme.cornerRadius
+    }
+
+    WlrLayershell.namespace: "dms:idle-inhibit-duration-menu"
+    WlrLayershell.layer: WlrLayershell.Overlay
+    WlrLayershell.exclusiveZone: -1
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+    color: "transparent"
+
+    anchors {
+        top: true
+        left: true
+        right: true
+        bottom: true
+    }
+
+    property point anchorPos: Qt.point(0, 0)
+    property bool isVertical: false
+    property string edge: "top"
+    screen: null
+    visible: false
+
+    function showAt(x, y, vertical, barEdge, targetScreen) {
+        if (targetScreen)
+            root.screen = targetScreen;
+        anchorPos = Qt.point(x, y);
+        isVertical = vertical ?? false;
+        edge = barEdge ?? "top";
+        visible = true;
+
+        if (root.screen)
+            TrayMenuManager.registerMenu(root.screen.name, root);
+    }
+
+    function close() {
+        if (!visible)
+            return;
+        visible = false;
+
+        if (root.screen)
+            TrayMenuManager.unregisterMenu(root.screen.name);
+    }
+
+    Component.onDestruction: {
+        if (visible && root.screen)
+            TrayMenuManager.unregisterMenu(root.screen.name);
+    }
+
+    Connections {
+        target: PopoutManager
+        function onPopoutOpening() {
+            root.close();
+        }
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        z: 0
+        acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
+        onClicked: root.close()
+    }
+
+    IdleInhibitDurationMenu {
+        id: menu
+        z: 1
+        visible: root.visible
+
+        x: {
+            if (root.isVertical) {
+                if (root.edge === "left")
+                    return Math.min(root.width - width - 10, root.anchorPos.x);
+                return Math.max(10, root.anchorPos.x - width);
+            }
+            return Math.max(10, Math.min(root.width - width - 10, root.anchorPos.x - width / 2));
+        }
+        y: {
+            if (root.isVertical)
+                return Math.max(10, Math.min(root.height - height - 10, root.anchorPos.y - height / 2));
+            if (root.edge === "bottom")
+                return Math.max(10, root.anchorPos.y - height);
+            return Math.min(root.height - height - 10, root.anchorPos.y);
+        }
+
+        onDismissed: root.close()
+    }
+}

--- a/quickshell/Modules/DankBar/Widgets/IdleInhibitor.qml
+++ b/quickshell/Modules/DankBar/Widgets/IdleInhibitor.qml
@@ -25,18 +25,40 @@ BasePill {
         }
     }
 
-    MouseArea {
-        z: 1
-        x: -root.leftMargin
-        y: -root.topMargin
-        width: root.width + root.leftMargin + root.rightMargin
-        height: root.height + root.topMargin + root.bottomMargin
-        cursorShape: Qt.PointingHandCursor
-        onPressed: mouse => {
-            root.triggerRipple(this, mouse.x, mouse.y);
+    onClicked: SessionService.toggleIdleInhibit()
+
+    onRightClicked: {
+        const screen = root.parentScreen || Screen;
+        if (!screen)
+            return;
+
+        const isVertical = root.axis?.isVertical ?? false;
+        const edge = root.axis?.edge ?? "top";
+        const gap = Math.max(Theme.spacingXS, root.barSpacing ?? Theme.spacingXS);
+        const barOffset = root.barThickness + root.barSpacing + gap;
+        const localPos = root.visualContent.mapToItem(null, root.visualContent.width / 2, root.visualContent.height / 2);
+
+        let anchorX;
+        let anchorY;
+        if (isVertical) {
+            anchorX = edge === "left" ? barOffset : screen.width - barOffset;
+            anchorY = localPos.y;
+        } else {
+            anchorX = localPos.x;
+            anchorY = edge === "bottom" ? screen.height - barOffset : barOffset;
         }
-        onClicked: {
-            SessionService.toggleIdleInhibit();
-        }
+
+        durationPopupLoader.active = true;
+        const popup = durationPopupLoader.item;
+        if (!popup)
+            return;
+
+        popup.showAt(anchorX, anchorY, isVertical, edge, screen);
+    }
+
+    Loader {
+        id: durationPopupLoader
+        active: false
+        sourceComponent: IdleInhibitDurationPopup {}
     }
 }

--- a/quickshell/Services/SessionService.qml
+++ b/quickshell/Services/SessionService.qml
@@ -630,17 +630,46 @@ Singleton {
     // * Idle Inhibitor
     signal inhibitorChanged
 
-    // The inhibitor is a state the user turns on explicitly, so it is persisted in the session
-    // like the other Control Center toggles (doNotDisturb, nightModeEnabled, ...). Without this
-    // it lived only in memory and every shell restart silently cleared it.
-    //
-    // Both entry points are needed because the two singletons are lazily created and the order is
-    // not fixed: onLoaded covers "service first, session file read later", the restore below
-    // covers "session already loaded by the time the service is instantiated". enableIdleInhibit
-    // is idempotent, so whichever runs second does nothing.
+    readonly property int _maxExpireInterval: 86400000
+
+    Timer {
+        id: inhibitExpireTimer
+        repeat: false
+        running: false
+        onTriggered: root._armExpireTimer()
+    }
+
+    // Timers use a monotonic clock that stops across suspend, so the deadline is
+    // re-checked against the wall clock on resume and after each chunk.
+    function _armExpireTimer() {
+        inhibitExpireTimer.stop();
+        if (!idleInhibited || SessionData.idleInhibitedUntil <= 0)
+            return;
+        const remaining = SessionData.idleInhibitedUntil - Date.now();
+        if (remaining <= 0) {
+            disableIdleInhibit();
+            return;
+        }
+        inhibitExpireTimer.interval = Math.min(remaining, _maxExpireInterval);
+        inhibitExpireTimer.start();
+    }
+
+    onSessionResumed: _armExpireTimer()
+
+    function _setIdleInhibited(enabled) {
+        if (idleInhibited === enabled)
+            return;
+        idleInhibited = enabled;
+        inhibitorChanged();
+    }
+
+    // Both entry points are deliberate: the singletons are created lazily in no fixed order, so
+    // whichever of these runs once the session is loaded does the restore; the other no-ops.
     function _restoreIdleInhibit() {
-        if (SessionData.idleInhibited && !idleInhibited)
-            enableIdleInhibit();
+        if (!SessionData._hasLoaded)
+            return;
+        _setIdleInhibited(SessionData.idleInhibited);
+        _armExpireTimer();
     }
 
     Connections {
@@ -653,20 +682,16 @@ Singleton {
 
     Component.onCompleted: _restoreIdleInhibit()
 
-    function enableIdleInhibit() {
-        if (idleInhibited)
-            return;
-        idleInhibited = true;
-        SessionData.setIdleInhibited(true);
-        inhibitorChanged();
+    function enableIdleInhibit(durationMinutes) {
+        SessionData.setIdleInhibited(true, durationMinutes);
+        _setIdleInhibited(true);
+        _armExpireTimer();
     }
 
     function disableIdleInhibit() {
-        if (!idleInhibited)
-            return;
-        idleInhibited = false;
         SessionData.setIdleInhibited(false);
-        inhibitorChanged();
+        _setIdleInhibited(false);
+        _armExpireTimer();
     }
 
     function toggleIdleInhibit() {


### PR DESCRIPTION
## Description

Lets the idle inhibitor be turned on for a set period instead of only indefinitely.

### UI

**Bar widget** — left-click still toggles (indefinite when turning on). Right-click opens a duration menu: *For 15 minutes / 30 minutes / 1 hour / 2 hours / 4 hours / 8 hours / Until I turn it off*, plus *Turn off now* while active. Its header shows the state — `1 h left · until 10:25`, or `On indefinitely`.

**Control Center** — the `idleInhibitor` widget becomes a `CompoundPill` ("Keep Awake", secondary text `Off` / `On` / `Until 10:25`) that expands into a detail with the same durations in a 3×2 grid, plus *Until I turn it off* and *Turn off*. The small (≤25% width) variant is unchanged.

Both surfaces follow the existing Do Not Disturb duration menu and detail, which they're modelled on.

### IPC

- `inhibit enableFor <minutes>` — positive integers only; `0`, negatives, decimals and zero-padded values are rejected with a usage message
- `inhibit enable` — indefinite, and downgrades a running timed inhibit to indefinite
- `inhibit status` — now reports remaining time (`Idle inhibit is enabled for 42 more minutes`)

`docs/IPC.md` is updated for both.

### Behaviour

- `idleInhibitedUntil` is added to the session spec next to the existing `idleInhibited`, so a timed inhibit survives a shell restart with its deadline intact. A deadline that passed while the shell wasn't running is cleared on load, mirroring `_applyDndExpirySanity`.
- Expiry is a `Timer` armed to the deadline. Its interval is capped at 24 h and re-armed, so a long `enableFor` can't overflow `Timer.interval` (int milliseconds — anything over ~24.8 days).
- On resume from suspend the deadline is re-checked against the wall clock. Qt timers use a monotonic clock that stops while suspended, so without this a keep-awake would outlive its own deadline by however long the machine slept. A window that elapsed during suspend clears immediately on wake; one that didn't continues with the correct remaining time.

**Deliberately unchanged:** the inhibitor still persists across shell restart, logout and reboot, and suspend/resume does not clear it on its own. It ends only when its timer expires or the user turns it off.

Three new translation terms: `Pick how long to stay awake`, `For 2 hours`, `For 4 hours`. Everything else reuses existing catalog entries.

Follow-ups not addressed here: the duration menu and detail are ~75% duplicated from their DND counterparts and would benefit from a shared component; bar context menus swallow the first click after opening (all of them, pre-existing); `DndDurationPopup` doesn't register with `TrayMenuManager`; and `notifications enableDoNotDisturbFor` has the same interval-overflow issue guarded against here.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Closes #1483.

The login-default part of #1483 is tracked separately in #3343 — the clarified intent turned out to be a change to existing persistence behaviour rather than an addition.

## Screenshots / video

<img width="306" height="414" alt="image" src="https://github.com/user-attachments/assets/ba327f01-7a12-4b03-8bb9-501a52ac99f4" />

<img width="683" height="422" alt="image" src="https://github.com/user-attachments/assets/ea5261ec-7615-4824-8218-f1dbcfe73ea4" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean — n/a, no Go changes
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs — happy to open one for the new IPC subcommand if wanted

### How it was tested

Verified against a live shell (`dms run -c <tree>`):

- `enableFor` validation — `0`, `abc`, `1.5`, `060`, empty all rejected
- timed enable persists `idleInhibitedUntil`; `enable` over it downgrades to indefinite; `toggle`/`disable` correct; keys drop from `session.json` at defaults
- **expiry** — `enableFor 1` cleared at exactly 60 s
- **suspend** — 1-minute inhibit, 75-second suspend, off on resume
- bar menu placement, Control Center pill and detail, and tray-menu interaction checked by hand
