### PR TITLE
fix(audio): apply sink volume via pactl for BlueZ sinks

### DIFF
--- a/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
+++ b/quickshell/Modules/DankDash/MediaDropdownOverlay.qml
@@ -69,7 +69,7 @@ Item {
             return;
         }
         if (AudioService.sink?.audio)
-            AudioService.sink.audio.volume = volume;
+            AudioService.setVolume(Math.round(volume * 100));
     }
 
     function selectPlayer(player) {

--- a/quickshell/Modules/DankDash/MediaPlayerTab.qml
+++ b/quickshell/Modules/DankDash/MediaPlayerTab.qml
@@ -189,7 +189,7 @@ Item {
             return;
         }
         if (AudioService.sink?.audio)
-            AudioService.sink.audio.volume = clamped;
+            AudioService.setVolume(Math.round(clamped * 100));
     }
 
     function adjustVolume(step) {

--- a/quickshell/Services/AudioService.qml
+++ b/quickshell/Services/AudioService.qml
@@ -1215,6 +1215,22 @@ EOFCONFIG
         objects: Pipewire.nodes.values.filter(node => node.audio && (SettingsData.audioShowStreamDevices || !node.isStream))
     }
 
+    // Some BlueZ/PipeWire sinks do not reliably apply the QML volume property
+    // setter. Keep the fallback here so every DMS volume surface shares it.
+    Process {
+        id: sinkVolumeProcess
+        running: false
+    }
+
+    // Takes a percentage (0..sinkMaxVolume), matching `pactl set-sink-volume`.
+    function setSinkVolume(percentage) {
+        if (!root.sink?.name)
+            return false;
+        sinkVolumeProcess.command = ["pactl", "set-sink-volume", root.sink.name, Math.round(percentage) + "%"];
+        sinkVolumeProcess.running = true;
+        return true;
+    }
+
     function setVolume(percentage) {
         if (!root.sink?.audio)
             return "No audio sink available";
@@ -1223,7 +1239,8 @@ EOFCONFIG
 
         const maxVol = root.sinkMaxVolume;
         const clampedVolume = Math.max(0, Math.min(maxVol, percentage));
-        root.sink.audio.volume = clampedVolume / 100;
+        if (!setSinkVolume(clampedVolume))
+            root.sink.audio.volume = clampedVolume / 100;
         return `Volume set to ${clampedVolume}%`;
     }
 
@@ -1242,7 +1259,8 @@ EOFCONFIG
         if (audio.muted)
             audio.muted = false;
 
-        audio.volume = newVolume / 100;
+        if (!setSinkVolume(newVolume))
+            audio.volume = newVolume / 100;
         return newVolume;
     }
 


### PR DESCRIPTION
## Problem

On some Bluetooth (BlueZ/PipeWire) sinks, writing the QML volume property does not
reach the device — the UI slider moves, the OSD changes, but the actual sink volume
stays where it was. Those sinks only respond to `pactl set-sink-volume`.

## Fix

Add `AudioService.setSinkVolume()`, which issues
`pactl set-sink-volume <sink> <n>%` and reports whether it handled the change.
`setVolume()` and `adjustDefaultSinkVolume()` try it first and fall back to the
existing property setter when no sink name is available.

The DankDash media dropdown and media player tab route their volume writes through
`AudioService.setVolume()` so every volume surface shares the same code path.

This follows existing precedent — `AudioService` already shells out to `pactl`
for sink enumeration and port switching (`pactl list sinks`, `pactl set-sink-port`).

## Units

`setSinkVolume()` takes a **percentage** (0..`sinkMaxVolume`), matching the `pactl`
argument. The QML `audio.volume` property keeps its **0..1 fraction** semantics, so
the fallback path still writes `volume / 100`.

## Testing

- `make lint-qml` — PASS (3 entrypoints)
- `make test-qml` fails on this machine, but **also fails on unmodified upstream
  `master`** in the same environment, so it is not a regression from this change.

Verified manually on a BlueZ sink that previously ignored UI volume changes:
volume now tracks the slider.
