### PR TITLE
fix(battery): report when no charge threshold exists instead of faking success

### DIFF
--- a/quickshell/Modules/Settings/BatteryTab.qml
+++ b/quickshell/Modules/Settings/BatteryTab.qml
@@ -16,22 +16,43 @@ Item {
         return Theme.surfaceText;
     }
 
+    // The sysfs names DMS can write, in the order they are tried. Hardware that
+    // exposes none of them, a Lenovo IdeaPad on ideapad_laptop for instance,
+    // used to run the apply script to completion without writing anything, and
+    // sh exiting 0 was indistinguishable from a successful write.
+    readonly property string thresholdFileList: "charge_control_limit_max charge_stop_threshold charge_control_end_threshold"
+    readonly property int noThresholdExitCode: 2
+
+    property bool chargeLimitSupported: true
+
+    Process {
+        id: thresholdProbe
+        running: Qt.platform.os === "linux"
+        command: ["sh", "-c", "for bat in /sys/class/power_supply/BAT*; do for file in " + root.thresholdFileList + "; do [ -f \"$bat/$file\" ] && exit 0; done; done; exit 1"]
+        onExited: exitCode => root.chargeLimitSupported = exitCode === 0
+    }
+
     Process {
         id: applyLimitProcess
         command: ["pkexec", "sh", "-c", "
+found=0
 for bat in /sys/class/power_supply/BAT*; do
-  if [ -f \"$bat/charge_control_limit_max\" ]; then
-    echo " + SettingsData.batteryChargeLimit + " > \"$bat/charge_control_limit_max\"
-  elif [ -f \"$bat/charge_stop_threshold\" ]; then
-    echo " + SettingsData.batteryChargeLimit + " > \"$bat/charge_stop_threshold\"
-  elif [ -f \"$bat/charge_control_end_threshold\" ]; then
-    echo " + SettingsData.batteryChargeLimit + " > \"$bat/charge_control_end_threshold\"
-  fi
+  for file in " + root.thresholdFileList + "; do
+    if [ -f \"$bat/$file\" ]; then
+      found=1
+      echo " + SettingsData.batteryChargeLimit + " > \"$bat/$file\" || exit 1
+      break
+    fi
+  done
 done
+[ \"$found\" = 1 ] || exit " + root.noThresholdExitCode + "
 "]
         running: false
         onExited: exitCode => {
-            if (exitCode !== 0) {
+            if (exitCode === root.noThresholdExitCode) {
+                root.chargeLimitSupported = false;
+                ToastService.showError(I18n.tr("Charge limit not supported on this hardware", "battery settings: toast title when sysfs has no charge threshold"), I18n.tr("No writable charge threshold file was found under /sys/class/power_supply.", "battery settings: why the charge limit could not be applied"));
+            } else if (exitCode !== 0) {
                 ToastService.showError(I18n.tr("Failed to apply charge limit to system"), I18n.tr("Process exited with code %1").arg(exitCode));
             } else {
                 ToastService.showInfo(I18n.tr("Charge limit applied successfully"), I18n.tr("Limit set to %1%").arg(SettingsData.batteryChargeLimit));
@@ -214,9 +235,18 @@ done
                     onSliderValueChanged: newValue => SettingsData.set("batteryChargeLimit", newValue)
                 }
 
+                StyledText {
+                    width: parent.width
+                    visible: Qt.platform.os === "linux" && !root.chargeLimitSupported
+                    text: I18n.tr("No writable charge threshold file was found under /sys/class/power_supply.", "battery settings: why the charge limit could not be applied")
+                    wrapMode: Text.WordWrap
+                    color: Theme.surfaceVariantText
+                    font.pixelSize: Theme.fontSizeMedium
+                }
+
                 Row {
                     // charge_control_* live in Linux sysfs; no BSD equivalent
-                    visible: Qt.platform.os === "linux"
+                    visible: Qt.platform.os === "linux" && root.chargeLimitSupported
                     width: parent.width
                     height: applyButton.height
                     layoutDirection: I18n.isRtl ? Qt.LeftToRight : Qt.RightToLeft

--- a/quickshell/Modules/Settings/BatteryTab.qml
+++ b/quickshell/Modules/Settings/BatteryTab.qml
@@ -237,7 +237,10 @@ done
 
                 StyledText {
                     width: parent.width
-                    visible: Qt.platform.os === "linux" && !root.chargeLimitSupported
+                    // A machine without a battery has no charge threshold to
+                    // write to either, but saying so there would be noise: the
+                    // limit was never applicable in the first place.
+                    visible: Qt.platform.os === "linux" && BatteryService.batteryAvailable && !root.chargeLimitSupported
                     text: I18n.tr("No writable charge threshold file was found under /sys/class/power_supply.", "battery settings: why the charge limit could not be applied")
                     wrapMode: Text.WordWrap
                     color: Theme.surfaceVariantText
@@ -245,8 +248,11 @@ done
                 }
 
                 Row {
-                    // charge_control_* live in Linux sysfs; no BSD equivalent
-                    visible: Qt.platform.os === "linux" && root.chargeLimitSupported
+                    // charge_control_* live in Linux sysfs; no BSD equivalent.
+                    // Without a battery the apply button cannot do anything,
+                    // and offering it anyway is what produced the false
+                    // success this change is about.
+                    visible: Qt.platform.os === "linux" && BatteryService.batteryAvailable && root.chargeLimitSupported
                     width: parent.width
                     height: applyButton.height
                     layoutDirection: I18n.isRtl ? Qt.LeftToRight : Qt.RightToLeft


### PR DESCRIPTION
## Description

On hardware that exposes none of the three sysfs charge threshold files, **Apply to Hardware** wrote nothing and still reported success. The script walks every `BAT*`, matches none of the three `if`/`elif` branches, and `sh` exits 0, which `onExited` could not tell apart from a real write.

This is not a rare corner. Lenovo IdeaPad and ThinkBook models on `ideapad_laptop` expose `charge_types` (`Fast` / `Standard` / `Long_Life`) instead, and the kernel says so itself: *"conservation_mode attribute has been deprecated, see charge_types"*. I have one of those machines here, so everything below was checked on the affected hardware rather than reasoned about.

Three changes:

**The script now says whether it wrote anything.** The `if`/`elif` chain became a loop over the same three names in the same order, so the priority does not change, with `found=1` set when a branch matches and `exit 2` when none did. A failed write still exits 1, so "this machine has no interface" and "the write failed" stay apart.

**The toast tells the truth.** Exit code 2 gives *"Charge limit not supported on this hardware"* instead of the success toast.

**The button is not offered when it cannot work.** A probe runs once when the tab loads and hides the Apply button if none of the three files exists, with a line naming the reason in its place. The exit code 2 branch stays as the authority, since the probe runs once and a battery can be removed or a driver reloaded after that.

**What I deliberately left alone:** the slider. The issue suggests disabling it too, but `batteryChargeLimit` also drives the "Charge Limit Reached" notification in `BatteryService.qml`, which works on this hardware and is independent of sysfs. Disabling the slider would break a working feature to tidy up a broken one.

**Not in this PR:** `charge_types` support. That interface is a mode selector, not a percentage, and the cap behind `Long_Life` is firmware defined, so it needs its own control and a decision about how it sits next to a 50-100 slider. That is the follow-up the issue describes as separable, and it seems better to agree on the shape of it first.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Fixes #3278

## Screenshots / video

Taken on the affected machine, a Lenovo IdeaPad whose `BAT0` has `charge_types` and none of the three threshold files, in a nested Hyprland running this branch.

![protection card before and after](https://raw.githubusercontent.com/Mario-Mohar/DankMaterialShell/pr-screenshots/3278-vorher-nachher.png)

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [x] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs

Notes on those boxes. Two new terms, `Charge limit not supported on this hardware` and `No writable charge threshold file was found under /sys/class/power_supply.`, both with a translator comment, and the second is shared by the toast and the inline line rather than duplicated. I ran `extract_translations.py` to confirm they land as expected and then reverted `en.json` and `template.json`, since those are yours to sync. No Go changes. `make lint-qml` wants a `.qmlls.ini` from a full install, so I ran `/usr/lib/qt6/bin/qmllint` on the file instead: nothing beyond the unresolved `qs.*` imports every file produces, and the `multiline-strings` count is unchanged from master, which is why the probe command is written on one line. No docs PR, the change removes a wrong message rather than adding behavior to document.

## How it was verified

The apply script and the probe were run against a fake `power_supply` tree as well as the real one:

| case | apply | probe |
| --- | --- | --- |
| this machine, only `charge_types` | 2, nothing written | 1, button hidden |
| `charge_control_end_threshold` present | 0, value written | 0 |
| two batteries, different file each | 0, both written | 0 |
| file present but not writable | 1, error toast | 0 |
| several files present | only `charge_control_limit_max` written, as before | 0 |
| no `BAT*` at all | 2 | 1 |
