### PR TITLE
settings: add safe Startup Apps manager

### DIFF
--- a/core/cmd/dms/commands_common.go
+++ b/core/cmd/dms/commands_common.go
@@ -793,6 +793,7 @@ func getCommonCommands() []*cobra.Command {
 		blurCmd,
 		trashCmd,
 		systemCmd,
+		startupCmd,
 		switchUserCmd,
 	}...)
 }

--- a/core/cmd/dms/commands_startup.go
+++ b/core/cmd/dms/commands_startup.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/AvengeMedia/DankMaterialShell/core/internal/startup"
+	"github.com/spf13/cobra"
+)
+
+var startupCmd = &cobra.Command{
+	Use:   "startup",
+	Short: "Manage user-facing startup applications",
+	Long:  "List and manage XDG autostart applications and safely classified user systemd application services.",
+}
+
+var startupListJSON bool
+
+var startupListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List manageable startup applications",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		entries, err := startup.NewManager().List(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if startupListJSON {
+			return json.NewEncoder(os.Stdout).Encode(entries)
+		}
+		for _, entry := range entries {
+			state := "disabled"
+			if entry.Enabled {
+				state = "enabled"
+			}
+			fmt.Printf("%s\t%s\t%s\n", entry.ID, state, entry.Name)
+		}
+		return nil
+	},
+}
+
+var startupEnableCmd = &cobra.Command{
+	Use:   "enable <entry-id>",
+	Short: "Enable a startup application for future sessions",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return startup.NewManager().SetEnabled(cmd.Context(), args[0], true)
+	},
+}
+
+var startupDisableCmd = &cobra.Command{
+	Use:   "disable <entry-id>",
+	Short: "Disable a startup application for future sessions",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return startup.NewManager().SetEnabled(cmd.Context(), args[0], false)
+	},
+}
+
+var (
+	startupAddName string
+	startupAddExec string
+	startupAddIcon string
+)
+
+var startupAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a user XDG startup application",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		_, err := startup.NewManager().Add(startupAddName, startupAddExec, startupAddIcon)
+		return err
+	},
+}
+
+var startupRemoveCmd = &cobra.Command{
+	Use:   "remove <entry-id>",
+	Short: "Remove a user-created XDG startup application",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return startup.NewManager().Remove(args[0])
+	},
+}
+
+func init() {
+	startupListCmd.Flags().BoolVar(&startupListJSON, "json", false, "Return startup applications as JSON")
+	startupAddCmd.Flags().StringVar(&startupAddName, "name", "", "Application display name")
+	startupAddCmd.Flags().StringVar(&startupAddExec, "exec", "", "Desktop entry Exec value")
+	startupAddCmd.Flags().StringVar(&startupAddIcon, "icon", "", "Optional application icon name")
+	_ = startupAddCmd.MarkFlagRequired("name")
+	_ = startupAddCmd.MarkFlagRequired("exec")
+	startupCmd.AddCommand(startupListCmd, startupEnableCmd, startupDisableCmd, startupAddCmd, startupRemoveCmd)
+}

--- a/core/internal/startup/desktop.go
+++ b/core/internal/startup/desktop.go
@@ -1,0 +1,335 @@
+package startup
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const managedOverrideKey = "X-DMS-Managed"
+
+type desktopFile struct {
+	content []byte
+	keys    map[string]string
+	valid   bool
+}
+
+type xdgRecord struct {
+	id     string
+	user   *desktopFile
+	system *desktopFile
+	entry  Entry
+}
+
+func readDesktopFile(path string) (*desktopFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make(map[string]string)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	inDesktopEntry := false
+	foundDesktopEntry := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inDesktopEntry = line == "[Desktop Entry]"
+			foundDesktopEntry = foundDesktopEntry || inDesktopEntry
+			continue
+		}
+		if !inDesktopEntry {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq <= 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:eq])
+		if strings.Contains(key, "[") {
+			continue
+		}
+		if _, exists := keys[key]; exists {
+			continue
+		}
+		keys[key] = strings.TrimSpace(line[eq+1:])
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	typeName := keys["Type"]
+	return &desktopFile{
+		content: data,
+		keys:    keys,
+		valid:   foundDesktopEntry && (typeName == "" || typeName == "Application"),
+	}, nil
+}
+
+func desktopBool(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+func desktopList(value string) []string {
+	fields := strings.FieldsFunc(value, func(r rune) bool { return r == ';' || r == ':' })
+	for i := range fields {
+		fields[i] = strings.ToLower(strings.TrimSpace(fields[i]))
+	}
+	return slices.DeleteFunc(fields, func(value string) bool { return value == "" })
+}
+
+func desktopString(value string) string {
+	var out strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] != '\\' || i+1 >= len(value) {
+			out.WriteByte(value[i])
+			continue
+		}
+		i++
+		switch value[i] {
+		case 'n':
+			out.WriteByte('\n')
+		case 'r':
+			out.WriteByte('\r')
+		case 't':
+			out.WriteByte('\t')
+		case 's':
+			out.WriteByte(' ')
+		case '\\':
+			out.WriteByte('\\')
+		default:
+			out.WriteByte('\\')
+			out.WriteByte(value[i])
+		}
+	}
+	return out.String()
+}
+
+func desktopVisible(keys map[string]string, currentDesktops []string) bool {
+	current := make(map[string]struct{}, len(currentDesktops))
+	for _, desktop := range currentDesktops {
+		current[strings.ToLower(desktop)] = struct{}{}
+	}
+
+	only := desktopList(keys["OnlyShowIn"])
+	if len(only) > 0 {
+		matched := slices.ContainsFunc(only, func(desktop string) bool {
+			_, ok := current[desktop]
+			return ok
+		})
+		if !matched {
+			return false
+		}
+	}
+
+	not := desktopList(keys["NotShowIn"])
+	return !slices.ContainsFunc(not, func(desktop string) bool {
+		_, ok := current[desktop]
+		return ok
+	})
+}
+
+func mergedDesktopKeys(user, system *desktopFile) map[string]string {
+	keys := make(map[string]string)
+	if system != nil {
+		for key, value := range system.keys {
+			keys[key] = value
+		}
+	}
+	if user != nil {
+		for key, value := range user.keys {
+			keys[key] = value
+		}
+	}
+	return keys
+}
+
+func desktopEnabled(keys map[string]string) bool {
+	if desktopBool(keys["Hidden"]) {
+		return false
+	}
+	value, exists := keys["X-GNOME-Autostart-enabled"]
+	return !exists || desktopBool(value)
+}
+
+func (m *Manager) listXDG() ([]xdgRecord, error) {
+	systemFiles := make(map[string]*desktopFile)
+	for _, configDir := range m.systemConfigDirs {
+		dir := filepath.Join(configDir, "autostart")
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, dirEntry := range entries {
+			id := dirEntry.Name()
+			if dirEntry.IsDir() || !validDesktopID(id) || systemFiles[id] != nil {
+				continue
+			}
+			file, err := readDesktopFile(filepath.Join(dir, id))
+			if err != nil {
+				continue
+			}
+			systemFiles[id] = file
+		}
+	}
+
+	userFiles := make(map[string]*desktopFile)
+	userDir := filepath.Join(m.userConfigDir, "autostart")
+	entries, err := os.ReadDir(userDir)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("read user autostart directory: %w", err)
+	}
+	for _, dirEntry := range entries {
+		id := dirEntry.Name()
+		if dirEntry.IsDir() || !validDesktopID(id) {
+			continue
+		}
+		file, err := readDesktopFile(filepath.Join(userDir, id))
+		if err != nil {
+			continue
+		}
+		userFiles[id] = file
+	}
+
+	ids := make(map[string]struct{}, len(systemFiles)+len(userFiles))
+	for id := range systemFiles {
+		ids[id] = struct{}{}
+	}
+	for id := range userFiles {
+		ids[id] = struct{}{}
+	}
+
+	records := make([]xdgRecord, 0, len(ids))
+	for id := range ids {
+		user := userFiles[id]
+		system := systemFiles[id]
+		effective := user
+		if effective == nil {
+			effective = system
+		}
+		if effective == nil || !effective.valid {
+			continue
+		}
+		keys := mergedDesktopKeys(user, system)
+		if desktopBool(keys["NoDisplay"]) || !desktopVisible(keys, m.currentDesktops) {
+			continue
+		}
+		name := desktopString(keys["Name"])
+		execLine := keys["Exec"]
+		if name == "" || execLine == "" || !safeXDGApplication(id, keys) {
+			continue
+		}
+
+		records = append(records, xdgRecord{
+			id:     id,
+			user:   user,
+			system: system,
+			entry: Entry{
+				ID:          string(SourceXDG) + ":" + id,
+				Name:        name,
+				Description: desktopString(keys["Comment"]),
+				Icon:        keys["Icon"],
+				Source:      SourceXDG,
+				Enabled:     desktopEnabled(keys),
+				Category:    CategoryApplication,
+				Mutable:     true,
+				Removable:   user != nil && system == nil && desktopBool(user.keys[managedOverrideKey]),
+			},
+		})
+	}
+	return records, nil
+}
+
+func safeXDGApplication(id string, keys map[string]string) bool {
+	identity := id + " " + keys["Name"] + " " + keys["Comment"] + " " + executableFromDesktop(keys["Exec"])
+	return !containsProtectedWord(identity)
+}
+
+func validDesktopID(id string) bool {
+	return id != "" && filepath.Base(id) == id && strings.HasSuffix(id, ".desktop")
+}
+
+func updateDesktopKeys(content []byte, values map[string]string) []byte {
+	lines := strings.Split(string(content), "\n")
+	found := make(map[string]bool, len(values))
+	inDesktopEntry := false
+	insertAt := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			if inDesktopEntry && insertAt < 0 {
+				insertAt = i
+			}
+			inDesktopEntry = trimmed == "[Desktop Entry]"
+			continue
+		}
+		if !inDesktopEntry {
+			continue
+		}
+		eq := strings.IndexByte(trimmed, '=')
+		if eq <= 0 {
+			continue
+		}
+		key := strings.TrimSpace(trimmed[:eq])
+		value, ok := values[key]
+		if !ok || found[key] {
+			continue
+		}
+		lines[i] = key + "=" + value
+		found[key] = true
+	}
+	if insertAt < 0 {
+		insertAt = len(lines)
+	}
+	missing := make([]string, 0, len(values))
+	for key, value := range values {
+		if !found[key] {
+			missing = append(missing, key+"="+value)
+		}
+	}
+	slices.Sort(missing)
+	lines = slices.Insert(lines, insertAt, missing...)
+	return []byte(strings.Join(lines, "\n"))
+}
+
+func atomicWriteFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".dms-startup-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o644); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/core/internal/startup/desktop_test.go
+++ b/core/internal/startup/desktop_test.go
@@ -1,0 +1,235 @@
+package startup
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testManager(t *testing.T) (*Manager, string, string, string) {
+	t.Helper()
+	root := t.TempDir()
+	user := filepath.Join(root, "user")
+	systemOne := filepath.Join(root, "system-one")
+	systemTwo := filepath.Join(root, "system-two")
+	return &Manager{
+		userConfigDir:    user,
+		systemConfigDirs: []string{systemOne, systemTwo},
+		currentDesktops:  []string{"dms"},
+		applications:     nil,
+		systemd:          &fakeSystemd{},
+	}, user, systemOne, systemTwo
+}
+
+func writeDesktop(t *testing.T, configDir, id, content string) string {
+	t.Helper()
+	dir := filepath.Join(configDir, "autostart")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, id)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func desktopContent(name, comment, execLine string) string {
+	return "[Desktop Entry]\nType=Application\nName=" + name + "\nComment=" + comment + "\nExec=" + execLine + "\n"
+}
+
+func TestListXDGUserAndSystemEntries(t *testing.T) {
+	manager, user, system, _ := testManager(t)
+	writeDesktop(t, user, "user.desktop", desktopContent("User App", "User comment", "/usr/bin/user-app"))
+	writeDesktop(t, system, "system.desktop", desktopContent("System App", "System comment", "/usr/bin/system-app"))
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "System App", entries[0].Name)
+	assert.Equal(t, SourceXDG, entries[0].Source)
+	assert.Equal(t, "User App", entries[1].Name)
+	assert.False(t, entries[1].Removable)
+}
+
+func TestOnlyDMSCreatedXDGEntriesAreRemovable(t *testing.T) {
+	manager, user, _, _ := testManager(t)
+	writeDesktop(t, user, "manual.desktop", desktopContent("Manual App", "", "/usr/bin/manual-app"))
+	created, err := manager.Add("Managed App", "/usr/bin/managed-app", "")
+	require.NoError(t, err)
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	byID := make(map[string]Entry, len(entries))
+	for _, entry := range entries {
+		byID[entry.ID] = entry
+	}
+	assert.False(t, byID["xdg:manual.desktop"].Removable)
+	assert.True(t, byID[created.ID].Removable)
+	assert.ErrorIs(t, manager.Remove("xdg:manual.desktop"), ErrProtected)
+}
+
+func TestListXDGUserOverrideTakesPrecedence(t *testing.T) {
+	manager, user, system, _ := testManager(t)
+	writeDesktop(t, system, "shared.desktop", desktopContent("System Name", "System comment", "/usr/bin/system-app"))
+	writeDesktop(t, user, "shared.desktop", desktopContent("User Name", "User comment", "/usr/bin/user-app"))
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "User Name", entries[0].Name)
+	assert.Equal(t, "User comment", entries[0].Description)
+	assert.False(t, entries[0].Removable)
+}
+
+func TestListXDGHiddenOverrideUsesSystemMetadata(t *testing.T) {
+	manager, user, system, _ := testManager(t)
+	writeDesktop(t, system, "shared.desktop", desktopContent("System Name", "System comment", "/usr/bin/system-app"))
+	writeDesktop(t, user, "shared.desktop", "[Desktop Entry]\nType=Application\nHidden=true\n")
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "System Name", entries[0].Name)
+	assert.False(t, entries[0].Enabled)
+}
+
+func TestSetXDGEnabledForUserEntry(t *testing.T) {
+	manager, user, _, _ := testManager(t)
+	path := writeDesktop(t, user, "user.desktop", desktopContent("User App", "", "/usr/bin/user-app")+"Hidden=true\n")
+
+	require.NoError(t, manager.SetEnabled(context.Background(), "xdg:user.desktop", true))
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "Hidden=false")
+	assert.Contains(t, string(data), "X-GNOME-Autostart-enabled=true")
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.True(t, entries[0].Enabled)
+}
+
+func TestDisableAndEnableSystemXDGEntry(t *testing.T) {
+	manager, user, system, _ := testManager(t)
+	systemPath := writeDesktop(t, system, "system.desktop", desktopContent("System App", "", "/usr/bin/system-app"))
+	userPath := filepath.Join(user, "autostart", "system.desktop")
+
+	require.NoError(t, manager.SetEnabled(context.Background(), "xdg:system.desktop", false))
+	override, err := os.ReadFile(userPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(override), "Hidden=true")
+	assert.Contains(t, string(override), managedOverrideKey+"=true")
+	systemData, err := os.ReadFile(systemPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(systemData), "Hidden=true")
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.False(t, entries[0].Enabled)
+
+	require.NoError(t, manager.SetEnabled(context.Background(), "xdg:system.desktop", true))
+	_, err = os.Stat(userPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestListXDGSkipsMalformedAndDeduplicates(t *testing.T) {
+	manager, user, systemOne, systemTwo := testManager(t)
+	writeDesktop(t, user, "broken.desktop", "this is not a desktop entry")
+	writeDesktop(t, systemOne, "duplicate.desktop", desktopContent("First", "", "/usr/bin/first"))
+	writeDesktop(t, systemTwo, "duplicate.desktop", desktopContent("Second", "", "/usr/bin/second"))
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "First", entries[0].Name)
+}
+
+func TestMalformedUserEntryStillShadowsSystemEntry(t *testing.T) {
+	manager, user, system, _ := testManager(t)
+	writeDesktop(t, system, "shared.desktop", desktopContent("System App", "", "/usr/bin/system-app"))
+	writeDesktop(t, user, "shared.desktop", "not a desktop entry")
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestXDGDesktopVisibility(t *testing.T) {
+	manager, user, _, _ := testManager(t)
+	writeDesktop(t, user, "only.desktop", desktopContent("Only", "", "/usr/bin/only")+"OnlyShowIn=GNOME;\n")
+	writeDesktop(t, user, "not.desktop", desktopContent("Not", "", "/usr/bin/not")+"NotShowIn=DMS;\n")
+	writeDesktop(t, user, "nodisplay.desktop", desktopContent("Hidden UI", "", "/usr/bin/hidden")+"NoDisplay=true\n")
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestListXDGProtectsSessionInfrastructure(t *testing.T) {
+	manager, _, system, _ := testManager(t)
+	writeDesktop(t, system, "vboxclient.desktop", desktopContent("vboxclient", "VirtualBox User Session Services", "/usr/bin/VBoxClient-all"))
+	writeDesktop(t, system, "dms.desktop", desktopContent("DMS", "Desktop shell", "/usr/bin/dms"))
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestListXDGProtectsInfrastructureByDesktopID(t *testing.T) {
+	manager, user, _, _ := testManager(t)
+	writeDesktop(t, user, "dms.service.desktop", desktopContent("Shell Helper", "", "/usr/bin/helper"))
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestAddXDGEntryHandlesSpacesAndDuplicateNames(t *testing.T) {
+	manager, user, _, _ := testManager(t)
+	first, err := manager.Add("My Startup App", "/usr/bin/my-app --flag \"two words\"", "my-app")
+	require.NoError(t, err)
+	second, err := manager.Add("My Startup App", "/usr/bin/my-app --other", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "xdg:my-startup-app.desktop", first.ID)
+	assert.Equal(t, "xdg:my-startup-app-2.desktop", second.ID)
+	data, err := os.ReadFile(filepath.Join(user, "autostart", "my-startup-app.desktop"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "Exec=/usr/bin/my-app --flag \"two words\"")
+}
+
+func TestXGNOMEAutostartEnabledFalse(t *testing.T) {
+	manager, user, _, _ := testManager(t)
+	writeDesktop(t, user, "gnome.desktop", desktopContent("GNOME App", "", "/usr/bin/gnome-app")+"X-GNOME-Autostart-enabled=false\n")
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.False(t, entries[0].Enabled)
+}
+
+func TestRemoveRejectsSystemXDGEntry(t *testing.T) {
+	manager, _, system, _ := testManager(t)
+	writeDesktop(t, system, "system.desktop", desktopContent("System", "", "/usr/bin/system"))
+	assert.ErrorIs(t, manager.Remove("xdg:system.desktop"), ErrProtected)
+}
+
+func TestSetEnabledRejectsUnknownSource(t *testing.T) {
+	manager, _, _, _ := testManager(t)
+	assert.True(t, errors.Is(manager.SetEnabled(context.Background(), "service:dms.service", false), ErrProtected))
+}
+
+func TestListContinuesWhenSystemdIsUnavailable(t *testing.T) {
+	manager, user, _, _ := testManager(t)
+	writeDesktop(t, user, "user.desktop", desktopContent("User App", "", "/usr/bin/user-app"))
+	manager.systemd = &fakeSystemd{err: errors.New("systemd unavailable")}
+
+	entries, err := manager.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "User App", entries[0].Name)
+}

--- a/core/internal/startup/manager.go
+++ b/core/internal/startup/manager.go
@@ -1,0 +1,237 @@
+package startup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/AvengeMedia/DankMaterialShell/core/internal/desktop"
+	"github.com/AvengeMedia/DankMaterialShell/core/internal/utils"
+)
+
+type Manager struct {
+	userConfigDir    string
+	systemConfigDirs []string
+	currentDesktops  []string
+	applications     []Application
+	systemd          SystemdBackend
+}
+
+func NewManager() *Manager {
+	configDirs := []string{"/etc/xdg"}
+	if value := os.Getenv("XDG_CONFIG_DIRS"); value != "" {
+		configDirs = filepath.SplitList(value)
+	}
+	currentDesktops := desktopList(os.Getenv("XDG_CURRENT_DESKTOP"))
+	applications := make([]Application, 0)
+	for _, entry := range desktop.AllEntries() {
+		if entry.Hidden || entry.NoDisplay || entry.Name == "" || entry.Exec == "" {
+			continue
+		}
+		name := entry.Name
+		if file, err := readDesktopFile(entry.Path); err == nil && file.keys["Name"] != "" {
+			name = desktopString(file.keys["Name"])
+		}
+		applications = append(applications, Application{ID: entry.ID, Name: name, Exec: entry.Exec, Icon: entry.Icon})
+	}
+	return &Manager{
+		userConfigDir:    utils.XDGConfigHome(),
+		systemConfigDirs: configDirs,
+		currentDesktops:  currentDesktops,
+		applications:     applications,
+		systemd:          commandSystemd{},
+	}
+}
+
+func (m *Manager) List(ctx context.Context) ([]Entry, error) {
+	xdg, err := m.listXDG()
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]Entry, 0, len(xdg))
+	for _, record := range xdg {
+		entries = append(entries, record.entry)
+	}
+
+	units, err := m.systemd.List(ctx)
+	if err == nil {
+		for _, unit := range units {
+			entry, category := classifySystemdUnit(unit, m.applications)
+			if category == CategoryApplication && entry.Mutable {
+				entries = append(entries, entry)
+			}
+		}
+	}
+
+	slices.SortStableFunc(entries, func(left, right Entry) int {
+		if cmp := strings.Compare(strings.ToLower(left.Name), strings.ToLower(right.Name)); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(left.ID, right.ID)
+	})
+	return entries, nil
+}
+
+func (m *Manager) SetEnabled(ctx context.Context, id string, enabled bool) error {
+	source, name, ok := strings.Cut(id, ":")
+	if !ok {
+		return ErrProtected
+	}
+	switch Source(source) {
+	case SourceXDG:
+		return m.setXDGEnabled(name, enabled)
+	case SourceSystemd:
+		return m.setSystemdEnabled(ctx, name, enabled)
+	default:
+		return ErrProtected
+	}
+}
+
+func (m *Manager) setXDGEnabled(id string, enabled bool) error {
+	if !validDesktopID(id) {
+		return ErrProtected
+	}
+	records, err := m.listXDG()
+	if err != nil {
+		return err
+	}
+	index := slices.IndexFunc(records, func(record xdgRecord) bool { return record.id == id })
+	if index < 0 {
+		return ErrNotFound
+	}
+	record := records[index]
+	if record.entry.Enabled == enabled {
+		return nil
+	}
+
+	userPath := filepath.Join(m.userConfigDir, "autostart", id)
+	if !enabled && record.user == nil {
+		content := []byte("[Desktop Entry]\nType=Application\nHidden=true\n" + managedOverrideKey + "=true\n")
+		return atomicWriteFile(userPath, content)
+	}
+	if enabled && record.user != nil && record.system != nil && (desktopBool(record.user.keys[managedOverrideKey]) || record.user.keys["Name"] == "" || record.user.keys["Exec"] == "") {
+		if err := os.Remove(userPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove XDG autostart override: %w", err)
+		}
+		return nil
+	}
+
+	file := record.user
+	if file == nil {
+		file = record.system
+	}
+	if file == nil {
+		return ErrNotFound
+	}
+	values := map[string]string{
+		"Hidden":                    fmt.Sprintf("%t", !enabled),
+		"X-GNOME-Autostart-enabled": fmt.Sprintf("%t", enabled),
+	}
+	return atomicWriteFile(userPath, updateDesktopKeys(file.content, values))
+}
+
+func (m *Manager) setSystemdEnabled(ctx context.Context, name string, enabled bool) error {
+	if filepath.Base(name) != name || !strings.HasSuffix(name, ".service") {
+		return ErrProtected
+	}
+	units, err := m.systemd.List(ctx)
+	if err != nil {
+		return fmt.Errorf("inspect systemd startup service: %w", err)
+	}
+	index := slices.IndexFunc(units, func(unit SystemdUnit) bool { return unit.Name == name })
+	if index < 0 {
+		return ErrNotFound
+	}
+	entry, category := classifySystemdUnit(units[index], m.applications)
+	if category != CategoryApplication || !entry.Mutable {
+		return ErrProtected
+	}
+	if entry.Enabled == enabled {
+		return nil
+	}
+	return m.systemd.SetEnabled(ctx, name, enabled)
+}
+
+func (m *Manager) Add(name, execLine, icon string) (Entry, error) {
+	name = strings.TrimSpace(name)
+	execLine = strings.TrimSpace(execLine)
+	icon = strings.TrimSpace(icon)
+	if name == "" || execLine == "" || strings.ContainsAny(name, "\x00\r\n") || strings.ContainsAny(execLine, "\x00\r\n") || strings.ContainsAny(icon, "\x00\r\n") {
+		return Entry{}, ErrInvalidEntry
+	}
+
+	dir := filepath.Join(m.userConfigDir, "autostart")
+	base := desktopSlug(name)
+	id := base + ".desktop"
+	for suffix := 2; ; suffix++ {
+		_, err := os.Lstat(filepath.Join(dir, id))
+		if os.IsNotExist(err) {
+			break
+		}
+		if err != nil {
+			return Entry{}, fmt.Errorf("check XDG autostart entry: %w", err)
+		}
+		id = fmt.Sprintf("%s-%d.desktop", base, suffix)
+	}
+
+	var content strings.Builder
+	content.WriteString("[Desktop Entry]\nType=Application\nName=")
+	content.WriteString(escapeDesktopString(name))
+	content.WriteString("\nExec=")
+	content.WriteString(execLine)
+	content.WriteByte('\n')
+	if icon != "" {
+		content.WriteString("Icon=")
+		content.WriteString(escapeDesktopString(icon))
+		content.WriteByte('\n')
+	}
+	content.WriteString(managedOverrideKey + "=true\n")
+	if err := atomicWriteFile(filepath.Join(dir, id), []byte(content.String())); err != nil {
+		return Entry{}, fmt.Errorf("write XDG autostart entry: %w", err)
+	}
+	return Entry{
+		ID: string(SourceXDG) + ":" + id, Name: name, Icon: icon, Source: SourceXDG, Enabled: true,
+		Category: CategoryApplication, Mutable: true, Removable: true,
+	}, nil
+}
+
+func (m *Manager) Remove(id string) error {
+	source, name, ok := strings.Cut(id, ":")
+	if !ok || Source(source) != SourceXDG || !validDesktopID(name) {
+		return ErrProtected
+	}
+	records, err := m.listXDG()
+	if err != nil {
+		return err
+	}
+	index := slices.IndexFunc(records, func(record xdgRecord) bool { return record.id == name })
+	if index < 0 {
+		return ErrNotFound
+	}
+	if !records[index].entry.Removable {
+		return ErrProtected
+	}
+	if err := os.Remove(filepath.Join(m.userConfigDir, "autostart", name)); err != nil {
+		if os.IsNotExist(err) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("remove XDG autostart entry: %w", err)
+	}
+	return nil
+}
+
+func desktopSlug(value string) string {
+	words := words(value)
+	if len(words) == 0 {
+		return "startup-app"
+	}
+	return strings.Join(words, "-")
+}
+
+func escapeDesktopString(value string) string {
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	return strings.ReplaceAll(value, "\t", "\\t")
+}

--- a/core/internal/startup/systemd.go
+++ b/core/internal/startup/systemd.go
@@ -1,0 +1,340 @@
+package startup
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+	"unicode"
+)
+
+type commandSystemd struct{}
+
+func (commandSystemd) List(ctx context.Context) ([]SystemdUnit, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	output, err := exec.CommandContext(ctx, "systemctl", "--user", "list-unit-files", "--type=service", "--no-legend", "--no-pager", "--plain").Output()
+	if err != nil {
+		return nil, fmt.Errorf("list user unit files: %w", err)
+	}
+
+	states := make(map[string]string)
+	var names []string
+	for line := range strings.SplitSeq(string(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || !strings.HasSuffix(fields[0], ".service") || strings.Contains(fields[0], "@") {
+			continue
+		}
+		if fields[1] != "enabled" && fields[1] != "disabled" {
+			continue
+		}
+		states[fields[0]] = fields[1]
+		names = append(names, fields[0])
+	}
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	args := []string{"--user", "show", "--no-pager", "--property=Id,Description,LoadState,UnitFileState,FragmentPath,SourcePath,Transient,DefaultDependencies,Before,After,Requires,Requisite,BindsTo,PartOf,RequiredBy,ExecStart"}
+	args = append(args, names...)
+	output, err = exec.CommandContext(ctx, "systemctl", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("inspect user unit files: %w", err)
+	}
+
+	units := parseSystemdShow(output)
+	for i := range units {
+		if units[i].UnitFileState == "" {
+			units[i].UnitFileState = states[units[i].Name]
+		}
+		units[i].InstallTargets = readInstallTargets(units[i].FragmentPath)
+	}
+	return units, nil
+}
+
+func (commandSystemd) SetEnabled(ctx context.Context, name string, enabled bool) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	action := "disable"
+	if enabled {
+		action = "enable"
+	}
+	output, err := exec.CommandContext(ctx, "systemctl", "--user", action, "--", name).CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail == "" {
+			detail = err.Error()
+		}
+		return fmt.Errorf("systemctl --user %s %s: %s", action, name, detail)
+	}
+	return nil
+}
+
+func parseSystemdShow(data []byte) []SystemdUnit {
+	var units []SystemdUnit
+	var current *SystemdUnit
+	for line := range strings.SplitSeq(string(data), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if key == "Id" {
+			units = append(units, SystemdUnit{Name: value, DefaultDependencies: true})
+			current = &units[len(units)-1]
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		switch key {
+		case "Description":
+			current.Description = value
+		case "LoadState":
+			current.LoadState = value
+		case "UnitFileState":
+			current.UnitFileState = value
+		case "FragmentPath":
+			current.FragmentPath = value
+		case "SourcePath":
+			current.SourcePath = value
+		case "ExecStart":
+			current.ExecStart = value
+		case "Before":
+			current.Before = strings.Fields(value)
+		case "Requires":
+			current.Requires = strings.Fields(value)
+		case "Requisite":
+			current.Requisite = strings.Fields(value)
+		case "BindsTo":
+			current.BindsTo = strings.Fields(value)
+		case "PartOf":
+			current.PartOf = strings.Fields(value)
+		case "RequiredBy":
+			current.RequiredBy = strings.Fields(value)
+		case "Transient":
+			current.Transient = value == "yes"
+		case "DefaultDependencies":
+			current.DefaultDependencies = value != "no"
+		}
+	}
+	return units
+}
+
+func readInstallTargets(path string) []string {
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	var targets []string
+	inInstall := false
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inInstall = line == "[Install]"
+			continue
+		}
+		if !inInstall {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || (key != "WantedBy" && key != "RequiredBy") {
+			continue
+		}
+		targets = append(targets, strings.Fields(value)...)
+	}
+	return targets
+}
+
+var protectedWords = map[string]struct{}{
+	"atspi": {}, "audio": {}, "authentication": {}, "bluez": {}, "bus": {}, "cgroup": {},
+	"colord": {}, "compositor": {}, "cosmic": {}, "daemon": {}, "dbus": {}, "dconf": {}, "dirmngr": {},
+	"dms": {}, "dsearch": {}, "fcitx": {}, "geoclue": {}, "gpg": {}, "greeter": {}, "gss": {}, "gvfs": {},
+	"hyprland": {}, "ibus": {}, "iwd": {}, "keyboxd": {}, "keyring": {}, "kwin": {}, "labwc": {},
+	"login": {}, "logind": {}, "mango": {}, "mangowc": {}, "networkmanager": {}, "niri": {},
+	"obex": {}, "packagekit": {}, "pipewire": {}, "polkit": {}, "portal": {}, "pulse": {},
+	"pulseaudio": {}, "quickshell": {}, "river": {}, "secret": {}, "session": {}, "socket": {},
+	"ssh": {}, "sway": {}, "systemd": {}, "target": {}, "udev": {}, "wayfire": {}, "wireplumber": {}, "xdg": {},
+}
+
+var genericApplicationWords = map[string]struct{}{
+	"app": {}, "application": {}, "client": {}, "desktop": {}, "service": {}, "startup": {},
+}
+
+var allowedInstallTargets = []string{
+	"default.target",
+	"graphical-session.target",
+	"xdg-desktop-autostart.target",
+}
+
+var protectedDependencyTargets = []string{
+	"basic.target",
+	"default.target",
+	"graphical-session-pre.target",
+	"graphical-session.target",
+	"sockets.target",
+}
+
+func classifySystemdUnit(unit SystemdUnit, applications []Application) (Entry, Category) {
+	if !safeSystemdUnit(unit) {
+		return Entry{}, CategoryProtected
+	}
+	application, ok := matchingApplication(unit, applications)
+	if !ok {
+		return Entry{}, CategoryProtected
+	}
+	description := strings.TrimSpace(unit.Description)
+	if strings.EqualFold(description, application.Name) {
+		description = ""
+	}
+	return Entry{
+		ID:          string(SourceSystemd) + ":" + unit.Name,
+		Name:        application.Name,
+		Description: description,
+		Icon:        application.Icon,
+		Source:      SourceSystemd,
+		Enabled:     unit.UnitFileState == "enabled",
+		Category:    CategoryApplication,
+		Mutable:     true,
+	}, CategoryApplication
+}
+
+func safeSystemdUnit(unit SystemdUnit) bool {
+	if filepath.Base(unit.Name) != unit.Name || !strings.HasSuffix(unit.Name, ".service") || strings.Contains(unit.Name, "@") {
+		return false
+	}
+	if unit.LoadState != "loaded" || (unit.UnitFileState != "enabled" && unit.UnitFileState != "disabled") {
+		return false
+	}
+	if unit.Transient || !unit.DefaultDependencies || unit.FragmentPath == "" || unit.ExecStart == "" {
+		return false
+	}
+	path := filepath.Clean(unit.FragmentPath)
+	if strings.HasPrefix(path, "/run/") || strings.HasPrefix(path, "/tmp/") || strings.HasPrefix(path, "/proc/") || strings.HasPrefix(path, "/sys/") || strings.HasPrefix(path, "/dev/") || strings.Contains(path, "/generator") || strings.Contains(path, "/transient") || unit.SourcePath != "" {
+		return false
+	}
+	if containsProtectedWord(strings.TrimSuffix(unit.Name, ".service")) || containsProtectedWord(unit.Description) || containsProtectedWord(executableFromSystemd(unit.ExecStart)) {
+		return false
+	}
+	if len(unit.InstallTargets) == 0 || slices.ContainsFunc(unit.InstallTargets, func(target string) bool {
+		return !slices.Contains(allowedInstallTargets, target)
+	}) {
+		return false
+	}
+	if intersects(unit.Before, protectedDependencyTargets) || intersects(unit.RequiredBy, protectedDependencyTargets) || intersects(unit.Requisite, protectedDependencyTargets) || intersects(unit.BindsTo, protectedDependencyTargets) {
+		return false
+	}
+	return true
+}
+
+func intersects(values, protected []string) bool {
+	return slices.ContainsFunc(values, func(value string) bool { return slices.Contains(protected, value) })
+}
+
+func containsProtectedWord(value string) bool {
+	for _, word := range words(value) {
+		if _, protected := protectedWords[word]; protected {
+			return true
+		}
+	}
+	return false
+}
+
+func executableFromSystemd(execStart string) string {
+	if index := strings.Index(execStart, "path="); index >= 0 {
+		value := execStart[index+len("path="):]
+		if end := strings.IndexAny(value, " ;}"); end >= 0 {
+			value = value[:end]
+		}
+		return filepath.Base(value)
+	}
+	return execStart
+}
+
+func matchingApplication(unit SystemdUnit, applications []Application) (Application, bool) {
+	unitStem := strings.TrimSuffix(unit.Name, ".service")
+	unitWords := wordSet(unitStem + " " + executableFromSystemd(unit.ExecStart))
+	unitName := normalized(unitStem)
+	description := normalized(unit.Description)
+
+	bestScore := 0
+	var best Application
+	for _, application := range applications {
+		if application.Name == "" {
+			continue
+		}
+		appID := strings.TrimSuffix(application.ID, ".desktop")
+		appName := normalized(application.Name)
+		appExec := normalized(executableFromDesktop(application.Exec))
+		if appName == "" || containsProtectedWord(appID+" "+application.Name+" "+appExec) {
+			continue
+		}
+
+		score := 0
+		if len(appName) >= 4 && (unitName == appName || description == appName) {
+			score += 100
+		}
+		if len(appName) >= 4 && strings.Contains(unitName, appName) {
+			score += 40
+		}
+		if appExec != "" && normalized(executableFromSystemd(unit.ExecStart)) == appExec {
+			score += 80
+		}
+		for word := range meaningfulWords(appID + " " + application.Name + " " + application.Exec) {
+			if _, matches := unitWords[word]; matches {
+				score += 15
+			}
+		}
+		if score > bestScore {
+			bestScore = score
+			best = application
+		}
+	}
+	return best, bestScore >= 40
+}
+
+func executableFromDesktop(execLine string) string {
+	fields := strings.Fields(execLine)
+	if len(fields) == 0 {
+		return ""
+	}
+	return filepath.Base(strings.Trim(fields[0], "\"'"))
+}
+
+func meaningfulWords(value string) map[string]struct{} {
+	result := wordSet(value)
+	for word := range result {
+		_, generic := genericApplicationWords[word]
+		if len(word) < 4 || generic {
+			delete(result, word)
+		}
+	}
+	return result
+}
+
+func wordSet(value string) map[string]struct{} {
+	result := make(map[string]struct{})
+	for _, word := range words(value) {
+		result[word] = struct{}{}
+	}
+	return result
+}
+
+func words(value string) []string {
+	return strings.FieldsFunc(strings.ToLower(value), func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsDigit(r) })
+}
+
+func normalized(value string) string {
+	return strings.Join(words(value), "")
+}

--- a/core/internal/startup/systemd_test.go
+++ b/core/internal/startup/systemd_test.go
@@ -1,0 +1,145 @@
+package startup
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type systemdCall struct {
+	name    string
+	enabled bool
+}
+
+type fakeSystemd struct {
+	units []SystemdUnit
+	err   error
+	calls []systemdCall
+}
+
+func (f *fakeSystemd) List(context.Context) ([]SystemdUnit, error) {
+	return f.units, f.err
+}
+
+func (f *fakeSystemd) SetEnabled(_ context.Context, name string, enabled bool) error {
+	f.calls = append(f.calls, systemdCall{name: name, enabled: enabled})
+	return f.err
+}
+
+func applicationUnit(name, description, execStart string) SystemdUnit {
+	return SystemdUnit{
+		Name: name, Description: description, ExecStart: execStart,
+		LoadState: "loaded", UnitFileState: "enabled",
+		FragmentPath:        "/usr/lib/systemd/user/" + name,
+		InstallTargets:      []string{"graphical-session.target"},
+		DefaultDependencies: true,
+	}
+}
+
+func TestSystemdApplicationClassifierAllowsIdentifiableApps(t *testing.T) {
+	applications := []Application{
+		{ID: "com.docker.DockerDesktop.desktop", Name: "Docker Desktop", Exec: "/opt/docker-desktop/bin/docker-desktop", Icon: "docker-desktop"},
+		{ID: "md.obsidian.Obsidian.desktop", Name: "Obsidian", Exec: "obsidian", Icon: "obsidian"},
+	}
+	units := []SystemdUnit{
+		applicationUnit("docker-desktop.service", "Docker Desktop", "{ path=/opt/docker-desktop/bin/com.docker.backend ; argv[]=/opt/docker-desktop/bin/com.docker.backend ; }"),
+		applicationUnit("brain-obsidian.service", "Brain OS Obsidian supervisor", "{ path=/home/user/obsidian-supervisor.sh ; argv[]=/home/user/obsidian-supervisor.sh ; }"),
+	}
+
+	for _, unit := range units {
+		entry, category := classifySystemdUnit(unit, applications)
+		assert.Equal(t, CategoryApplication, category, unit.Name)
+		assert.True(t, entry.Mutable, unit.Name)
+		assert.Equal(t, SourceSystemd, entry.Source, unit.Name)
+	}
+}
+
+func TestSystemdApplicationClassifierProtectsInfrastructure(t *testing.T) {
+	applications := []Application{{ID: "org.example.Foo.desktop", Name: "Foo", Exec: "/usr/bin/foo", Icon: "foo"}}
+	protected := []SystemdUnit{
+		applicationUnit("dms.service", "DMS", "{ path=/usr/bin/dms ; }"),
+		applicationUnit("pipewire.service", "PipeWire", "{ path=/usr/bin/pipewire ; }"),
+		applicationUnit("wireplumber.service", "WirePlumber", "{ path=/usr/bin/wireplumber ; }"),
+		applicationUnit("dbus-broker.service", "D-Bus Broker", "{ path=/usr/bin/dbus-broker-launch ; }"),
+		applicationUnit("xdg-user-dirs.service", "User directories", "{ path=/usr/bin/xdg-user-dirs-update ; }"),
+		applicationUnit("systemd-tmpfiles-setup.service", "Systemd tmpfiles", "{ path=/usr/lib/systemd/systemd-tmpfiles ; }"),
+		applicationUnit("hyprland-session.service", "Hyprland session", "{ path=/usr/bin/Hyprland ; }"),
+		applicationUnit("foo.socket", "Foo", "{ path=/usr/bin/foo ; }"),
+		applicationUnit("foo.timer", "Foo", "{ path=/usr/bin/foo ; }"),
+		applicationUnit("foo.target", "Foo", "{ path=/usr/bin/foo ; }"),
+	}
+	generated := applicationUnit("foo.service", "Foo", "{ path=/usr/bin/foo ; }")
+	generated.FragmentPath = "/run/user/1000/systemd/generator/foo.service"
+	protected = append(protected, generated)
+	transient := applicationUnit("foo.service", "Foo", "{ path=/usr/bin/foo ; }")
+	transient.Transient = true
+	protected = append(protected, transient)
+	critical := applicationUnit("foo.service", "Foo", "{ path=/usr/bin/foo ; }")
+	critical.RequiredBy = []string{"graphical-session.target"}
+	protected = append(protected, critical)
+	masked := applicationUnit("foo.service", "Foo", "{ path=/usr/bin/foo ; }")
+	masked.UnitFileState = "masked"
+	protected = append(protected, masked)
+
+	for _, unit := range protected {
+		_, category := classifySystemdUnit(unit, applications)
+		assert.Equal(t, CategoryProtected, category, unit.Name)
+	}
+}
+
+func TestSystemdClassifierRequiresApplicationEvidence(t *testing.T) {
+	unit := applicationUnit("unknown-background.service", "Unknown background task", "{ path=/usr/bin/unknown-background ; }")
+	_, category := classifySystemdUnit(unit, nil)
+	assert.Equal(t, CategoryProtected, category)
+}
+
+func TestSystemdClassifierRejectsWeakSharedWord(t *testing.T) {
+	unit := applicationUnit("media-indexer.service", "Media indexer", "{ path=/usr/bin/media-indexer ; }")
+	applications := []Application{{ID: "org.example.MediaPlayer.desktop", Name: "Media Player", Exec: "/usr/bin/media-player"}}
+
+	_, category := classifySystemdUnit(unit, applications)
+	assert.Equal(t, CategoryProtected, category)
+}
+
+func TestProtectedSystemdUnitCannotBeDisabledDirectly(t *testing.T) {
+	backend := &fakeSystemd{units: []SystemdUnit{applicationUnit("dms.service", "Dank Material Shell", "{ path=/usr/bin/dms ; }")}}
+	manager := &Manager{
+		userConfigDir: t.TempDir(), systemd: backend,
+		applications: []Application{{ID: "dms.desktop", Name: "Dank Material Shell", Exec: "/usr/bin/dms"}},
+	}
+
+	err := manager.SetEnabled(context.Background(), "systemd:dms.service", false)
+	assert.True(t, errors.Is(err, ErrProtected))
+	assert.Empty(t, backend.calls)
+}
+
+func TestApplicationSystemdUnitCanBeDisabled(t *testing.T) {
+	backend := &fakeSystemd{units: []SystemdUnit{applicationUnit("docker-desktop.service", "Docker Desktop", "{ path=/opt/docker-desktop/bin/com.docker.backend ; }")}}
+	manager := &Manager{
+		userConfigDir: t.TempDir(), systemd: backend,
+		applications: []Application{{ID: "com.docker.DockerDesktop.desktop", Name: "Docker Desktop", Exec: "/opt/docker-desktop/bin/docker-desktop"}},
+	}
+
+	require.NoError(t, manager.SetEnabled(context.Background(), "systemd:docker-desktop.service", false))
+	assert.Equal(t, []systemdCall{{name: "docker-desktop.service", enabled: false}}, backend.calls)
+}
+
+func TestCommandSystemdDoesNotChangeRuntimeState(t *testing.T) {
+	binDir := t.TempDir()
+	argsPath := filepath.Join(t.TempDir(), "args")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$DMS_STARTUP_TEST_ARGS\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "systemctl"), []byte(script), 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("DMS_STARTUP_TEST_ARGS", argsPath)
+
+	require.NoError(t, (commandSystemd{}).SetEnabled(context.Background(), "example.service", false))
+	data, err := os.ReadFile(argsPath)
+	require.NoError(t, err)
+	assert.Equal(t, "--user\ndisable\n--\nexample.service\n", string(data))
+	assert.NotContains(t, string(data), "--now")
+}

--- a/core/internal/startup/types.go
+++ b/core/internal/startup/types.go
@@ -1,0 +1,69 @@
+package startup
+
+import (
+	"context"
+	"errors"
+)
+
+type Source string
+
+const (
+	SourceXDG     Source = "xdg"
+	SourceSystemd Source = "systemd"
+)
+
+type Category string
+
+const (
+	CategoryApplication Category = "application"
+	CategoryProtected   Category = "protected"
+)
+
+var (
+	ErrInvalidEntry = errors.New("name and command must be non-empty single-line values")
+	ErrNotFound     = errors.New("startup entry not found")
+	ErrProtected    = errors.New("service is protected and cannot be managed by Startup Apps")
+)
+
+type Entry struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Icon        string   `json:"icon,omitempty"`
+	Source      Source   `json:"source"`
+	Enabled     bool     `json:"enabled"`
+	Category    Category `json:"category"`
+	Mutable     bool     `json:"mutable"`
+	Removable   bool     `json:"removable,omitempty"`
+}
+
+type Application struct {
+	ID   string
+	Name string
+	Exec string
+	Icon string
+}
+
+type SystemdUnit struct {
+	Name                string
+	Description         string
+	LoadState           string
+	UnitFileState       string
+	FragmentPath        string
+	SourcePath          string
+	ExecStart           string
+	Before              []string
+	Requires            []string
+	Requisite           []string
+	BindsTo             []string
+	PartOf              []string
+	RequiredBy          []string
+	InstallTargets      []string
+	Transient           bool
+	DefaultDependencies bool
+}
+
+type SystemdBackend interface {
+	List(context.Context) ([]SystemdUnit, error)
+	SetEnabled(context.Context, string, bool) error
+}

--- a/quickshell/Common/SettingsTabs.qml
+++ b/quickshell/Common/SettingsTabs.qml
@@ -248,10 +248,9 @@ Singleton {
                 },
                 {
                     "id": "autostart",
-                    "text": I18n.tr("Autostart Apps"),
-                    "icon": "line_start",
-                    "tabIndex": 36,
-                    "autostartOnly": true
+                    "text": I18n.tr("Startup Apps"),
+                    "icon": "rocket_launch",
+                    "tabIndex": 36
                 },
                 {
                     "id": "window_rules",

--- a/quickshell/Modals/Settings/SettingsSidebar.qml
+++ b/quickshell/Modals/Settings/SettingsSidebar.qml
@@ -121,8 +121,6 @@ Rectangle {
             return false;
         if (item.greeterOnly && !GreeterService.available)
             return false;
-        if (item.autostartOnly && !DesktopService.autostartAvailable)
-            return false;
         if (item.frameOnly && !SettingsData.frameEnabled)
             return false;
         if (item.islandOnly && SettingsData.islandBarConfigs.length === 0)

--- a/quickshell/Modules/Settings/AutoStartTab.qml
+++ b/quickshell/Modules/Settings/AutoStartTab.qml
@@ -1,6 +1,5 @@
 import QtCore
 import QtQuick
-import Qt.labs.folderlistmodel
 import Quickshell
 import Quickshell.Io
 import qs.Common
@@ -15,142 +14,97 @@ Item {
     property var parentModal: null
     property var entries: []
     property var desktopApps: []
+    property bool loading: false
+    property bool refreshPending: false
+    property bool showAddForm: false
+    property string lastError: ""
     property string newEntryType: "desktop"
     property string newEntryName: ""
     property string newEntryExec: ""
     property string newEntryDesktopId: ""
     property string newEntryCommandWrapper: "%command%"
 
-    readonly property string autostartDir: {
-        const configHome = Paths.strip(StandardPaths.writableLocation(StandardPaths.ConfigLocation));
-        return configHome + "/autostart";
+    function refresh() {
+        if (loadProcess.running) {
+            refreshPending = true;
+            return;
+        }
+        loading = true;
+        lastError = "";
+        loadProcess.outputText = "";
+        loadProcess.errorText = "";
+        loadProcess.running = true;
     }
 
-    function lookupDesktopIcon(name, exec, fileName) {
-        const appId = fileName ? fileName.replace(/\.desktop$/, "") : "";
-        let entry = appId ? DesktopEntries.heuristicLookup(appId) : null;
-        if (entry && entry.icon)
-            return entry.icon;
-        if (exec) {
-            const cmdBase = exec.split(" ")[0].split("/").pop();
-            for (let i = 0; i < root.desktopApps.length; i++) {
-                const app = root.desktopApps[i];
-                if (app.icon) {
-                    const appExec = (app.exec || app.execString || "").split(" ")[0].split("/").pop();
-                    if (appExec === cmdBase)
-                        return app.icon;
-                }
-            }
-        }
-        return "";
+    function updateEntryEnabled(id, enabled) {
+        const list = entries.slice();
+        const index = list.findIndex(entry => entry.id === id);
+        if (index < 0)
+            return;
+        list[index] = Object.assign({}, list[index], {
+            enabled: enabled
+        });
+        entries = list;
     }
 
-    function parseDesktopFile(content, filePath) {
-        if (!content || content.length === 0)
-            return null;
-        const lines = content.split("\n");
-        let name = "";
-        let execCmd = "";
-        let icon = "";
-        let hidden = false;
-        let isDesktopEntry = false;
-        for (let i = 0; i < lines.length; i++) {
-            const line = lines[i].trim();
-            if (line === "[Desktop Entry]") {
-                isDesktopEntry = true;
-            } else if (isDesktopEntry) {
-                if (line.startsWith("["))
-                    break;
-                const nameMatch = line.match(/^Name=(.+)$/);
-                if (nameMatch)
-                    name = nameMatch[1];
-                const execMatch = line.match(/^Exec=(.+)$/);
-                if (execMatch)
-                    execCmd = execMatch[1];
-                const iconMatch = line.match(/^Icon=(.+)$/);
-                if (iconMatch)
-                    icon = iconMatch[1];
-                const hiddenMatch = line.match(/^Hidden=(true|false)$/);
-                if (hiddenMatch)
-                    hidden = hiddenMatch[1] === "true";
-            }
-        }
-        if (!isDesktopEntry || !name || !execCmd)
-            return null;
-        const fileName = filePath.split("/").pop();
-        if (!icon)
-            icon = root.lookupDesktopIcon(name, execCmd, fileName);
-        return {
-            name: name,
-            exec: execCmd,
-            icon: icon,
-            hidden: hidden,
-            filePath: filePath,
-            fileName: fileName,
-            content: content
-        };
+    function setEnabled(entry, enabled) {
+        if (!entry || !entry.mutable || operationProcess.running)
+            return;
+        updateEntryEnabled(entry.id, enabled);
+        operationProcess.operation = enabled ? "enable" : "disable";
+        operationProcess.entryId = entry.id;
+        operationProcess.errorText = "";
+        operationProcess.command = ["dms", "startup", operationProcess.operation, entry.id];
+        operationProcess.running = true;
+    }
+
+    function removeEntry(entry) {
+        if (!entry || !entry.removable || operationProcess.running)
+            return;
+        operationProcess.operation = "remove";
+        operationProcess.entryId = entry.id;
+        operationProcess.errorText = "";
+        operationProcess.command = ["dms", "startup", "remove", entry.id];
+        operationProcess.running = true;
+    }
+
+    function selectedDesktopApp() {
+        return desktopApps.find(app => (app.id || app.execString) === newEntryDesktopId);
+    }
+
+    function entryDescription(entry) {
+        if (entry.description)
+            return entry.description;
+        const source = entry.source === "systemd" ? I18n.tr("systemd user service") : I18n.tr("XDG Autostart");
+        return I18n.tr("Startup source: %1").arg(source);
     }
 
     function addEntry() {
+        if (operationProcess.running)
+            return;
+
+        let name = newEntryName.trim();
+        let execLine = newEntryExec.trim();
+        let icon = "";
         if (newEntryType === "desktop") {
-            if (!newEntryDesktopId)
-                return;
-            const app = desktopApps.find(a => (a.id || a.execString) === newEntryDesktopId);
+            const app = selectedDesktopApp();
             if (!app)
                 return;
-            const entryName = app.name || newEntryDesktopId;
-            const appExec = app.exec || app.execString || "";
-            const execCmd = root.newEntryCommandWrapper.replace("%command%", appExec);
-            const appIcon = app.icon || "";
-            const fileName = entryName.toLowerCase().replace(/[^a-z0-9]/g, "-") + ".desktop";
-            writeDesktopFile(fileName, entryName, execCmd, appIcon);
-        } else {
-            if (!newEntryName || !newEntryExec)
-                return;
-            const fileName = newEntryName.toLowerCase().replace(/[^a-z0-9]/g, "-") + ".desktop";
-            writeDesktopFile(fileName, newEntryName, newEntryExec, "");
+            name = app.name || newEntryDesktopId;
+            execLine = newEntryCommandWrapper.replace("%command%", app.exec || app.execString || "");
+            icon = app.icon || "";
         }
-    }
-
-    function writeDesktopFile(fileName, name, execCmd, icon) {
-        let content = "[Desktop Entry]\nType=Application\nName=" + name + "\nExec=" + execCmd + "\n";
-        if (icon)
-            content += "Icon=" + icon + "\n";
-        writerFileView.path = root.autostartDir + "/" + fileName;
-        writerFileView.setText(content);
-        root.resetNewEntry();
-    }
-
-    function setHidden(entry, hidden) {
-        if (!entry || !entry.content)
+        if (!name || !execLine)
             return;
-        const lines = entry.content.split("\n");
-        const hiddenValue = hidden ? "true" : "false";
-        let found = false;
-        const merged = lines.map(line => {
-            const m = line.match(/^Hidden=(true|false)\s*$/);
-            if (m) {
-                found = true;
-                return "Hidden=" + hiddenValue;
-            }
-            return line;
-        });
-        if (!found) {
-            const idx = merged.findIndex(l => l.trim() === "[Desktop Entry]");
-            if (idx >= 0)
-                merged.splice(idx + 1, 0, "Hidden=" + hiddenValue);
-            else
-                merged.unshift("Hidden=" + hiddenValue);
-        }
-        writerFileView.path = entry.filePath;
-        writerFileView.setText(merged.join("\n"));
-    }
 
-    function removeEntry(filePath) {
-        const proc = removeFileComponent.createObject(root, {
-            targetPath: filePath,
-            running: true
-        });
+        const command = ["dms", "startup", "add", "--name", name, "--exec", execLine];
+        if (icon)
+            command.push("--icon", icon);
+        operationProcess.operation = "add";
+        operationProcess.entryId = "";
+        operationProcess.errorText = "";
+        operationProcess.command = command;
+        operationProcess.running = true;
     }
 
     function resetNewEntry() {
@@ -161,114 +115,78 @@ Item {
         newEntryCommandWrapper = "%command%";
     }
 
-    function addOrUpdateEntry(entry) {
-        var list = root.entries.slice();
-        for (var i = 0; i < list.length; i++) {
-            if (list[i].filePath === entry.filePath) {
-                list[i] = entry;
-                root.entries = list;
-                return;
-            }
-        }
-        list.push(entry);
-        list.sort((a, b) => a.fileName.localeCompare(b.fileName));
-        root.entries = list;
-    }
+    Process {
+        id: loadProcess
+        command: ["dms", "startup", "list", "--json"]
+        running: false
+        property string outputText: ""
+        property string errorText: ""
 
-    function removeEntryByPath(filePath) {
-        var list = root.entries.filter(e => e.filePath !== filePath);
-        root.entries = list;
-    }
-
-    FileView {
-        id: writerFileView
-        blockLoading: true
-        atomicWrites: true
-        onSaveFailed: error => {
-            ToastService.showError(I18n.tr("Failed to write autostart entry"));
-            log.warn("Failed to write autostart entry to " + writerFileView.path + ": " + error);
-        }
-    }
-
-    FolderListModel {
-        id: folderModel
-        nameFilters: ["*.desktop"]
-        showDirs: false
-        showDotAndDotDot: false
-        showHidden: false
-        sortField: FolderListModel.Name
-
-        onStatusChanged: {
-            if (status !== FolderListModel.Ready)
-                return;
-            // rebuild entries
-            const validPaths = new Set();
-            for (let i = 0; i < folderModel.count; i++) {
-                const fp = folderModel.get(i, "filePath") || "";
-                validPaths.add(fp.startsWith("file://") ? fp.substring(7) : fp);
-            }
-            const filtered = root.entries.filter(e => validPaths.has(e.filePath));
-            if (filtered.length !== root.entries.length) {
-                root.entries = filtered;
-            }
+        stdout: StdioCollector {
+            onStreamFinished: loadProcess.outputText = text
         }
 
-        onCountChanged: {
-            fileReaderRepeater.model = count;
+        stderr: StdioCollector {
+            onStreamFinished: loadProcess.errorText = text.trim()
         }
-    }
 
-    Repeater {
-        id: fileReaderRepeater
-        model: 0
-
-        Item {
-            required property int index
-
-            readonly property string filePath: {
-                const fp = folderModel.get(index, "filePath") || "";
-                return fp.startsWith("file://") ? fp.substring(7) : fp;
-            }
-
-            FileView {
-                id: fileView
-                path: filePath ? "file://" + filePath : ""
-                watchChanges: true
-
-                onLoaded: {
-                    const entry = root.parseDesktopFile(fileView.text(), filePath);
-                    if (entry) {
-                        root.addOrUpdateEntry(entry);
-                    } else {
-                        root.removeEntryByPath(filePath);
-                    }
+        onExited: exitCode => {
+            root.loading = false;
+            if (exitCode === 0) {
+                try {
+                    const parsed = JSON.parse(outputText || "[]");
+                    root.entries = parsed.filter(entry => entry.category === "application" && entry.mutable === true);
+                    root.lastError = "";
+                } catch (error) {
+                    root.lastError = I18n.tr("Failed to read startup applications");
+                    root.log.warn("Failed to parse startup application list: " + error);
                 }
-
-                onFileChanged: reload()
-
-                onLoadFailed: {
-                    root.removeEntryByPath(filePath);
-                }
+            } else {
+                root.lastError = errorText || I18n.tr("Failed to read startup applications");
+                root.log.warn("Failed to load startup applications: " + root.lastError);
+            }
+            if (root.refreshPending) {
+                root.refreshPending = false;
+                Qt.callLater(root.refresh);
             }
         }
     }
 
-    Component {
-        id: removeFileComponent
-        Process {
-            property string targetPath: ""
-            command: ["rm", "-f", targetPath]
-            onExited: (exitCode, exitStatus) => {
-                root.removeEntryByPath(targetPath);
-                destroy();
-            }
+    Process {
+        id: operationProcess
+        running: false
+        property string operation: ""
+        property string entryId: ""
+        property string errorText: ""
+
+        stderr: StdioCollector {
+            onStreamFinished: operationProcess.errorText = text.trim()
         }
+
+        onExited: exitCode => {
+            if (exitCode !== 0) {
+                const title = operation === "add" ? I18n.tr("Failed to add startup application") : (operation === "remove" ? I18n.tr("Failed to remove startup application") : I18n.tr("Failed to update startup application"));
+                ToastService.showError(title, "", errorText.split("\n")[0]);
+                root.log.warn(title + ": " + errorText);
+            } else if (operation === "add") {
+                root.resetNewEntry();
+                root.showAddForm = false;
+            }
+            root.refresh();
+        }
+    }
+
+    Timer {
+        interval: 30000
+        repeat: true
+        running: root.visible
+        onTriggered: root.refresh()
     }
 
     function generateTrayIconFixSystemdOverride() {
         const configHome = Paths.strip(StandardPaths.writableLocation(StandardPaths.ConfigLocation));
         const dir = configHome + "/systemd/user/app-@autostart.service.d";
-        const proc = systemdOverrideMkDirComp.createObject(root, {
+        systemdOverrideMkDirComp.createObject(root, {
             targetPath: dir,
             running: true
         });
@@ -278,20 +196,17 @@ Item {
         id: systemdOverrideWriter
         atomicWrites: true
 
-        // make sure we don't overwrite an existing override with a default one, in case the user has already customized it
         function buildOverrideContent(existing) {
             if (!existing)
                 return "[Unit]\nAfter=dms.service\n";
             const lines = existing.split("\n");
-            const hasAfter = lines.some(l => l.trim() === "After=dms.service");
-            if (hasAfter)
+            if (lines.some(line => line.trim() === "After=dms.service"))
                 return existing;
-            const unitIdx = lines.findIndex(l => l.trim() === "[Unit]");
-            if (unitIdx >= 0) {
-                lines.splice(unitIdx + 1, 0, "After=dms.service");
-            } else {
+            const unitIndex = lines.findIndex(line => line.trim() === "[Unit]");
+            if (unitIndex >= 0)
+                lines.splice(unitIndex + 1, 0, "After=dms.service");
+            else
                 lines.push("[Unit]", "After=dms.service");
-            }
             return lines.join("\n");
         }
 
@@ -309,34 +224,21 @@ Item {
 
         onSaveFailed: error => {
             ToastService.showError(I18n.tr("Failed to generate systemd override"));
-            log.warn("Failed to write systemd override to " + systemdOverrideWriter.path + ": " + error);
+            root.log.warn("Failed to write systemd override to " + path + ": " + error);
         }
     }
 
     Component {
         id: systemdOverrideMkDirComp
+
         Process {
             property string targetPath: ""
             command: ["mkdir", "-p", targetPath]
             onExited: exitCode => {
-                if (exitCode === 0) {
+                if (exitCode === 0)
                     systemdOverrideWriter.path = targetPath + "/override.conf";
-                } else {
+                else
                     ToastService.showError(I18n.tr("Failed to generate systemd override"));
-                }
-                destroy();
-            }
-        }
-    }
-
-    Component {
-        id: autostartInitMkDirComp
-        Process {
-            command: ["mkdir", "-p", root.autostartDir]
-            onExited: exitCode => {
-                if (exitCode === 0) {
-                    folderModel.folder = "file://" + root.autostartDir;
-                }
                 destroy();
             }
         }
@@ -344,14 +246,10 @@ Item {
 
     Component.onCompleted: {
         desktopApps = AppSearchService.getVisibleApplications() || [];
-        autostartInitMkDirComp.createObject(root, {
-            running: true
-        });
+        refresh();
     }
 
-    Component.onDestruction: {
-        desktopApps = [];
-    }
+    Component.onDestruction: desktopApps = []
 
     DankFlickable {
         anchors.fill: parent
@@ -372,14 +270,169 @@ Item {
             width: Math.min(550, parent.width - Theme.spacingL * 2)
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: Theme.spacingXL
-            visible: DesktopService.autostartAvailable
 
             SettingsCard {
-                settingKey: "autostartAddEntry"
-                tags: ["autostart", "add", "entry", "command", "startup"]
+                width: parent.width
+                iconName: "rocket_launch"
+                title: I18n.tr("Startup Apps")
+                settingKey: "autostartEntries"
+                tags: ["startup", "autostart", "applications", "login"]
+
+                headerActions: [
+                    DankRefreshButton {
+                        busy: root.loading
+                        tooltipText: I18n.tr("Refresh")
+                        onClicked: root.refresh()
+                    },
+                    DankActionButton {
+                        iconName: root.showAddForm ? "close" : "add"
+                        iconColor: Theme.primary
+                        tooltipText: root.showAddForm ? I18n.tr("Close") : I18n.tr("Add Startup App")
+                        onClicked: root.showAddForm = !root.showAddForm
+                    }
+                ]
+
+                StyledText {
+                    width: parent.width
+                    text: I18n.tr("Applications that automatically start when you sign in.")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceVariantText
+                    wrapMode: Text.WordWrap
+                }
+
+                Column {
+                    width: parent.width
+                    spacing: Theme.spacingS
+                    visible: root.entries.length > 0
+
+                    Repeater {
+                        model: root.entries
+
+                        delegate: Rectangle {
+                            id: entryRow
+                            required property var modelData
+                            width: parent.width
+                            height: 64
+                            radius: Theme.cornerRadius
+                            color: Theme.floatingWindowFieldColor
+                            opacity: operationProcess.running && operationProcess.entryId === modelData.id ? 0.6 : 1
+
+                            Behavior on opacity {
+                                NumberAnimation {
+                                    duration: Theme.shortDuration
+                                    easing.type: Theme.standardEasing
+                                }
+                            }
+
+                            Image {
+                                id: entryIcon
+                                width: 32
+                                height: 32
+                                anchors.left: parent.left
+                                anchors.leftMargin: Theme.spacingM
+                                anchors.verticalCenter: parent.verticalCenter
+                                source: Paths.resolveIconUrl(entryRow.modelData.icon || "application-x-executable")
+                                sourceSize.width: 32
+                                sourceSize.height: 32
+                                fillMode: Image.PreserveAspectFit
+                                onStatusChanged: {
+                                    if (status === Image.Error)
+                                        source = "image://icon/application-x-executable";
+                                }
+                            }
+
+                            Column {
+                                anchors.left: entryIcon.right
+                                anchors.leftMargin: Theme.spacingM
+                                anchors.right: entryToggle.left
+                                anchors.rightMargin: Theme.spacingM
+                                anchors.verticalCenter: parent.verticalCenter
+                                spacing: Theme.spacingXXS
+
+                                StyledText {
+                                    width: parent.width
+                                    text: entryRow.modelData.name
+                                    font.pixelSize: Theme.fontSizeMedium
+                                    font.weight: Font.Medium
+                                    color: entryRow.modelData.enabled ? Theme.surfaceText : Theme.surfaceVariantText
+                                    maximumLineCount: 1
+                                    elide: Text.ElideRight
+                                    horizontalAlignment: Text.AlignLeft
+                                }
+
+                                StyledText {
+                                    width: parent.width
+                                    text: root.entryDescription(entryRow.modelData)
+                                    font.pixelSize: Theme.fontSizeSmall
+                                    color: Theme.surfaceVariantText
+                                    maximumLineCount: 1
+                                    elide: Text.ElideRight
+                                    horizontalAlignment: Text.AlignLeft
+                                }
+                            }
+
+                            DankToggle {
+                                id: entryToggle
+                                anchors.right: entryRemoveButton.visible ? entryRemoveButton.left : parent.right
+                                anchors.rightMargin: Theme.spacingM
+                                anchors.verticalCenter: parent.verticalCenter
+                                checked: entryRow.modelData.enabled
+                                enabled: entryRow.modelData.mutable && !operationProcess.running
+                                toggling: operationProcess.running && operationProcess.entryId === entryRow.modelData.id
+                                onToggled: checked => root.setEnabled(entryRow.modelData, checked)
+                            }
+
+                            DankActionButton {
+                                id: entryRemoveButton
+                                anchors.right: parent.right
+                                anchors.rightMargin: Theme.spacingS
+                                anchors.verticalCenter: parent.verticalCenter
+                                iconName: "delete"
+                                iconSize: 18
+                                buttonSize: 32
+                                iconColor: Theme.error
+                                tooltipText: I18n.tr("Remove")
+                                visible: entryRow.modelData.removable === true
+                                enabled: !operationProcess.running
+                                onClicked: root.removeEntry(entryRow.modelData)
+                            }
+                        }
+                    }
+                }
+
+                DankSpinner {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    visible: root.loading && root.entries.length === 0
+                    running: visible
+                }
+
+                StyledText {
+                    width: parent.width
+                    text: root.lastError
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.error
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                    visible: root.lastError.length > 0
+                }
+
+                StyledText {
+                    width: parent.width
+                    text: I18n.tr("No startup applications found")
+                    font.pixelSize: Theme.fontSizeMedium
+                    color: Theme.surfaceVariantText
+                    horizontalAlignment: Text.AlignHCenter
+                    visible: !root.loading && root.lastError.length === 0 && root.entries.length === 0
+                }
+            }
+
+            SettingsCard {
                 width: parent.width
                 iconName: "add_circle"
-                title: I18n.tr("Add Entry")
+                title: I18n.tr("Add Startup App")
+                settingKey: "autostartAddEntry"
+                tags: ["startup", "autostart", "add", "application", "command"]
+                visible: root.showAddForm
 
                 SettingsDropdownRow {
                     width: parent.width
@@ -387,9 +440,7 @@ Item {
                     description: I18n.tr("Choose whether to launch a desktop app or a command")
                     currentValue: root.newEntryType === "desktop" ? I18n.tr("Desktop Application") : I18n.tr("Command Line")
                     options: [I18n.tr("Desktop Application"), I18n.tr("Command Line")]
-                    onValueChanged: val => {
-                        root.newEntryType = val === I18n.tr("Desktop Application") ? "desktop" : "command";
-                    }
+                    onValueChanged: value => root.newEntryType = value === I18n.tr("Desktop Application") ? "desktop" : "command"
                 }
 
                 Column {
@@ -397,28 +448,12 @@ Item {
                     visible: root.newEntryType === "desktop"
                     spacing: Theme.spacingM
 
-                    Item {
+                    StyledText {
                         width: parent.width
-                        height: appLabelColumn.height
-
-                        Column {
-                            id: appLabelColumn
-                            anchors.verticalCenter: parent.verticalCenter
-                            spacing: Theme.spacingXS
-
-                            StyledText {
-                                text: I18n.tr("Application")
-                                font.pixelSize: Theme.fontSizeMedium
-                                font.weight: Font.Medium
-                                color: Theme.surfaceText
-                            }
-
-                            StyledText {
-                                text: I18n.tr("Select a desktop application")
-                                font.pixelSize: Theme.fontSizeSmall
-                                color: Theme.surfaceVariantText
-                            }
-                        }
+                        text: I18n.tr("Select an application")
+                        font.pixelSize: Theme.fontSizeMedium
+                        font.weight: Font.Medium
+                        color: Theme.surfaceText
                     }
 
                     Row {
@@ -426,61 +461,37 @@ Item {
                         spacing: Theme.spacingM
 
                         StyledRect {
+                            width: parent.width - browseButton.width - Theme.spacingM
                             height: 40
                             radius: Theme.cornerRadius
-                            color: root.newEntryDesktopId ? Theme.floatingWindowFieldColor : Theme.withAlpha(Theme.surfaceContainerHigh, Theme.floatingWindowForegroundLayers ? Theme.floatingWindowForegroundTransparency * 0.5 : 0)
-                            LayoutMirroring.enabled: I18n.isRtl
-                            LayoutMirroring.childrenInherit: true
-
-                            readonly property string selectedName: {
-                                if (!root.newEntryDesktopId)
-                                    return "";
-                                const app = root.desktopApps.find(a => (a.id || a.execString) === root.newEntryDesktopId);
-                                return app ? (app.name || app.id || "") : root.newEntryDesktopId;
-                            }
-
-                            width: parent.width - browseButton.width - Theme.spacingM
+                            color: Theme.floatingWindowFieldColor
 
                             Row {
                                 anchors.left: parent.left
                                 anchors.leftMargin: Theme.spacingM
+                                anchors.right: parent.right
+                                anchors.rightMargin: Theme.spacingM
                                 anchors.verticalCenter: parent.verticalCenter
                                 spacing: Theme.spacingM
-                                visible: root.newEntryDesktopId !== ""
 
                                 Image {
                                     width: 24
                                     height: 24
-                                    source: {
-                                        const app = root.desktopApps.find(a => (a.id || a.execString) === root.newEntryDesktopId);
-                                        return Paths.resolveIconUrl(app?.icon || "application-x-executable");
-                                    }
+                                    source: Paths.resolveIconUrl(root.selectedDesktopApp()?.icon || "application-x-executable")
                                     sourceSize.width: 24
                                     sourceSize.height: 24
                                     fillMode: Image.PreserveAspectFit
-                                    anchors.verticalCenter: parent.verticalCenter
-                                    onStatusChanged: {
-                                        if (status === Image.Error)
-                                            source = "image://icon/application-x-executable";
-                                    }
+                                    visible: root.newEntryDesktopId !== ""
                                 }
 
                                 StyledText {
-                                    text: parent.parent.selectedName
+                                    width: parent.width - (root.newEntryDesktopId !== "" ? 24 + Theme.spacingM : 0)
+                                    text: root.selectedDesktopApp()?.name || I18n.tr("No application selected")
                                     font.pixelSize: Theme.fontSizeMedium
-                                    color: Theme.surfaceText
-                                    anchors.verticalCenter: parent.verticalCenter
+                                    color: root.newEntryDesktopId ? Theme.surfaceText : Theme.surfaceVariantText
+                                    maximumLineCount: 1
+                                    elide: Text.ElideRight
                                 }
-                            }
-
-                            StyledText {
-                                anchors.left: parent.left
-                                anchors.leftMargin: Theme.spacingM
-                                anchors.verticalCenter: parent.verticalCenter
-                                text: I18n.tr("No application selected")
-                                font.pixelSize: Theme.fontSizeMedium
-                                color: Theme.surfaceVariantText
-                                visible: root.newEntryDesktopId === ""
                             }
                         }
 
@@ -492,28 +503,12 @@ Item {
                         }
                     }
 
-                    Item {
+                    StyledText {
                         width: parent.width
-                        height: wrapperLabelColumn.height
-
-                        Column {
-                            id: wrapperLabelColumn
-                            anchors.verticalCenter: parent.verticalCenter
-                            spacing: Theme.spacingXS
-
-                            StyledText {
-                                text: I18n.tr("Command")
-                                font.pixelSize: Theme.fontSizeMedium
-                                font.weight: Font.Medium
-                                color: Theme.surfaceText
-                            }
-
-                            StyledText {
-                                text: I18n.tr("Wrap the app command. %command% is replaced with the actual executable")
-                                font.pixelSize: Theme.fontSizeSmall
-                                color: Theme.surfaceVariantText
-                            }
-                        }
+                        text: I18n.tr("Command")
+                        font.pixelSize: Theme.fontSizeMedium
+                        font.weight: Font.Medium
+                        color: Theme.surfaceText
                     }
 
                     DankTextField {
@@ -529,28 +524,11 @@ Item {
                     visible: root.newEntryType === "command"
                     spacing: Theme.spacingM
 
-                    Item {
-                        width: parent.width
-                        height: labelColumn.height
-
-                        Column {
-                            id: labelColumn
-                            anchors.verticalCenter: parent.verticalCenter
-                            spacing: Theme.spacingXS
-
-                            StyledText {
-                                text: I18n.tr("Name")
-                                font.pixelSize: Theme.fontSizeMedium
-                                font.weight: Font.Medium
-                                color: Theme.surfaceText
-                            }
-
-                            StyledText {
-                                text: I18n.tr("Display name for this entry")
-                                font.pixelSize: Theme.fontSizeSmall
-                                color: Theme.surfaceVariantText
-                            }
-                        }
+                    StyledText {
+                        text: I18n.tr("Name")
+                        font.pixelSize: Theme.fontSizeMedium
+                        font.weight: Font.Medium
+                        color: Theme.surfaceText
                     }
 
                     DankTextField {
@@ -560,28 +538,11 @@ Item {
                         onTextChanged: root.newEntryName = text
                     }
 
-                    Item {
-                        width: parent.width
-                        height: labelColumn2.height
-
-                        Column {
-                            id: labelColumn2
-                            anchors.verticalCenter: parent.verticalCenter
-                            spacing: Theme.spacingXS
-
-                            StyledText {
-                                text: I18n.tr("Command")
-                                font.pixelSize: Theme.fontSizeMedium
-                                font.weight: Font.Medium
-                                color: Theme.surfaceText
-                            }
-
-                            StyledText {
-                                text: I18n.tr("Full command to execute")
-                                font.pixelSize: Theme.fontSizeSmall
-                                color: Theme.surfaceVariantText
-                            }
-                        }
+                    StyledText {
+                        text: I18n.tr("Command")
+                        font.pixelSize: Theme.fontSizeMedium
+                        font.weight: Font.Medium
+                        color: Theme.surfaceText
                     }
 
                     DankTextField {
@@ -594,174 +555,19 @@ Item {
 
                 StyledText {
                     width: parent.width
-                    text: I18n.tr("These add entries to the XDG autostart directory (~/.config/autostart/*.desktop)")
+                    text: I18n.tr("This creates an XDG startup entry for your user.")
                     font.pixelSize: Theme.fontSizeSmall
                     color: Theme.surfaceVariantText
                     wrapMode: Text.WordWrap
                     horizontalAlignment: Text.AlignHCenter
                 }
 
-                Item {
-                    width: parent.width
-                    height: Theme.spacingM
-                }
-
                 DankButton {
                     anchors.horizontalCenter: parent.horizontalCenter
-                    text: I18n.tr("Add to Autostart")
+                    text: I18n.tr("Add Startup App")
                     iconName: "add"
-                    enabled: {
-                        if (root.newEntryType === "desktop")
-                            return root.newEntryDesktopId !== "";
-                        return root.newEntryName !== "" && root.newEntryExec !== "";
-                    }
+                    enabled: !operationProcess.running && (root.newEntryType === "desktop" ? root.newEntryDesktopId !== "" : root.newEntryName.trim() !== "" && root.newEntryExec.trim() !== "")
                     onClicked: root.addEntry()
-                }
-            }
-
-            SettingsCard {
-                id: entriesCard
-                width: parent.width
-                iconName: "line_start"
-                title: I18n.tr("Autostart Entries")
-                settingKey: "autostartEntries"
-                collapsible: true
-                expanded: true
-
-                Row {
-                    width: parent.width
-                    spacing: Theme.spacingM
-
-                    StyledText {
-                        width: parent.width - clearAllButton.width - Theme.spacingM
-                        text: I18n.tr("Applications and commands to start automatically when you log in")
-                        font.pixelSize: Theme.fontSizeSmall
-                        color: Theme.surfaceVariantText
-                        wrapMode: Text.WordWrap
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-
-                    DankActionButton {
-                        id: clearAllButton
-                        iconName: "delete_sweep"
-                        iconSize: Theme.iconSize - 2
-                        iconColor: Theme.error
-                        anchors.verticalCenter: parent.verticalCenter
-                        onClicked: {
-                            for (let i = 0; i < root.entries.length; i++) {
-                                root.removeEntry(root.entries[i].filePath);
-                            }
-                        }
-                    }
-                }
-
-                Column {
-                    id: entriesList
-                    width: parent.width
-                    spacing: Theme.spacingS
-
-                    Repeater {
-                        model: root.entries
-
-                        delegate: Rectangle {
-                            width: entriesList.width
-                            height: 48
-                            radius: Theme.cornerRadius
-                            color: Theme.floatingWindowFieldColor
-                            border.width: 0
-
-                            Row {
-                                anchors.left: parent.left
-                                anchors.right: entryToggle.left
-                                anchors.leftMargin: Theme.spacingM
-                                anchors.rightMargin: Theme.spacingM
-                                anchors.verticalCenter: parent.verticalCenter
-                                spacing: Theme.spacingM
-
-                                StyledText {
-                                    text: (index + 1).toString()
-                                    font.pixelSize: Theme.fontSizeSmall
-                                    font.weight: Font.Medium
-                                    color: Theme.primary
-                                    width: 20
-                                    anchors.verticalCenter: parent.verticalCenter
-                                }
-
-                                Image {
-                                    width: 24
-                                    height: 24
-                                    source: Paths.resolveIconUrl(modelData.icon || "application-x-executable")
-                                    sourceSize.width: 24
-                                    sourceSize.height: 24
-                                    fillMode: Image.PreserveAspectFit
-                                    anchors.verticalCenter: parent.verticalCenter
-                                    onStatusChanged: {
-                                        if (status === Image.Error)
-                                            source = "image://icon/application-x-executable";
-                                    }
-                                }
-
-                                Column {
-                                    width: parent.width - 20 - 24 - Theme.spacingM * 2
-                                    anchors.verticalCenter: parent.verticalCenter
-                                    spacing: Theme.spacingXXS
-
-                                    StyledText {
-                                        width: parent.width
-                                        text: modelData.name
-                                        font.pixelSize: Theme.fontSizeMedium
-                                        font.weight: Font.Medium
-                                        color: modelData.hidden ? Theme.surfaceVariantText : Theme.surfaceText
-                                        maximumLineCount: 1
-                                        elide: Text.ElideRight
-                                        horizontalAlignment: Text.AlignLeft
-                                        opacity: modelData.hidden ? 0.6 : 1.0
-                                    }
-
-                                    StyledText {
-                                        width: parent.width
-                                        text: modelData.hidden ? I18n.tr("Disabled") : modelData.exec
-                                        font.pixelSize: Theme.fontSizeSmall
-                                        color: Theme.surfaceVariantText
-                                        maximumLineCount: 1
-                                        elide: Text.ElideRight
-                                        horizontalAlignment: Text.AlignLeft
-                                    }
-                                }
-                            }
-
-                            DankToggle {
-                                id: entryToggle
-                                anchors.right: entryRemoveButton.left
-                                anchors.rightMargin: Theme.spacingS
-                                anchors.verticalCenter: parent.verticalCenter
-                                checked: !modelData.hidden
-                                onToggled: checked => root.setHidden(modelData, !checked)
-                            }
-
-                            DankActionButton {
-                                id: entryRemoveButton
-                                anchors.right: parent.right
-                                anchors.rightMargin: Theme.spacingS
-                                anchors.verticalCenter: parent.verticalCenter
-                                iconName: "close"
-                                iconSize: 16
-                                buttonSize: 32
-                                circular: true
-                                iconColor: Theme.error
-                                onClicked: root.removeEntry(modelData.filePath)
-                            }
-                        }
-                    }
-
-                    StyledText {
-                        width: parent.width
-                        text: I18n.tr("No autostart entries")
-                        font.pixelSize: Theme.fontSizeMedium
-                        color: Theme.surfaceVariantText
-                        horizontalAlignment: Text.AlignHCenter
-                        visible: root.entries.length === 0
-                    }
                 }
             }
 
@@ -773,24 +579,19 @@ Item {
                 title: I18n.tr("Tray Icon Fix")
                 visible: DesktopService.isSystemd
 
-                Column {
+                StyledText {
                     width: parent.width
-                    spacing: Theme.spacingM
+                    text: I18n.tr("If autostart app icons don't appear in the system tray, generate a systemd override to ensure DMS starts before autostart apps")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceVariantText
+                    wrapMode: Text.WordWrap
+                }
 
-                    StyledText {
-                        width: parent.width
-                        text: I18n.tr("If autostart app icons don't appear in the system tray, generate a systemd override to ensure DMS starts before autostart apps")
-                        font.pixelSize: Theme.fontSizeSmall
-                        color: Theme.surfaceVariantText
-                        wrapMode: Text.WordWrap
-                    }
-
-                    DankButton {
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        text: I18n.tr("Generate Override")
-                        iconName: "build"
-                        onClicked: root.generateTrayIconFixSystemdOverride()
-                    }
+                DankButton {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: I18n.tr("Generate Override")
+                    iconName: "build"
+                    onClicked: root.generateTrayIconFixSystemdOverride()
                 }
             }
         }

--- a/quickshell/Services/DesktopService.qml
+++ b/quickshell/Services/DesktopService.qml
@@ -14,9 +14,6 @@ Singleton {
     property var _cache: ({})
 
     property bool isSystemd: false
-    property bool systemdAutostartTargetActive: false
-    property bool systemdAutostartTargetChecked: false
-    readonly property bool autostartAvailable: root.systemdAutostartTargetChecked && (!root.isSystemd || root.systemdAutostartTargetActive)
 
     Component.onCompleted: {
         Paths.desktopIconResolver = name => resolveIconPath(name);
@@ -28,25 +25,7 @@ Singleton {
         command: ["sh", "-c", "cat /proc/1/comm 2>/dev/null | tr -d '\\n'"]
         running: false
         stdout: StdioCollector {
-            onStreamFinished: {
-                root.isSystemd = (text || "").trim() === "systemd";
-                if (!root.isSystemd)
-                    root.systemdAutostartTargetChecked = true;
-                else
-                    systemdAutostartTargetCheck.running = true;
-            }
-        }
-    }
-
-    Process {
-        id: systemdAutostartTargetCheck
-        command: ["systemctl", "--user", "is-active", "xdg-desktop-autostart.target"]
-        running: false
-        stdout: StdioCollector {
-            onStreamFinished: {
-                root.systemdAutostartTargetActive = (text || "").trim() === "active";
-                root.systemdAutostartTargetChecked = true;
-            }
+            onStreamFinished: root.isSystemd = (text || "").trim() === "systemd"
         }
     }
 

--- a/quickshell/translations/extract_settings_index.py
+++ b/quickshell/translations/extract_settings_index.py
@@ -90,7 +90,7 @@ CATEGORY_KEYWORDS = {
     "Dank Island": ["island", "activities", "dynamic island"],
     "Default Apps": ["browser", "terminal", "handlers", "mime"],
     "Users": ["accounts", "user", "profile"],
-    "Autostart": ["startup", "launch", "boot"],
+    "Startup Apps": ["autostart", "launch", "login", "programs"],
 }
 
 TAB_INDEX_MAP = {
@@ -189,7 +189,7 @@ TAB_CATEGORY_MAP = {
     33: "Frame",
     34: "Default Apps",
     35: "Users",
-    36: "Autostart Apps",
+    36: "Startup Apps",
     37: "Personalization",
     38: "Applications",
     39: "Network",

--- a/quickshell/translations/settings_search_index.json
+++ b/quickshell/translations/settings_search_index.json
@@ -10416,18 +10416,21 @@
   },
   {
     "section": "autostartAddEntry",
-    "label": "Add Entry",
+    "label": "Add Startup App",
     "tabIndex": 36,
-    "category": "Autostart Apps",
+    "category": "Startup Apps",
     "keywords": [
       "add",
+      "app",
+      "application",
       "apps",
       "autostart",
       "choose",
       "command",
       "desktop",
-      "entry",
       "launch",
+      "login",
+      "programs",
       "startup",
       "whether"
     ],
@@ -10435,39 +10438,36 @@
     "description": "Choose whether to launch a desktop app or a command"
   },
   {
-    "section": "_tab_36",
-    "label": "Autostart Apps",
-    "tabIndex": 36,
-    "category": "Autostart Apps",
-    "keywords": [
-      "apps",
-      "autostart"
-    ],
-    "icon": "line_start"
-  },
-  {
     "section": "autostartEntries",
-    "label": "Autostart Entries",
+    "label": "Startup Apps",
     "tabIndex": 36,
-    "category": "Autostart Apps",
+    "category": "Startup Apps",
     "keywords": [
+      "applications",
       "apps",
       "autostart",
-      "entries"
+      "launch",
+      "login",
+      "programs",
+      "startup"
     ],
-    "icon": "line_start"
+    "icon": "rocket_launch"
   },
   {
     "section": "autostartTrayIconFix",
     "label": "Tray Icon Fix",
     "tabIndex": 36,
-    "category": "Autostart Apps",
+    "category": "Startup Apps",
     "keywords": [
       "apps",
       "autostart",
       "fix",
       "icon",
       "icons",
+      "launch",
+      "login",
+      "programs",
+      "startup",
       "systemd",
       "tray"
     ],


### PR DESCRIPTION
## Summary

Add a Startup Apps page that manages normal per-user login applications without exposing DMS or desktop/session infrastructure as a generic service manager.

- list and toggle XDG autostart entries from user and system configuration directories
- disable system XDG entries through user overrides without modifying `/etc`
- list only conservatively classified user-facing systemd application services
- change systemd enablement without `--now`, so running applications are not started or stopped
- add and remove DMS-created user XDG startup entries
- refresh while the page is open and integrate the page with Settings search

## Safety

Systemd units are excluded by default. A service must be a persistent, loaded `.service`, use an allowed login target, avoid protected identities and critical session dependencies, and match a visible desktop application. Socket, timer, target, template, transient, generated, masked, static, DMS, compositor, audio, bus, portal, keyring, and session infrastructure is rejected.

The backend repeats classification before every systemd mutation. Protected entries therefore cannot be changed by calling the CLI directly. User-authored XDG files can be toggled but only entries created by DMS can be deleted.

## Validation

- `go test ./internal/startup ./cmd/dms`
- `go test -race ./internal/startup`
- `go vet ./internal/startup ./cmd/dms`
- `golangci-lint v2.13.1 run ./...` — 0 issues
- `make build`
- settings search-index generation and validation
- QML parse/syntax checks with Qt 6 `qmlformat` and `qmllint`
- live DMS smoke test: page load, search data, application discovery, and protected direct mutation

The complete `go test ./...` run passes Startup Apps and the rest of the reported packages, but still hits the existing unrelated `internal/screenshot` `TestWaylandOutputBoundsScaled` failure. `make test-qml` could not run locally because `qmltestrunner` is not installed.

