### PR TITLE
display config: read live layout from hyprland instead of the cached wlr snapshot

### DIFF
--- a/quickshell/Modules/Settings/DisplayConfig/DisplayConfigState.qml
+++ b/quickshell/Modules/Settings/DisplayConfig/DisplayConfigState.qml
@@ -1114,6 +1114,13 @@ Singleton {
     }
 
     Connections {
+        target: HyprlandService
+        function onMonitorLayoutChanged() {
+            root.outputs = root.buildOutputsMap();
+        }
+    }
+
+    Connections {
         target: CompositorService
         function onCompositorChanged() {
             root.checkIncludeStatus();
@@ -1806,6 +1813,13 @@ Singleton {
                     "transform": mapWlrTransform(output.transform)
                 }
             };
+            const live = HyprlandService.liveMonitor(output.name);
+            if (!live)
+                continue;
+            map[output.name].logical.x = live.x;
+            map[output.name].logical.y = live.y;
+            map[output.name].logical.scale = live.scale || 1.0;
+            map[output.name].logical.transform = hyprlandToTransform(live.lastIpcObject?.transform ?? 0);
         }
         return map;
     }

--- a/quickshell/Services/CompositorService.qml
+++ b/quickshell/Services/CompositorService.qml
@@ -275,7 +275,7 @@ Singleton {
         enabled: isHyprland
 
         function onRawEvent(event) {
-            if (event.name === "monitoraddedv2" || event.name === "monitorremoved") {
+            if (event.name === "monitoraddedv2" || event.name === "monitorremoved" || event.name === "configreloaded") {
                 root.refreshHyprlandMonitorLayout();
                 return;
             }

--- a/quickshell/Services/HyprlandService.qml
+++ b/quickshell/Services/HyprlandService.qml
@@ -21,6 +21,8 @@ Singleton {
     readonly property bool luaConfigActive: CompositorService.isHyprland && (Hyprland.usingLua === true || luaConfigDetected)
 
     property int _lastGapValue: -1
+    property string _monitorLayoutSignature: ""
+    signal monitorLayoutChanged
     property bool luaConfigDetected: false
     property bool luaConfigStatusReady: false
     property bool luaConfigStatusLoading: false
@@ -296,9 +298,36 @@ Singleton {
         Proc.runCommand("hyprctl-reload", ["hyprctl", "reload"], (output, exitCode) => {
             if (exitCode !== 0)
                 log.warn("hyprctl reload failed:", output);
+            else
+                Hyprland.refreshMonitors();
             if (callback)
                 callback(exitCode === 0);
         });
+    }
+
+    function liveMonitor(name) {
+        if (!CompositorService.isHyprland)
+            return null;
+        return Hyprland.monitors.values.find(m => m.name === name) ?? null;
+    }
+
+    function _syncMonitorLayout() {
+        const signature = Hyprland.monitors.values.map(m => `${m.name}:${m.x},${m.y},${m.scale},${m.lastIpcObject?.transform ?? 0}`).join("|");
+        if (signature === _monitorLayoutSignature)
+            return;
+        _monitorLayoutSignature = signature;
+        monitorLayoutChanged();
+    }
+
+    Instantiator {
+        model: CompositorService.isHyprland ? Hyprland.monitors : null
+        delegate: Connections {
+            required property HyprlandMonitor modelData
+            target: modelData
+            function onLastIpcObjectChanged() {
+                root._syncMonitorLayout();
+            }
+        }
     }
 
     function setLayoutXray(enabled) {


### PR DESCRIPTION
## Description

On Hyprland the display config canvas and profile matching use position/transform/scale from the daemon's `zwlr_output_manager_v1` snapshot taken at shell start. Hyprland only re-sends those head properties on a mode change, so rotating or moving an output from Settings never updates the canvas: a 90° output stays drawn as landscape until dms is restarted.

- `HyprlandService`: `liveMonitor()` from `Hyprland.monitors`, refresh monitors after `hyprctl reload`, emit `monitorLayoutChanged` only when name/x/y/scale/transform actually change (Quickshell refreshes monitors on every workspace switch, so this is a no-op otherwise).
- `CompositorService`: treat `configreloaded` like `monitoraddedv2`.
- `DisplayConfigState.buildOutputsMap()`: overlay live x/y/scale/transform from Hyprland when the output is present there; rebuild on `monitorLayoutChanged`. Disabled outputs keep the wlr values.

niri and other compositors are untouched.

Tested on Fedora 44, dms 1.5.3 + this patch, Hyprland 0.56.2 (Lua config), DVI-I-1 1920x1080 + HDMI-A-1 3840x2160@2: Transform 90° → Normal → 90° updates the canvas without a restart, snapping against the portrait output works, no QML warnings in the journal.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Fixes #3417

## Screenshots / video

See #3417 for the before state.

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [ ] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new behaviors: https://github.com/AvengeMedia/DankLinux-Docs
