### PR TITLE
feat: add touchpad click method in settings

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -209,6 +209,7 @@ Singleton {
     property string mouseScrollMethod: "default"
     property string touchpadAccelProfile: "default"
     property real touchpadAccelSpeed: 0.0
+    property string touchpadClickMethod: "default"
     property bool touchpadDisableOnExternalMouse: false
     property bool touchpadDisableWhileTyping: true
     property bool touchpadDragLock: false

--- a/quickshell/Common/settings/SettingsSpec.js
+++ b/quickshell/Common/settings/SettingsSpec.js
@@ -56,6 +56,7 @@ var SPEC = {
     mouseScrollMethod: { def: "default", onChange: "updateCompositorInput" },
     touchpadAccelProfile: { def: "default", onChange: "updateCompositorInput" },
     touchpadAccelSpeed: { def: 0.0, onChange: "updateCompositorInput" },
+    touchpadClickMethod: { def: "default", onChange: "updateCompositorInput" },
     touchpadDisableOnExternalMouse: { def: false, onChange: "updateCompositorInput" },
     touchpadDisableWhileTyping: { def: true, onChange: "updateCompositorInput" },
     touchpadDragLock: { def: false, onChange: "updateCompositorInput" },

--- a/quickshell/Modules/Settings/MouseTouchpadTab.qml
+++ b/quickshell/Modules/Settings/MouseTouchpadTab.qml
@@ -238,6 +238,25 @@ Item {
                     }
                 }
 
+                SettingsDropdownRow {
+                    id: touchpadClickMethodRow
+
+                    readonly property var methods: ["default", "button-areas", "clickfinger"]
+
+                    tags: ["touchpad", "click", "method"]
+                    settingKey: "touchpadClickMethod"
+                    text: I18n.tr("Click Method")
+                    description: I18n.tr("Button areas determines click type by position; Clickfinger by finger count")
+                    options: [I18n.tr("Default"), I18n.tr("Button areas"), I18n.tr("Clickfinger")]
+                    currentValue: options[Math.max(0, methods.indexOf(SettingsData.touchpadClickMethod))]
+                    onValueChanged: value => {
+                        const index = touchpadClickMethodRow.options.indexOf(value);
+                        if (index < 0)
+                            return;
+                        SettingsData.set("touchpadClickMethod", touchpadClickMethodRow.methods[index]);
+                    }
+                }
+
                 SettingsToggleRow {
                     tags: ["touchpad", "disable", "typing", "dwt"]
                     settingKey: "touchpadDisableWhileTyping"

--- a/quickshell/Modules/Settings/MouseTouchpadTab.qml
+++ b/quickshell/Modules/Settings/MouseTouchpadTab.qml
@@ -245,9 +245,12 @@ Item {
 
                     tags: ["touchpad", "click", "method"]
                     settingKey: "touchpadClickMethod"
-                    text: I18n.tr("Click Method")
-                    description: I18n.tr("Button areas determines click type by position; Clickfinger by finger count")
-                    options: [I18n.tr("Default"), I18n.tr("Button areas"), I18n.tr("Clickfinger")]
+                    text: I18n.tr("Click Method", "Rules by which touchpad input determines left, right and middle click")
+                    description: I18n.tr("Button areas determines click type by finger position; Clickfinger by finger count")
+                    options: [
+                        I18n.tr("Default"),
+                        I18n.tr("Button areas", "Touchpad click method: click type is determined by finger position"),
+                        I18n.tr("Clickfinger", "Touchpad click method: click type is determined by finger count")]
                     currentValue: options[Math.max(0, methods.indexOf(SettingsData.touchpadClickMethod))]
                     onValueChanged: value => {
                         const index = touchpadClickMethodRow.options.indexOf(value);

--- a/quickshell/Services/NiriService.qml
+++ b/quickshell/Services/NiriService.qml
@@ -1664,6 +1664,7 @@ window-rule {
         const defaultMouseScrollMethod = "default";
         const defaultMouseSpeed = 0.0;
 
+        const defaultTouchpadClickMethod = "default";
         const defaultTouchpadDisableOnExternalMouse = false;
         const defaultTouchpadDisableWhileTyping = true;
         const defaultTouchpadDragLock = false;
@@ -1684,6 +1685,7 @@ window-rule {
         const mouseScrollMethod = typeof SettingsData !== "undefined" ? SettingsData.mouseScrollMethod : defaultMouseScrollMethod;
         const mouseSpeed = typeof SettingsData !== "undefined" ? SettingsData.mouseAccelSpeed : defaultMouseSpeed;
 
+        const touchpadClickMethod = typeof SettingsData !== "undefined" ? SettingsData.touchpadClickMethod : defaultTouchpadClickMethod;
         const touchpadDisableOnExternalMouse = typeof SettingsData !== "undefined" ? SettingsData.touchpadDisableOnExternalMouse : defaultTouchpadDisableOnExternalMouse;
         const touchpadDisableWhileTyping = typeof SettingsData !== "undefined" ? SettingsData.touchpadDisableWhileTyping : defaultTouchpadDisableWhileTyping;
         const touchpadDragLock = typeof SettingsData !== "undefined" ? SettingsData.touchpadDragLock : defaultTouchpadDragLock;
@@ -1746,6 +1748,9 @@ window-rule {
         inputContent += `        accel-speed ${touchpadSpeed.toFixed(1)}\n`;
         if (touchpadProfile !== "default") {
             inputContent += `        accel-profile "${touchpadProfile}"\n`;
+        }
+        if (touchpadClickMethod !== "default") {
+            inputContent += `        click-method "${touchpadClickMethod}"\n`;
         }
         if (touchpadNaturalScroll) {
             inputContent += "        natural-scroll\n";

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -11778,6 +11778,29 @@
     "conditionKey": "isNiri"
   },
   {
+    "section": "touchpadClickMethod",
+    "label": "Click Method",
+    "tabIndex": 44,
+    "category": "System",
+    "keywords": [
+      "areas",
+      "button",
+      "click",
+      "clickfinger",
+      "count",
+      "determines",
+      "finger",
+      "linux",
+      "method",
+      "os",
+      "system",
+      "touchpad",
+      "type"
+    ],
+    "description": "Button areas determines click type by position; Clickfinger by finger count",
+    "conditionKey": "isNiri"
+  },
+  {
     "section": "touchpadDisableWhileTyping",
     "label": "Disable While Typing",
     "tabIndex": 44,

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -11797,7 +11797,7 @@
       "touchpad",
       "type"
     ],
-    "description": "Button areas determines click type by position; Clickfinger by finger count",
+    "description": "Button areas determines click type by finger position; Clickfinger by finger count",
     "conditionKey": "isNiri"
   },
   {


### PR DESCRIPTION
## Description
Adds an option to configure the niri touchpad click-method ( button-areas or clickfinger, defaults to button-areas )  in Settings -> Mouse & Touchpad with a drop down ui.

## Why
The generated input.kdl overwrites  the niri inputs sow if you wanted  the clickfinger click method you couldn't have the graphical settings 

<!-- What does this PR do and why? -->

## Type of change

<!-- Check all that apply. -->

- [x] New feature (non-breaking change that adds functionality)

## Screenshots / video
<img width="925" height="991" alt="Screenshot from 2026-09-07 16-30-02" src="https://github.com/user-attachments/assets/4d347bc5-27b9-4d01-8b05-dbe6ecaf90b3" />

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] QML changes: ran `make lint-qml` with no new warnings