### PR TITLE
outputs: only re-enable displays the cycle itself turned off

### DIFF
--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -118,9 +118,9 @@ The command returns immediately with one of these statuses:
 - `OUTPUT_CYCLE_NOOP` — fewer than two outputs are connected, or DMS could not start switching outputs.
 - `OUTPUT_CYCLE_UNSUPPORTED` — the active compositor is not Niri, its IPC socket is unavailable, or DMS output-state notifications are unavailable.
 
-If the selected output disconnects and no connected output is enabled, DMS enables the previous connected output in the cycle.
-This fallback also works before the first cycle command and leaves any already-enabled outputs unchanged.
-DMS keeps this cycle order in memory until it restarts.
+If the selected output disconnects and no connected output is enabled, DMS re-enables the previous output in the cycle, but only if a cycle command disabled it.
+Outputs that were already off, such as those disabled in display settings, are never enabled by this fallback.
+DMS keeps this cycle order and the list of outputs it disabled in memory until it restarts.
 
 ### Niri keybinding example
 

--- a/quickshell/Services/OutputCycleState.js
+++ b/quickshell/Services/OutputCycleState.js
@@ -4,7 +4,8 @@ function emptyState() {
     return {
         ring: [],
         selected: "",
-        pending: ""
+        pending: "",
+        original: {}
     };
 }
 
@@ -19,10 +20,13 @@ function requestCycle(state, outputs, currentOutput) {
     const current = findOutput(outputs, currentOutput) ? currentOutput : (firstEnabled(outputs) || ring[0]);
     const target = ring[(ring.indexOf(current) + 1) % ring.length];
     const targetOutput = findOutput(outputs, target);
-    if (targetOutput.enabled)
-        return result(withState(state, { selected: target }), "accepted", disableOthers(outputs, target));
+    if (targetOutput.enabled) {
+        const intents = disableOthers(outputs, target);
+        return result(withState(state, { selected: target, original: recordOriginal(state.original, outputs, intents) }), "accepted", intents);
+    }
 
-    return result(withState(state, { pending: target }), "accepted", [{ id: target, enabled: true }]);
+    const intents = [{ id: target, enabled: true }];
+    return result(withState(state, { pending: target, original: recordOriginal(state.original, outputs, intents) }), "accepted", intents);
 }
 
 function handleOutputsChanged(state, outputs) {
@@ -30,23 +34,24 @@ function handleOutputsChanged(state, outputs) {
     if (ring.length === 0)
         return result(state, "", []);
 
-    let nextState = state;
+    let nextState = withState(state, { original: pruneRestored(state.original, outputs) });
     let intents = [];
     if (state.pending) {
         const pendingOutput = findOutput(outputs, state.pending);
         if (!pendingOutput) {
             nextState = withState(nextState, { pending: "" });
         } else if (pendingOutput.enabled) {
+            intents = disableOthers(outputs, pendingOutput.id);
             nextState = withState(nextState, {
                 pending: "",
-                selected: pendingOutput.id
+                selected: pendingOutput.id,
+                original: recordOriginal(nextState.original, outputs, intents)
             });
-            intents = disableOthers(outputs, pendingOutput.id);
         }
     }
 
     if (!nextState.pending && nextState.selected && !findOutput(outputs, nextState.selected) && !firstEnabled(outputs)) {
-        const fallback = previousConnectedOutput(state.ring, nextState.selected, outputs);
+        const fallback = previousConnectedOutput(state.ring, nextState.selected, outputs, nextState.original);
         if (fallback) {
             nextState = withState(nextState, { selected: fallback.id });
             intents = intents.concat([{ id: fallback.id, enabled: true }]);
@@ -86,23 +91,43 @@ function disableOthers(outputs, selected) {
         .map(output => ({ id: output.id, enabled: false }));
 }
 
-function previousConnectedOutput(ring, selected, outputs) {
+function previousConnectedOutput(ring, selected, outputs, original) {
     const selectedIndex = ring.indexOf(selected);
     if (selectedIndex < 0)
         return null;
     for (let offset = 1; offset < ring.length; offset++) {
         const candidate = findOutput(outputs, ring[(selectedIndex - offset + ring.length) % ring.length]);
-        if (candidate)
+        if (candidate && original[candidate.id] === true)
             return candidate;
     }
     return null;
+}
+
+function recordOriginal(original, outputs, intents) {
+    const next = Object.assign({}, original);
+    for (const intent of intents) {
+        if (next[intent.id] === undefined)
+            next[intent.id] = findOutput(outputs, intent.id).enabled;
+    }
+    return next;
+}
+
+function pruneRestored(original, outputs) {
+    const next = {};
+    for (const id in original) {
+        const output = findOutput(outputs, id);
+        if (!output || output.enabled !== original[id])
+            next[id] = original[id];
+    }
+    return next;
 }
 
 function withState(state, changes) {
     return {
         ring: changes.ring !== undefined ? changes.ring : state.ring,
         selected: changes.selected !== undefined ? changes.selected : state.selected,
-        pending: changes.pending !== undefined ? changes.pending : state.pending
+        pending: changes.pending !== undefined ? changes.pending : state.pending,
+        original: changes.original !== undefined ? changes.original : (state.original || {})
     };
 }
 

--- a/quickshell/tests/tst_NiriOutputCycle.qml
+++ b/quickshell/tests/tst_NiriOutputCycle.qml
@@ -133,16 +133,15 @@ TestCase {
         compareRequests([["DP-1", "On"], ["eDP-1", "Off"]]);
     }
 
-    function test_initialSelectionRecoversDisabledHeadAfterUnplug() {
+    function test_initialSelectionLeavesDisabledHeadAloneAfterUnplug() {
         start([head("DP-1", true), head("eDP-1", false)], "DP-1");
         compareRequests([]);
 
         wlr.publish([head("eDP-1", false)]);
-        compareRequests([["eDP-1", "On"]]);
+        compareRequests([]);
 
-        wlr.publish([head("eDP-1", true)]);
-        compareRequests([["eDP-1", "On"]]);
-        compare(adapter.cycleSingleOutput(), "OUTPUT_CYCLE_NOOP");
+        wlr.publish([head("DP-1", true), head("eDP-1", false)]);
+        compareRequests([]);
     }
 
     function test_unpluggedPendingTargetCancelsAndNewHeadJoinsCycle() {

--- a/quickshell/tests/tst_OutputCycleState.qml
+++ b/quickshell/tests/tst_OutputCycleState.qml
@@ -95,7 +95,7 @@ TestCase {
     }
 
     function test_disabledFallbackOnlyEnablesPreviousOutput() {
-        const state = { ring: ["DP-1", "HDMI-A-1", "eDP-1"], selected: "HDMI-A-1", pending: "" };
+        const state = { ring: ["DP-1", "HDMI-A-1", "eDP-1"], selected: "HDMI-A-1", pending: "", original: { "DP-1": true, "eDP-1": true } };
         const result = OutputCycleState.handleOutputsChanged(state, [
             output("DP-1", false),
             output("eDP-1", false)
@@ -127,18 +127,54 @@ TestCase {
     }
 
     function test_fallbackConfirmationDoesNotDisableNewlyEnabledPeer() {
-        const state = OutputCycleState.handleOutputsChanged(OutputCycleState.emptyState(), [
-            output("DP-1", true), output("DP-2", false), output("eDP-1", false)
-        ]).state;
-        const unplugged = OutputCycleState.handleOutputsChanged(state, [
-            output("DP-2", false), output("eDP-1", false)
+        const heads = [output("DP-1", true), output("DP-2", false), output("eDP-1", false)];
+        const initial = OutputCycleState.handleOutputsChanged(OutputCycleState.emptyState(), heads).state;
+
+        const cycle = OutputCycleState.requestCycle(initial, heads, "DP-1");
+        compare(cycle.intents, [{ id: "DP-2", enabled: true }]);
+        const cycled = OutputCycleState.handleOutputsChanged(cycle.state, [
+            output("DP-1", true), output("DP-2", true), output("eDP-1", false)
         ]);
-        compare(unplugged.intents, [{ id: "eDP-1", enabled: true }]);
+        compare(cycled.intents, [{ id: "DP-1", enabled: false }]);
+
+        const unplugged = OutputCycleState.handleOutputsChanged(cycled.state, [
+            output("DP-1", false), output("eDP-1", false)
+        ]);
+        compare(unplugged.intents, [{ id: "DP-1", enabled: true }]);
         const confirmed = OutputCycleState.handleOutputsChanged(unplugged.state, [
-            output("DP-2", true), output("eDP-1", true)
+            output("DP-1", true), output("eDP-1", false)
         ]);
         compare(confirmed.intents, []);
         compare(confirmed.state.pending, "");
+        compare(confirmed.state.original, { "DP-2": false });
+    }
+
+    function test_unplugWithoutCycleLeavesDisabledOutputAlone() {
+        const state = OutputCycleState.handleOutputsChanged(OutputCycleState.emptyState(), [
+            output("DP-2", true), output("HDMI-A-2", false)
+        ]).state;
+        const asleep = OutputCycleState.handleOutputsChanged(state, [output("HDMI-A-2", false)]);
+        compare(asleep.intents, []);
+        const awake = OutputCycleState.handleOutputsChanged(asleep.state, [
+            output("DP-2", true), output("HDMI-A-2", false)
+        ]);
+        compare(awake.intents, []);
+    }
+
+    function test_cycleRoundTripForgetsOutputDmsEnabled() {
+        let state = OutputCycleState.handleOutputsChanged(OutputCycleState.emptyState(), [
+            output("DP-2", true), output("HDMI-A-2", false)
+        ]).state;
+        state = OutputCycleState.requestCycle(state, [output("DP-2", true), output("HDMI-A-2", false)], "DP-2").state;
+        state = OutputCycleState.handleOutputsChanged(state, [output("DP-2", true), output("HDMI-A-2", true)]).state;
+        state = OutputCycleState.handleOutputsChanged(state, [output("DP-2", false), output("HDMI-A-2", true)]).state;
+        state = OutputCycleState.requestCycle(state, [output("DP-2", false), output("HDMI-A-2", true)], "HDMI-A-2").state;
+        state = OutputCycleState.handleOutputsChanged(state, [output("DP-2", true), output("HDMI-A-2", true)]).state;
+        state = OutputCycleState.handleOutputsChanged(state, [output("DP-2", true), output("HDMI-A-2", false)]).state;
+        compare(state.original, {});
+
+        const asleep = OutputCycleState.handleOutputsChanged(state, [output("HDMI-A-2", false)]);
+        compare(asleep.intents, []);
     }
 
     function test_missingPendingTargetCancelsWithoutIntent() {


### PR DESCRIPTION
## Description

Follow up to #3362.

The output cycle fallback could fire without the user ever running a cycle. With one display enabled and a second one marked 'off' in display settings, DMS treated the enabled display as the "selected" one. When that display disconnected, DMS turned the disabled one on to avoid a black screen.

DisplayPort monitors drop the link when they go into standby, so an ordinary DPMS timeout looks like an unplug to niri. DMS sent `Output <name> On` over IPC for a display the user had disabled in settings (`off` in outputs.kdl). niri keeps that override until the next config reload, and the workspaces get shuffled through the extra display when the main one came back.

The fix limits the fallback to displays the cycle itself turned off. The state module records each output's enabled state the first time a cycle touches it, forgets it once the output is back at that state, and only re-enables outputs that were on before a cycle disabled them. Displays that were already 'off' are never enabled automatically. The cycle command itself is unchanged.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [x] Documentation
- [ ] Other

## Related issues

<!-- e.g. "Fixes #123", "Closes #123". Leave blank if none. -->

## Screenshots / video

<!-- Include screenshots or a video for any user-facing or visual change. -->

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
