### PR TITLE
launcher: add vpn connections as a search provider

### DIFF
--- a/quickshell/Modules/Settings/LauncherTab.qml
+++ b/quickshell/Modules/Settings/LauncherTab.qml
@@ -815,7 +815,7 @@ Item {
                     spacing: Theme.spacingS
 
                     Repeater {
-                        model: ["dms_settings", "dms_notepad", "dms_sysmon", "dms_settings_search", "dms_clipboard_search", "dms_power", "dms_colorpicker", "dms_qr_generator"]
+                        model: ["dms_settings", "dms_notepad", "dms_sysmon", "dms_settings_search", "dms_clipboard_search", "dms_power", "dms_vpn", "dms_colorpicker", "dms_qr_generator"]
 
                         delegate: Rectangle {
                             id: pluginDelegate

--- a/quickshell/Services/AppSearchService.qml
+++ b/quickshell/Services/AppSearchService.qml
@@ -222,6 +222,17 @@ Singleton {
                 viewModeEnforced: true,
                 defaultSectionPriority: 2.3
             },
+            "dms_vpn": {
+                id: "dms_vpn",
+                name: I18n.tr("VPN"),
+                cornerIcon: "vpn_key",
+                comment: "DMS",
+                defaultTrigger: "",
+                isLauncher: true,
+                viewMode: "list",
+                viewModeEnforced: true,
+                defaultSectionPriority: 2.4
+            },
             "dms_qr_generator": {
                 id: "dms_qr_generator",
                 name: I18n.tr("QR Generator"),
@@ -378,6 +389,34 @@ Singleton {
                     }));
         }
 
+        if (pluginId === "dms_vpn") {
+            if (!DMSNetworkService.vpnAvailable)
+                return [];
+            const q = (query || "").toString().trim().toLowerCase();
+            return (DMSNetworkService.profiles || []).map(profile => {
+                const id = profile.uuid || profile.name || "";
+                const active = DMSNetworkService.isActiveVpnUuid(id);
+                const connecting = DMSNetworkService.isVpnConnectingUuid(id);
+                const typeLabel = VPNService.getVpnTypeFromProfile(profile);
+                return {
+                    name: profile.name || I18n.tr("VPN"),
+                    icon: active ? "material:vpn_lock" : "material:vpn_key_off",
+                    comment: typeLabel,
+                    action: "vpn:" + id,
+                    keywords: ["vpn", typeLabel, active ? "disconnect" : "connect"],
+                    badgeLabel: connecting ? I18n.tr("Connecting...") : (active ? I18n.tr("Connected") : I18n.tr("Disconnected")),
+                    isBuiltInLauncher: true,
+                    builtInPluginId: pluginId
+                };
+            }).filter(item => {
+                if (!q)
+                    return true;
+                if (item.name.toLowerCase().includes(q))
+                    return true;
+                return item.keywords.some(k => k.toLowerCase().includes(q));
+            });
+        }
+
         if (pluginId === "dms_qr_generator") {
             const text = (query || "").toString().trim();
             return [
@@ -437,6 +476,14 @@ Singleton {
             return true;
         case "power":
             return executePowerLauncherAction(parts.slice(1).join(":"));
+        case "vpn":
+            {
+                const id = parts.slice(1).join(":");
+                if (!id)
+                    return false;
+                DMSNetworkService.toggleVpn(id);
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
## Description

Adds a `dms_vpn` built-in launcher plugin that indexes every configured VPN profile and toggles it on enter, so a VPN can be brought up or down without leaving the keyboard.

Rows reflect connection state: connected profiles get a lock icon and a **Connected** badge, in-progress ones show **Connecting...**, the rest get a crossed-out key. The subtitle is the connection type (WireGuard, OpenVPN, and so on), which is also matched when searching.

Profiles come from `DMSNetworkService.profiles`, which is populated from the network state the shell already fetches at startup. No new timer, process, subscription or request is introduced, and nothing runs while the launcher is closed. The provider returns nothing when the backend is not NetworkManager.

Toggling reuses the existing `toggleVpn`, the same call the Control Center VPN list uses, so credential prompts and error toasts behave identically.

Two notes on the design:

- **It ships without a trigger.** A matched trigger prefix replaces the entire result set, so claiming `vpn` would have hidden every application whenever someone typed it to find their VPN client, and would have produced an empty launcher on iwd or wpa_supplicant. Matching on a `vpn` keyword instead keeps applications and profiles in one list. A trigger can still be set per user in Settings.
- **Connected state is read from the same predicate the toggle branches on.** Core reports `activating` and `deactivating` in the active connection list, so testing only for `activated` would have shown a connection still coming up as disconnected while enter tore it down.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Closes #3352

## Screenshots / video

Disconnected state:

<img width="885" height="168" alt="1789068266209977869" src="https://github.com/user-attachments/assets/c1b84d38-9977-4f14-b2bd-de5f2664f67a" />

Connected state:

<img width="885" height="169" alt="1789068280152218439" src="https://github.com/user-attachments/assets/07103ebd-0d40-4d12-8ab7-59510322eb9a" />

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] ~~Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean~~ **N/A** — no Go in this PR, QML only
- [x] QML changes: ran `make lint-qml` with no new warnings
- [x] ~~I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs~~ **N/A**
