### PR TITLE
settings: add support for multiple config files

### DIFF
--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -89,7 +89,6 @@ Singleton {
     property bool _pluginParseError: false
     property bool _hasLoaded: false
     property bool _isReadOnly: false
-    property bool _hasUnsavedChanges: false
     property bool _selfWrite: false
     property var _loadedSettingsSnapshot: null
     property var pluginSettings: ({})
@@ -1788,7 +1787,6 @@ Singleton {
     function loadSettings() {
         _loading = true;
         _parseError = false;
-        _hasUnsavedChanges = false;
         _pendingMigration = null;
 
         try {
@@ -1908,12 +1906,10 @@ Singleton {
         const wasReadOnly = _isReadOnly;
         _isReadOnly = !writable;
         if (_isReadOnly) {
-            _hasUnsavedChanges = _checkForUnsavedChanges();
             if (!wasReadOnly)
                 log.info("settings.json is now read-only");
         } else {
             _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
-            _hasUnsavedChanges = false;
             if (wasReadOnly)
                 log.info("settings.json is now writable");
             if (_pendingMigration)
@@ -3533,7 +3529,6 @@ Singleton {
 
     function _registerSaveFailure() {
         root._isReadOnly = Object.values(settingFiles).some(file => file.isReadOnly)
-        root._hasUnsavedChanges = root._checkForUnsavedChanges();
     }
 
     function _mitigateLoadFailure() {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3681,6 +3681,10 @@ Singleton {
         repeat: false
         running: false
         onTriggered: {
+            if (!configDirExists.checked) {
+                restart();
+                return;
+            }
             if (!configDirExists.exists) {
                 return;
             }
@@ -3734,6 +3738,9 @@ Singleton {
         // qmllint disable signal-handler-parameters
         onExited: (code) => {
             exists = code === 0;
+            if (exists) {
+                settingsFilesModelSyncDebounce.restart();
+            }
             checked = true;
             _checkIfAllSettingsFilesFound()
         }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3578,7 +3578,6 @@ Singleton {
                     const txt = settingsFileView.text();
                     if (!txt || !txt.trim()) {
                         hasParseFailed = true;
-                        settingsFile.parseError();
                         return;
                     }
                     settingsFile.settings = JSON.parse(txt);

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1792,7 +1792,7 @@ Singleton {
         _loading = true;
 
         try {
-            let obj = getSettingsObject();
+            let obj = _getSettingsObjectFromFiles();
             let loadedSettings = JSON.stringify(obj);
 
             if (isInitial) {
@@ -3637,7 +3637,7 @@ Singleton {
             _startAfterSettingsFilesFound();
         }
     }
-    function getSettingsObject() {
+    function _getSettingsObjectFromFiles() {
         const settingsObject = {};
         for (const path of _settingsFilesPaths) {
             const settingsFile = _settingsFiles.get(path);

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3462,6 +3462,7 @@ Singleton {
     function getSettingsObject() {
         const settingsObject = {};
         Object.assign(settingsObject, ...Object.values(loadedSettings));
+        return settingsObject;
     }
     function fileLoaded(fileName, obj) {
         loadedSettings[fileName] = obj;
@@ -3476,7 +3477,7 @@ Singleton {
         }
 
         if (allLoaded()) {
-            Store.parse(root, obj)
+            Store.parse(root, getSettingsObject())
             _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
             _hasLoaded = true;
             applyStoredTheme();

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3476,13 +3476,11 @@ Singleton {
             SessionData.saveSettings();
         }
 
-        if (allLoaded()) {
-            Store.parse(root, getSettingsObject())
-            _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
-            _hasLoaded = true;
-            applyStoredTheme();
-            updateCompositorCursor();
-        }
+        Store.parse(root, getSettingsObject())
+        _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
+        _hasLoaded = allLoaded();
+        applyStoredTheme();
+        updateCompositorCursor();
     }
 
 

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3490,6 +3490,66 @@ Singleton {
         id: rightWidgetsModel
     }
 
+    function _udpateSettingsAfterReload(file) {
+        try {
+            const filesArray = Object.values(settingFiles);
+            _loading = filesArray.every(file => file.isLoaded && !file.loading);
+            if (_parseError) {
+                _parseError = filesArray.some(file => file.hasParseFailed);
+            }
+
+            const prevFrameEnabled = frameEnabled;
+            const prevFrameMode = frameMode;
+
+            const loadedSettings = file.settings;
+
+            if (loadedSettings.weatherLocation !== undefined) {
+                _legacyWeatherLocation = loadedSettings.weatherLocation;
+            }
+            if (loadedSettings.weatherCoordinates !== undefined) {
+                _legacyWeatherCoordinates = loadedSettings.weatherCoordinates;
+            }
+            if (loadedSettings.vpnLastConnected !== undefined && loadedSettings.vpnLastConnected !== "") {
+                _legacyVpnLastConnected = loadedSettings.vpnLastConnected;
+                SessionData.vpnLastConnected = _legacyVpnLastConnected;
+                SessionData.saveSettings();
+            }
+
+            Store.parse(root, getSettingsObject())
+
+            _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
+            applyStoredTheme();
+            updateCompositorCursor();
+
+            if (_hasLoaded) {
+                // External edits reload under _loading, which skips the per-property transition triggers
+                const frameChanged = (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode));
+                if (!_parseError && frameChanged) {
+                    updateFrameCompositorLayout();
+                }
+            } else {
+                _hasLoaded = Object.values(settingFiles).every(file => file.hasLoaded);
+            }
+        } catch (error) {
+            const msg = error.message;
+            log.error(`Failed to reload ${file.filePath} - file will not be overwritten. Error:`, msg);
+            Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg("settings.json"), msg));
+        }
+    }
+
+    function _diagnoseSaveFailure() {
+        root._isReadOnly = Object.values(settingFiles).some(file => file.isReadOnly)
+        root._hasUnsavedChanges = root._checkForUnsavedChanges();
+    }
+
+    function _mitigateLoadFailure() {
+        if (isGreeterMode) {
+            return;
+        }
+        applyStoredTheme();
+    }
+
+
     component SettingsFile : QtObject {
         id: settingsFile
 
@@ -3572,65 +3632,6 @@ Singleton {
             }
         }
         return settingsObject;
-    }
-
-    function _udpateSettingsAfterReload(file) {
-        try {
-            const filesArray = Object.values(settingFiles);
-            _loading = filesArray.every(file => file.isLoaded && !file.loading);
-            if (_parseError) {
-                _parseError = filesArray.some(file => file.hasParseFailed);
-            }
-
-            const prevFrameEnabled = frameEnabled;
-            const prevFrameMode = frameMode;
-
-            const loadedSettings = file.settings;
-
-            if (loadedSettings.weatherLocation !== undefined) {
-                _legacyWeatherLocation = loadedSettings.weatherLocation;
-            }
-            if (loadedSettings.weatherCoordinates !== undefined) {
-                _legacyWeatherCoordinates = loadedSettings.weatherCoordinates;
-            }
-            if (loadedSettings.vpnLastConnected !== undefined && loadedSettings.vpnLastConnected !== "") {
-                _legacyVpnLastConnected = loadedSettings.vpnLastConnected;
-                SessionData.vpnLastConnected = _legacyVpnLastConnected;
-                SessionData.saveSettings();
-            }
-
-            Store.parse(root, getSettingsObject())
-
-            _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
-            applyStoredTheme();
-            updateCompositorCursor();
-
-            if (_hasLoaded) {
-                // External edits reload under _loading, which skips the per-property transition triggers
-                const frameChanged = (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode));
-                if (!_parseError && frameChanged) {
-                    updateFrameCompositorLayout();
-                }
-            } else {
-                _hasLoaded = Object.values(settingFiles).every(file => file.hasLoaded);
-            }
-        } catch (error) {
-            const msg = error.message;
-            log.error(`Failed to reload ${file.filePath} - file will not be overwritten. Error:`, msg);
-            Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg("settings.json"), msg));
-        }
-    }
-
-    function _diagnoseSaveFailure() {
-        root._isReadOnly = Object.values(settingFiles).some(file => file.isReadOnly)
-        root._hasUnsavedChanges = root._checkForUnsavedChanges();
-    }
-
-    function _mitigateLoadFailure() {
-        if (isGreeterMode) {
-            return;
-        }
-        applyStoredTheme();
     }
 
     SettingsFile {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1909,8 +1909,18 @@ Singleton {
         }
     }
 
+    function _getCurrentSettings() {
+        const setKeys = new Set();
+        for (const path of _settingsFilesPaths) {
+            const file = _settingsFiles.get(path);
+            for (const key in file.settings) {
+                setKeys.add(key);
+            }
+        }
+        return Store.toJson(root, setKeys);
+    }
     function getCurrentSettingsJson() {
-        return JSON.stringify(Store.toJson(root), null, 2);
+        return JSON.stringify(_getCurrentSettings(), null, 2);
     }
 
     function _resetPluginSettings() {
@@ -2001,7 +2011,7 @@ Singleton {
         settingsSaveDebounce.restart();
     }
     function _saveSettings() {
-        const settings = Store.toJson(root);
+        const settings = _getCurrentSettings();
         const splitSettings = _splitSettingsByFile(settings);
         for (const path in splitSettings) {
             const fileSettings = splitSettings[path];

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1995,10 +1995,41 @@ Singleton {
     }
 
     function saveSettings() {
-        if (_loading || _parseError || !_hasLoaded)
+        try {
+            if (_loading || _parseError || !_hasLoaded)
             return;
-        _selfWrite = true;
-        settingsFile.setText(JSON.stringify(Store.toJson(root), null, 2));
+            _selfWrite = true;
+            const settings = Store.toJson(root);
+            const loadedFiles = Object.keys(loadedSettings);
+
+            // Reverse order ensures only the effective value will get overwritten.
+            loadedFiles.reverse()
+            for (const file of loadedFiles) {
+                const settingsToSave = {};
+                for (const setting of Object.keys(loadedSettings[file] || {})) {
+                    if (settings[setting] === undefined) continue;
+                    settingsToSave[setting] = settings[setting];
+                    settings[setting] = undefined;
+                }
+            }
+
+            const leftoverSettings = {};
+            const leftovers = false;
+            for (let setting in Object.keys(settings)) {
+                if (settings[setting] !== undefined) {
+                    leftoverSettings[setting] = settings[setting];
+                    leftovers = true;
+                }
+            }
+
+            if (leftovers) {
+                fileViews["default.json"].setText(JSON.stringify(settingsToSave, null, 2));
+            }
+
+        } catch (e) {
+            log.error(`Failed to save settings at ${e.lineNumber}`, e)
+        }
+
         if (_isReadOnly)
             _checkSettingsWritable();
     }
@@ -3456,6 +3487,7 @@ Singleton {
     }
 
     property var loadedSettings: ({})
+    property var fileViews: ({})
     function allLoaded() {
         return Object.keys(loadedSettings).length >= settingsFolderModel.count;
     }
@@ -3538,6 +3570,7 @@ Singleton {
                         const obj = JSON.parse(txt);
                         _parseError = false;
                         fileLoaded(fileName, obj);
+                        fileViews[fileName] = settingsFile;
                     } catch (e) {
                         _parseError = true;
                         const msg = e.message;

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3561,7 +3561,6 @@ Singleton {
                 }
                 isLoading = true;
                 _loading = true;
-                _settingsFilesLoading = true
                 const hadParseFailed = hasParseFailed;
                 hasParseFailed = false;
                 try {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3595,7 +3595,11 @@ Singleton {
             });
         }
         _settingsFiles.set(filePath, file);
-        _settingsFilesPaths.splice(index, 0, filePath);
+        if (index >= 0) {
+            _settingsFilesPaths.splice(index, 0, filePath);
+        } else {
+            _settingsFilesPaths.push(filePath);
+        }
         _checkIfAllSettingsFilesFound();
     }
     function _unregisterSettingsFile(file) {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -89,6 +89,7 @@ Singleton {
     property bool _pluginParseError: false
     property bool _hasLoaded: false
     property bool _allSettingsFilesLoaded: false
+    property bool isReadOnly: false
     property var pluginSettings: ({})
     property var builtInPluginSettings: ({})
 
@@ -3486,6 +3487,7 @@ Singleton {
         property bool hasLoaded: false
         property bool hasParseFailed: false
         property bool hasUnsavedChanges: false
+        property bool isFileReadOnly: false
         property bool selfWrite: false
         function setSettings(newSettings) {
             const newSettingsJson = JSON.stringify(newSettings, null, 2);
@@ -3579,15 +3581,26 @@ Singleton {
                 }
             }
             onSaved: {
+                const filesArray = Array.from(_settingsFiles.values());
                 hasUnsavedChanges = false;
+                hasUnsavedChanges = filesArray.every(file => !file.hasUnsavedChanges);
+                isFileReadOnly = false;
+                isReadOnly = filesArray.every(file => !file.isFileReadOnly)
+
                 const fileName = filePath?.split("/").pop() || "unknown";
                 if (_failedSaveSettingsFiles.has(settingsFile)) {
                     log.info(`Settings file '${fileName}' saved successfully after previous failures`)
                     _failedSaveSettingsFiles.delete(settingsFile);
                 }
             }
-            onSaveFailed: {
+            onSaveFailed: (error) => {
+                if (error === FileViewError.PermissionDenied) {
+                    isFileReadOnly = true;
+                    isReadOnly = true;
+                }
                 _failedSaveSettingsFiles.add(settingsFile);
+                const fileName = filePath?.split("/").pop() || "unknown";
+                log.warn(`Failed to save ${fileName}, retrying...`)
                 settingsSaveFailRecovery.start();
             }
             onLoadFailed: {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1787,7 +1787,6 @@ Singleton {
     function loadSettings() {
         _loading = true;
         _parseError = false;
-        _pendingMigration = null;
 
         try {
             let obj = getSettingsObject();
@@ -1799,7 +1798,6 @@ Singleton {
             if (oldVersion < settingsConfigVersion) {
                 const migrated = Store.migrateToVersion(obj, settingsConfigVersion);
                 if (migrated) {
-                    _pendingMigration = migrated;
                     obj = migrated;
                 }
             }
@@ -1874,8 +1872,6 @@ Singleton {
         Qt.callLater(() => _reconcileConnectedFrameBarStyles());
     }
 
-    property var _pendingMigration: null
-
     function _mergeSessionState() {
         if (!_hasLoaded || !SessionData._hasLoaded)
             return;
@@ -1912,10 +1908,7 @@ Singleton {
             _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
             if (wasReadOnly)
                 log.info("settings.json is now writable");
-            if (_pendingMigration)
-                settingsFile.setText(JSON.stringify(_pendingMigration, null, 2));
         }
-        _pendingMigration = null;
     }
 
     function _checkForUnsavedChanges() {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1784,7 +1784,7 @@ Singleton {
     }
 
     function _loadSettings() {
-        const isInitial = _hasLoaded;
+        const isInitial = !_hasLoaded;
         if (!_allSettingsFilesLoaded || _parseError) {
             return;
         }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1794,6 +1794,7 @@ Singleton {
 
         try {
             let obj = getSettingsObject();
+            let loadedSettings = JSON.stringify(obj);
 
             if (isInitial) {
                 const oldVersion = obj?.configVersion ?? 0;
@@ -1822,8 +1823,9 @@ Singleton {
                 if (obj?.lockScreenActiveMonitor !== undefined) {
                     var oldVal = obj.lockScreenActiveMonitor;
                     if (oldVal && oldVal !== "all") {
-                        if (!obj.screenPreferences)
-                        obj.screenPreferences = {};
+                        if (!obj.screenPreferences) {
+                            obj.screenPreferences = {};
+                        }
                         if (obj.screenPreferences.lockScreen === undefined) {
                             obj.screenPreferences.lockScreen = [oldVal];
                         }
@@ -1839,7 +1841,7 @@ Singleton {
 
             const prevFrameEnabled = frameEnabled;
             const prevFrameMode = frameMode;
-
+            const unsavedChanges = loadedSettings !== JSON.stringify(obj);
             Store.parse(root, obj);
 
             // set() enforces this pair, but a hand-edited settings.json bypasses set() entirely.
@@ -1866,7 +1868,6 @@ Singleton {
             if (isInitial) {
                 _mergeSessionState();
                 Qt.callLater(checkIconThemeDrift);
-                _checkSettingsWritable();
             }
             applyStoredTheme();
             updateCompositorCursor();
@@ -1876,6 +1877,9 @@ Singleton {
                 if (!_parseError && frameChanged) {
                     updateFrameCompositorLayout();
                 }
+            }
+            if (unsavedChanges) {
+                saveSettings();
             }
 
         } catch (e) {
@@ -1913,30 +1917,6 @@ Singleton {
         function onLoaded() {
             root._mergeSessionState();
         }
-    }
-
-    function _checkSettingsWritable() {
-        settingsWritableCheckProcess.running = true;
-    }
-
-    function _onWritableCheckComplete(writable) {
-        const wasReadOnly = _isReadOnly;
-        _isReadOnly = !writable;
-        if (_isReadOnly) {
-            if (!wasReadOnly)
-                log.info("settings.json is now read-only");
-        } else {
-            _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
-            if (wasReadOnly)
-                log.info("settings.json is now writable");
-        }
-    }
-
-    function _checkForUnsavedChanges() {
-        if (!_hasLoaded || !_loadedSettingsSnapshot)
-            return false;
-        const current = JSON.stringify(Store.toJson(root));
-        return current !== _loadedSettingsSnapshot;
     }
 
     function getCurrentSettingsJson() {
@@ -3521,10 +3501,13 @@ Singleton {
         property bool hasLoaded: false
         property bool hasParseFailed: false
         property bool isReadOnly: false
+        property bool hasUnsavedChanges: false
         property bool selfWrite: false
-        function setSettings(settings) {
+        function setSettings(newSettings) {
             selfWrite = true;
-            settingsFileView.setText(JSON.stringify(settings, null, 2));
+            hasUnsavedChanges = true;
+            settings = newSettings;
+            settingsFileView.setText(JSON.stringify(newSettings, null, 2));
         }
         function getSettings() {
             if (!hasLoaded) {
@@ -3559,6 +3542,10 @@ Singleton {
                 if (isGreeterMode) {
                     return;
                 }
+                if (hasUnsavedChanges) {
+                    log.warn("Ignoring settings file loaded event, there are unsaved changes which could've been lost.")
+                    return
+                }
                 isLoading = true;
                 _loading = true;
                 const hadParseFailed = hasParseFailed;
@@ -3590,6 +3577,9 @@ Singleton {
                         _loadSettings();
                     }
                 }
+            }
+            onSaved: {
+                hasUnsavedChanges = false;
             }
             onLoadFailed: {
                 _mitigateLoadFailure();
@@ -3692,37 +3682,4 @@ Singleton {
     }
 
     property bool pluginSettingsFileExists: false
-
-    Process {
-        id: settingsWritableCheckProcess
-
-        function checkWritable(file) {
-            fileQueue = fileQueue.concat(file);
-            if (!running) {
-                running = true;
-            }
-        }
-
-        property var fileQueue: ([])
-        property var file: fileQueue.length > 0 ? fileQueue[0] : null
-        property string filePath: {
-            if (file !== null) {
-                return Paths.strip(file.path);
-            }
-            return "";
-        }
-        command: ["sh", "-c", "[ ! -f \"" + filePath + "\" ] || [ -w \"" + filePath + "\" ] && echo 'writable' || echo 'readonly'"]
-        running: false
-
-        stdout: StdioCollector {
-            onStreamFinished: {
-                const result = text.trim();
-                root._onWritableCheckComplete(result === "writable");
-                fileQueue.shift();
-                if (fileQueue.length > 0) {
-                    settingsWritableCheckProcess.running = true
-                }
-            }
-        }
-    }
 }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3625,7 +3625,6 @@ Singleton {
     function _unregisterSettingsFile(file) {
         _settingsFiles.delete(file.filePath);
         _settingsFilesPaths = _settingsFilesPaths.filter(path => path != file.filePath);
-        _registeredFiles--;
     }
     function _checkIfAllSettingsFilesFound() {
         if (_allFilesRegistered || settingsFolderModel.status !== FolderListModel.Ready) {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3701,6 +3701,25 @@ Singleton {
             settingsFilesModelSyncDebounce.restart()
         }
     }
+    Process {
+        command: ["mkdir", "-p", Paths.strip(settingsFolderModel.folder)]
+        property string errorMsg: "";
+        stderr: StdioCollector {
+            onStreamFinished: {
+                errorMsg = text.trim();
+            }
+        }
+        running: true
+        // qmllint disable signal-handler-parameters
+        onExited: (code, _) => {
+            if (code !== 0) {
+                log.error(`Failed to create config.d directory, exited with code ${code}:`, errorMsg);
+            } else {
+                _checkIfAllSettingsFilesFound();
+            }
+
+        }
+    }
 
     Instantiator {
         id: settingsLoader

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3486,37 +3486,92 @@ Singleton {
         id: rightWidgetsModel
     }
 
-    property var loadedSettings: ({})
-    property var fileViews: ({})
-    function allLoaded() {
-        return Object.keys(loadedSettings).length >= settingsFolderModel.count;
-    }
-    function getSettingsObject() {
-        const settingsObject = {};
-        Object.assign(settingsObject, ...Object.values(loadedSettings));
-        return settingsObject;
-    }
-    function fileLoaded(fileName, obj) {
-        loadedSettings[fileName] = obj;
-        if (obj.weatherLocation !== undefined)
-        _legacyWeatherLocation = obj.weatherLocation;
-        if (obj.weatherCoordinates !== undefined)
-        _legacyWeatherCoordinates = obj.weatherCoordinates;
-        if (obj.vpnLastConnected !== undefined && obj.vpnLastConnected !== "") {
-            _legacyVpnLastConnected = obj.vpnLastConnected;
-            SessionData.vpnLastConnected = _legacyVpnLastConnected;
-            SessionData.saveSettings();
+    component SettingsFile : QtObject {
+        id: settingsFile
+
+        required property string filePath
+        property var settings: ({})
+        property bool isLoading: true
+        property bool hasLoaded: false
+        property bool hasParseFailed: false
+        property bool isReadOnly: false
+        signal loading()
+        signal loaded()
+        signal parseError()
+        signal saveFailed(error: FileViewError)
+        signal loadFailed(error: FileViewError)
+
+        property Timer timer: Timer {
+            id: settingsFileReloadDebounce
+            interval: 50
+            onTriggered: settingsFileView.reload()
+            repeat: false
         }
 
-        Store.parse(root, getSettingsObject())
-        _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
-        _hasLoaded = allLoaded();
-        applyStoredTheme();
-        updateCompositorCursor();
+        property FileView fileView: FileView {
+            id: settingsFileView
+
+            path: isGreeterMode ? "" : filePath
+            blockLoading: true
+            blockWrites: true
+            atomicWrites: true
+            watchChanges: !isGreeterMode
+            onFileChanged: {
+                if (_selfWrite) {
+                    _selfWrite = false;
+                    return;
+                }
+                settingsFileReloadDebounce.restart();
+            }
+            onLoaded: {
+                if (isGreeterMode) {
+                    return;
+                }
+                isLoading = true;
+                isReadOnly = false;
+                settingsFile.loading();
+                try {
+                    const txt = settingsFileView.text();
+                    if (!txt || !txt.trim()) {
+                        hasParseFailed = true;
+                        settingsFile.parseError();
+                        return;
+                    }
+                    settingsFile.settings = JSON.parse(txt);
+
+                    isLoading = false;
+                    hasLoaded = true;
+                    settingsFile.loaded();
+                } catch (error) {
+                    hasParseFailed = true;
+                    settingsFile.parseError();
+                    const msg = error.msg;
+                    Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
+                } finally {
+                    hasParseFailed = false;
+                }
+            }
+            onLoadFailed: settingsFile.loadFailed
+            onSaveFailed: (error) => {
+                isReadOnly = true;
+                settingsFile.readFailed(error);
+            }
+        }
     }
 
+    property var settingFiles: ({})
+    function getSettingsObject() {
+        const settingsObject = {};
+        for (const index in settingFiles) {
+            const settingFile = settingFiles[index];
+            if (settingFile.hasLoaded) {
+                Object.assign(settingsObject, settingFile.settings);
+            }
+        }
+        return settingsObject;
+    }
 
-    Repeater {
+    Instantiator {
         id: settingsLoader
 
         model: FolderListModel {
@@ -3526,72 +3581,71 @@ Singleton {
             nameFilters: ["*.json"]
         }
 
-        delegate: Item {
-            id: settingsFileViewWrapper
-            required property string filePath
-            required property string fileName
+        onObjectAdded: (index, file) => {
+            settingFiles[index + 1] = file;
+        }
 
-            Timer {
-                id: settingsFileReloadDebounce
-                interval: 50
-                onTriggered: settingsFile.reload()
-                repeat: false
+        onObjectRemoved: (index, file) => {
+            delete settingFiles[index + 1]
+        }
+
+        delegate: SettingsFile {
+            id: settingsFile
+
+            onLoading: {
+                _loading = true;
             }
-
-            FileView {
-                id: settingsFile
-
-                path: isGreeterMode ? "" : filePath
-                blockLoading: true
-                blockWrites: true
-                atomicWrites: true
-                watchChanges: !isGreeterMode
-                onFileChanged: {
-                    if (_selfWrite) {
-                        _selfWrite = false;
-                        return;
-                    }
-                    settingsFileReloadDebounce.restart();
+            onLoaded: {
+                _loading = Object.values(settingFiles).every(file => file.isLoaded && !file.loading);
+                if (_parseError) {
+                    _parseError = Object.values(settingFiles).some(file => file.hasParseFailed);
                 }
-                onLoaded: {
-                    if (isGreeterMode)
-                    return;
-                    const wasLoaded = _hasLoaded;
-                    const prevFrameEnabled = frameEnabled;
-                    const prevFrameMode = frameMode;
-                    _loading = true;
-                    _hasUnsavedChanges = false;
-                    try {
-                        const txt = settingsFile.text();
-                        if (!txt || !txt.trim()) {
-                            _parseError = true;
-                            return;
-                        }
-                        const obj = JSON.parse(txt);
-                        _parseError = false;
-                        fileLoaded(fileName, obj);
-                        fileViews[fileName] = settingsFile;
-                    } catch (e) {
-                        _parseError = true;
-                        const msg = e.message;
-                        log.error(`Failed to reload ${fileName} - file will not be overwritten. Error:`, msg);
-                        Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
-                    } finally {
-                        _loading = false;
-                    }
+
+                const prevFrameEnabled = frameEnabled;
+                const prevFrameMode = frameMode;
+
+                const loadedSettings = settingsFile.settings;
+
+                if (loadedSettings.weatherLocation !== undefined) {
+                    _legacyWeatherLocation = loadedSettings.weatherLocation;
+                }
+                if (loadedSettings.weatherCoordinates !== undefined) {
+                    _legacyWeatherCoordinates = loadedSettings.weatherCoordinates;
+                }
+                if (loadedSettings.vpnLastConnected !== undefined && loadedSettings.vpnLastConnected !== "") {
+                    _legacyVpnLastConnected = loadedSettings.vpnLastConnected;
+                    SessionData.vpnLastConnected = _legacyVpnLastConnected;
+                    SessionData.saveSettings();
+                }
+
+                Store.parse(root, getSettingsObject())
+
+                _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
+                applyStoredTheme();
+                updateCompositorCursor();
+
+                if (_hasLoaded) {
                     // External edits reload under _loading, which skips the per-property transition triggers
-                    if (wasLoaded && !_parseError && (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode)))
-                    updateFrameCompositorLayout();
+                    const frameChanged = (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode));
+                    if (!_parseError && frameChanged) {
+                        updateFrameCompositorLayout();
+                    }
+                } else {
+                    _hasLoaded = Object.values(settingFiles).every(file => file.hasLoaded);
                 }
-                onLoadFailed: error => {
-                    if (isGreeterMode)
+            }
+            onParseError: {
+                _parseError = true;
+            }
+            onLoadFailed: error => {
+                if (isGreeterMode) {
                     return;
-                    applyStoredTheme();
                 }
-                onSaveFailed: error => {
-                    root._isReadOnly = true;
-                    root._hasUnsavedChanges = root._checkForUnsavedChanges();
-                }
+                applyStoredTheme();
+            }
+            onSaveFailed: error => {
+                root._isReadOnly = Object.values(settingFiles).some(file => file.isReadOnly)
+                root._hasUnsavedChanges = root._checkForUnsavedChanges();
             }
         }
     }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3773,6 +3773,7 @@ Singleton {
             if (_failedSaveSettingsFiles.size === 0 || tries >= 15) {
                 tries = 0;
                 stop();
+                return;
             }
             tries++;
             for (const file of _failedSaveSettingsFiles) {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3467,7 +3467,7 @@ Singleton {
 
         required property string filePath
         property var settings: ({})
-        property bool isLoading: true
+        property bool isLoading: false
         property bool hasLoaded: false
         property bool hasParseFailed: false
         property bool hasUnsavedChanges: false
@@ -3516,6 +3516,7 @@ Singleton {
                 if (selfWrite) {
                     selfWrite = false;
                 } else {
+                    isLoading = true;
                     settingsFileReloadDebounce.restart();
                 }
             }
@@ -3565,6 +3566,7 @@ Singleton {
                 if (isGreeterMode) {
                     return;
                 }
+                isLoading = false;
                 _loading = _settingsFilesPaths.some(path => _settingsFiles.get(path).isLoading);
                 applyStoredTheme();
             }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -2,6 +2,7 @@ pragma Singleton
 pragma ComponentBehavior: Bound
 
 import QtCore
+import Qt.labs.folderlistmodel
 import QtQuick
 import Quickshell
 import Quickshell.Io
@@ -1791,8 +1792,7 @@ Singleton {
         _pendingMigration = null;
 
         try {
-            const txt = settingsFile.text();
-            let obj = (txt && txt.trim()) ? JSON.parse(txt) : null;
+            let obj = getSettingsObject();
 
             const oldVersion = obj?.configVersion ?? 0;
             const legacyPins = oldVersion < 13 ? Store.extractPins(obj) : null;
@@ -3455,82 +3455,112 @@ Singleton {
         id: rightWidgetsModel
     }
 
-    property alias settingsFile: settingsFile
+    property var loadedSettings: ({})
+    function allLoaded() {
+        return Object.keys(loadedSettings).length >= settingsFolderModel.count;
+    }
+    function getSettingsObject() {
+        const settingsObject = {};
+        Object.assign(settingsObject, ...Object.values(loadedSettings));
+    }
+    function fileLoaded(fileName, obj) {
+        loadedSettings[fileName] = obj;
+        if (obj.weatherLocation !== undefined)
+        _legacyWeatherLocation = obj.weatherLocation;
+        if (obj.weatherCoordinates !== undefined)
+        _legacyWeatherCoordinates = obj.weatherCoordinates;
+        if (obj.vpnLastConnected !== undefined && obj.vpnLastConnected !== "") {
+            _legacyVpnLastConnected = obj.vpnLastConnected;
+            SessionData.vpnLastConnected = _legacyVpnLastConnected;
+            SessionData.saveSettings();
+        }
 
-    Timer {
-        id: settingsFileReloadDebounce
-        interval: 50
-        onTriggered: settingsFile.reload()
-        repeat: false
+        if (allLoaded()) {
+            Store.parse(root, obj)
+            _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
+            _hasLoaded = true;
+            applyStoredTheme();
+            updateCompositorCursor();
+        }
     }
 
-    FileView {
-        id: settingsFile
 
-        path: isGreeterMode ? "" : StandardPaths.writableLocation(StandardPaths.ConfigLocation) + "/DankMaterialShell/settings.json"
-        blockLoading: true
-        blockWrites: true
-        atomicWrites: true
-        watchChanges: !isGreeterMode
-        onFileChanged: {
-            if (_selfWrite) {
-                _selfWrite = false;
-                return;
-            }
-            settingsFileReloadDebounce.restart();
+    Repeater {
+        id: settingsLoader
+
+        model: FolderListModel {
+            id: settingsFolderModel
+            folder: StandardPaths.writableLocation(StandardPaths.ConfigLocation) + "/DankMaterialShell/config.d"
+            showDirs: false
+            nameFilters: ["*.json"]
         }
-        onLoaded: {
-            if (isGreeterMode)
-                return;
-            const wasLoaded = _hasLoaded;
-            const prevFrameEnabled = frameEnabled;
-            const prevFrameMode = frameMode;
-            _loading = true;
-            _hasUnsavedChanges = false;
-            try {
-                const txt = settingsFile.text();
-                if (!txt || !txt.trim()) {
-                    _parseError = true;
+
+        delegate: Item {
+            id: settingsFileViewWrapper
+            required property string filePath
+            required property string fileName
+
+            Timer {
+                id: settingsFileReloadDebounce
+                interval: 50
+                onTriggered: settingsFile.reload()
+                repeat: false
+            }
+
+            FileView {
+                id: settingsFile
+
+                path: isGreeterMode ? "" : filePath
+                blockLoading: true
+                blockWrites: true
+                atomicWrites: true
+                watchChanges: !isGreeterMode
+                onFileChanged: {
+                    if (_selfWrite) {
+                        _selfWrite = false;
+                        return;
+                    }
+                    settingsFileReloadDebounce.restart();
+                }
+                onLoaded: {
+                    if (isGreeterMode)
                     return;
+                    const wasLoaded = _hasLoaded;
+                    const prevFrameEnabled = frameEnabled;
+                    const prevFrameMode = frameMode;
+                    _loading = true;
+                    _hasUnsavedChanges = false;
+                    try {
+                        const txt = settingsFile.text();
+                        if (!txt || !txt.trim()) {
+                            _parseError = true;
+                            return;
+                        }
+                        const obj = JSON.parse(txt);
+                        _parseError = false;
+                        fileLoaded(fileName, obj);
+                    } catch (e) {
+                        _parseError = true;
+                        const msg = e.message;
+                        log.error(`Failed to reload ${fileName} - file will not be overwritten. Error:`, msg);
+                        Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
+                    } finally {
+                        _loading = false;
+                    }
+                    // External edits reload under _loading, which skips the per-property transition triggers
+                    if (wasLoaded && !_parseError && (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode)))
+                    updateFrameCompositorLayout();
                 }
-                const obj = JSON.parse(txt);
-                _parseError = false;
-                Store.parse(root, obj);
-
-                if (obj.weatherLocation !== undefined)
-                    _legacyWeatherLocation = obj.weatherLocation;
-                if (obj.weatherCoordinates !== undefined)
-                    _legacyWeatherCoordinates = obj.weatherCoordinates;
-                if (obj.vpnLastConnected !== undefined && obj.vpnLastConnected !== "") {
-                    _legacyVpnLastConnected = obj.vpnLastConnected;
-                    SessionData.vpnLastConnected = _legacyVpnLastConnected;
-                    SessionData.saveSettings();
+                onLoadFailed: error => {
+                    if (isGreeterMode)
+                    return;
+                    applyStoredTheme();
                 }
-
-                _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
-                _hasLoaded = true;
-                applyStoredTheme();
-                updateCompositorCursor();
-            } catch (e) {
-                _parseError = true;
-                const msg = e.message;
-                log.error("Failed to reload settings.json - file will not be overwritten. Error:", msg);
-                Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg("settings.json"), msg));
-            } finally {
-                _loading = false;
+                onSaveFailed: error => {
+                    root._isReadOnly = true;
+                    root._hasUnsavedChanges = root._checkForUnsavedChanges();
+                }
             }
-            // External edits reload under _loading, which skips the per-property transition triggers
-            if (wasLoaded && !_parseError && (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode)))
-                updateFrameCompositorLayout();
-        }
-        onLoadFailed: error => {
-            if (isGreeterMode)
-                return;
-            applyStoredTheme();
-        }
-        onSaveFailed: error => {
-            root._isReadOnly = true;
-            root._hasUnsavedChanges = root._checkForUnsavedChanges();
         }
     }
 

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -2005,7 +2005,6 @@ Singleton {
         }
         return splitSettings;
     }
-
     function saveSettings() {
         if (_loading || _parseError || !_hasLoaded) return;
         settingsSaveDebounce.restart();
@@ -3494,9 +3493,9 @@ Singleton {
             if (JSON.stringify(settings, null, 2) !== newSettingsJson) {
                 settings = newSettings;
                 hasUnsavedChanges = true;
-                selfWrite = true;
             }
             if (hasUnsavedChanges) {
+                selfWrite = true;
                 settingsFileView.setText(newSettingsJson);
             }
         }
@@ -3505,6 +3504,15 @@ Singleton {
                 settingsFileView.waitForJob();
             }
             return settings;
+        }
+        function retrySaving() {
+            if (!hasUnsavedChanges) {
+                return;
+            }
+            // Quickshell only writes if the text has changed, but doesn't provide a way to force a write.
+            const json = JSON.stringify(settings, null, 2) + (settingsSaveFailRecovery.tries % 2 === 1) ? " " : "";
+            selfWrite = true;
+            settingsFileView.setText(json);
         }
 
         property Timer timer: Timer {
@@ -3534,7 +3542,9 @@ Singleton {
                     return;
                 }
                 if (hasUnsavedChanges) {
-                    log.warn("Aborting settings file reload, there are unsaved changes which would've been lost.")
+                    const fileName = filePath?.split("/").pop() || "unknown";
+                    log.warn(`Aborting ${fileName} reload, there are unsaved changes which would've been lost`)
+                    settingsSaveFailRecovery.start();
                     return
                 }
                 isLoading = true;
@@ -3571,6 +3581,15 @@ Singleton {
             }
             onSaved: {
                 hasUnsavedChanges = false;
+                const fileName = filePath?.split("/").pop() || "unknown";
+                if (_failedSaveSettingsFiles.has(settingsFile)) {
+                    log.info(`Settings file '${fileName}' saved successfully after previous failures`)
+                    _failedSaveSettingsFiles.delete(settingsFile);
+                }
+            }
+            onSaveFailed: {
+                _failedSaveSettingsFiles.add(settingsFile);
+                settingsSaveFailRecovery.start();
             }
             onLoadFailed: {
                 _mitigateLoadFailure();
@@ -3581,6 +3600,7 @@ Singleton {
     property bool _allFilesRegistered: false
     property var _settingsFiles: new Map()
     property var _settingsFilesPaths: ([])
+    property var _failedSaveSettingsFiles: new Set()
     function _registerSettingsFile(file) {
         const filePath = file.filePath;
         if (_settingsFiles.has(filePath)) {
@@ -3723,6 +3743,28 @@ Singleton {
             if (!_isMissingPluginSettingsError(error))
                 log.warn("Failed to load plugin_settings.json. Error:", msg);
             _resetPluginSettings();
+        }
+    }
+
+    Timer {
+        id: settingsSaveFailRecovery
+
+        property int tries: 0
+        interval: {
+            const delay = 2 ** (tries + 1);
+            return (delay > 60 ? 60 : delay) * 1000;
+        }
+        repeat: true
+        running: false
+        onTriggered: {
+            if (_failedSaveSettingsFiles.size === 0 || tries >= 15) {
+                tries = 0;
+                stop();
+            }
+            tries++;
+            for (const file of _failedSaveSettingsFiles) {
+                file.retrySaving();
+            }
         }
     }
 

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1786,9 +1786,11 @@ Singleton {
 
     function _loadSettings() {
         const isInitial = _hasLoaded;
-        if (_loading || !_allSettingsFilesLoaded || _parseError) {
+        if (!_allSettingsFilesLoaded || _parseError) {
             return;
         }
+        // false when ran from _startAfterSettingsFilesFound
+        _loading = true;
 
         try {
             let obj = getSettingsObject();
@@ -1860,6 +1862,7 @@ Singleton {
             }
 
             _hasLoaded = true;
+
             if (isInitial) {
                 _mergeSessionState();
                 Qt.callLater(checkIconThemeDrift);
@@ -3583,7 +3586,9 @@ Singleton {
                     if (_parseError) {
                         _parseError = filesArray.some(file => file.hasParseFailed);
                     }
-                    _loadSettings();
+                    if (!filesArray.some(file => file.loading)) {
+                        _loadSettings();
+                    }
                 }
             }
             onLoadFailed: {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1783,11 +1783,6 @@ Singleton {
 
     function _loadSettings() {
         const isInitial = !_hasLoaded;
-        if (!_allSettingsFilesLoaded || _parseError) {
-            return;
-        }
-        // false when ran from _startAfterSettingsFilesFound
-        _loading = true;
 
         try {
             let obj = _getSettingsObjectFromFiles();
@@ -1884,8 +1879,6 @@ Singleton {
             log.error("Failed to load settings. Error:", msg);
             Qt.callLater(() => ToastService.showError(I18n.tr("Failed to load settings"), msg));
             applyStoredTheme();
-        } finally {
-            _loading = false;
         }
 
         if (isInitial) {
@@ -3469,13 +3462,6 @@ Singleton {
         id: rightWidgetsModel
     }
 
-    function _mitigateLoadFailure() {
-        if (isGreeterMode) {
-            return;
-        }
-        applyStoredTheme();
-    }
-
     component SettingsFile : QtObject {
         id: settingsFile
 
@@ -3558,27 +3544,28 @@ Singleton {
                 } catch (error) {
                     hasParseFailed = true;
                     _parseError = true;
+
                     const msg = error.message;
                     const fileName = filePath?.split("/").pop();
                     log.error(`Failed to reload ${fileName} - file will not be overwritten. Error:`, msg);
                     Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
                 } finally {
                     isLoading = false;
-                    const filesArray = Array.from(_settingsFiles.values());
+                    const files = Array.from(_settingsFiles.values());
                     _allSettingsFilesLoaded = _allSettingsFilesLoaded || (
-                        hasLoaded && _allFilesRegistered && filesArray.every(file => file.hasLoaded))
+                        hasLoaded && _allFilesRegistered && files.every(file => file.hasLoaded))
                     if (hadParseFailed && !hasParseFailed) {
-                        _parseError = filesArray.some(file => file.hasParseFailed);
+                        _parseError = files.some(file => file.hasParseFailed);
                     }
-
-                    if (!_hasLoaded) {
-                        if (_allSettingsFilesLoaded) {
-                            _runStartSequence();
-                        }
-                    } else if (filesArray.every(file => !file.isLoading)) {
-                        _loadSettings();
-                    }
+                    _loadSettingsOrStartIfReady();
                 }
+            }
+            onLoadFailed: {
+                if (isGreeterMode) {
+                    return;
+                }
+                _loading = _settingsFilesPaths.some(path => _settingsFiles.get(path).isLoading);
+                applyStoredTheme();
             }
             onSaved: {
                 const filesArray = Array.from(_settingsFiles.values());
@@ -3601,9 +3588,6 @@ Singleton {
                 const fileName = filePath?.split("/").pop() || "unknown";
                 log.warn(`Failed to save ${fileName}, retrying...`)
                 settingsSaveFailRecovery.start();
-            }
-            onLoadFailed: {
-                _mitigateLoadFailure();
             }
         }
     }
@@ -3665,6 +3649,23 @@ Singleton {
             Object.assign(settingsObject, settingsFile.getSettings());
         }
         return settingsObject;
+    }
+
+    function _loadSettingsOrStartIfReady() {
+        const files = Array.from(_settingsFiles.values());
+        if (!_allSettingsFilesLoaded || files.some(file => file.isLoading)) {
+            return;
+        }
+        if (!_parseError) {
+            // Already true when ran from onLoaded, but false otherwise.
+            _loading = true;
+            if (!_hasLoaded) {
+                _runStartSequence();
+            } else {
+                _loadSettings();
+            }
+        }
+        _loading = false;
     }
 
     SettingsFile {
@@ -3758,7 +3759,7 @@ Singleton {
         }
         onObjectRemoved: (_, file) => {
             _unregisterSettingsFile(file);
-            _loadSettings();
+            _loadSettingsOrStartIfReady();
         }
         delegate: SettingsFile {
             id: settingsFile

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1987,22 +1987,22 @@ Singleton {
         const settings = Store.toJson(root);
         const splitSettings = {};
 
-        const fileIndicies = Object.keys(settingFiles);
+        const filePaths = _settingsFilesPaths.slice()
         // Reverse order ensures only the effective value gets overwritten.
-        fileIndicies.reverse();
-        for (const index of fileIndicies) {
-            const file = settingFiles[index];
+        filePaths.reverse();
+        for (const path of filePaths) {
+            const file = _settingsFiles.get(path);
             const fileSettings = {};
-            for (const setting of Object.keys(file.settings)) {
+            for (const setting in file.settings) {
                 if (!(setting in settings)) continue;
                 fileSettings[setting] = settings[setting];
                 delete settings[setting];
             }
-            splitSettings[index] = fileSettings;
+            splitSettings[path] = fileSettings;
         }
 
         for (const setting in settings) {
-            splitSettings[0][setting] = settings[setting];
+            splitSettings[defaultSettingsFile.filePath][setting] = settings[setting];
         }
         return splitSettings;
     }
@@ -3560,7 +3560,7 @@ Singleton {
                     Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
                 } finally {
                     isLoading = false;
-                    const filesArray = Object.values(settingFiles);
+                    const filesArray = Object.values(_settingsFiles);
                     _allSettingsFilesLoaded = _allSettingsFilesLoaded || (hasLoaded && filesArray.every(file => file.hasLoaded))
 
                     if (hadParseFailed && !hasParseFailed) {
@@ -3581,32 +3581,45 @@ Singleton {
     }
 
     property bool _allFilesRegistered: false
-    property int _registeredFiles: 0
-    property var settingFiles: ({})
-    function _registerSettingsFile(index, file) {
-        settingFiles[index] = file;
-        _registeredFiles++;
+    property var _settingsFiles: new Map()
+    property var _settingsFilesPaths: ([])
+    function _registerSettingsFile(file) {
+        const filePath = file.filePath;
+        if (_settingsFiles.has(filePath)) {
+            return;
+        }
+        let index;
+        if (file === defaultSettingsFile) {
+            index = 0;
+        } else {
+            index = _settingsFilesPaths.find((path, index) => {
+                return path > filePath && index > 0;
+            });
+        }
+        _settingsFiles.set(filePath, file);
+        _settingsFilesPaths.splice(index, 0, filePath);
         _checkIfAllSettingsFilesFound();
+    }
+    function _unregisterSettingsFile(file) {
+        _settingsFiles.delete(file.filePath);
+        _settingsFilesPaths = _settingsFilesPaths.filter(path => path != file.filePath);
+        _registeredFiles--;
     }
     function _checkIfAllSettingsFilesFound() {
         if (_allFilesRegistered || settingsFolderModel.status !== FolderListModel.Ready) {
             return;
         }
         const expectedCount = settingsFolderModel.count + 1;
-        if (_registeredFiles === expectedCount) {
+        if (_settingsFilesPaths.length === expectedCount) {
             _allFilesRegistered = true;
             _startAfterSettingsFilesFound();
         }
     }
-    function _unregisterSettingsFile(index) {
-        delete settingFiles[index];
-        _registeredFiles--;
-    }
     function getSettingsObject() {
         const settingsObject = {};
-        for (const index in settingFiles) {
-            const settingFile = settingFiles[index];
-            Object.assign(settingsObject, settingFile.getSettings());
+        for (const path of _settingsFilesPaths) {
+            const settingsFile = _settingsFiles.get(path);
+            Object.assign(settingsObject, settingsFile.getSettings());
         }
         return settingsObject;
     }
@@ -3617,7 +3630,7 @@ Singleton {
         filePath: StandardPaths.writableLocation(StandardPaths.ConfigLocation) + "/DankMaterialShell/settings.json"
 
         Component.onCompleted: {
-            _registerSettingsFile(0, defaultSettingsFile);
+            _registerSettingsFile(defaultSettingsFile);
         }
     }
 
@@ -3637,9 +3650,11 @@ Singleton {
         }
         onObjectAdded: (index, file) => {
             _registerSettingsFile(index + 1, file);
+            _registerSettingsFile(file);
         }
         onObjectRemoved: (index) => {
             _unregisterSettingsFile(index + 1);
+            _unregisterSettingsFile(file);
         }
         delegate: SettingsFile {
             id: settingsFile

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3510,7 +3510,7 @@ Singleton {
                 return;
             }
             // Quickshell only writes if the text has changed, but doesn't provide a way to force a write.
-            const json = JSON.stringify(settings, null, 2) + (settingsSaveFailRecovery.tries % 2 === 1) ? " " : "";
+            const json = JSON.stringify(settings, null, 2) + ((settingsSaveFailRecovery.tries % 2 === 1) ? " " : "");
             selfWrite = true;
             settingsFileView.setText(json);
         }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -89,7 +89,6 @@ Singleton {
     property bool _pluginParseError: false
     property bool _hasLoaded: false
     property bool _allSettingsFilesLoaded: false
-    property var _loadedSettingsSnapshot: null
     property var pluginSettings: ({})
     property var builtInPluginSettings: ({})
 

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -88,6 +88,7 @@ Singleton {
     property bool _parseError: false
     property bool _pluginParseError: false
     property bool _hasLoaded: false
+    property bool _allSettingsFilesLoaded: false
     property bool _isReadOnly: false
     property var _loadedSettingsSnapshot: null
     property var pluginSettings: ({})
@@ -1496,7 +1497,7 @@ Singleton {
         if (isGreeterMode)
             return;
         Processes.settingsRoot = root;
-        loadSettings();
+        _loadSettings();
         initializeListModels();
         refreshAuthAvailability();
         Processes.checkPluginSettings();
@@ -1783,50 +1784,59 @@ Singleton {
         updateBarConfigs();
     }
 
-    function loadSettings() {
-        _loading = true;
-        _parseError = false;
+    function _loadSettings() {
+        const isInitial = _hasLoaded;
+        if (_loading || !_allSettingsFilesLoaded || _parseError) {
+            return;
+        }
 
         try {
             let obj = getSettingsObject();
 
-            const oldVersion = obj?.configVersion ?? 0;
-            const legacyPins = oldVersion < 13 ? Store.extractPins(obj) : null;
-            const sessionPayload = oldVersion < 15 ? Store.extractSessionPayload(obj) : null;
-            const cachePayload = oldVersion < 15 ? Store.extractCachePayload(obj) : null;
-            if (oldVersion < settingsConfigVersion) {
-                const migrated = Store.migrateToVersion(obj, settingsConfigVersion);
-                if (migrated) {
-                    obj = migrated;
-                }
-            }
-            if (legacyPins)
-                Qt.callLater(() => CacheData.migratePins(legacyPins));
-            if (cachePayload)
-                Qt.callLater(() => CacheData.migrateUsageHistories(cachePayload));
-            if (sessionPayload) {
-                Qt.callLater(() => {
-                    SessionData.importFromSettings(sessionPayload);
-                    _mergeSessionState();
-                });
-            }
-
-            if (obj?.lockScreenActiveMonitor !== undefined) {
-                var oldVal = obj.lockScreenActiveMonitor;
-                if (oldVal && oldVal !== "all") {
-                    if (!obj.screenPreferences)
-                        obj.screenPreferences = {};
-                    if (obj.screenPreferences.lockScreen === undefined) {
-                        obj.screenPreferences.lockScreen = [oldVal];
+            if (isInitial) {
+                const oldVersion = obj?.configVersion ?? 0;
+                const legacyPins = oldVersion < 13 ? Store.extractPins(obj) : null;
+                const sessionPayload = oldVersion < 15 ? Store.extractSessionPayload(obj) : null;
+                const cachePayload = oldVersion < 15 ? Store.extractCachePayload(obj) : null;
+                if (oldVersion < settingsConfigVersion) {
+                    const migrated = Store.migrateToVersion(obj, settingsConfigVersion);
+                    if (migrated) {
+                        obj = migrated;
                     }
                 }
-                delete obj.lockScreenActiveMonitor;
+
+                if (legacyPins) {
+                    Qt.callLater(() => CacheData.migratePins(legacyPins));
+                }
+                if (cachePayload) {
+                    Qt.callLater(() => CacheData.migrateUsageHistories(cachePayload));
+                } if (sessionPayload) {
+                    Qt.callLater(() => {
+                        SessionData.importFromSettings(sessionPayload);
+                        _mergeSessionState();
+                    });
+                }
+
+                if (obj?.lockScreenActiveMonitor !== undefined) {
+                    var oldVal = obj.lockScreenActiveMonitor;
+                    if (oldVal && oldVal !== "all") {
+                        if (!obj.screenPreferences)
+                        obj.screenPreferences = {};
+                        if (obj.screenPreferences.lockScreen === undefined) {
+                            obj.screenPreferences.lockScreen = [oldVal];
+                        }
+                    }
+                    delete obj.lockScreenActiveMonitor;
+                }
+
+                if (obj?.use24HourClock !== undefined && obj?.clockFormat === undefined) {
+                    obj.clockFormat = obj.use24HourClock ? "24h" : "12h";
+                    delete obj.use24HourClock;
+                }
             }
 
-            if (obj?.use24HourClock !== undefined && obj?.clockFormat === undefined) {
-                obj.clockFormat = obj.use24HourClock ? "24h" : "12h";
-                delete obj.use24HourClock;
-            }
+            const prevFrameEnabled = frameEnabled;
+            const prevFrameMode = frameMode;
 
             Store.parse(root, obj);
 
@@ -1842,33 +1852,42 @@ Singleton {
 
             if (obj?.weatherLocation !== undefined)
                 _legacyWeatherLocation = obj.weatherLocation;
-            if (obj?.weatherCoordinates !== undefined)
-                _legacyWeatherCoordinates = obj.weatherCoordinates;
-            if (obj?.vpnLastConnected !== undefined && obj.vpnLastConnected !== "") {
+
+            if (obj.vpnLastConnected !== undefined && obj.vpnLastConnected !== "") {
                 _legacyVpnLastConnected = obj.vpnLastConnected;
                 SessionData.vpnLastConnected = _legacyVpnLastConnected;
                 SessionData.saveSettings();
             }
 
-            _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
             _hasLoaded = true;
-            _mergeSessionState();
+            if (isInitial) {
+                _mergeSessionState();
+                Qt.callLater(checkIconThemeDrift);
+                _checkSettingsWritable();
+            }
             applyStoredTheme();
             updateCompositorCursor();
-            Qt.callLater(checkIconThemeDrift);
+            if (isInitial) {
+                // External edits reload under _loading, which skips the per-property transition triggers
+                const frameChanged = (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode));
+                if (!_parseError && frameChanged) {
+                    updateFrameCompositorLayout();
+                }
+            }
 
-            _checkSettingsWritable();
         } catch (e) {
-            _parseError = true;
             const msg = e.message;
-            log.error("Failed to parse settings.json - file will not be overwritten. Error:", msg);
-            Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg("settings.json"), msg));
+            log.error("Failed to apply settings. Error:", msg);
+            Qt.callLater(() => ToastService.showError(I18n.tr("Failed to apply settings"), msg));
             applyStoredTheme();
         } finally {
             _loading = false;
         }
-        loadPluginSettings();
-        Qt.callLater(() => _reconcileConnectedFrameBarStyles());
+
+        if (isInitial) {
+            loadPluginSettings();
+            Qt.callLater(() => _reconcileConnectedFrameBarStyles());
+        }
     }
 
     function _mergeSessionState() {
@@ -3478,47 +3497,6 @@ Singleton {
         id: rightWidgetsModel
     }
 
-    function _udpateSettingsAfterReload(file) {
-        const filesArray = Object.values(settingFiles);
-        _loading = !filesArray.every(file => file.hasLoaded && !file.loading);
-        if (_parseError) {
-            _parseError = filesArray.some(file => file.hasParseFailed);
-        }
-
-        const prevFrameEnabled = frameEnabled;
-        const prevFrameMode = frameMode;
-
-        const loadedSettings = file.settings;
-
-        if (loadedSettings.weatherLocation !== undefined) {
-            _legacyWeatherLocation = loadedSettings.weatherLocation;
-        }
-        if (loadedSettings.weatherCoordinates !== undefined) {
-            _legacyWeatherCoordinates = loadedSettings.weatherCoordinates;
-        }
-        if (loadedSettings.vpnLastConnected !== undefined && loadedSettings.vpnLastConnected !== "") {
-            _legacyVpnLastConnected = loadedSettings.vpnLastConnected;
-            SessionData.vpnLastConnected = _legacyVpnLastConnected;
-            SessionData.saveSettings();
-        }
-
-        Store.parse(root, getSettingsObject())
-
-        _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
-        applyStoredTheme();
-        updateCompositorCursor();
-
-        if (_hasLoaded) {
-            // External edits reload under _loading, which skips the per-property transition triggers
-            const frameChanged = (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode));
-            if (!_parseError && frameChanged) {
-                updateFrameCompositorLayout();
-            }
-        } else {
-            _hasLoaded = Object.values(settingFiles).every(file => file.hasLoaded);
-        }
-    }
-
     function _registerSaveFailure() {
         root._isReadOnly = Object.values(settingFiles).some(file => file.isReadOnly)
     }
@@ -3580,7 +3558,6 @@ Singleton {
                 }
                 isLoading = true;
                 _loading = true;
-                isReadOnly = false;
                 try {
                     const txt = settingsFileView.text();
                     if (!txt || !txt.trim()) {
@@ -3588,18 +3565,25 @@ Singleton {
                         return;
                     }
                     settingsFile.settings = JSON.parse(txt);
-                    isLoading = false;
                     hasLoaded = true;
-                    _udpateSettingsAfterReload(settingsFile);
                 } catch (error) {
-                        hasParseFailed = true;
-                        _parseError = true;
-                        const msg = error.message;
-                        const fileName = filePath?.split("/").pop();
-                        log.error(`Failed to reload ${fileName} - file will not be overwritten. Error:`, msg);
-                        Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
+                    hasParseFailed = true;
+                    _parseError = true;
+                    const msg = error.message;
+                    const fileName = filePath?.split("/").pop();
+                    log.error(`Failed to reload ${fileName} - file will not be overwritten. Error:`, msg);
+                    Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
                 } finally {
+                    isLoading = false;
+                    const filesArray = Object.values(settingFiles);
+                    _loading = filesArray.some(file => file.loading);
+                    _allSettingsFilesLoaded = filesArray.every(file => file.hasLoaded)
+
                     hasParseFailed = false;
+                    if (_parseError) {
+                        _parseError = filesArray.some(file => file.hasParseFailed);
+                    }
+                    _loadSettings();
                 }
             }
             onLoadFailed: {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3510,7 +3510,7 @@ Singleton {
             settingsFileView.setText(JSON.stringify(newSettings, null, 2));
         }
         function getSettings() {
-            if (!hasLoaded) {
+            if (!hasLoaded || isLoading) {
                 settingsFileView.waitForJob();
             }
             return settings;

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1883,8 +1883,8 @@ Singleton {
 
         } catch (e) {
             const msg = e.message;
-            log.error("Failed to apply settings. Error:", msg);
-            Qt.callLater(() => ToastService.showError(I18n.tr("Failed to apply settings"), msg));
+            log.error("Failed to load settings. Error:", msg);
+            Qt.callLater(() => ToastService.showError(I18n.tr("Failed to load settings"), msg));
             applyStoredTheme();
         } finally {
             _loading = false;
@@ -3497,10 +3497,15 @@ Singleton {
         property bool hasUnsavedChanges: false
         property bool selfWrite: false
         function setSettings(newSettings) {
-            selfWrite = true;
-            hasUnsavedChanges = true;
-            settings = newSettings;
-            settingsFileView.setText(JSON.stringify(newSettings, null, 2));
+            const newSettingsJson = JSON.stringify(newSettings);
+            if (JSON.stringify(settings) !== newSettingsJson) {
+                settings = newSettings;
+                hasUnsavedChanges = true;
+                selfWrite = true;
+            }
+            if (hasUnsavedChanges) {
+                settingsFileView.setText(newSettingsJson);
+            }
         }
         function getSettings() {
             if (!hasLoaded || isLoading) {
@@ -3628,36 +3633,75 @@ Singleton {
         id: defaultSettingsFile
 
         filePath: StandardPaths.writableLocation(StandardPaths.ConfigLocation) + "/DankMaterialShell/settings.json"
+        property int index: 0
 
         Component.onCompleted: {
             _registerSettingsFile(defaultSettingsFile);
         }
     }
 
+    Timer {
+        id: settingsFilesModelSyncDebounce
+        interval: 50
+        repeat: false
+        running: false
+        onTriggered: {
+            try {
+                const folderModel = settingsFolderModel;
+                const listModel = settingsFilesListModel;
+
+                if (folderModel.status === FolderListModel.Ready) {
+                    const folderPaths = (new Array(folderModel.count)).fill(1).map((_, index) => {
+                        return folderModel.get(index, "filePath")
+                    });
+
+                    for (const filePath of folderPaths) {
+                        if (!_settingsFiles.has(filePath)) {
+                            listModel.append({ filePath });
+                        }
+                    }
+                    const folderPathsSet = new Set(folderPaths);
+                    for (let i = 1; i < _settingsFilesPaths.length; i++) {
+                        const filePath = _settingsFilesPaths[i];
+                        if (!folderPathsSet.has(filePath)) {
+                            const file = _settingsFiles.get(filePath);
+                            listModel.remove(file.index);
+                        }
+                    }
+                } else {
+                    restart();
+                }
+            } catch (e) {
+                log.error("Failed to sync settings files models:", e)
+            }
+        }
+    }
+    ListModel {
+        id: settingsFilesListModel
+    }
+    FolderListModel {
+        id: settingsFolderModel
+        folder: StandardPaths.writableLocation(StandardPaths.ConfigLocation) + "/DankMaterialShell/config.d"
+        showDirs: false
+        nameFilters: ["*.json"]
+        onStatusChanged: {
+            settingsFilesModelSyncDebounce.restart()
+        }
+    }
+
     Instantiator {
         id: settingsLoader
 
-        model: FolderListModel {
-            id: settingsFolderModel
-            folder: StandardPaths.writableLocation(StandardPaths.ConfigLocation) + "/DankMaterialShell/config.d"
-            showDirs: false
-            nameFilters: ["*.json"]
-            onStatusChanged: {
-                if (status === FolderListModel.Ready) {
-                    _checkIfAllSettingsFilesFound();
-                }
-            }
-        }
-        onObjectAdded: (index, file) => {
-            _registerSettingsFile(index + 1, file);
+        model: settingsFilesListModel
+        onObjectAdded: (_, file) => {
             _registerSettingsFile(file);
         }
-        onObjectRemoved: (index) => {
-            _unregisterSettingsFile(index + 1);
+        onObjectRemoved: (_, file) => {
             _unregisterSettingsFile(file);
         }
         delegate: SettingsFile {
             id: settingsFile
+            property int index
         }
     }
 

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3579,7 +3579,7 @@ Singleton {
                 } finally {
                     isLoading = false;
                     const filesArray = Object.values(settingFiles);
-                    _allSettingsFilesLoaded = hasLoaded && filesArray.every(file => file.hasLoaded)
+                    _allSettingsFilesLoaded = _allSettingsFilesLoaded || (hasLoaded && filesArray.every(file => file.hasLoaded))
 
                     hasParseFailed = false;
                     if (_parseError) {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3585,7 +3585,7 @@ Singleton {
                 hasUnsavedChanges = false;
                 hasUnsavedChanges = filesArray.every(file => !file.hasUnsavedChanges);
                 isFileReadOnly = false;
-                isReadOnly = filesArray.every(file => !file.isFileReadOnly)
+                isReadOnly = filesArray.some(file => file.isFileReadOnly)
 
                 const fileName = filePath?.split("/").pop() || "unknown";
                 if (_failedSaveSettingsFiles.has(settingsFile)) {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1492,9 +1492,7 @@ Singleton {
         Processes.detectAuthCapabilities();
     }
 
-    function _startAfterSettingsFilesFound() {
-        if (isGreeterMode)
-            return;
+    function _runStartSequence() {
         Processes.settingsRoot = root;
         _loadSettings();
         initializeListModels();
@@ -3501,9 +3499,6 @@ Singleton {
             }
         }
         function getSettings() {
-            if (!hasLoaded || isLoading) {
-                settingsFileView.waitForJob();
-            }
             return settings;
         }
         function retrySaving() {
@@ -3527,7 +3522,7 @@ Singleton {
             id: settingsFileView
 
             path: isGreeterMode ? "" : filePath
-            blockLoading: true
+            blockLoading: false
             blockWrites: true
             atomicWrites: true
             watchChanges: !isGreeterMode
@@ -3570,12 +3565,17 @@ Singleton {
                 } finally {
                     isLoading = false;
                     const filesArray = Array.from(_settingsFiles.values());
-                    _allSettingsFilesLoaded = _allSettingsFilesLoaded || (hasLoaded && filesArray.every(file => file.hasLoaded))
-
+                    _allSettingsFilesLoaded = _allSettingsFilesLoaded || (
+                        hasLoaded && _allFilesRegistered && filesArray.every(file => file.hasLoaded))
                     if (hadParseFailed && !hasParseFailed) {
                         _parseError = filesArray.some(file => file.hasParseFailed);
                     }
-                    if (!_hasLoaded && !filesArray.some(file => file.isLoading)) {
+
+                    if (!_hasLoaded) {
+                        if (_allSettingsFilesLoaded) {
+                            _runStartSequence();
+                        }
+                    } else if (filesArray.every(file => !file.isLoading)) {
                         _loadSettings();
                     }
                 }
@@ -3643,16 +3643,19 @@ Singleton {
         }
         let expectedCount = 1;
         if (configDirExists.exists) {
-            const folderModelReady = settingsFolderModel.status === FolderListModel.Ready;
-            if (!folderModelReady) {
+            if (!(settingsFolderModel.status === FolderListModel.Ready)) {
                 return;
             }
             expectedCount += settingsFolderModel.count;
-        } else {
         }
         if (_settingsFilesPaths.length == expectedCount) {
             _allFilesRegistered = true;
-            _startAfterSettingsFilesFound();
+            if (expectedCount === 1) {
+                _allSettingsFilesLoaded = defaultSettingsFile.hasLoaded;
+            }
+            if (_allSettingsFilesLoaded) {
+                _runStartSequence();
+            }
         }
     }
     function _getSettingsObjectFromFiles() {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3568,7 +3568,7 @@ Singleton {
                     Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
                 } finally {
                     isLoading = false;
-                    const filesArray = Object.values(_settingsFiles);
+                    const filesArray = Array.from(_settingsFiles.values());
                     _allSettingsFilesLoaded = _allSettingsFilesLoaded || (hasLoaded && filesArray.every(file => file.hasLoaded))
 
                     if (hadParseFailed && !hasParseFailed) {
@@ -3610,7 +3610,7 @@ Singleton {
         if (file === defaultSettingsFile) {
             index = 0;
         } else {
-            index = _settingsFilesPaths.find((path, index) => {
+            index = _settingsFilesPaths.findIndex((path, index) => {
                 return path > filePath && index > 0;
             });
         }
@@ -3676,11 +3676,10 @@ Singleton {
                     }
                 }
                 const folderPathsSet = new Set(folderPaths);
-                for (let i = 1; i < _settingsFilesPaths.length; i++) {
-                    const filePath = _settingsFilesPaths[i];
+                for (let i = listModel.count - 1; i >= 0; i--) {
+                    const filePath = listModel.get(i).filePath;
                     if (!folderPathsSet.has(filePath)) {
-                        const file = _settingsFiles.get(filePath);
-                        listModel.remove(file.index);
+                        listModel.remove(i);
                     }
                 }
             } else {
@@ -3732,7 +3731,6 @@ Singleton {
         }
         delegate: SettingsFile {
             id: settingsFile
-            property int index
         }
     }
 

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1498,6 +1498,7 @@ Singleton {
         initializeListModels();
         refreshAuthAvailability();
         Processes.checkPluginSettings();
+        log.error("startup sequence ran")
     }
 
     function applyStoredTheme() {
@@ -3562,13 +3563,22 @@ Singleton {
                     _loadSettingsOrStartIfReady();
                 }
             }
-            onLoadFailed: {
+            onLoadFailed: (error) => {
                 if (isGreeterMode) {
                     return;
                 }
                 isLoading = false;
                 _loading = _settingsFilesPaths.some(path => _settingsFiles.get(path).isLoading);
+                const name = filePath.split("/").pop() || "unknown";
+                if (error === FileViewError.FileNotFound) {
+                    // fake that file has been loaded so that it gets written after a change.
+                    hasLoaded = true;
+                }
                 applyStoredTheme();
+                if (hasLoaded) {
+                    _checkIfAllSettingsFilesLoaded();
+                }
+                _loadSettingsOrStartIfReady();
             }
             onSaved: {
                 const filesArray = Array.from(_settingsFiles.values());

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3579,8 +3579,7 @@ Singleton {
                 } finally {
                     isLoading = false;
                     const filesArray = Object.values(settingFiles);
-                    _loading = filesArray.some(file => file.loading);
-                    _allSettingsFilesLoaded = filesArray.every(file => file.hasLoaded)
+                    _allSettingsFilesLoaded = hasLoaded && filesArray.every(file => file.hasLoaded)
 
                     hasParseFailed = false;
                     if (_parseError) {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3575,7 +3575,7 @@ Singleton {
                     if (hadParseFailed && !hasParseFailed) {
                         _parseError = filesArray.some(file => file.hasParseFailed);
                     }
-                    if (!filesArray.some(file => file.isLoading)) {
+                    if (!_hasLoaded && !filesArray.some(file => file.isLoading)) {
                         _loadSettings();
                     }
                 }
@@ -3638,11 +3638,19 @@ Singleton {
         _settingsFilesPaths = _settingsFilesPaths.filter(path => path != file.filePath);
     }
     function _checkIfAllSettingsFilesFound() {
-        if (_allFilesRegistered || settingsFolderModel.status !== FolderListModel.Ready) {
+        if (_allFilesRegistered || !configDirExists.checked) {
             return;
         }
-        const expectedCount = settingsFolderModel.count + 1;
-        if (_settingsFilesPaths.length === expectedCount) {
+        let expectedCount = 1;
+        if (configDirExists.exists) {
+            const folderModelReady = settingsFolderModel.status === FolderListModel.Ready;
+            if (!folderModelReady) {
+                return;
+            }
+            expectedCount += settingsFolderModel.count;
+        } else {
+        }
+        if (_settingsFilesPaths.length == expectedCount) {
             _allFilesRegistered = true;
             _startAfterSettingsFilesFound();
         }
@@ -3703,30 +3711,28 @@ Singleton {
     }
     FolderListModel {
         id: settingsFolderModel
-        folder: StandardPaths.writableLocation(StandardPaths.ConfigLocation) + "/DankMaterialShell/config.d"
+
+        // Folder seems to be reset to the CWD if the directory doesn't exist.
+        property url dir: StandardPaths.writableLocation(StandardPaths.ConfigLocation) + "/DankMaterialShell/config.d"
+        folder: dir
         showDirs: false
         nameFilters: ["*.json"]
         onStatusChanged: {
-            settingsFilesModelSyncDebounce.restart()
+            settingsFilesModelSyncDebounce.restart();
         }
     }
     Process {
-        command: ["mkdir", "-p", Paths.strip(settingsFolderModel.folder)]
-        property string errorMsg: "";
-        stderr: StdioCollector {
-            onStreamFinished: {
-                errorMsg = text.trim();
-            }
-        }
-        running: !isGreeterMode
-        // qmllint disable signal-handler-parameters
-        onExited: (code, _) => {
-            if (code !== 0) {
-                log.error(`Failed to create config.d directory, exited with code ${code}:`, errorMsg);
-            } else {
-                _checkIfAllSettingsFilesFound();
-            }
+        id: configDirExists
 
+        command: ["test", "-d", settingsFolderModel.dir]
+        running: true
+        property bool checked: false
+        property bool exists: false
+        // qmllint disable signal-handler-parameters
+        onExited: (code) => {
+            exists = code === 0;
+            checked = true;
+            _checkIfAllSettingsFilesFound()
         }
     }
 

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3696,15 +3696,32 @@ Singleton {
     Process {
         id: settingsWritableCheckProcess
 
-        property string settingsPath: Paths.strip(settingsFile.path)
+        function checkWritable(file) {
+            fileQueue = fileQueue.concat(file);
+            if (!running) {
+                running = true;
+            }
+        }
 
-        command: ["sh", "-c", "[ ! -f \"" + settingsPath + "\" ] || [ -w \"" + settingsPath + "\" ] && echo 'writable' || echo 'readonly'"]
+        property var fileQueue: ([])
+        property var file: fileQueue.length > 0 ? fileQueue[0] : null
+        property string filePath: {
+            if (file !== null) {
+                return Paths.strip(file.path);
+            }
+            return "";
+        }
+        command: ["sh", "-c", "[ ! -f \"" + filePath + "\" ] || [ -w \"" + filePath + "\" ] && echo 'writable' || echo 'readonly'"]
         running: false
 
         stdout: StdioCollector {
             onStreamFinished: {
                 const result = text.trim();
                 root._onWritableCheckComplete(result === "writable");
+                fileQueue.shift();
+                if (fileQueue.length > 0) {
+                    settingsWritableCheckProcess.running = true
+                }
             }
         }
     }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1870,7 +1870,7 @@ Singleton {
             }
             applyStoredTheme();
             updateCompositorCursor();
-            if (isInitial) {
+            if (!isInitial) {
                 // External edits reload under _loading, which skips the per-property transition triggers
                 const frameChanged = (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode));
                 if (!_parseError && frameChanged) {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3543,7 +3543,7 @@ Singleton {
                     return;
                 }
                 if (hasUnsavedChanges) {
-                    log.warn("Ignoring settings file loaded event, there are unsaved changes which could've been lost.")
+                    log.warn("Aborting settings file reload, there are unsaved changes which would've been lost.")
                     return
                 }
                 isLoading = true;

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3573,7 +3573,7 @@ Singleton {
                     if (hadParseFailed && !hasParseFailed) {
                         _parseError = filesArray.some(file => file.hasParseFailed);
                     }
-                    if (!filesArray.some(file => file.loading)) {
+                    if (!filesArray.some(file => file.isLoading)) {
                         _loadSettings();
                     }
                 }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1994,36 +1994,40 @@ Singleton {
         }
     }
 
+    function _getSettingsSplitByFile() {
+        const settings = Store.toJson(root);
+        const splitSettings = {};
+
+        const fileIndicies = Object.keys(settingFiles);
+        // Reverse order ensures only the effective value gets overwritten.
+        fileIndicies.reverse();
+        for (const index of fileIndicies) {
+            const file = settingFiles[index];
+            const fileSettings = {};
+            for (const setting of Object.keys(file.settings)) {
+                if (!(setting in settings)) continue;
+                fileSettings[setting] = settings[setting];
+                delete settings[setting];
+            }
+            splitSettings[index] = fileSettings;
+        }
+
+        for (const setting of settings) {
+            splitSettings[0][setting] = settings[setting];
+        }
+        return splitSettings;
+    }
+
     function saveSettings() {
         try {
             if (_loading || _parseError || !_hasLoaded)
             return;
             _selfWrite = true;
-            const settings = Store.toJson(root);
-            const loadedFiles = Object.keys(loadedSettings);
-
-            // Reverse order ensures only the effective value will get overwritten.
-            loadedFiles.reverse()
-            for (const file of loadedFiles) {
-                const settingsToSave = {};
-                for (const setting of Object.keys(loadedSettings[file] || {})) {
-                    if (settings[setting] === undefined) continue;
-                    settingsToSave[setting] = settings[setting];
-                    settings[setting] = undefined;
-                }
-            }
-
-            const leftoverSettings = {};
-            const leftovers = false;
-            for (let setting in Object.keys(settings)) {
-                if (settings[setting] !== undefined) {
-                    leftoverSettings[setting] = settings[setting];
-                    leftovers = true;
-                }
-            }
-
-            if (leftovers) {
-                fileViews["default.json"].setText(JSON.stringify(settingsToSave, null, 2));
+            const splitSettings = _getSettingsSplitByFile();
+            for (const index in splitSettings) {
+                const fileSettings = splitSettings[index];
+                const file = settingFiles[index];
+                file.setSettings(fileSettings);
             }
 
         } catch (e) {
@@ -3500,6 +3504,9 @@ Singleton {
         signal parseError()
         signal saveFailed(error: FileViewError)
         signal loadFailed(error: FileViewError)
+        function setSettings(settings) {
+            settingsFileView.setText(JSON.stringify(settings, null, 2));
+        }
 
         property Timer timer: Timer {
             id: settingsFileReloadDebounce

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3728,6 +3728,7 @@ Singleton {
         }
         onObjectRemoved: (_, file) => {
             _unregisterSettingsFile(file);
+            _loadSettings();
         }
         delegate: SettingsFile {
             id: settingsFile

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3499,11 +3499,6 @@ Singleton {
         property bool hasLoaded: false
         property bool hasParseFailed: false
         property bool isReadOnly: false
-        signal loading()
-        signal loaded()
-        signal parseError()
-        signal saveFailed(error: FileViewError)
-        signal loadFailed(error: FileViewError)
         function setSettings(settings) {
             settingsFileView.setText(JSON.stringify(settings, null, 2));
         }
@@ -3535,8 +3530,8 @@ Singleton {
                     return;
                 }
                 isLoading = true;
+                _loading = true;
                 isReadOnly = false;
-                settingsFile.loading();
                 try {
                     const txt = settingsFileView.text();
                     if (!txt || !txt.trim()) {
@@ -3545,23 +3540,24 @@ Singleton {
                         return;
                     }
                     settingsFile.settings = JSON.parse(txt);
-
                     isLoading = false;
                     hasLoaded = true;
-                    settingsFile.loaded();
+                    _udpateSettingsAfterReload(settingsFile);
                 } catch (error) {
                     hasParseFailed = true;
-                    settingsFile.parseError();
+                    _parseError = true;
                     const msg = error.msg;
                     Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
                 } finally {
                     hasParseFailed = false;
                 }
             }
-            onLoadFailed: settingsFile.loadFailed
+            onLoadFailed: {
+                _mitigateLoadFailure();
+            }
             onSaveFailed: (error) => {
                 isReadOnly = true;
-                settingsFile.saveFailed(error);
+                _diagnoseSaveFailure();
             }
         }
     }
@@ -3630,32 +3626,17 @@ Singleton {
         root._hasUnsavedChanges = root._checkForUnsavedChanges();
     }
 
+    function _mitigateLoadFailure() {
+        if (isGreeterMode) {
+            return;
+        }
+        applyStoredTheme();
+    }
+
     SettingsFile {
         id: defaultSettingsFile
 
         filePath: StandardPaths.writableLocation(StandardPaths.ConfigLocation) + "/DankMaterialShell/settings.json"
-        onLoading: {
-            _loading = true;
-        }
-        onLoaded: {
-            try {
-                _udpateSettingsAfterReload(defaultSettingsFile);
-            } catch (e) {
-                log.error(e);
-            }
-        }
-        onParseError: {
-            _parseError = true;
-        }
-        onLoadFailed: error => {
-            if (isGreeterMode) {
-                return;
-            }
-            applyStoredTheme();
-        }
-        onSaveFailed: error => {
-            _diagnoseSaveFailure();
-        }
 
         Component.onCompleted: {
             settingFiles[0] = defaultSettingsFile;
@@ -3682,29 +3663,6 @@ Singleton {
 
         delegate: SettingsFile {
             id: settingsFile
-
-            onLoading: {
-                _loading = true;
-            }
-            onLoaded: {
-                try {
-                    _udpateSettingsAfterReload(settingsFile);
-                } catch (e) {
-                    log.error(e);
-                }
-            }
-            onParseError: {
-                _parseError = true;
-            }
-            onLoadFailed: error => {
-                if (isGreeterMode) {
-                    return;
-                }
-                applyStoredTheme();
-            }
-            onSaveFailed: error => {
-                _diagnoseSaveFailure();
-            }
         }
     }
 

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3561,6 +3561,9 @@ Singleton {
                 }
                 isLoading = true;
                 _loading = true;
+                _settingsFilesLoading = true
+                const hadParseFailed = hasParseFailed;
+                hasParseFailed = false;
                 try {
                     const txt = settingsFileView.text();
                     if (!txt || !txt.trim()) {
@@ -3581,8 +3584,7 @@ Singleton {
                     const filesArray = Object.values(settingFiles);
                     _allSettingsFilesLoaded = _allSettingsFilesLoaded || (hasLoaded && filesArray.every(file => file.hasLoaded))
 
-                    hasParseFailed = false;
-                    if (_parseError) {
+                    if (hadParseFailed && !hasParseFailed) {
                         _parseError = filesArray.some(file => file.hasParseFailed);
                     }
                     if (!filesArray.some(file => file.loading)) {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3554,7 +3554,7 @@ Singleton {
             onLoadFailed: settingsFile.loadFailed
             onSaveFailed: (error) => {
                 isReadOnly = true;
-                settingsFile.readFailed(error);
+                settingsFile.saveFailed(error);
             }
         }
     }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3583,7 +3583,6 @@ Singleton {
             onSaved: {
                 const filesArray = Array.from(_settingsFiles.values());
                 hasUnsavedChanges = false;
-                hasUnsavedChanges = filesArray.every(file => !file.hasUnsavedChanges);
                 isFileReadOnly = false;
                 isReadOnly = filesArray.some(file => file.isFileReadOnly)
 

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1492,7 +1492,7 @@ Singleton {
         Processes.detectAuthCapabilities();
     }
 
-    Component.onCompleted: {
+    function _startAfterSettingsFilesFound() {
         if (isGreeterMode)
             return;
         Processes.settingsRoot = root;
@@ -3545,6 +3545,12 @@ Singleton {
             selfWrite = true;
             settingsFileView.setText(JSON.stringify(settings, null, 2));
         }
+        function getSettings() {
+            if (!hasLoaded) {
+                settingsFileView.waitForJob();
+            }
+            return settings;
+        }
 
         property Timer timer: Timer {
             id: settingsFileReloadDebounce
@@ -3589,7 +3595,7 @@ Singleton {
                         hasParseFailed = true;
                         _parseError = true;
                         const msg = error.message;
-                        const fileName = filePath.split("/").pop();
+                        const fileName = filePath?.split("/").pop();
                         log.error(`Failed to reload ${fileName} - file will not be overwritten. Error:`, msg);
                         Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
                 } finally {
@@ -3606,14 +3612,33 @@ Singleton {
         }
     }
 
+    property bool _allFilesRegistered: false
+    property int _registeredFiles: 0
     property var settingFiles: ({})
+    function _registerSettingsFile(index, file) {
+        settingFiles[index] = file;
+        _registeredFiles++;
+        _checkIfAllSettingsFilesFound();
+    }
+    function _checkIfAllSettingsFilesFound() {
+        if (_allFilesRegistered || settingsFolderModel.status !== FolderListModel.Ready) {
+            return;
+        }
+        const expectedCount = settingsFolderModel.count + 1;
+        if (_registeredFiles === expectedCount) {
+            _allFilesRegistered = true;
+            _startAfterSettingsFilesFound();
+        }
+    }
+    function _unregisterSettingsFile(index) {
+        delete settingFiles[index];
+        _registeredFiles--;
+    }
     function getSettingsObject() {
         const settingsObject = {};
         for (const index in settingFiles) {
             const settingFile = settingFiles[index];
-            if (settingFile.hasLoaded) {
-                Object.assign(settingsObject, settingFile.settings);
-            }
+            Object.assign(settingsObject, settingFile.getSettings());
         }
         return settingsObject;
     }
@@ -3624,7 +3649,7 @@ Singleton {
         filePath: StandardPaths.writableLocation(StandardPaths.ConfigLocation) + "/DankMaterialShell/settings.json"
 
         Component.onCompleted: {
-            settingFiles[0] = defaultSettingsFile;
+            _registerSettingsFile(0, defaultSettingsFile);
         }
     }
 
@@ -3636,12 +3661,17 @@ Singleton {
             folder: StandardPaths.writableLocation(StandardPaths.ConfigLocation) + "/DankMaterialShell/config.d"
             showDirs: false
             nameFilters: ["*.json"]
+            onStatusChanged: {
+                if (status === FolderListModel.Ready) {
+                    _checkIfAllSettingsFilesFound();
+                }
+            }
         }
         onObjectAdded: (index, file) => {
-            settingFiles[index + 1] = file;
+            _registerSettingsFile(index + 1, file);
         }
-        onObjectRemoved: (index, file) => {
-            delete settingFiles[index + 1]
+        onObjectRemoved: (index) => {
+            _unregisterSettingsFile(index + 1);
         }
         delegate: SettingsFile {
             id: settingsFile

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3649,15 +3649,12 @@ Singleton {
             showDirs: false
             nameFilters: ["*.json"]
         }
-
         onObjectAdded: (index, file) => {
             settingFiles[index + 1] = file;
         }
-
         onObjectRemoved: (index, file) => {
             delete settingFiles[index + 1]
         }
-
         delegate: SettingsFile {
             id: settingsFile
         }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3480,7 +3480,7 @@ Singleton {
 
     function _udpateSettingsAfterReload(file) {
         const filesArray = Object.values(settingFiles);
-        _loading = filesArray.every(file => file.isLoaded && !file.loading);
+        _loading = !filesArray.every(file => file.hasLoaded && !file.loading);
         if (_parseError) {
             _parseError = filesArray.some(file => file.hasParseFailed);
         }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3681,6 +3681,9 @@ Singleton {
         repeat: false
         running: false
         onTriggered: {
+            if (!configDirExists.exists) {
+                return;
+            }
             const folderModel = settingsFolderModel;
             const listModel = settingsFilesListModel;
 

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3578,6 +3578,90 @@ Singleton {
         return settingsObject;
     }
 
+    function _udpateSettingsAfterReload(file) {
+        try {
+            const filesArray = Object.values(settingFiles);
+            _loading = filesArray.every(file => file.isLoaded && !file.loading);
+            if (_parseError) {
+                _parseError = filesArray.some(file => file.hasParseFailed);
+            }
+
+            const prevFrameEnabled = frameEnabled;
+            const prevFrameMode = frameMode;
+
+            const loadedSettings = file.settings;
+
+            if (loadedSettings.weatherLocation !== undefined) {
+                _legacyWeatherLocation = loadedSettings.weatherLocation;
+            }
+            if (loadedSettings.weatherCoordinates !== undefined) {
+                _legacyWeatherCoordinates = loadedSettings.weatherCoordinates;
+            }
+            if (loadedSettings.vpnLastConnected !== undefined && loadedSettings.vpnLastConnected !== "") {
+                _legacyVpnLastConnected = loadedSettings.vpnLastConnected;
+                SessionData.vpnLastConnected = _legacyVpnLastConnected;
+                SessionData.saveSettings();
+            }
+
+            Store.parse(root, getSettingsObject())
+
+            _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
+            applyStoredTheme();
+            updateCompositorCursor();
+
+            if (_hasLoaded) {
+                // External edits reload under _loading, which skips the per-property transition triggers
+                const frameChanged = (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode));
+                if (!_parseError && frameChanged) {
+                    updateFrameCompositorLayout();
+                }
+            } else {
+                _hasLoaded = Object.values(settingFiles).every(file => file.hasLoaded);
+            }
+        } catch (error) {
+            const msg = error.message;
+            log.error(`Failed to reload ${file.filePath} - file will not be overwritten. Error:`, msg);
+            Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg("settings.json"), msg));
+        }
+    }
+
+    function _diagnoseSaveFailure() {
+        root._isReadOnly = Object.values(settingFiles).some(file => file.isReadOnly)
+        root._hasUnsavedChanges = root._checkForUnsavedChanges();
+    }
+
+    SettingsFile {
+        id: defaultSettingsFile
+
+        filePath: StandardPaths.writableLocation(StandardPaths.ConfigLocation) + "/DankMaterialShell/settings.json"
+        onLoading: {
+            _loading = true;
+        }
+        onLoaded: {
+            try {
+                _udpateSettingsAfterReload(defaultSettingsFile);
+            } catch (e) {
+                log.error(e);
+            }
+        }
+        onParseError: {
+            _parseError = true;
+        }
+        onLoadFailed: error => {
+            if (isGreeterMode) {
+                return;
+            }
+            applyStoredTheme();
+        }
+        onSaveFailed: error => {
+            _diagnoseSaveFailure();
+        }
+
+        Component.onCompleted: {
+            settingFiles[0] = defaultSettingsFile;
+        }
+    }
+
     Instantiator {
         id: settingsLoader
 
@@ -3603,43 +3687,10 @@ Singleton {
                 _loading = true;
             }
             onLoaded: {
-                const filesArray = Object.values(settingFiles);
-                _loading = filesArray.every(file => file.isLoaded && !file.loading);
-                if (_parseError) {
-                    _parseError = filesArray.some(file => file.hasParseFailed);
-                }
-
-                const prevFrameEnabled = frameEnabled;
-                const prevFrameMode = frameMode;
-
-                const loadedSettings = settingsFile.settings;
-
-                if (loadedSettings.weatherLocation !== undefined) {
-                    _legacyWeatherLocation = loadedSettings.weatherLocation;
-                }
-                if (loadedSettings.weatherCoordinates !== undefined) {
-                    _legacyWeatherCoordinates = loadedSettings.weatherCoordinates;
-                }
-                if (loadedSettings.vpnLastConnected !== undefined && loadedSettings.vpnLastConnected !== "") {
-                    _legacyVpnLastConnected = loadedSettings.vpnLastConnected;
-                    SessionData.vpnLastConnected = _legacyVpnLastConnected;
-                    SessionData.saveSettings();
-                }
-
-                Store.parse(root, getSettingsObject())
-
-                _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
-                applyStoredTheme();
-                updateCompositorCursor();
-
-                if (_hasLoaded) {
-                    // External edits reload under _loading, which skips the per-property transition triggers
-                    const frameChanged = (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode));
-                    if (!_parseError && frameChanged) {
-                        updateFrameCompositorLayout();
-                    }
-                } else {
-                    _hasLoaded = Object.values(settingFiles).every(file => file.hasLoaded);
+                try {
+                    _udpateSettingsAfterReload(settingsFile);
+                } catch (e) {
+                    log.error(e);
                 }
             }
             onParseError: {
@@ -3652,8 +3703,7 @@ Singleton {
                 applyStoredTheme();
             }
             onSaveFailed: error => {
-                root._isReadOnly = Object.values(settingFiles).some(file => file.isReadOnly)
-                root._hasUnsavedChanges = root._checkForUnsavedChanges();
+                _diagnoseSaveFailure();
             }
         }
     }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3663,33 +3663,29 @@ Singleton {
         repeat: false
         running: false
         onTriggered: {
-            try {
-                const folderModel = settingsFolderModel;
-                const listModel = settingsFilesListModel;
+            const folderModel = settingsFolderModel;
+            const listModel = settingsFilesListModel;
 
-                if (folderModel.status === FolderListModel.Ready) {
-                    const folderPaths = (new Array(folderModel.count)).fill(1).map((_, index) => {
-                        return folderModel.get(index, "filePath")
-                    });
+            if (folderModel.status === FolderListModel.Ready) {
+                const folderPaths = (new Array(folderModel.count)).fill(1).map((_, index) => {
+                    return folderModel.get(index, "filePath")
+                });
 
-                    for (const filePath of folderPaths) {
-                        if (!_settingsFiles.has(filePath)) {
-                            listModel.append({ filePath });
-                        }
+                for (const filePath of folderPaths) {
+                    if (!_settingsFiles.has(filePath)) {
+                        listModel.append({ filePath });
                     }
-                    const folderPathsSet = new Set(folderPaths);
-                    for (let i = 1; i < _settingsFilesPaths.length; i++) {
-                        const filePath = _settingsFilesPaths[i];
-                        if (!folderPathsSet.has(filePath)) {
-                            const file = _settingsFiles.get(filePath);
-                            listModel.remove(file.index);
-                        }
-                    }
-                } else {
-                    restart();
                 }
-            } catch (e) {
-                log.error("Failed to sync settings files models:", e)
+                const folderPathsSet = new Set(folderPaths);
+                for (let i = 1; i < _settingsFilesPaths.length; i++) {
+                    const filePath = _settingsFilesPaths[i];
+                    if (!folderPathsSet.has(filePath)) {
+                        const file = _settingsFiles.get(filePath);
+                        listModel.remove(file.index);
+                    }
+                }
+            } else {
+                restart();
             }
         }
     }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3491,49 +3491,43 @@ Singleton {
     }
 
     function _udpateSettingsAfterReload(file) {
-        try {
-            const filesArray = Object.values(settingFiles);
-            _loading = filesArray.every(file => file.isLoaded && !file.loading);
-            if (_parseError) {
-                _parseError = filesArray.some(file => file.hasParseFailed);
+        const filesArray = Object.values(settingFiles);
+        _loading = filesArray.every(file => file.isLoaded && !file.loading);
+        if (_parseError) {
+            _parseError = filesArray.some(file => file.hasParseFailed);
+        }
+
+        const prevFrameEnabled = frameEnabled;
+        const prevFrameMode = frameMode;
+
+        const loadedSettings = file.settings;
+
+        if (loadedSettings.weatherLocation !== undefined) {
+            _legacyWeatherLocation = loadedSettings.weatherLocation;
+        }
+        if (loadedSettings.weatherCoordinates !== undefined) {
+            _legacyWeatherCoordinates = loadedSettings.weatherCoordinates;
+        }
+        if (loadedSettings.vpnLastConnected !== undefined && loadedSettings.vpnLastConnected !== "") {
+            _legacyVpnLastConnected = loadedSettings.vpnLastConnected;
+            SessionData.vpnLastConnected = _legacyVpnLastConnected;
+            SessionData.saveSettings();
+        }
+
+        Store.parse(root, getSettingsObject())
+
+        _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
+        applyStoredTheme();
+        updateCompositorCursor();
+
+        if (_hasLoaded) {
+            // External edits reload under _loading, which skips the per-property transition triggers
+            const frameChanged = (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode));
+            if (!_parseError && frameChanged) {
+                updateFrameCompositorLayout();
             }
-
-            const prevFrameEnabled = frameEnabled;
-            const prevFrameMode = frameMode;
-
-            const loadedSettings = file.settings;
-
-            if (loadedSettings.weatherLocation !== undefined) {
-                _legacyWeatherLocation = loadedSettings.weatherLocation;
-            }
-            if (loadedSettings.weatherCoordinates !== undefined) {
-                _legacyWeatherCoordinates = loadedSettings.weatherCoordinates;
-            }
-            if (loadedSettings.vpnLastConnected !== undefined && loadedSettings.vpnLastConnected !== "") {
-                _legacyVpnLastConnected = loadedSettings.vpnLastConnected;
-                SessionData.vpnLastConnected = _legacyVpnLastConnected;
-                SessionData.saveSettings();
-            }
-
-            Store.parse(root, getSettingsObject())
-
-            _loadedSettingsSnapshot = JSON.stringify(Store.toJson(root));
-            applyStoredTheme();
-            updateCompositorCursor();
-
-            if (_hasLoaded) {
-                // External edits reload under _loading, which skips the per-property transition triggers
-                const frameChanged = (frameEnabled !== prevFrameEnabled || (frameEnabled && frameMode !== prevFrameMode));
-                if (!_parseError && frameChanged) {
-                    updateFrameCompositorLayout();
-                }
-            } else {
-                _hasLoaded = Object.values(settingFiles).every(file => file.hasLoaded);
-            }
-        } catch (error) {
-            const msg = error.message;
-            log.error(`Failed to reload ${file.filePath} - file will not be overwritten. Error:`, msg);
-            Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg("settings.json"), msg));
+        } else {
+            _hasLoaded = Object.values(settingFiles).every(file => file.hasLoaded);
         }
     }
 
@@ -3604,10 +3598,12 @@ Singleton {
                     hasLoaded = true;
                     _udpateSettingsAfterReload(settingsFile);
                 } catch (error) {
-                    hasParseFailed = true;
-                    _parseError = true;
-                    const msg = error.msg;
-                    Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
+                        hasParseFailed = true;
+                        _parseError = true;
+                        const msg = error.message;
+                        const fileName = filePath.split("/").pop();
+                        log.error(`Failed to reload ${fileName} - file will not be overwritten. Error:`, msg);
+                        Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
                 } finally {
                     hasParseFailed = false;
                 }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1983,8 +1983,7 @@ Singleton {
         }
     }
 
-    function _getSettingsSplitByFile() {
-        const settings = Store.toJson(root);
+    function _splitSettingsByFile(settings) {
         const splitSettings = {};
 
         const filePaths = _settingsFilesPaths.slice()
@@ -2008,23 +2007,17 @@ Singleton {
     }
 
     function saveSettings() {
-        try {
-            if (_loading || _parseError || !_hasLoaded)
-            return;
-            _selfWrite = true;
-            const splitSettings = _getSettingsSplitByFile();
-            for (const index in splitSettings) {
-                const fileSettings = splitSettings[index];
-                const file = settingFiles[index];
-                file.setSettings(fileSettings);
-            }
-
-        } catch (e) {
-            log.error(`Failed to save settings at ${e.lineNumber}`, e)
+        if (_loading || _parseError || !_hasLoaded) return;
+        settingsSaveDebounce.restart();
+    }
+    function _saveSettings() {
+        const settings = Store.toJson(root);
+        const splitSettings = _splitSettingsByFile(settings);
+        for (const path in splitSettings) {
+            const fileSettings = splitSettings[path];
+            const file = _settingsFiles.get(path);
+            file.setSettings(fileSettings);
         }
-
-        if (_isReadOnly)
-            _checkSettingsWritable();
     }
 
     function savePluginSettings() {
@@ -3497,8 +3490,8 @@ Singleton {
         property bool hasUnsavedChanges: false
         property bool selfWrite: false
         function setSettings(newSettings) {
-            const newSettingsJson = JSON.stringify(newSettings);
-            if (JSON.stringify(settings) !== newSettingsJson) {
+            const newSettingsJson = JSON.stringify(newSettings, null, 2);
+            if (JSON.stringify(settings, null, 2) !== newSettingsJson) {
                 settings = newSettings;
                 hasUnsavedChanges = true;
                 selfWrite = true;
@@ -3727,6 +3720,14 @@ Singleton {
                 log.warn("Failed to load plugin_settings.json. Error:", msg);
             _resetPluginSettings();
         }
+    }
+
+    Timer {
+        id: settingsSaveDebounce
+        interval: 50
+        repeat: false
+        running: false
+        onTriggered: _saveSettings()
     }
 
     property bool pluginSettingsFileExists: false

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3718,7 +3718,7 @@ Singleton {
                 errorMsg = text.trim();
             }
         }
-        running: true
+        running: !isGreeterMode
         // qmllint disable signal-handler-parameters
         onExited: (code, _) => {
             if (code !== 0) {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -2012,7 +2012,7 @@ Singleton {
             splitSettings[index] = fileSettings;
         }
 
-        for (const setting of settings) {
+        for (const setting in settings) {
             splitSettings[0][setting] = settings[setting];
         }
         return splitSettings;

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3596,9 +3596,10 @@ Singleton {
                 _loading = true;
             }
             onLoaded: {
-                _loading = Object.values(settingFiles).every(file => file.isLoaded && !file.loading);
+                const filesArray = Object.values(settingFiles);
+                _loading = filesArray.every(file => file.isLoaded && !file.loading);
                 if (_parseError) {
-                    _parseError = Object.values(settingFiles).some(file => file.hasParseFailed);
+                    _parseError = filesArray.some(file => file.hasParseFailed);
                 }
 
                 const prevFrameEnabled = frameEnabled;

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -89,7 +89,6 @@ Singleton {
     property bool _pluginParseError: false
     property bool _hasLoaded: false
     property bool _isReadOnly: false
-    property bool _selfWrite: false
     property var _loadedSettingsSnapshot: null
     property var pluginSettings: ({})
     property var builtInPluginSettings: ({})
@@ -3541,7 +3540,9 @@ Singleton {
         property bool hasLoaded: false
         property bool hasParseFailed: false
         property bool isReadOnly: false
+        property bool selfWrite: false
         function setSettings(settings) {
+            selfWrite = true;
             settingsFileView.setText(JSON.stringify(settings, null, 2));
         }
 
@@ -3561,11 +3562,11 @@ Singleton {
             atomicWrites: true
             watchChanges: !isGreeterMode
             onFileChanged: {
-                if (_selfWrite) {
-                    _selfWrite = false;
-                    return;
+                if (selfWrite) {
+                    selfWrite = false;
+                } else {
+                    settingsFileReloadDebounce.restart();
                 }
-                settingsFileReloadDebounce.restart();
             }
             onLoaded: {
                 if (isGreeterMode) {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -1498,7 +1498,6 @@ Singleton {
         initializeListModels();
         refreshAuthAvailability();
         Processes.checkPluginSettings();
-        log.error("startup sequence ran")
     }
 
     function applyStoredTheme() {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3552,8 +3552,9 @@ Singleton {
                 } finally {
                     isLoading = false;
                     const files = Array.from(_settingsFiles.values());
-                    _allSettingsFilesLoaded = _allSettingsFilesLoaded || (
-                        hasLoaded && _allFilesRegistered && files.every(file => file.hasLoaded))
+                    if (hasLoaded) {
+                        _checkIfAllSettingsFilesLoaded()
+                    }
                     if (hadParseFailed && !hasParseFailed) {
                         _parseError = files.some(file => file.hasParseFailed);
                     }
@@ -3634,12 +3635,8 @@ Singleton {
         }
         if (_settingsFilesPaths.length == expectedCount) {
             _allFilesRegistered = true;
-            if (expectedCount === 1) {
-                _allSettingsFilesLoaded = defaultSettingsFile.hasLoaded;
-            }
-            if (_allSettingsFilesLoaded) {
-                _runStartSequence();
-            }
+            _checkIfAllSettingsFilesLoaded()
+            _loadSettingsOrStartIfReady();
         }
     }
     function _getSettingsObjectFromFiles() {
@@ -3666,6 +3663,19 @@ Singleton {
             }
         }
         _loading = false;
+    }
+    function _checkIfAllSettingsFilesLoaded() {
+        if (_allSettingsFilesLoaded || !_allFilesRegistered) {
+            return;
+        }
+        _allSettingsFilesLoaded = true;
+        for (const path of _settingsFilesPaths) {
+            const file = _settingsFiles.get(path);
+            if (!file.hasLoaded) {
+                _allSettingsFilesLoaded = false;
+                return;
+            }
+        }
     }
 
     SettingsFile {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3531,7 +3531,7 @@ Singleton {
         }
     }
 
-    function _diagnoseSaveFailure() {
+    function _registerSaveFailure() {
         root._isReadOnly = Object.values(settingFiles).some(file => file.isReadOnly)
         root._hasUnsavedChanges = root._checkForUnsavedChanges();
     }
@@ -3613,7 +3613,7 @@ Singleton {
             }
             onSaveFailed: (error) => {
                 isReadOnly = true;
-                _diagnoseSaveFailure();
+                _registerSaveFailure();
             }
         }
     }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3655,14 +3655,12 @@ Singleton {
         if (!_allSettingsFilesLoaded || files.some(file => file.isLoading)) {
             return;
         }
-        if (!_parseError) {
-            // Already true when ran from onLoaded, but false otherwise.
-            _loading = true;
-            if (!_hasLoaded) {
-                _runStartSequence();
-            } else {
-                _loadSettings();
-            }
+        // Already true when ran from onLoaded, but false otherwise.
+        _loading = true;
+        if (!_hasLoaded) {
+            _runStartSequence();
+        } else {
+            _loadSettings();
         }
         _loading = false;
     }

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3534,11 +3534,11 @@ Singleton {
                 _loading = true;
                 const hadParseFailed = hasParseFailed;
                 hasParseFailed = false;
+                const fileName = filePath?.split("/").pop();
                 try {
                     const txt = settingsFileView.text();
                     if (!txt || !txt.trim()) {
-                        hasParseFailed = true;
-                        return;
+                        throw new Error(`File ${fileName} is empty`)
                     }
                     settings = JSON.parse(txt);
                     hasLoaded = true;
@@ -3547,7 +3547,6 @@ Singleton {
                     _parseError = true;
 
                     const msg = error.message;
-                    const fileName = filePath?.split("/").pop();
                     log.error(`Failed to reload ${fileName} - file will not be overwritten. Error:`, msg);
                     Qt.callLater(() => ToastService.showError(I18n.tr("Failed to parse %1").arg(fileName), msg));
                 } finally {

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3727,7 +3727,7 @@ Singleton {
     Process {
         id: configDirExists
 
-        command: ["test", "-d", settingsFolderModel.dir]
+        command: ["test", "-d", Paths.strip(settingsFolderModel.dir)]
         running: true
         property bool checked: false
         property bool exists: false

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -3549,7 +3549,7 @@ Singleton {
                         hasParseFailed = true;
                         return;
                     }
-                    settingsFile.settings = JSON.parse(txt);
+                    settings = JSON.parse(txt);
                     hasLoaded = true;
                 } catch (error) {
                     hasParseFailed = true;

--- a/quickshell/Common/SettingsData.qml
+++ b/quickshell/Common/SettingsData.qml
@@ -89,7 +89,6 @@ Singleton {
     property bool _pluginParseError: false
     property bool _hasLoaded: false
     property bool _allSettingsFilesLoaded: false
-    property bool _isReadOnly: false
     property var _loadedSettingsSnapshot: null
     property var pluginSettings: ({})
     property var builtInPluginSettings: ({})
@@ -3480,17 +3479,12 @@ Singleton {
         id: rightWidgetsModel
     }
 
-    function _registerSaveFailure() {
-        root._isReadOnly = Object.values(settingFiles).some(file => file.isReadOnly)
-    }
-
     function _mitigateLoadFailure() {
         if (isGreeterMode) {
             return;
         }
         applyStoredTheme();
     }
-
 
     component SettingsFile : QtObject {
         id: settingsFile
@@ -3500,7 +3494,6 @@ Singleton {
         property bool isLoading: true
         property bool hasLoaded: false
         property bool hasParseFailed: false
-        property bool isReadOnly: false
         property bool hasUnsavedChanges: false
         property bool selfWrite: false
         function setSettings(newSettings) {
@@ -3583,10 +3576,6 @@ Singleton {
             }
             onLoadFailed: {
                 _mitigateLoadFailure();
-            }
-            onSaveFailed: (error) => {
-                isReadOnly = true;
-                _registerSaveFailure();
             }
         }
     }

--- a/quickshell/Common/settings/SettingsStore.js
+++ b/quickshell/Common/settings/SettingsStore.js
@@ -170,7 +170,6 @@ function toJson(root) {
         var value = root[k];
         if (k === "desktopWidgetInstances") value = withoutInstancePositions(value);
         if (k === "builtInPluginSettings") value = withoutSessionBackedPluginState(value);
-        if (Util.isDefault(value, SPEC[k].def)) continue;
         out[k] = value;
     }
     out.configVersion = root.settingsConfigVersion;

--- a/quickshell/Common/settings/SettingsStore.js
+++ b/quickshell/Common/settings/SettingsStore.js
@@ -161,7 +161,7 @@ function parse(root, jsonObj) {
     }
 }
 
-function toJson(root) {
+function toJson(root, setKeys) {
     var SPEC = SpecModule.SPEC;
     var out = {};
     for (var k in SPEC) {
@@ -170,6 +170,7 @@ function toJson(root) {
         var value = root[k];
         if (k === "desktopWidgetInstances") value = withoutInstancePositions(value);
         if (k === "builtInPluginSettings") value = withoutSessionBackedPluginState(value);
+        if (!setKeys.has(k) && Util.isDefault(value, SPEC[k].def)) continue;
         out[k] = value;
     }
     out.configVersion = root.settingsConfigVersion;

--- a/quickshell/Modals/Settings/SettingsModal.qml
+++ b/quickshell/Modals/Settings/SettingsModal.qml
@@ -321,7 +321,7 @@ DankFloatingWindow {
                     DankButton {
                         id: copySettingsButton
 
-                        visible: SettingsData._isReadOnly && SettingsData._hasUnsavedChanges
+                        visible: SettingsData.isReadOnly
                         text: "settings.json"
                         iconName: "content_copy"
                         backgroundColor: Theme.primary

--- a/quickshell/Modals/Settings/SettingsModal.qml
+++ b/quickshell/Modals/Settings/SettingsModal.qml
@@ -275,7 +275,7 @@ DankFloatingWindow {
             Rectangle {
                 id: readOnlyBanner
 
-                property bool showBanner: (SettingsData._isReadOnly && SettingsData._hasUnsavedChanges) || (SessionData._isReadOnly && SessionData._hasUnsavedChanges)
+                property bool showBanner: (SettingsData.isReadOnly) || (SessionData._isReadOnly && SessionData._hasUnsavedChanges)
 
                 width: parent.width
                 height: showBanner ? bannerContent.implicitHeight + Theme.spacingM * 2 : 0


### PR DESCRIPTION
## Description 

This PR adds support for multiple settings files by sourcing all json files from `config.d/` on top of `settings.json`. As outlined in #1732 this change makes it easier to manage DMS dotfiles across multiple machines.

### New Behaviour

- During startup, if `config.d/` directory exists in the configuration directory, all json files located in it are automatically sourced alongside settings.json. If it doesn't only settings.json is loaded. This check is not repeated so a restart is currently required after creating the directory.

- All the settings files are loaded asynchronously populating their own setting stores. Once all of the files are loaded a startup sequence runs (formerly `Component.onCompleted` signal handler), which, among other things, merges settings from all the files and applies them.

- When settings are being saved the object returned by `Store.toJson` is split between files based on where the settings were loaded from (defaults to `settings.json`).

#### File order

The default `settings.json` file is sourced first, followed by all the files from `config.d` in lexicographic order. A file loaded later can overwrite settings defined by it's precedents. When settings are changed from the UI, only its effective (last sourced) location is changed.

I tried my best to keep compatibility and the behavior should, for the most part, be the same as previously for anyone who doesn't have a `config.d` directory.

### Use of AI 

Everything here has been coded manually and thought out by me. I've occasionally used AI to inquire about specifics of QML which I'm new to and Javascript which I haven't used in ages. Finally, I used an AI to check my code for bugs.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Refactor / internal cleanup
- [ ] Documentation
- [ ] Other

## Related issues

Closes #1732

## Screenshots / video

Not visual

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator
  context, reusing existing terms where possible
- [ ] Go changes: ran `make fmt`, added/updated tests, `make test` passes, and
  `go mod tidy` is clean
- [x] QML changes: ran `make lint-qml` with no new warnings
- [ ] I have opened a corresponding pull request in dlx-docs to document any new
  behaviors: https://github.com/AvengeMedia/DankLinux-Docs

## Changes Breakdown

### Default Value Skip

Formerly Store.toJson would disregard any setting which is set to the default value. This would cause the settings to jump between files. For example:

If you were to set `showSeconds` to true in `config.d/module.json` and then from the UI flick it off and right back on the setting would be removed from `module.json` and re-appear in the default location - `settings.json`

Now `Store.toJson` only ignores default values if they haven't been featured in any of the loaded files.

### Startup sequence 

Previously, the startup sequence would run inside a `Component.onCompleted` signal handler. However with asynchronous file loading that handler fires off before all the `config.d/*.json` files are known. 

This has been replaced by a 3 stage system. 1. **Discovering**: config.d is inspected. If it exists all json files are passed over to the Instantiator. 2. **Loading**: During this stage all the SettingsFile(s) delegated by the Instantiator are created. 3. **Ready**: At the beginning of this stage the startup sequence (formerly `Component.onCompleted`) runs. Settings are ready for saving and reloading.

### FolderListModel Proxy and Debouncing 

FolderListModel will catch all sorts of changes and immediately update its list. The problem, however is that file editors (e.g (neo)vim) commonly create temporary files to which they write the new content and then replace the original file to maintain atomicity of writes. This causes multiple file updates and if `settingsFolderModel` were directly linked to the Instantiator this would remove and re-add the corresponding SettingsFile when a file view was just updated. This would completely bypass the file reload debouncing and immediately reload the file as if had just been created.

This is solved by introducing a proxy `settingsFilesListModel` ListModel which receives debounced updates from the FolderListModel.

### Refactor 

Because I had to pretty much rebuild the settings file management I took this opportunity to cleanup some of the settings management logic:

- centralized settings processing: Previously settings mutiple settings processing checks like migrations, weather location updates, or vpn connections were scattered between loadSettings() which ran during the initial load, and FileView.onLoaded handler which ran on every load. And some logic was even present in both which led to a duplicate check on the initial load.

  Now _loadSettings runs on every load and just adjusts its behaviour based on the _hasLoaded flag. This makes it easy to see what runs when and prevents the duplication. I migrated all these checks to run exactly as they'd formerly do, but I'm pretty sure some of them are not placed correctly (for example clock format check which only runs on the initial load or the vpnLastConnected which doesn't even exist in the SettingsSpec).

- _pendingMigration system removed: The previous system would store a snapshot of settings which would be forcefully saved once a file is known to be writable. This approach successfully ensured that migrations will be preserved, but posed a risk of disregarding user choice (the snapshot could get out of date) and was just quite tricky for me to translate to the multi file system.

  Now the _loadSettings function sequence forces a save if the loaded settings object was modified. Then any affected files have their unsavedChanges flagged and are prevented from reloading (and corrupting the in-memory migrated settings).

### Save Fail Recovery 

Because the system now prevents reloads of files with unsaved changes I thought it is important to re-check if a file can be written to. I've made it so that if any file fails to save it triggers a save fail recovery which re-attempts to save every file which hasn't been saved successfully. The retries are performed in exponential intervals starting at 2 seconds, capping out at 60 seconds. A total of 15 retries is performed.

### Writable check & Read-Only Modal 

There is a modal in the settings app, which triggers when there are unsaved changes and the settings file is read only. I've made it so that the isReadOnly flag is set only after a save fails due to missing permissions. This way it's only ever set if there are any unsaved changes. This, combined with the removal of the migration system, makes the Process for checking whether `settings.json` is writable obsolete.

#### Modal 
That Read-Only modal features a button for copying all the current settings. Dumping the entire configuration no longer really makes sense in a multi-file setup where settings can be split between multiple files. 

Ideally, it should allow copying changes per-file or showing which file they belong to. However, I decided not to change it for now due to the ongoing settings app re-design, and frankly, my own incompetence when it comes to UI work.
