### PR TITLE
fix(clipboard): preserve pinned state when editing entries

### DIFF
--- a/core/internal/server/clipboard/handlers.go
+++ b/core/internal/server/clipboard/handlers.go
@@ -49,6 +49,8 @@ func HandleRequest(conn *models.Conn, req models.Request, m *Manager) {
 		handlePinEntry(conn, req, m)
 	case "clipboard.unpinEntry":
 		handleUnpinEntry(conn, req, m)
+	case "clipboard.editEntry":
+		handleEditEntry(conn, req, m)
 	case "clipboard.getPinnedEntries":
 		handleGetPinnedEntries(conn, req, m)
 	case "clipboard.getPinnedCount":
@@ -421,4 +423,25 @@ func handleCopyFile(conn *models.Conn, req models.Request, m *Manager) {
 	}
 
 	models.Respond(conn, req.ID, models.SuccessResult{Success: true, Message: "copied"})
+}
+
+func handleEditEntry(conn *models.Conn, req models.Request, m *Manager) {
+	id, err := params.Int(req.Params, "id")
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+
+	text, err := params.String(req.Params, "text")
+	if err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+
+	if err := m.EditEntry(uint64(id), text); err != nil {
+		models.RespondError(conn, req.ID, err.Error())
+		return
+	}
+
+	models.Respond(conn, req.ID, models.SuccessResult{Success: true, Message: "entry updated"})
 }

--- a/core/internal/server/clipboard/manager.go
+++ b/core/internal/server/clipboard/manager.go
@@ -217,6 +217,9 @@ func (m *Manager) dbView(fn func(tx *bolt.Tx) error) (err error) {
 }
 
 func (m *Manager) post(fn func()) {
+	if m.wlCtx == nil {
+		return
+	}
 	m.wlCtx.Post(fn)
 }
 
@@ -1953,6 +1956,101 @@ func (m *Manager) UnpinEntry(id uint64) error {
 		}
 
 		return b.Put(itob(id), encoded)
+	})
+
+	if err == nil {
+		m.updateState()
+		m.notifySubscribers()
+	}
+
+	return err
+}
+
+func (m *Manager) EditEntry(id uint64, text string) error {
+	if m.db == nil {
+		return fmt.Errorf("database not available")
+	}
+
+	data := []byte(text)
+	mimeType := "text/plain;charset=utf-8"
+
+	if err := m.SetClipboard(data, mimeType); err != nil {
+		return err
+	}
+
+	newHash := computeHash(data)
+	preview := m.textPreview(data)
+
+	err := m.dbUpdate(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("clipboard"))
+		if b == nil {
+			return fmt.Errorf("clipboard bucket missing")
+		}
+
+		oldKey := itob(id)
+		v := b.Get(oldKey)
+		if v == nil {
+			return errEntryNotFound
+		}
+
+		existing, err := decodeEntry(v)
+		if err != nil {
+			return err
+		}
+
+		if existing.IsImage {
+			return errors.New("cannot edit image entry")
+		}
+
+		wasPinned := existing.Pinned
+
+		if err := b.Delete(oldKey); err != nil {
+			return err
+		}
+
+		if err := m.deduplicateInTx(b, newHash); err != nil {
+			return err
+		}
+
+		if wasPinned {
+			c := b.Cursor()
+			for k, val := c.First(); k != nil; k, val = c.Next() {
+				if extractHash(val) == newHash {
+					meta, err := decodeEntryMeta(val)
+					if err == nil && meta.Pinned {
+						return nil
+					}
+				}
+			}
+		}
+
+		newID, err := b.NextSequence()
+		if err != nil {
+			return err
+		}
+
+		newEntry := Entry{
+			ID:        newID,
+			Data:      data,
+			MimeType:  mimeType,
+			Preview:   preview,
+			Size:      len(data),
+			Timestamp: time.Now(),
+			IsImage:   false,
+			Hash:      newHash,
+			Pinned:    wasPinned,
+		}
+
+		encoded, err := encodeEntry(newEntry)
+		if err != nil {
+			return err
+		}
+
+		if err := b.Put(itob(newID), encoded); err != nil {
+			return err
+		}
+
+		return m.trimLengthInTx(b)
 	})
 
 	if err == nil {

--- a/core/internal/server/clipboard/manager.go
+++ b/core/internal/server/clipboard/manager.go
@@ -2004,6 +2004,10 @@ func (m *Manager) EditEntry(id uint64, text string) error {
 			return errors.New("cannot edit image entry")
 		}
 
+		if existing.MimeType != "" && !strings.HasPrefix(existing.MimeType, "text/plain") {
+			return errors.New("cannot edit non-text entry")
+		}
+
 		wasPinned := existing.Pinned
 
 		if err := b.Delete(oldKey); err != nil {

--- a/core/internal/server/clipboard/manager.go
+++ b/core/internal/server/clipboard/manager.go
@@ -217,9 +217,6 @@ func (m *Manager) dbView(fn func(tx *bolt.Tx) error) (err error) {
 }
 
 func (m *Manager) post(fn func()) {
-	if m.wlCtx == nil {
-		return
-	}
 	m.wlCtx.Post(fn)
 }
 
@@ -1974,10 +1971,6 @@ func (m *Manager) EditEntry(id uint64, text string) error {
 	data := []byte(text)
 	mimeType := "text/plain;charset=utf-8"
 
-	if err := m.SetClipboard(data, mimeType); err != nil {
-		return err
-	}
-
 	newHash := computeHash(data)
 	preview := m.textPreview(data)
 
@@ -2054,6 +2047,9 @@ func (m *Manager) EditEntry(id uint64, text string) error {
 	})
 
 	if err == nil {
+		if clipErr := m.SetClipboard(data, mimeType); clipErr != nil {
+			log.Errorf("Failed to set clipboard selection: %v", clipErr)
+		}
 		m.updateState()
 		m.notifySubscribers()
 	}

--- a/core/internal/server/clipboard/manager.go
+++ b/core/internal/server/clipboard/manager.go
@@ -795,6 +795,13 @@ func selectAltTextMimeType(mimes []string) string {
 	return ""
 }
 
+func isTextMimeType(mime string) bool {
+	if mime == "" || strings.HasPrefix(mime, "text/plain") {
+		return true
+	}
+	return slices.Contains(altTextMimeTypes, mime)
+}
+
 func (m *Manager) isImageMimeType(mime string) bool {
 	return strings.HasPrefix(mime, "image/")
 }
@@ -2004,7 +2011,7 @@ func (m *Manager) EditEntry(id uint64, text string) error {
 			return errors.New("cannot edit image entry")
 		}
 
-		if existing.MimeType != "" && !strings.HasPrefix(existing.MimeType, "text/plain") {
+		if !isTextMimeType(existing.MimeType) {
 			return errors.New("cannot edit non-text entry")
 		}
 

--- a/core/internal/server/clipboard/manager.go
+++ b/core/internal/server/clipboard/manager.go
@@ -1971,6 +1971,15 @@ func (m *Manager) EditEntry(id uint64, text string) error {
 	data := []byte(text)
 	mimeType := "text/plain;charset=utf-8"
 
+	if len(bytes.TrimSpace(data)) == 0 {
+		return fmt.Errorf("cannot save empty entry")
+	}
+
+	cfg := m.getConfig()
+	if int64(len(data)) > cfg.MaxEntrySize {
+		return fmt.Errorf("data too large")
+	}
+
 	newHash := computeHash(data)
 	preview := m.textPreview(data)
 

--- a/core/internal/server/clipboard/manager_test.go
+++ b/core/internal/server/clipboard/manager_test.go
@@ -655,6 +655,27 @@ func TestEditEntry_ImageReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot edit image entry")
 }
 
+func TestEditEntry_NonTextReturnsError(t *testing.T) {
+	m := newTestManagerWithDB(t)
+
+	uriEntry := Entry{
+		Data:      []byte("file:///path/to/file\n"),
+		MimeType:  "text/uri-list",
+		Preview:   "file:///path/to/file",
+		Size:      21,
+		Timestamp: time.Now().Truncate(time.Second),
+		IsImage:   false,
+	}
+	require.NoError(t, m.storeEntry(uriEntry))
+	history := m.GetHistory()
+	require.Len(t, history, 1)
+	id := history[0].ID
+
+	err := m.EditEntry(id, "replacement text")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot edit non-text entry")
+}
+
 func TestEditEntry_EmptyOrWhitespaceReturnsError(t *testing.T) {
 	m := newTestManagerWithDB(t)
 	id := storeTestEntry(t, m, "keep me")

--- a/core/internal/server/clipboard/manager_test.go
+++ b/core/internal/server/clipboard/manager_test.go
@@ -676,6 +676,29 @@ func TestEditEntry_NonTextReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot edit non-text entry")
 }
 
+func TestEditEntry_AltTextMimeTypesAllowed(t *testing.T) {
+	for _, mime := range []string{"UTF8_STRING", "STRING", "TEXT", "text/plain;charset=utf-8", "text/plain"} {
+		t.Run(mime, func(t *testing.T) {
+			m := newTestManagerWithDB(t)
+			entry := Entry{
+				Data:      []byte("old text"),
+				MimeType:  mime,
+				Preview:   "old text",
+				Size:      8,
+				Timestamp: time.Now().Truncate(time.Second),
+				IsImage:   false,
+			}
+			require.NoError(t, m.storeEntry(entry))
+			history := m.GetHistory()
+			require.Len(t, history, 1)
+			id := history[0].ID
+
+			err := m.EditEntry(id, "replacement text")
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestEditEntry_EmptyOrWhitespaceReturnsError(t *testing.T) {
 	m := newTestManagerWithDB(t)
 	id := storeTestEntry(t, m, "keep me")

--- a/core/internal/server/clipboard/manager_test.go
+++ b/core/internal/server/clipboard/manager_test.go
@@ -655,6 +655,35 @@ func TestEditEntry_ImageReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot edit image entry")
 }
 
+func TestEditEntry_EmptyOrWhitespaceReturnsError(t *testing.T) {
+	m := newTestManagerWithDB(t)
+	id := storeTestEntry(t, m, "keep me")
+
+	for _, badText := range []string{"", "   ", "\t\n\r"} {
+		err := m.EditEntry(id, badText)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot save empty entry")
+	}
+
+	history := m.GetHistory()
+	require.Len(t, history, 1)
+	assert.Equal(t, "keep me", history[0].Preview)
+}
+
+func TestEditEntry_DataTooLargeReturnsError(t *testing.T) {
+	m := newTestManagerWithDB(t)
+	m.config.MaxEntrySize = 10
+	id := storeTestEntry(t, m, "small")
+
+	err := m.EditEntry(id, "this text exceeds the 10-byte limit")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "data too large")
+
+	history := m.GetHistory()
+	require.Len(t, history, 1)
+	assert.Equal(t, "small", history[0].Preview)
+}
+
 func TestHandleEditEntry_SuccessAndValidation(t *testing.T) {
 	m := newTestManagerWithDB(t)
 	id := storeTestEntry(t, m, "before edit")

--- a/core/internal/server/clipboard/manager_test.go
+++ b/core/internal/server/clipboard/manager_test.go
@@ -578,6 +578,102 @@ func TestCreateHistoryEntryFromPinned_KeepsLatestUnpinnedDuplicate(t *testing.T)
 	assert.NotEqual(t, firstDuplicate.ID, latestDuplicate.ID)
 }
 
+func TestEditEntry_UnpinnedEntry(t *testing.T) {
+	m := newTestManagerWithDB(t)
+
+	id := storeTestEntry(t, m, "original unpinned")
+	require.NoError(t, m.EditEntry(id, "edited unpinned"))
+
+	history := m.GetHistory()
+	require.Len(t, history, 1)
+	assert.Equal(t, "edited unpinned", history[0].Preview)
+	assert.False(t, history[0].Pinned)
+	assert.NotEqual(t, id, history[0].ID)
+
+	// Old entry should not exist
+	oldEntry, err := m.GetEntry(id)
+	assert.ErrorIs(t, err, errEntryNotFound)
+	assert.Nil(t, oldEntry)
+}
+
+func TestEditEntry_PinnedEntryRemainsPinned(t *testing.T) {
+	m := newTestManagerWithDB(t)
+
+	id := storeTestEntry(t, m, "original pinned")
+	require.NoError(t, m.PinEntry(id))
+	assert.Equal(t, 1, m.GetPinnedCount())
+
+	require.NoError(t, m.EditEntry(id, "edited pinned"))
+
+	history := m.GetHistory()
+	require.Len(t, history, 1)
+	assert.Equal(t, "edited pinned", history[0].Preview)
+	assert.True(t, history[0].Pinned)
+
+	pinnedEntries := m.GetPinnedEntries()
+	require.Len(t, pinnedEntries, 1)
+	assert.Equal(t, "edited pinned", pinnedEntries[0].Preview)
+	assert.Equal(t, 1, m.GetPinnedCount())
+
+	// Old pinned entry should be deleted
+	oldEntry, err := m.GetEntry(id)
+	assert.ErrorIs(t, err, errEntryNotFound)
+	assert.Nil(t, oldEntry)
+}
+
+func TestEditEntry_NotFound(t *testing.T) {
+	m := newTestManagerWithDB(t)
+
+	err := m.EditEntry(99999, "new text")
+	assert.ErrorIs(t, err, errEntryNotFound)
+}
+
+func TestEditEntry_ImageReturnsError(t *testing.T) {
+	m := newTestManagerWithDB(t)
+
+	imgEntry := Entry{
+		Data:      []byte{0x89, 0x50, 0x4E, 0x47},
+		MimeType:  "image/png",
+		Preview:   "[[ image ]]",
+		Size:      4,
+		Timestamp: time.Now().Truncate(time.Second),
+		IsImage:   true,
+	}
+	require.NoError(t, m.storeEntry(imgEntry))
+	history := m.GetHistory()
+	require.Len(t, history, 1)
+	id := history[0].ID
+
+	err := m.EditEntry(id, "replacement text")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot edit image entry")
+}
+
+func TestHandleEditEntry_SuccessAndValidation(t *testing.T) {
+	m := newTestManagerWithDB(t)
+	id := storeTestEntry(t, m, "before edit")
+
+	mc := newClipboardTestConn()
+	conn := models.NewConn(mc)
+	handleEditEntry(conn, models.Request{
+		ID: 1,
+		Params: map[string]any{
+			"id":   float64(id),
+			"text": "after edit",
+		},
+	}, m)
+
+	var resp models.Response[models.SuccessResult]
+	require.NoError(t, json.NewDecoder(mc.writeBuf).Decode(&resp))
+	assert.Empty(t, resp.Error)
+	require.NotNil(t, resp.Result)
+	assert.True(t, resp.Result.Success)
+
+	history := m.GetHistory()
+	require.Len(t, history, 1)
+	assert.Equal(t, "after edit", history[0].Preview)
+}
+
 func TestManager_ConcurrentSubscriberAccess(t *testing.T) {
 	m := &Manager{
 		subscribers: make(map[string]chan State),

--- a/core/internal/server/clipboard/manager_test.go
+++ b/core/internal/server/clipboard/manager_test.go
@@ -45,9 +45,15 @@ func newTestManagerWithDB(t *testing.T) *Manager {
 		db.Close()
 	})
 
+	mockCtx := mocks_wlcontext.NewMockWaylandContext(t)
+	mockCtx.EXPECT().Post(mock.AnythingOfType("func()")).Run(func(fn func()) {
+		fn()
+	}).Maybe()
+
 	return &Manager{
 		config: DefaultConfig(),
 		db:     db,
+		wlCtx:  mockCtx,
 	}
 }
 

--- a/quickshell/Modals/Clipboard/ClipboardContextMenu.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContextMenu.qml
@@ -28,7 +28,7 @@ Item {
     readonly property bool blurActive: renderActive && openState && BlurService.enabled && Theme.connectedSurfaceBlurEnabled
 
     readonly property bool hasPinnedDuplicate: !!entry && !entry.pinned && ClipboardService.getPinnedEntryByHash(entry.hash) !== null
-    readonly property bool canEditEntry: !!entry && !(entry.isImage ?? false)
+    readonly property bool canEditEntry: !!entry && !(entry.isImage ?? false) && (!entry.mimeType || entry.mimeType.startsWith("text/plain"))
     readonly property bool hasTextAlternative: !!entry && (entry.altMimeType ?? "") !== ""
     readonly property string pinText: entry?.pinned || hasPinnedDuplicate ? I18n.tr("Unpin") : I18n.tr("Pin")
     readonly property string pinIcon: entry?.pinned || hasPinnedDuplicate ? "keep_off" : "push_pin"

--- a/quickshell/Modals/Clipboard/ClipboardContextMenu.qml
+++ b/quickshell/Modals/Clipboard/ClipboardContextMenu.qml
@@ -28,7 +28,7 @@ Item {
     readonly property bool blurActive: renderActive && openState && BlurService.enabled && Theme.connectedSurfaceBlurEnabled
 
     readonly property bool hasPinnedDuplicate: !!entry && !entry.pinned && ClipboardService.getPinnedEntryByHash(entry.hash) !== null
-    readonly property bool canEditEntry: !!entry && !(entry.isImage ?? false) && (!entry.mimeType || entry.mimeType.startsWith("text/plain"))
+    readonly property bool canEditEntry: ClipboardService.canEditEntry(entry)
     readonly property bool hasTextAlternative: !!entry && (entry.altMimeType ?? "") !== ""
     readonly property string pinText: entry?.pinned || hasPinnedDuplicate ? I18n.tr("Unpin") : I18n.tr("Pin")
     readonly property string pinIcon: entry?.pinned || hasPinnedDuplicate ? "keep_off" : "push_pin"

--- a/quickshell/Modals/Clipboard/ClipboardEditor.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEditor.qml
@@ -22,8 +22,7 @@ Item {
         repeat: false
         onTriggered: {
             if (!root.textLoaded) {
-                root.entry = null;
-                root.textLoaded = true;
+                ToastService.showError(I18n.tr("Failed to load clipboard entry"));
             }
         }
     }
@@ -110,8 +109,7 @@ Item {
                 return;
             }
             if (response.error || !response.result) {
-                root.entry = null;
-                root.textLoaded = true;
+                ToastService.showError(I18n.tr("Failed to load clipboard entry"));
                 if (!response.result) {
                     ClipboardService.refresh();
                 }
@@ -126,8 +124,7 @@ Item {
             }
 
             if (!fullText || fullText.length === 0) {
-                root.entry = null;
-                root.textLoaded = true;
+                ToastService.showError(I18n.tr("Failed to load clipboard entry"));
                 return;
             }
             root.textLoaded = true;

--- a/quickshell/Modals/Clipboard/ClipboardEditor.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEditor.qml
@@ -130,7 +130,6 @@ Item {
     function saveEntry(action) {
         const saveAction = action ?? "history";
         const entryId = root.entry?.id ?? 0;
-        const wasPinned = root.entry?.pinned ?? false;
 
         const onComplete = function () {
             if (saveAction === "history") {
@@ -155,39 +154,11 @@ Item {
 
         if (entryId > 0) {
             ClipboardService.editEntry(root.entry, root.editorText, function (response) {
-                if (!response.error) {
-                    onComplete();
+                if (response.error) {
+                    ToastService.showError(I18n.tr("Failed to update clipboard"));
                     return;
                 }
-                // Fallback for older daemon versions that lack clipboard.editEntry
-                DMSService.sendRequest("clipboard.copy", {
-                    "text": root.editorText
-                }, function (copyResponse) {
-                    if (copyResponse.error) {
-                        ToastService.showError(I18n.tr("Failed to update clipboard"));
-                        return;
-                    }
-                    if (wasPinned) {
-                        DMSService.sendRequest("clipboard.unpinEntry", {
-                            "id": entryId
-                        }, function () {
-                            DMSService.sendRequest("clipboard.getHistory", null, function (histResponse) {
-                                const entries = histResponse.result || [];
-                                if (entries.length > 0) {
-                                    DMSService.sendRequest("clipboard.pinEntry", {
-                                        "id": entries[0].id
-                                    }, function () {
-                                        onComplete();
-                                    });
-                                } else {
-                                    onComplete();
-                                }
-                            });
-                        });
-                    } else {
-                        onComplete();
-                    }
-                });
+                onComplete();
             });
             return;
         }

--- a/quickshell/Modals/Clipboard/ClipboardEditor.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEditor.qml
@@ -129,13 +129,10 @@ Item {
 
     function saveEntry(action) {
         const saveAction = action ?? "history";
-        DMSService.sendRequest("clipboard.copy", {
-            "text": root.editorText
-        }, function (response) {
-            if (response.error) {
-                ToastService.showError(I18n.tr("Failed to update clipboard"));
-                return;
-            }
+        const entryId = root.entry?.id ?? 0;
+        const wasPinned = root.entry?.pinned ?? false;
+
+        const onComplete = function () {
             if (saveAction === "history") {
                 modal.mode = "history";
                 Qt.callLater(function () {
@@ -154,6 +151,55 @@ Item {
             if (saveAction === "paste") {
                 ClipboardService.pasteClipboard(modal.hide);
             }
+        };
+
+        if (entryId > 0) {
+            ClipboardService.editEntry(root.entry, root.editorText, function (response) {
+                if (!response.error) {
+                    onComplete();
+                    return;
+                }
+                // Fallback for older daemon versions that lack clipboard.editEntry
+                DMSService.sendRequest("clipboard.copy", {
+                    "text": root.editorText
+                }, function (copyResponse) {
+                    if (copyResponse.error) {
+                        ToastService.showError(I18n.tr("Failed to update clipboard"));
+                        return;
+                    }
+                    if (wasPinned) {
+                        DMSService.sendRequest("clipboard.unpinEntry", {
+                            "id": entryId
+                        }, function () {
+                            DMSService.sendRequest("clipboard.getHistory", null, function (histResponse) {
+                                const entries = histResponse.result || [];
+                                if (entries.length > 0) {
+                                    DMSService.sendRequest("clipboard.pinEntry", {
+                                        "id": entries[0].id
+                                    }, function () {
+                                        onComplete();
+                                    });
+                                } else {
+                                    onComplete();
+                                }
+                            });
+                        });
+                    } else {
+                        onComplete();
+                    }
+                });
+            });
+            return;
+        }
+
+        DMSService.sendRequest("clipboard.copy", {
+            "text": root.editorText
+        }, function (response) {
+            if (response.error) {
+                ToastService.showError(I18n.tr("Failed to update clipboard"));
+                return;
+            }
+            onComplete();
         });
     }
 

--- a/quickshell/Modals/Clipboard/ClipboardEditor.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEditor.qml
@@ -15,6 +15,7 @@ Item {
     property var entry: null
     property string editorText: ""
     property bool textLoaded: false
+    property bool loadFailed: false
 
     Timer {
         id: loadTimeoutTimer
@@ -22,6 +23,7 @@ Item {
         repeat: false
         onTriggered: {
             if (!root.textLoaded) {
+                root.loadFailed = true;
                 ToastService.showError(I18n.tr("Failed to load clipboard entry", "clipboard editor: fetching the entry's full text failed"));
             }
         }
@@ -80,26 +82,8 @@ Item {
         }
     }
 
-    function setEntry(newEntry) {
-        entry = newEntry;
-        textLoaded = !newEntry || !ClipboardService.canEditEntry(newEntry) || !(newEntry.id > 0);
-        editorText = newEntry?.text ?? newEntry?.preview ?? "";
-        if (editField) {
-            editField.text = editorText;
-        }
-        Qt.callLater(function () {
-            if (editField) {
-                editField.forceActiveFocus();
-                editField.cursorPosition = editField.text.length;
-            }
-        });
-
-        if (!newEntry || !ClipboardService.canEditEntry(newEntry) || !(newEntry.id > 0)) {
-            loadTimeoutTimer.stop();
-            return;
-        }
-
-        const requestedId = newEntry.id;
+    function fetchEntry(requestedId) {
+        loadFailed = false;
         loadTimeoutTimer.restart();
         DMSService.sendRequest("clipboard.getEntry", {
             "id": requestedId
@@ -109,6 +93,7 @@ Item {
                 return;
             }
             if (response.error || !response.result) {
+                root.loadFailed = true;
                 ToastService.showError(I18n.tr("Failed to load clipboard entry", "clipboard editor: fetching the entry's full text failed"));
                 if (!response.result) {
                     ClipboardService.refresh();
@@ -124,9 +109,11 @@ Item {
             }
 
             if (!fullText || fullText.length === 0) {
+                root.loadFailed = true;
                 ToastService.showError(I18n.tr("Failed to load clipboard entry", "clipboard editor: fetching the entry's full text failed"));
                 return;
             }
+            root.loadFailed = false;
             root.textLoaded = true;
             root.editorText = fullText;
             if (editField) {
@@ -145,12 +132,41 @@ Item {
         });
     }
 
+    function setEntry(newEntry) {
+        entry = newEntry;
+        loadFailed = false;
+        const hasFullText = typeof newEntry?.text === "string";
+        textLoaded = !newEntry || !ClipboardService.canEditEntry(newEntry) || !(newEntry.id > 0) || hasFullText;
+        editorText = newEntry?.text ?? newEntry?.preview ?? "";
+        if (editField) {
+            editField.text = editorText;
+        }
+        Qt.callLater(function () {
+            if (editField) {
+                editField.forceActiveFocus();
+                editField.cursorPosition = editField.text.length;
+            }
+        });
+
+        if (hasFullText || !newEntry || !ClipboardService.canEditEntry(newEntry) || !(newEntry.id > 0)) {
+            loadTimeoutTimer.stop();
+            return;
+        }
+
+        fetchEntry(newEntry.id);
+    }
+
     function saveEntry(action) {
         const saveAction = action ?? "history";
         const entryId = root.entry?.id ?? 0;
 
         if (entryId > 0 && !root.textLoaded) {
-            ToastService.showWarning(I18n.tr("Loading full text, please wait...", "clipboard editor: save blocked while the entry's full text is still being fetched"));
+            if (root.loadFailed) {
+                ToastService.showError(I18n.tr("Failed to load clipboard entry", "clipboard editor: fetching the entry's full text failed"));
+                root.fetchEntry(entryId);
+            } else {
+                ToastService.showWarning(I18n.tr("Loading full text, please wait...", "clipboard editor: save blocked while the entry's full text is still being fetched"));
+            }
             return;
         }
 

--- a/quickshell/Modals/Clipboard/ClipboardEditor.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEditor.qml
@@ -16,6 +16,18 @@ Item {
     property string editorText: ""
     property bool textLoaded: false
 
+    Timer {
+        id: loadTimeoutTimer
+        interval: 5000
+        repeat: false
+        onTriggered: {
+            if (!root.textLoaded) {
+                root.entry = null;
+                root.textLoaded = true;
+            }
+        }
+    }
+
     function releaseTextInputFocus() {
         if (editField) {
             editField.setFocus(false);
@@ -83,22 +95,26 @@ Item {
             }
         });
 
-        if (!newEntry || newEntry.isImage) {
+        if (!newEntry || newEntry.isImage || !(newEntry.id > 0)) {
+            loadTimeoutTimer.stop();
             return;
         }
 
         const requestedId = newEntry.id;
+        loadTimeoutTimer.restart();
         DMSService.sendRequest("clipboard.getEntry", {
             "id": requestedId
         }, function (response) {
-            if (response.error) {
-                return;
-            }
+            loadTimeoutTimer.stop();
             if (!root.entry || root.entry.id !== requestedId) {
                 return;
             }
-            if (!response.result) {
-                ClipboardService.refresh();
+            if (response.error || !response.result) {
+                root.entry = null;
+                root.textLoaded = true;
+                if (!response.result) {
+                    ClipboardService.refresh();
+                }
                 return;
             }
             const result = response.result;
@@ -110,6 +126,8 @@ Item {
             }
 
             if (!fullText || fullText.length === 0) {
+                root.entry = null;
+                root.textLoaded = true;
                 return;
             }
             root.textLoaded = true;
@@ -135,8 +153,11 @@ Item {
         const entryId = root.entry?.id ?? 0;
 
         if (entryId > 0 && !root.textLoaded) {
+            ToastService.showWarning(I18n.tr("Loading full text, please wait..."));
             return;
         }
+
+        loadTimeoutTimer.stop();
 
         const onComplete = function () {
             if (saveAction === "history") {
@@ -316,6 +337,7 @@ Item {
 
                 width: cancelButton.width
                 height: buttonHeight
+                opacity: root.textLoaded ? 1 : 0.6
 
                 Rectangle {
                     anchors.fill: parent

--- a/quickshell/Modals/Clipboard/ClipboardEditor.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEditor.qml
@@ -22,7 +22,7 @@ Item {
         repeat: false
         onTriggered: {
             if (!root.textLoaded) {
-                ToastService.showError(I18n.tr("Failed to load clipboard entry"));
+                ToastService.showError(I18n.tr("Failed to load clipboard entry", "clipboard editor: fetching the entry's full text failed"));
             }
         }
     }
@@ -94,7 +94,7 @@ Item {
             }
         });
 
-        if (!newEntry || newEntry.isImage || !(newEntry.id > 0)) {
+        if (!newEntry || newEntry.isImage || (newEntry.mimeType && !newEntry.mimeType.startsWith("text/plain")) || !(newEntry.id > 0)) {
             loadTimeoutTimer.stop();
             return;
         }
@@ -109,7 +109,7 @@ Item {
                 return;
             }
             if (response.error || !response.result) {
-                ToastService.showError(I18n.tr("Failed to load clipboard entry"));
+                ToastService.showError(I18n.tr("Failed to load clipboard entry", "clipboard editor: fetching the entry's full text failed"));
                 if (!response.result) {
                     ClipboardService.refresh();
                 }
@@ -124,7 +124,7 @@ Item {
             }
 
             if (!fullText || fullText.length === 0) {
-                ToastService.showError(I18n.tr("Failed to load clipboard entry"));
+                ToastService.showError(I18n.tr("Failed to load clipboard entry", "clipboard editor: fetching the entry's full text failed"));
                 return;
             }
             root.textLoaded = true;
@@ -150,7 +150,7 @@ Item {
         const entryId = root.entry?.id ?? 0;
 
         if (entryId > 0 && !root.textLoaded) {
-            ToastService.showWarning(I18n.tr("Loading full text, please wait..."));
+            ToastService.showWarning(I18n.tr("Loading full text, please wait...", "clipboard editor: save blocked while the entry's full text is still being fetched"));
             return;
         }
 

--- a/quickshell/Modals/Clipboard/ClipboardEditor.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEditor.qml
@@ -82,7 +82,7 @@ Item {
 
     function setEntry(newEntry) {
         entry = newEntry;
-        textLoaded = !newEntry || Boolean(newEntry.isImage) || !(newEntry.id > 0);
+        textLoaded = !newEntry || !ClipboardService.canEditEntry(newEntry) || !(newEntry.id > 0);
         editorText = newEntry?.text ?? newEntry?.preview ?? "";
         if (editField) {
             editField.text = editorText;
@@ -94,7 +94,7 @@ Item {
             }
         });
 
-        if (!newEntry || newEntry.isImage || (newEntry.mimeType && !newEntry.mimeType.startsWith("text/plain")) || !(newEntry.id > 0)) {
+        if (!newEntry || !ClipboardService.canEditEntry(newEntry) || !(newEntry.id > 0)) {
             loadTimeoutTimer.stop();
             return;
         }

--- a/quickshell/Modals/Clipboard/ClipboardEditor.qml
+++ b/quickshell/Modals/Clipboard/ClipboardEditor.qml
@@ -14,6 +14,7 @@ Item {
 
     property var entry: null
     property string editorText: ""
+    property bool textLoaded: false
 
     function releaseTextInputFocus() {
         if (editField) {
@@ -70,6 +71,7 @@ Item {
 
     function setEntry(newEntry) {
         entry = newEntry;
+        textLoaded = !newEntry || Boolean(newEntry.isImage) || !(newEntry.id > 0);
         editorText = newEntry?.text ?? newEntry?.preview ?? "";
         if (editField) {
             editField.text = editorText;
@@ -110,6 +112,7 @@ Item {
             if (!fullText || fullText.length === 0) {
                 return;
             }
+            root.textLoaded = true;
             root.editorText = fullText;
             if (editField) {
                 if (fullText.length > 50000) {
@@ -130,6 +133,10 @@ Item {
     function saveEntry(action) {
         const saveAction = action ?? "history";
         const entryId = root.entry?.id ?? 0;
+
+        if (entryId > 0 && !root.textLoaded) {
+            return;
+        }
 
         const onComplete = function () {
             if (saveAction === "history") {

--- a/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
@@ -184,8 +184,41 @@ FocusScope {
         if (!ClipboardService.canEditEntry(entry)) {
             return;
         }
-        editorView.setEntry(entry);
-        mode = "editor";
+
+        const requestedId = entry.id;
+        if (!requestedId) {
+            editorView.setEntry(entry);
+            mode = "editor";
+            return;
+        }
+
+        DMSService.sendRequest("clipboard.getEntry", {
+            "id": requestedId
+        }, function (response) {
+            if (response.error || !response.result) {
+                ToastService.showError(I18n.tr("Failed to load clipboard entry", "clipboard editor: fetching the entry's full text failed"));
+                if (!response.result) {
+                    ClipboardService.refresh();
+                }
+                return;
+            }
+            const result = response.result;
+            let fullText = "";
+            if (result?.data) {
+                fullText = editorView.decodeEntryData(result.data);
+            } else {
+                fullText = result?.preview ?? "";
+            }
+
+            if (!fullText && (entry.preview ?? "").length > 0) {
+                ToastService.showError(I18n.tr("Failed to load clipboard entry", "clipboard editor: fetching the entry's full text failed"));
+                return;
+            }
+
+            const entryWithText = Object.assign({}, entry, { "text": fullText });
+            editorView.setEntry(entryWithText);
+            mode = "editor";
+        });
     }
 
     function resetState() {

--- a/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
@@ -181,7 +181,7 @@ FocusScope {
     }
 
     function editEntry(entry) {
-        if (!entry || entry.isImage || (entry.mimeType && !entry.mimeType.startsWith("text/plain"))) {
+        if (!ClipboardService.canEditEntry(entry)) {
             return;
         }
         editorView.setEntry(entry);

--- a/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
+++ b/quickshell/Modals/Clipboard/ClipboardHistoryContent.qml
@@ -181,7 +181,7 @@ FocusScope {
     }
 
     function editEntry(entry) {
-        if (!entry || entry.isImage) {
+        if (!entry || entry.isImage || (entry.mimeType && !entry.mimeType.startsWith("text/plain"))) {
             return;
         }
         editorView.setEntry(entry);

--- a/quickshell/Services/ClipboardService.qml
+++ b/quickshell/Services/ClipboardService.qml
@@ -200,6 +200,7 @@ Singleton {
         internalEntries = [];
         clipboardEntries = [];
         unpinnedEntries = [];
+        pinnedEntries = [];
     }
 
     function copyEntry(entry, closeCallback, textOnly) {
@@ -331,6 +332,33 @@ Singleton {
             }
             ToastService.showInfo(I18n.tr("Entry unpinned"));
             refresh();
+        });
+    }
+
+    function editEntry(entry, text, callback) {
+        if (!entry || typeof entry.id !== "number") {
+            if (callback) {
+                callback({
+                    "error": "Invalid entry"
+                });
+            }
+            return;
+        }
+        DMSService.sendRequest("clipboard.editEntry", {
+            "id": entry.id,
+            "text": text
+        }, function (response) {
+            if (response.error) {
+                log.warn("Failed to edit entry:", response.error);
+                if (callback) {
+                    callback(response);
+                }
+                return;
+            }
+            refresh();
+            if (callback) {
+                callback(response);
+            }
         });
     }
 

--- a/quickshell/Services/ClipboardService.qml
+++ b/quickshell/Services/ClipboardService.qml
@@ -399,6 +399,17 @@ Singleton {
         return entry.preview || "";
     }
 
+    function isTextMimeType(mimeType) {
+        if (!mimeType || mimeType.startsWith("text/plain")) {
+            return true;
+        }
+        return mimeType === "UTF8_STRING" || mimeType === "STRING" || mimeType === "TEXT";
+    }
+
+    function canEditEntry(entry) {
+        return !!entry && !(entry.isImage ?? false) && isTextMimeType(entry.mimeType);
+    }
+
     function getEntryType(entry) {
         if (entry.isImage) {
             return "image";


### PR DESCRIPTION
When saving edits to a pinned clipboard entry, the editor previously called clipboard.copy, which only created a new unpinned entry in recents while leaving the original pinned entry unchanged in the "Saved" tab.