### PR TITLE
fix(settings): size the plugin update spinner to fit its row

### DIFF
--- a/quickshell/Modules/Settings/PluginUpdatesDialog.qml
+++ b/quickshell/Modules/Settings/PluginUpdatesDialog.qml
@@ -162,6 +162,7 @@ StyledRect {
                 spacing: Theme.spacingM
 
                 DankSpinner {
+                    size: Theme.iconSize
                     running: root.isUpdating
                     anchors.verticalCenter: parent.verticalCenter
                 }


### PR DESCRIPTION
## Description

The spinner shown while plugins update is cut off at the top and the bottom.

`DankSpinner` defaults to `size: 48`, and in `PluginUpdatesDialog.qml` it is the only place in the tree that does not pass a size. The row it sits in is 40 px high with `clip: true`, so the arc loses 4 px on each side. Every other spinner in the repo passes an explicit size (18, 20, 24, 32, 40), so this reads as an oversight rather than an intent.

Setting `size: Theme.iconSize` (24) puts it inside the row and next to the label at `fontSizeMedium`, which matches how the other inline spinners are sized.

I checked the three other call sites that omit a size, `SettingsContent.qml:162`, `SettingsContent.qml:604` and `GreeterPluginsPage.qml:133`. All three are centred in a page sized container, so 48 fits there and I left them alone.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Fixes #3375

## Screenshots / video

Rebuilt the exact geometry outside the settings window so the two cases can sit side by side: the same 40 px row with `clip: true`, the spinner arc drawn from `DankSpinner` with its animation frozen so both sides show the same frame. Left is master, right is with the size set.

![spinner before and after](https://raw.githubusercontent.com/Mario-Mohar/DankMaterialShell/pr-screenshots/3375-vorher-nachher.png)

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [x] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs

Notes on the boxes above: no new strings and no Go changes in this one. `make lint-qml` does not run here because it wants a `.qmlls.ini` from a full install, so I ran `/usr/lib/qt6/bin/qmllint` on the changed file instead and it reports nothing beyond the unresolved `qs.*` imports that every file in the tree produces. No docs PR either, there is no new behavior to document.
